### PR TITLE
Replace all Korean text with English across project docs and tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,20 +4,20 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Aerospike UI — Aerospike Community Edition을 위한 풀스택 GUI 관리 도구. FastAPI 백엔드 + Next.js 프론트엔드로 구성되며, Docker Compose로 오케스트레이션된다.
+Aerospike UI — A full-stack GUI management tool for Aerospike Community Edition. Built with FastAPI backend + Next.js frontend, orchestrated via Docker Compose.
 
 ## Commands
 
 ### Full Stack (Docker)
 ```bash
-docker compose up --build          # 전체 스택 실행 (Aerospike + Backend + Frontend)
-docker compose down                # 전체 스택 종료
+docker compose up --build          # Run full stack (Aerospike + Backend + Frontend)
+docker compose down                # Stop full stack
 ```
 
 ### Backend (Python 3.13 / FastAPI)
 ```bash
 cd backend
-uv run uvicorn aerospike_ui_api.main:app --reload  # 개발 서버 (port 8000)
+uv run uvicorn aerospike_ui_api.main:app --reload  # Dev server (port 8000)
 uv run ruff check src --fix                         # lint + autofix
 uv run ruff format src                              # format
 ```
@@ -25,22 +25,22 @@ uv run ruff format src                              # format
 ### Frontend (Next.js 16 / React 19)
 ```bash
 cd frontend
-npm run dev              # 개발 서버 (port 3000)
-npm run build            # 프로덕션 빌드
+npm run dev              # Dev server (port 3000)
+npm run build            # Production build
 npm run lint             # ESLint
 npm run lint:fix         # ESLint autofix
 npm run format           # Prettier format
 npm run format:check     # Prettier check
 npm run type-check       # TypeScript strict check
-npm run test             # Vitest 단위 테스트
-npm run test:watch       # Vitest watch 모드
+npm run test             # Vitest unit tests
+npm run test:watch       # Vitest watch mode
 npm run test:coverage    # Vitest + coverage (v8)
-npm run test:e2e         # Playwright E2E 테스트
+npm run test:e2e         # Playwright E2E tests
 ```
 
 ### Pre-commit
 ```bash
-pre-commit run --all-files  # 전체 파일에 pre-commit 실행
+pre-commit run --all-files  # Run pre-commit on all files
 ```
 
 ## Architecture
@@ -49,61 +49,61 @@ pre-commit run --all-files  # 전체 파일에 pre-commit 실행
 aerospike-ui/
 ├── backend/           # FastAPI REST API (Python 3.13, uv)
 │   └── src/aerospike_ui_api/
-│       ├── main.py        # FastAPI app, CORS, router 등록, /api/health
-│       ├── config.py      # 환경변수 기반 설정
-│       ├── store.py       # in-memory mock data store (개발용)
-│       ├── models/        # Pydantic 모델 (connection, cluster, record, index, admin, udf, metrics, query, terminal)
-│       ├── routers/       # REST 엔드포인트 (/api/* prefix)
-│       └── mock_data/     # 개발용 mock 데이터 생성기
+│       ├── main.py        # FastAPI app, CORS, router registration, /api/health
+│       ├── config.py      # Environment variable based configuration
+│       ├── store.py       # in-memory mock data store (for development)
+│       ├── models/        # Pydantic models (connection, cluster, record, index, admin, udf, metrics, query, terminal)
+│       ├── routers/       # REST endpoints (/api/* prefix)
+│       └── mock_data/     # Mock data generators for development
 ├── frontend/          # Next.js 16 App Router (React 19, TypeScript)
 │   └── src/
-│       ├── app/           # 페이지 라우팅 (App Router)
-│       ├── components/    # UI 컴포넌트
-│       │   ├── ui/        # Radix 기반 공통 프리미티브 (shadcn/ui 패턴)
-│       │   ├── common/    # 재사용 컴포넌트 (json-viewer, code-editor, status-badge 등)
-│       │   ├── layout/    # 앱 쉘 (header, sidebar, tab-bar)
-│       │   └── connection/, admin/  # 도메인별 컴포넌트
-│       ├── stores/        # Zustand 스토어 (connection, browser, query, admin, metrics, ui)
-│       ├── hooks/         # 커스텀 훅 (use-async-data, use-debounce, use-pagination 등)
+│       ├── app/           # Page routing (App Router)
+│       ├── components/    # UI components
+│       │   ├── ui/        # Radix-based shared primitives (shadcn/ui pattern)
+│       │   ├── common/    # Reusable components (json-viewer, code-editor, status-badge, etc.)
+│       │   ├── layout/    # App shell (header, sidebar, tab-bar)
+│       │   └── connection/, admin/  # Domain-specific components
+│       ├── stores/        # Zustand stores (connection, browser, query, admin, metrics, ui)
+│       ├── hooks/         # Custom hooks (use-async-data, use-debounce, use-pagination, etc.)
 │       └── lib/
