### PR TITLE
feat: persist connections in SQLite and async health checks

### DIFF
--- a/backend/src/aerospike_py_admin_ui_api/config.py
+++ b/backend/src/aerospike_py_admin_ui_api/config.py
@@ -6,3 +6,5 @@ CORS_ORIGINS: list[str] = os.getenv("CORS_ORIGINS", "http://localhost:3000").spl
 
 HOST: str = os.getenv("HOST", "0.0.0.0")
 PORT: int = int(os.getenv("PORT", "8000"))
+
+DATABASE_PATH: str = os.getenv("DATABASE_PATH", "data/connections.db")

--- a/backend/src/aerospike_py_admin_ui_api/db.py
+++ b/backend/src/aerospike_py_admin_ui_api/db.py
@@ -1,0 +1,203 @@
+"""SQLite persistence layer for connection profiles.
+
+Uses stdlib sqlite3 with asyncio.to_thread() to avoid blocking the event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+from aerospike_py_admin_ui_api import config
+from aerospike_py_admin_ui_api.models.connection import ConnectionProfile
+
+_connection: sqlite3.Connection | None = None
+
+CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS connections (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    hosts       TEXT NOT NULL,
+    port        INTEGER NOT NULL DEFAULT 3000,
+    cluster_name TEXT,
+    username    TEXT,
+    password    TEXT,
+    color       TEXT NOT NULL DEFAULT '#0097D3',
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+"""
+
+
+def _get_conn() -> sqlite3.Connection:
+    if _connection is None:
+        raise RuntimeError("Database not initialized. Call init_db() first.")
+    return _connection
+
+
+def init_db() -> None:
+    global _connection
+    db_path = Path(config.DATABASE_PATH)
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    _connection = sqlite3.connect(str(db_path), check_same_thread=False)
+    _connection.row_factory = sqlite3.Row
+    _connection.execute("PRAGMA journal_mode=WAL;")
+    _connection.execute(CREATE_TABLE_SQL)
+    _connection.commit()
+    _seed_if_empty()
+
+
+def close_db() -> None:
+    global _connection
+    if _connection:
+        _connection.close()
+        _connection = None
+
+
+# ---------------------------------------------------------------------------
+# Row ↔ Model helpers
+# ---------------------------------------------------------------------------
+
+
+def _row_to_profile(row: sqlite3.Row) -> ConnectionProfile:
+    return ConnectionProfile(
+        id=row["id"],
+        name=row["name"],
+        hosts=json.loads(row["hosts"]),
+        port=row["port"],
+        clusterName=row["cluster_name"],
+        username=row["username"],
+        password=row["password"],
+        color=row["color"],
+        createdAt=row["created_at"],
+        updatedAt=row["updated_at"],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sync helpers (run inside asyncio.to_thread)
+# ---------------------------------------------------------------------------
+
+
+def _get_all_sync() -> list[ConnectionProfile]:
+    cur = _get_conn().execute("SELECT * FROM connections ORDER BY created_at")
+    return [_row_to_profile(row) for row in cur.fetchall()]
+
+
+def _get_one_sync(conn_id: str) -> ConnectionProfile | None:
+    cur = _get_conn().execute("SELECT * FROM connections WHERE id = ?", (conn_id,))
+    row = cur.fetchone()
+    return _row_to_profile(row) if row else None
+
+
+def _insert_sync(conn: ConnectionProfile) -> None:
+    _get_conn().execute(
+        """INSERT INTO connections (id, name, hosts, port, cluster_name, username, password, color, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            conn.id,
+            conn.name,
+            json.dumps(conn.hosts),
+            conn.port,
+            conn.clusterName,
+            conn.username,
+            conn.password,
+            conn.color,
+            conn.createdAt,
+            conn.updatedAt,
+        ),
+    )
+    _get_conn().commit()
+
+
+def _update_sync(conn_id: str, data: dict) -> ConnectionProfile | None:
+    existing = _get_one_sync(conn_id)
+    if not existing:
+        return None
+
+    merged = existing.model_dump()
+    merged.update(data)
+    merged["id"] = conn_id
+    merged["updatedAt"] = datetime.now(UTC).isoformat()
+
+    _get_conn().execute(
+        """UPDATE connections
+           SET name = ?, hosts = ?, port = ?, cluster_name = ?, username = ?, password = ?, color = ?, updated_at = ?
+           WHERE id = ?""",
+        (
+            merged["name"],
+            json.dumps(merged["hosts"]),
+            merged["port"],
+            merged.get("clusterName"),
+            merged.get("username"),
+            merged.get("password"),
+            merged["color"],
+            merged["updatedAt"],
+            conn_id,
+        ),
+    )
+    _get_conn().commit()
+    return _get_one_sync(conn_id)
+
+
+def _delete_sync(conn_id: str) -> bool:
+    cur = _get_conn().execute("DELETE FROM connections WHERE id = ?", (conn_id,))
+    _get_conn().commit()
+    return cur.rowcount > 0
+
+
+# ---------------------------------------------------------------------------
+# Async public API
+# ---------------------------------------------------------------------------
+
+
+async def get_all_connections() -> list[ConnectionProfile]:
+    return await asyncio.to_thread(_get_all_sync)
+
+
+async def get_connection(conn_id: str) -> ConnectionProfile | None:
+    return await asyncio.to_thread(_get_one_sync, conn_id)
+
+
+async def create_connection(conn: ConnectionProfile) -> None:
+    await asyncio.to_thread(_insert_sync, conn)
+
+
+async def update_connection(conn_id: str, data: dict) -> ConnectionProfile | None:
+    return await asyncio.to_thread(_update_sync, conn_id, data)
+
+
+async def delete_connection(conn_id: str) -> bool:
+    return await asyncio.to_thread(_delete_sync, conn_id)
+
+
+# ---------------------------------------------------------------------------
+# Seed
+# ---------------------------------------------------------------------------
+
+
+def _seed_if_empty() -> None:
+    cur = _get_conn().execute("SELECT COUNT(*) FROM connections")
+    count = cur.fetchone()[0]
+    if count > 0:
+        return
+
+    from aerospike_py_admin_ui_api.mock_data.connections import mock_connections
+
+    for mc in mock_connections:
+        profile = ConnectionProfile(
+            id=mc.id,
+            name=mc.name,
+            hosts=mc.hosts,
+            port=mc.port,
+            clusterName=mc.clusterName,
+            username=mc.username,
+            password=mc.password,
+            color=mc.color,
+            createdAt=mc.createdAt,
+            updatedAt=mc.updatedAt,
+        )
+        _insert_sync(profile)

--- a/backend/src/aerospike_py_admin_ui_api/main.py
+++ b/backend/src/aerospike_py_admin_ui_api/main.py
@@ -1,7 +1,10 @@
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from aerospike_py_admin_ui_api import config
+from aerospike_py_admin_ui_api import config, db
 from aerospike_py_admin_ui_api.routers import (
     admin_roles,
     admin_users,
@@ -15,7 +18,15 @@ from aerospike_py_admin_ui_api.routers import (
     udfs,
 )
 
-app = FastAPI(title="Aerospike Py Admin UI API", version="0.1.0")
+
+@asynccontextmanager
+async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    db.init_db()
+    yield
+    db.close_db()
+
+
+app = FastAPI(title="Aerospike Py Admin UI API", version="0.1.0", lifespan=lifespan)
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/src/aerospike_py_admin_ui_api/store.py
+++ b/backend/src/aerospike_py_admin_ui_api/store.py
@@ -9,20 +9,16 @@ from __future__ import annotations
 import copy
 
 from aerospike_py_admin_ui_api.mock_data.clusters import mock_clusters  # read-only, no copy needed
-from aerospike_py_admin_ui_api.mock_data.connections import mock_connections
 from aerospike_py_admin_ui_api.mock_data.indexes import mock_indexes
 from aerospike_py_admin_ui_api.mock_data.records import mock_records
 from aerospike_py_admin_ui_api.mock_data.udfs import mock_udfs
 from aerospike_py_admin_ui_api.mock_data.users import mock_roles, mock_users
 from aerospike_py_admin_ui_api.models.admin import AerospikeRole, AerospikeUser, Privilege
-from aerospike_py_admin_ui_api.models.connection import ConnectionWithStatus
 from aerospike_py_admin_ui_api.models.index import SecondaryIndex
 from aerospike_py_admin_ui_api.models.record import AerospikeRecord
 from aerospike_py_admin_ui_api.models.udf import UDFModule
 
 # --- Mutable stores (deep-copied) -----------------------------------------
-
-connections: list[ConnectionWithStatus] = copy.deepcopy(mock_connections)
 
 records: dict[str, dict[str, list[AerospikeRecord]]] = copy.deepcopy(mock_records)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       start_period: 10s
     restart: unless-stopped
 
-  backend:
+  aerospike-py-admin-ui-backend:
     container_name: aerospike-py-admin-ui-backend
     build: ./backend
     ports:
@@ -27,6 +27,9 @@ services:
       - PORT=8000
       - AEROSPIKE_HOST=${AEROSPIKE_HOST:-aerospike}
       - AEROSPIKE_PORT=${AEROSPIKE_PORT:-3000}
+      - DATABASE_PATH=/app/data/connections.db
+    volumes:
+      - backend-data:/app/data
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8000/api/health"]
       interval: 10s
@@ -38,14 +41,20 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
-  frontend:
+  aerospike-py-admin-ui-frontend:
     container_name: aerospike-py-admin-ui-frontend
-    build: ./frontend
+    build:
+      context: ./frontend
+      args:
+        BACKEND_URL: http://aerospike-py-admin-ui-backend:8000
     ports:
       - "${FRONTEND_PORT:-3100}:3000"
     environment:
-      - BACKEND_URL=http://backend:8000
+      - BACKEND_URL=http://aerospike-py-admin-ui-backend:8000
     depends_on:
-      backend:
+      aerospike-py-admin-ui-backend:
         condition: service_healthy
     restart: unless-stopped
+
+volumes:
+  backend-data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,6 +9,8 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+ARG BACKEND_URL=http://localhost:8000
+ENV BACKEND_URL=${BACKEND_URL}
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build
 

--- a/frontend/src/components/common/status-badge.tsx
+++ b/frontend/src/components/common/status-badge.tsx
@@ -6,6 +6,7 @@ import { cn } from "@/lib/utils";
 type StatusType =
   | "connected"
   | "disconnected"
+  | "checking"
   | "ready"
   | "building"
   | "error"
@@ -23,6 +24,12 @@ const statusConfig: Record<StatusType, { label: string; className: string; dotCo
     label: "Disconnected",
     className: "bg-red-500/10 text-red-700 dark:bg-red-500/15 dark:text-red-400 border-red-500/20",
     dotColor: "bg-red-500",
+  },
+  checking: {
+    label: "Checking...",
+    className:
+      "bg-slate-500/10 text-slate-700 dark:bg-slate-500/15 dark:text-slate-400 border-slate-500/20",
+    dotColor: "bg-slate-400",
   },
   ready: {
     label: "Ready",
@@ -64,7 +71,12 @@ interface StatusBadgeProps {
 
 export function StatusBadge({ status, label, className, pulse }: StatusBadgeProps) {
   const config = statusConfig[status];
-  const showPulse = pulse || status === "connected" || status === "live" || status === "ready";
+  const showPulse =
+    pulse ||
+    status === "connected" ||
+    status === "live" ||
+    status === "ready" ||
+    status === "checking";
 
   return (
     <Badge

--- a/frontend/src/components/connection/connection-card.tsx
+++ b/frontend/src/components/connection/connection-card.tsx
@@ -11,18 +11,31 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Badge } from "@/components/ui/badge";
 import { StatusBadge } from "@/components/common/status-badge";
-import type { ConnectionWithStatus } from "@/lib/api/types";
+import type { ConnectionProfile, ConnectionStatus } from "@/lib/api/types";
 import { cn } from "@/lib/utils";
 
 interface ConnectionCardProps {
-  conn: ConnectionWithStatus;
+  conn: ConnectionProfile;
+  status?: ConnectionStatus;
+  isCheckingHealth?: boolean;
   index: number;
   onClick: () => void;
   onEdit: () => void;
   onDelete: () => void;
 }
 
-export function ConnectionCard({ conn, index, onClick, onEdit, onDelete }: ConnectionCardProps) {
+export function ConnectionCard({
+  conn,
+  status,
+  isCheckingHealth,
+  index,
+  onClick,
+  onEdit,
+  onDelete,
+}: ConnectionCardProps) {
+  const badgeStatus =
+    isCheckingHealth && !status ? "checking" : status?.connected ? "connected" : "disconnected";
+
   return (
     <Card
       className={cn(
@@ -96,24 +109,24 @@ export function ConnectionCard({ conn, index, onClick, onEdit, onDelete }: Conne
       </CardHeader>
       <CardContent className="pb-4">
         <div className="flex flex-wrap items-center gap-2">
-          <StatusBadge status={conn.status.connected ? "connected" : "disconnected"} />
-          {conn.status.connected && (
+          <StatusBadge status={badgeStatus} />
+          {status?.connected && (
             <>
               <Badge variant="secondary" className="gap-1 text-[11px]">
                 <Server className="h-3 w-3" />
-                {conn.status.nodeCount} node
-                {conn.status.nodeCount !== 1 ? "s" : ""}
+                {status.nodeCount} node
+                {status.nodeCount !== 1 ? "s" : ""}
               </Badge>
               <Badge variant="secondary" className="gap-1 text-[11px]">
                 <Database className="h-3 w-3" />
-                {conn.status.namespaceCount} ns
+                {status.namespaceCount} ns
               </Badge>
             </>
           )}
         </div>
-        {conn.status.connected && conn.status.build && (
+        {status?.connected && status.build && (
           <p className="text-muted-foreground mt-2.5 font-mono text-xs">
-            {conn.status.edition} {conn.status.build}
+            {status.edition} {status.build}
           </p>
         )}
       </CardContent>

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -16,16 +16,18 @@ import {
 import { cn } from "@/lib/utils";
 import { useConnectionStore } from "@/stores/connection-store";
 import { useUIStore } from "@/stores/ui-store";
-import type { ConnectionWithStatus } from "@/lib/api/types";
+import type { ConnectionProfile } from "@/lib/api/types";
 
 interface ConnectionItemProps {
-  connection: ConnectionWithStatus;
+  connection: ConnectionProfile;
 }
 
 const ConnectionItem = React.memo(function ConnectionItem({ connection }: ConnectionItemProps) {
   const router = useRouter();
   const pathname = usePathname();
   const selectConnection = useConnectionStore((s) => s.selectConnection);
+  const status = useConnectionStore((s) => s.healthStatuses[connection.id]);
+  const isChecking = useConnectionStore((s) => s.checkingHealth[connection.id]);
 
   const isActive = pathname?.includes(`/${connection.id}`);
 
@@ -53,9 +55,11 @@ const ConnectionItem = React.memo(function ConnectionItem({ connection }: Connec
         <span
           className={cn(
             "ring-offset-sidebar h-2.5 w-2.5 shrink-0 rounded-full ring-2 ring-offset-1 transition-shadow",
-            connection.status.connected
-              ? "status-glow-green ring-emerald-500/30"
-              : "status-glow-red ring-red-500/30",
+            isChecking && !status
+              ? "ring-slate-400/30"
+              : status?.connected
+                ? "status-glow-green ring-emerald-500/30"
+                : "status-glow-red ring-red-500/30",
           )}
           style={{ backgroundColor: connection.color }}
         />
@@ -63,7 +67,11 @@ const ConnectionItem = React.memo(function ConnectionItem({ connection }: Connec
         <span
           className={cn(
             "ml-auto h-1.5 w-1.5 shrink-0 rounded-full transition-colors",
-            connection.status.connected ? "bg-emerald-500" : "bg-red-500",
+            isChecking && !status
+              ? "animate-pulse bg-slate-400"
+              : status?.connected
+                ? "bg-emerald-500"
+                : "bg-red-500",
           )}
         />
       </button>

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -73,7 +73,11 @@ async function request<T>(path: string, options?: RequestInit & { timeout?: numb
 
 export const api = {
   // Connections
-  getConnections: () => request<import("./types").ConnectionWithStatus[]>("/api/connections"),
+  getConnections: () => request<import("./types").ConnectionProfile[]>("/api/connections"),
+  getConnectionHealth: (id: string) =>
+    request<import("./types").ConnectionStatus>(`/api/connections/${id}/health`, {
+      timeout: 10_000,
+    }),
   createConnection: (data: Partial<import("./types").ConnectionProfile>) =>
     request<import("./types").ConnectionProfile>("/api/connections", {
       method: "POST",

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -21,7 +21,7 @@ export interface ConnectionStatus {
 }
 
 export interface ConnectionWithStatus extends ConnectionProfile {
-  status: ConnectionStatus;
+  status?: ConnectionStatus;
 }
 
 // === Cluster ===


### PR DESCRIPTION
## Summary
- Connection 프로필을 SQLite에 영속 저장하여 서버 재시작 후에도 데이터 유지
- Health check를 프로필 조회와 분리하여 페이지 로딩을 블로킹하지 않고 connection별 비동기 확인
- Docker 환경에서 BACKEND_URL 빌드 ARG 전달로 프록시 ECONNREFUSED 문제 해결

## Changes

### Backend
- `db.py`: stdlib sqlite3 + asyncio.to_thread 기반 connection CRUD 모듈
- `GET /api/connections/{id}/health` 엔드포인트 추가
- FastAPI lifespan으로 DB 초기화/종료 관리
- in-memory store에서 connections 제거

### Frontend
- connection store에 `healthStatuses`, `checkingHealth` 상태 추가
- StatusBadge에 "checking" 상태 타입 추가 (pulse 애니메이션)
- 페이지/카드/사이드바에서 비동기 health 데이터 사용

### Infra
- docker-compose에 backend-data 볼륨 추가
- frontend Dockerfile에 BACKEND_URL 빌드 ARG 추가

## Test plan
- [x] Backend ruff check 통과
- [x] Frontend TypeScript type-check 통과
- [x] Frontend Vitest 131 tests 통과 (18 files)