-│           ├── api/       # API 클라이언트 (자동 retry, timeout, 타입 안전)
-│           ├── validations/  # Zod 스키마
-│           ├── constants.ts  # CE 제한, 브랜드 컬러, 페이지 사이즈
-│           ├── formatters.ts # 숫자/바이트/업타임 포매터
+│           ├── api/       # API client (auto retry, timeout, type-safe)
+│           ├── validations/  # Zod schemas
+│           ├── constants.ts  # CE limits, brand colors, page sizes
+│           ├── formatters.ts # Number/byte/uptime formatters
 │           └── utils.ts      # cn() (clsx + tailwind-merge)
 └── docker-compose.yml  # Aerospike + Backend + Frontend
 ```
 
 ### Key Architectural Decisions
 
-- **API Proxy**: Next.js의 `rewrites`를 통해 `/api/*` 요청을 백엔드로 프록시. `BACKEND_URL` 환경변수로 대상 설정 (기본: `http://localhost:8000`).
-- **State Management**: Zustand 스토어가 도메인별로 분리됨. `ui-store`만 `persist` 미들웨어로 localStorage에 영속화.
-- **Type Mirroring**: 백엔드 Pydantic 모델과 프론트엔드 TypeScript 타입(`lib/api/types.ts`)이 수동으로 동기화됨. 모델 변경 시 양쪽 모두 업데이트 필요.
-- **Styling**: Tailwind CSS 4 + DaisyUI 5. CSS 커스텀 프로퍼티로 라이트/다크 모드 테마. `globals.css`에 커스텀 애니메이션 정의.
-- **Path Alias**: `@/`가 `frontend/src/`를 가리킴 (tsconfig + vitest에서 모두 설정됨).
+- **API Proxy**: `/api/*` requests are proxied to the backend via Next.js `rewrites`. Target is configured with `BACKEND_URL` env var (default: `http://localhost:8000`).
+- **State Management**: Zustand stores are separated by domain. Only `ui-store` persists to localStorage via `persist` middleware.
+- **Type Mirroring**: Backend Pydantic models and frontend TypeScript types (`lib/api/types.ts`) are manually synchronized. Both sides must be updated when models change.
+- **Styling**: Tailwind CSS 4 + DaisyUI 5. Light/dark mode themes via CSS custom properties. Custom animations defined in `globals.css`.
+- **Path Alias**: `@/` points to `frontend/src/` (configured in both tsconfig and vitest).
 
 ### Frontend Route Structure
-| Route | 기능 |
+| Route | Description |
 |---|---|
-| `/` | 커넥션 목록/관리 |
-| `/cluster/[connId]` | 클러스터 개요, 노드, 네임스페이스, 메트릭, Prometheus |
-| `/browser/[connId]` | 네임스페이스/셋 트리 |
-| `/browser/[connId]/[ns]/[set]` | 레코드 브라우저 (페이지네이션) |
-| `/query/[connId]` | 쿼리 빌더 (scan/query + predicates) |
-| `/indexes/[connId]` | 세컨더리 인덱스 관리 |
-| `/admin/[connId]` | 사용자/역할 관리 |
-| `/udfs/[connId]` | UDF 관리 |
-| `/terminal/[connId]` | AQL 터미널 |
+| `/` | Connection list/management |
+| `/cluster/[connId]` | Cluster overview, nodes, namespaces, metrics, Prometheus |
+| `/browser/[connId]` | Namespace/set tree |
+| `/browser/[connId]/[ns]/[set]` | Record browser (pagination) |
+| `/query/[connId]` | Query builder (scan/query + predicates) |
+| `/indexes/[connId]` | Secondary index management |
+| `/admin/[connId]` | User/role management |
+| `/udfs/[connId]` | UDF management |
+| `/terminal/[connId]` | AQL terminal |
 
 ## Code Style
 
-- **Backend**: Ruff (line-length=120, target=py313). isort로 import 정렬. `E`, `W`, `F`, `I`, `UP`, `B`, `SIM`, `RUF` 규칙 적용.
-- **Frontend**: ESLint (next/core-web-vitals + typescript). Prettier (printWidth=100, doubleQuote). `no-console: warn`. 테스트 파일에서 `no-explicit-any` 허용.
-- **Pre-commit**: trailing-whitespace, end-of-file-fixer, check-yaml/json, Ruff(backend), ESLint+Prettier(frontend) 자동 실행.
+- **Backend**: Ruff (line-length=120, target=py313). Import sorting via isort. Rules: `E`, `W`, `F`, `I`, `UP`, `B`, `SIM`, `RUF`.
+- **Frontend**: ESLint (next/core-web-vitals + typescript). Prettier (printWidth=100, doubleQuote). `no-console: warn`. `no-explicit-any` allowed in test files.
+- **Pre-commit**: trailing-whitespace, end-of-file-fixer, check-yaml/json, Ruff(backend), ESLint+Prettier(frontend) auto-run.
 
 ## Environment Variables
 
-`.env.example` 참조. Docker Compose에서 사용:
-- `AEROSPIKE_HOST`, `AEROSPIKE_PORT` — Aerospike 서버 접속 정보
-- `BACKEND_PORT` (기본 8000), `FRONTEND_PORT` (기본 3100)
-- `CORS_ORIGINS` — 백엔드 CORS 허용 오리진
+See `.env.example`. Used in Docker Compose:
+- `AEROSPIKE_HOST`, `AEROSPIKE_PORT` — Aerospike server connection info
+- `BACKEND_PORT` (default 8000), `FRONTEND_PORT` (default 3100)
+- `CORS_ORIGINS` — Backend CORS allowed origins

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Aerospike UI
 
-Aerospike Community Edition을 위한 웹 기반 GUI 관리 도구.
+A web-based GUI management tool for Aerospike Community Edition.
 
-클러스터 모니터링, 레코드 브라우징, 쿼리 실행, 인덱스 관리, 사용자/역할 관리, UDF 관리, AQL 터미널 등의 기능을 제공합니다.
+Provides cluster monitoring, record browsing, query execution, index management, user/role management, UDF management, AQL terminal, and more.
 
 ## Tech Stack
 
@@ -15,7 +15,7 @@ Aerospike Community Edition을 위한 웹 기반 GUI 관리 도구.
 
 ## Quick Start
 
-### Docker Compose (권장)
+### Docker Compose (Recommended)
 
 ```bash
 cp .env.example .env
@@ -31,31 +31,31 @@ docker compose up --build
 **Backend:**
 ```bash
 cd backend
-uv sync                            # 의존성 설치
+uv sync                            # Install dependencies
 uv run uvicorn aerospike_ui_api.main:app --reload
 ```
 
 **Frontend:**
 ```bash
 cd frontend
-npm install                        # 의존성 설치
+npm install                        # Install dependencies
 npm run dev                        # http://localhost:3000
 ```
 
-> Frontend 개발 서버는 `/api/*` 요청을 `http://localhost:8000`으로 프록시합니다.
+> The frontend dev server proxies `/api/*` requests to `http://localhost:8000`.
 
 ## Features
 
-- **Connection Management** — 다중 Aerospike 클러스터 접속 프로필 관리
-- **Cluster Overview** — 노드 상태, 네임스페이스, 실시간 메트릭 모니터링
-- **Record Browser** — 네임스페이스/셋 탐색, 레코드 CRUD, 페이지네이션
-- **Query Builder** — Scan/Query 실행, predicate 기반 필터링
-- **Index Management** — 세컨더리 인덱스 생성/삭제
-- **Admin** — 사용자/역할 CRUD (CE 제한 표시 포함)
-- **UDF Management** — Lua UDF 업로드/삭제
-- **AQL Terminal** — 웹 기반 AQL 명령어 실행
-- **Prometheus Metrics** — 클러스터 메트릭 내보내기
-- **Light/Dark Mode** — 시스템 테마 연동
+- **Connection Management** — Manage multiple Aerospike cluster connection profiles
+- **Cluster Overview** — Node status, namespaces, real-time metrics monitoring
+- **Record Browser** — Namespace/set browsing, record CRUD, pagination
+- **Query Builder** — Scan/Query execution, predicate-based filtering
+- **Index Management** — Secondary index creation/deletion
+- **Admin** — User/role CRUD (with CE limitation indicators)
+- **UDF Management** — Lua UDF upload/delete
+- **AQL Terminal** — Web-based AQL command execution
+- **Prometheus Metrics** — Cluster metrics export
+- **Light/Dark Mode** — System theme integration
 
 ## Project Structure
 

--- a/frontend/e2e/all-pages.spec.ts
+++ b/frontend/e2e/all-pages.spec.ts
@@ -2,9 +2,9 @@ import { test, expect } from "@playwright/test";
 
 const CONN_ID = "conn-1";
 
-test.describe("Aerospike UI - 전체 페이지 테스트", () => {
+test.describe("Aerospike UI - All Pages Test", () => {
   // ── 1. Connections Page (Home) ──
-  test("01. Connections 페이지 로드", async ({ page }) => {
+  test("01. Connections page load", async ({ page }) => {
     await page.goto("/");
     const main = page.locator("main");
     await expect(main.getByText("Local Docker")).toBeVisible({ timeout: 15000 });
@@ -14,7 +14,7 @@ test.describe("Aerospike UI - 전체 페이지 테스트", () => {
   });
 
   // ── 2. Browser Page ──
-  test("02. Browser 페이지 - 레코드 테이블", async ({ page }) => {
+  test("02. Browser page - record table", async ({ page }) => {
     await page.goto(`/browser/${CONN_ID}/test/users`);
     await expect(page.locator("table").first()).toBeVisible({ timeout: 15000 });
     await expect(page.getByText("50 records")).toBeVisible({ timeout: 5000 });
@@ -22,7 +22,7 @@ test.describe("Aerospike UI - 전체 페이지 테스트", () => {
   });
 
   // ── 3. Cluster Page ──
-  test("03. Cluster 페이지 - 노드/네임스페이스", async ({ page }) => {
+  test("03. Cluster page - nodes/namespaces", async ({ page }) => {
     await page.goto(`/cluster/${CONN_ID}`);
     await expect(page.getByRole("heading", { name: "Cluster" })).toBeVisible({ timeout: 15000 });
     await expect(page.getByText("BB9060016AE4202").first()).toBeVisible({ timeout: 5000 });
@@ -31,7 +31,7 @@ test.describe("Aerospike UI - 전체 페이지 테스트", () => {
   });
 
   // ── 4. Query Page ──
-  test("04. Query 페이지 - 쿼리 빌더", async ({ page }) => {
+  test("04. Query page - query builder", async ({ page }) => {
     await page.goto(`/query/${CONN_ID}`);
     await expect(page.getByText("Query Builder")).toBeVisible({ timeout: 15000 });
     await expect(page.getByText("Execute").first()).toBeVisible();
@@ -39,7 +39,7 @@ test.describe("Aerospike UI - 전체 페이지 테스트", () => {
   });
 
   // ── 5. Indexes Page ──
-  test("05. Indexes 페이지 - 인덱스 목록", async ({ page }) => {
+  test("05. Indexes page - index list", async ({ page }) => {
     await page.goto(`/indexes/${CONN_ID}`);
     await expect(page.getByRole("heading", { name: "Secondary Indexes" })).toBeVisible({
       timeout: 15000,
@@ -48,29 +48,29 @@ test.describe("Aerospike UI - 전체 페이지 테스트", () => {
   });
 
   // ── 6. Admin Page ──
-  test("06. Admin 페이지 - User/Role 관리", async ({ page }) => {
+  test("06. Admin page - User/Role management", async ({ page }) => {
     await page.goto(`/admin/${CONN_ID}`);
     await expect(page.getByRole("tab", { name: /Users/i })).toBeVisible({ timeout: 15000 });
     await page.screenshot({ path: "e2e/screenshots/06-admin.png", fullPage: true });
   });
 
   // ── 7. UDFs Page ──
-  test("07. UDFs 페이지 - 모듈 목록", async ({ page }) => {
+  test("07. UDFs page - module list", async ({ page }) => {
     await page.goto(`/udfs/${CONN_ID}`);
     await expect(page.getByText(/UDF Modules|UDF/i).first()).toBeVisible({ timeout: 15000 });
     await page.screenshot({ path: "e2e/screenshots/07-udfs.png", fullPage: true });
   });
 
   // ── 8. Terminal Page ──
-  test("08. Terminal 페이지 - 명령어 입력", async ({ page }) => {
+  test("08. Terminal page - command input", async ({ page }) => {
     await page.goto(`/terminal/${CONN_ID}`);
     await expect(page.getByText("Quick:")).toBeVisible({ timeout: 15000 });
     await expect(page.getByText("namespaces").first()).toBeVisible();
     await page.screenshot({ path: "e2e/screenshots/08-terminal.png", fullPage: true });
   });
 
-  // ── 9. Cluster Metrics 탭 ──
-  test("09. Cluster Metrics 탭 - 메트릭 대시보드", async ({ page }) => {
+  // ── 9. Cluster Metrics tab ──
+  test("09. Cluster Metrics tab - metrics dashboard", async ({ page }) => {
     await page.goto(`/cluster/${CONN_ID}`);
     await expect(page.getByRole("heading", { name: "Cluster" })).toBeVisible({ timeout: 15000 });
     await page.getByRole("tab", { name: /Metrics/i }).click();
@@ -80,7 +80,7 @@ test.describe("Aerospike UI - 전체 페이지 테스트", () => {
   });
 
   // ── 10. Settings Page ──
-  test("10. Settings 페이지 - 테마/정보", async ({ page }) => {
+  test("10. Settings page - theme/info", async ({ page }) => {
     await page.goto("/settings");
     await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible({ timeout: 15000 });
     await expect(page.getByText("Appearance")).toBeVisible();
@@ -88,8 +88,8 @@ test.describe("Aerospike UI - 전체 페이지 테스트", () => {
     await page.screenshot({ path: "e2e/screenshots/10-settings.png", fullPage: true });
   });
 
-  // ── 11. Dark Mode 토글 ──
-  test("11. 다크모드 토글", async ({ page }) => {
+  // ── 11. Dark Mode toggle ──
+  test("11. Dark mode toggle", async ({ page }) => {
     await page.goto("/settings");
     await expect(page.getByText("Appearance")).toBeVisible({ timeout: 15000 });
     await page.getByText("Dark", { exact: true }).click();
@@ -98,8 +98,8 @@ test.describe("Aerospike UI - 전체 페이지 테스트", () => {
     await page.screenshot({ path: "e2e/screenshots/11-dark-mode.png", fullPage: true });
   });
 
-  // ── 12. Prometheus 메트릭 탭 ──
-  test("12. Prometheus 메트릭 탭", async ({ page }) => {
+  // ── 12. Prometheus Metrics tab ──
+  test("12. Prometheus Metrics tab", async ({ page }) => {
     await page.goto(`/cluster/${CONN_ID}`);
     await expect(page.getByRole("heading", { name: "Cluster" })).toBeVisible({ timeout: 15000 });
     await page.getByRole("tab", { name: /Metrics/i }).click();
@@ -109,8 +109,8 @@ test.describe("Aerospike UI - 전체 페이지 테스트", () => {
     await page.screenshot({ path: "e2e/screenshots/12-prometheus.png", fullPage: true });
   });
 
-  // ── 13. TabBar 탭 전환 ──
-  test("13. TabBar 탭 전환", async ({ page }) => {
+  // ── 13. TabBar tab switching ──
+  test("13. TabBar tab switching", async ({ page }) => {
     await page.goto(`/cluster/${CONN_ID}`);
     await expect(page.getByRole("heading", { name: "Cluster" })).toBeVisible({ timeout: 15000 });
     await page.getByRole("button", { name: "Indexes" }).last().click();
@@ -119,8 +119,8 @@ test.describe("Aerospike UI - 전체 페이지 테스트", () => {
     await page.screenshot({ path: "e2e/screenshots/13-tabbar-nav.png", fullPage: true });
   });
 
-  // ── 14. Sidebar 연결 트리 ──
-  test("14. Sidebar 연결 트리", async ({ page }) => {
+  // ── 14. Sidebar connection tree ──
+  test("14. Sidebar connection tree", async ({ page }) => {
     await page.goto(`/cluster/${CONN_ID}`);
     await expect(page.getByRole("heading", { name: "Cluster" })).toBeVisible({ timeout: 15000 });
     const sidebar = page.locator("aside");


### PR DESCRIPTION
Translated Korean comments, descriptions, and test names to English
in CLAUDE.md, README.md, and frontend/e2e/all-pages.spec.ts.

https://claude.ai/code/session_018eAPexq4YLUwXPhJEcjqYn