### PR TITLE
feat(fe): responsive web design for mobile/tablet

### DIFF
--- a/frontend/src/app/admin/[connId]/page.tsx
+++ b/frontend/src/app/admin/[connId]/page.tsx
@@ -343,8 +343,8 @@ export default function AdminPage({ params }: { params: Promise<{ connId: string
                   <TableRow>
                     <TableHead>Role Name</TableHead>
                     <TableHead>Privileges</TableHead>
-                    <TableHead>Whitelist</TableHead>
-                    <TableHead>Quotas</TableHead>
+                    <TableHead className="hidden md:table-cell">Whitelist</TableHead>
+                    <TableHead className="hidden md:table-cell">Quotas</TableHead>
                     <TableHead className="w-[80px]">Actions</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -363,14 +363,14 @@ export default function AdminPage({ params }: { params: Promise<{ connId: string
                           ))}
                         </div>
                       </TableCell>
-                      <TableCell>
+                      <TableCell className="hidden md:table-cell">
                         {role.whitelist.length > 0 ? (
                           <span className="font-mono text-xs">{role.whitelist.join(", ")}</span>
                         ) : (
                           <span className="text-muted-foreground text-xs italic">any</span>
                         )}
                       </TableCell>
-                      <TableCell>
+                      <TableCell className="hidden md:table-cell">
                         <div className="space-y-0.5 text-xs">
                           <div>R: {role.readQuota}</div>
                           <div>W: {role.writeQuota}</div>

--- a/frontend/src/app/cluster/[connId]/page.tsx
+++ b/frontend/src/app/cluster/[connId]/page.tsx
@@ -352,19 +352,21 @@ export default function ClusterPage({ params }: { params: Promise<{ connId: stri
         <TabsList>
           <TabsTrigger value="nodes">
             <Server className="mr-1.5 h-3.5 w-3.5" />
-            Nodes ({cluster.nodes.length})
+            <span className="hidden sm:inline">Nodes ({cluster.nodes.length})</span>
+            <span className="sm:hidden">{cluster.nodes.length}</span>
           </TabsTrigger>
           <TabsTrigger value="namespaces">
             <Database className="mr-1.5 h-3.5 w-3.5" />
-            Namespaces ({cluster.namespaces.length})
+            <span className="hidden sm:inline">Namespaces ({cluster.namespaces.length})</span>
+            <span className="sm:hidden">{cluster.namespaces.length}</span>
           </TabsTrigger>
           <TabsTrigger value="metrics" className="gap-1">
             <Activity className="mr-1.5 h-3.5 w-3.5" />
-            Metrics
+            <span className="hidden sm:inline">Metrics</span>
           </TabsTrigger>
           <TabsTrigger value="prometheus" className="gap-1">
             <BookOpen className="mr-1.5 h-3.5 w-3.5" />
-            Prometheus
+            <span className="hidden sm:inline">Prometheus</span>
           </TabsTrigger>
         </TabsList>
 
@@ -572,7 +574,7 @@ export default function ClusterPage({ params }: { params: Promise<{ connId: stri
         <TabsContent value="metrics" className="mt-4 space-y-6">
           {!metrics ? (
             <div className="space-y-6">
-              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+              <div className="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-6">
                 {Array.from({ length: 6 }).map((_, i) => (
                   <Skeleton key={i} className="h-[90px] rounded-lg" />
                 ))}
@@ -586,7 +588,7 @@ export default function ClusterPage({ params }: { params: Promise<{ connId: stri
           ) : (
             <>
               {/* Summary cards */}
-              <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+              <div className="grid grid-cols-2 gap-4 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-6">
                 <StatCard
                   label="Read Requests"
                   value={formatNumber(metrics.totalReadReqs)}
@@ -629,7 +631,7 @@ export default function ClusterPage({ params }: { params: Promise<{ connId: stri
                     <CardDescription>Transactions per second over time</CardDescription>
                   </CardHeader>
                   <CardContent>
-                    <div className="h-[250px]">
+                    <div className="h-[180px] sm:h-[220px] lg:h-[250px]">
                       <ResponsiveContainer width="100%" height="100%">
                         <LineChart data={tpsData}>
                           <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
@@ -674,7 +676,7 @@ export default function ClusterPage({ params }: { params: Promise<{ connId: stri
                     <CardDescription>Active connections over time</CardDescription>
                   </CardHeader>
                   <CardContent>
-                    <div className="h-[250px]">
+                    <div className="h-[180px] sm:h-[220px] lg:h-[250px]">
                       <ResponsiveContainer width="100%" height="100%">
                         <LineChart data={connData}>
                           <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
@@ -713,7 +715,7 @@ export default function ClusterPage({ params }: { params: Promise<{ connId: stri
                     <CardDescription>Percentage of memory used per namespace</CardDescription>
                   </CardHeader>
                   <CardContent>
-                    <div className="h-[250px]">
+                    <div className="h-[180px] sm:h-[220px] lg:h-[250px]">
                       <ResponsiveContainer width="100%" height="100%">
                         <AreaChart data={memData}>
                           <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
@@ -762,7 +764,7 @@ export default function ClusterPage({ params }: { params: Promise<{ connId: stri
                     </CardDescription>
                   </CardHeader>
                   <CardContent>
-                    <div className="h-[250px]">
+                    <div className="h-[180px] sm:h-[220px] lg:h-[250px]">
                       <ResponsiveContainer width="100%" height="100%">
                         <AreaChart data={devData}>
                           <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
@@ -904,7 +906,7 @@ export default function ClusterPage({ params }: { params: Promise<{ connId: stri
                       OpenMetrics-compatible output from aerospike-py
                     </CardDescription>
                   </div>
-                  <div className="relative w-64">
+                  <div className="relative w-full sm:w-64">
                     <Search className="text-muted-foreground absolute top-2.5 left-2 h-4 w-4" />
                     <Input
                       placeholder="Filter metrics..."

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -543,3 +543,27 @@ kbd {
 .grid-skeleton-row {
   animation: glow-pulse 1.8s ease-in-out infinite;
 }
+
+/* ─── Responsive / Mobile ──────────────────────────── */
+
+/* Touch device minimum target size (WCAG 2.5.8) */
+@media (pointer: coarse) {
+  button:not([data-compact]):not(.page-num-btn),
+  [role="button"]:not([data-compact]) {
+    min-height: 44px;
+    min-width: 44px;
+  }
+}
+
+/* Safe area padding for iOS notch/home indicator */
+.safe-bottom {
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+}
+
+/* Row actions visible on touch devices (no hover) */
+@media (pointer: coarse) {
+  .record-grid-row .row-actions-group {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}

--- a/frontend/src/app/indexes/[connId]/page.tsx
+++ b/frontend/src/app/indexes/[connId]/page.tsx
@@ -192,10 +192,10 @@ export default function IndexesPage({ params }: { params: Promise<{ connId: stri
               <TableRow>
                 <TableHead>Name</TableHead>
                 <TableHead>Namespace</TableHead>
-                <TableHead>Set</TableHead>
+                <TableHead className="hidden md:table-cell">Set</TableHead>
                 <TableHead>Bin</TableHead>
                 <TableHead>Type</TableHead>
-                <TableHead>State</TableHead>
+                <TableHead className="hidden md:table-cell">State</TableHead>
                 <TableHead className="w-[80px]">Actions</TableHead>
               </TableRow>
             </TableHeader>
@@ -207,14 +207,14 @@ export default function IndexesPage({ params }: { params: Promise<{ connId: stri
                 >
                   <TableCell className="font-mono font-medium">{index.name}</TableCell>
                   <TableCell>{index.namespace}</TableCell>
-                  <TableCell>
+                  <TableCell className="hidden md:table-cell">
                     {index.set || <span className="text-muted-foreground italic">all</span>}
                   </TableCell>
                   <TableCell className="font-mono">{index.bin}</TableCell>
                   <TableCell>
                     <Badge variant={indexTypeBadgeVariant(index.type)}>{index.type}</Badge>
                   </TableCell>
-                  <TableCell>
+                  <TableCell className="hidden md:table-cell">
                     <StatusBadge
                       status={
                         index.state === "ready"

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -281,8 +281,8 @@ export default function ConnectionsPage() {
             Export
           </Button>
           <Button onClick={openCreateDialog}>
-            <Plus className="mr-2 h-4 w-4" />
-            New Connection
+            <Plus className="mr-2 h-4 w-4 sm:mr-2" />
+            <span className="hidden sm:inline">New Connection</span>
           </Button>
         </div>
       </div>
@@ -343,7 +343,7 @@ export default function ConnectionsPage() {
                         <Button
                           variant="ghost"
                           size="sm"
-                          className="h-7 w-7 p-0 opacity-0 transition-opacity group-hover:opacity-100"
+                          className="h-7 w-7 p-0 opacity-100 transition-opacity sm:opacity-0 sm:group-hover:opacity-100"
                           onClick={(e) => e.stopPropagation()}
                         >
                           <span className="sr-only">Actions</span>

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -58,7 +58,7 @@ export default function SettingsPage() {
           <CardDescription>Customize the look and feel of the application</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="grid grid-cols-3 gap-3">
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
             {themeOptions.map((opt) => (
               <button
                 key={opt.value}

--- a/frontend/src/app/terminal/[connId]/page.tsx
+++ b/frontend/src/app/terminal/[connId]/page.tsx
@@ -129,7 +129,7 @@ export default function TerminalPage({ params }: { params: Promise<{ connId: str
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder="Enter aql command..."
-            className="flex-1 border-zinc-700 bg-zinc-900 font-mono text-zinc-200 placeholder:text-zinc-600 focus-visible:ring-zinc-600"
+            className="flex-1 border-zinc-700 bg-zinc-900 font-mono text-base text-zinc-200 placeholder:text-zinc-600 focus-visible:ring-zinc-600 sm:text-sm"
             disabled={loading}
             autoComplete="off"
             spellCheck={false}

--- a/frontend/src/app/udfs/[connId]/page.tsx
+++ b/frontend/src/app/udfs/[connId]/page.tsx
@@ -234,7 +234,7 @@ export default function UDFsPage({ params }: { params: Promise<{ connId: string 
               <TableRow>
                 <TableHead>Filename</TableHead>
                 <TableHead>Type</TableHead>
-                <TableHead>Hash</TableHead>
+                <TableHead className="hidden md:table-cell">Hash</TableHead>
                 <TableHead className="w-[160px]">Actions</TableHead>
               </TableRow>
             </TableHeader>
@@ -245,7 +245,7 @@ export default function UDFsPage({ params }: { params: Promise<{ connId: string 
                   <TableCell>
                     <Badge variant="secondary">{udf.type}</Badge>
                   </TableCell>
-                  <TableCell className="text-muted-foreground font-mono text-xs">
+                  <TableCell className="text-muted-foreground hidden font-mono text-xs md:table-cell">
                     {truncateMiddle(udf.hash, 24)}
                   </TableCell>
                   <TableCell>

--- a/frontend/src/components/common/page-header.tsx
+++ b/frontend/src/components/common/page-header.tsx
@@ -6,9 +6,9 @@ interface PageHeaderProps {
 
 export function PageHeader({ title, description, actions }: PageHeaderProps) {
   return (
-    <div className="flex items-center justify-between">
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div>
-        <h1 className="text-2xl font-bold tracking-tight">{title}</h1>
+        <h1 className="text-xl font-bold tracking-tight sm:text-2xl">{title}</h1>
         {description && <p className="text-muted-foreground mt-0.5 text-sm">{description}</p>}
       </div>
       {actions && <div className="flex items-center gap-2">{actions}</div>}

--- a/frontend/src/components/common/responsive-table.tsx
+++ b/frontend/src/components/common/responsive-table.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import React from "react";
+import { useBreakpoint } from "@/hooks/use-breakpoint";
+
+interface ResponsiveTableProps<T> {
+  data: T[];
+  renderTable: () => React.ReactNode;
+  renderCard: (item: T, index: number) => React.ReactNode;
+  className?: string;
+}
+
+export function ResponsiveTable<T>({
+  data,
+  renderTable,
+  renderCard,
+  className,
+}: ResponsiveTableProps<T>) {
+  const { isDesktop } = useBreakpoint();
+
+  if (isDesktop) {
+    return <div className={className}>{renderTable()}</div>;
+  }
+
+  return (
+    <div className={className}>
+      {data.map((item, index) => (
+        <React.Fragment key={index}>{renderCard(item, index)}</React.Fragment>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/common/stat-card.tsx
+++ b/frontend/src/components/common/stat-card.tsx
@@ -25,12 +25,12 @@ export const StatCard = React.memo(function StatCard({
             <p className="text-muted-foreground text-xs font-medium tracking-wider uppercase">
               {label}
             </p>
-            <p className="metric-value text-2xl font-bold tracking-tight">{value}</p>
+            <p className="metric-value text-xl font-bold tracking-tight sm:text-2xl">{value}</p>
             {subtitle && <p className="text-muted-foreground text-xs">{subtitle}</p>}
           </div>
           <div
             className={cn(
-              "flex h-10 w-10 items-center justify-center rounded-lg",
+              "flex h-8 w-8 items-center justify-center rounded-lg sm:h-10 sm:w-10",
               trend === "up" && "bg-green-500/10 text-green-500",
               trend === "down" && "bg-red-500/10 text-red-500",
               (!trend || trend === "neutral") && "bg-accent/10 text-accent",

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { Moon, Sun, Monitor, PanelLeft } from "lucide-react";
+import { Moon, Sun, Monitor, PanelLeft, Menu } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -10,10 +10,20 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { useUIStore, type Theme } from "@/stores/ui-store";
+import { useBreakpoint } from "@/hooks/use-breakpoint";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 
 export function Header() {
-  const { theme, setTheme, toggleSidebar } = useUIStore();
+  const { theme, setTheme, toggleSidebar, setMobileNavOpen, mobileNavOpen } = useUIStore();
+  const { isDesktop } = useBreakpoint();
+
+  const handleToggle = () => {
+    if (isDesktop) {
+      toggleSidebar();
+    } else {
+      setMobileNavOpen(!mobileNavOpen);
+    }
+  };
 
   return (
     <header className="bg-card/80 relative z-50 flex h-12 items-center justify-between border-b px-4 backdrop-blur-sm">
@@ -26,10 +36,10 @@ export function Header() {
             <Button
               variant="ghost"
               size="icon"
-              onClick={toggleSidebar}
-              className="text-muted-foreground hover:text-foreground h-8 w-8"
+              onClick={handleToggle}
+              className="text-muted-foreground hover:text-foreground h-10 w-10 md:h-8 md:w-8"
             >
-              <PanelLeft className="h-4 w-4" />
+              {isDesktop ? <PanelLeft className="h-4 w-4" /> : <Menu className="h-5 w-5" />}
             </Button>
           </TooltipTrigger>
           <TooltipContent side="bottom">Toggle Sidebar (Cmd+B)</TooltipContent>
@@ -42,7 +52,7 @@ export function Header() {
           </div>
           <div className="flex flex-col">
             <span className="text-sm leading-none font-semibold tracking-tight">Aerospike</span>
-            <span className="text-muted-foreground mt-0.5 text-[10px] leading-none font-medium tracking-wide uppercase">
+            <span className="text-muted-foreground mt-0.5 hidden text-[10px] leading-none font-medium tracking-wide uppercase sm:block">
               UI Manager
             </span>
           </div>
@@ -55,7 +65,7 @@ export function Header() {
             <Button
               variant="ghost"
               size="icon"
-              className="text-muted-foreground hover:text-foreground h-8 w-8"
+              className="text-muted-foreground hover:text-foreground h-10 w-10 md:h-8 md:w-8"
             >
               {theme === "dark" ? (
                 <Moon className="h-4 w-4" />

--- a/frontend/src/components/layout/mobile-nav.tsx
+++ b/frontend/src/components/layout/mobile-nav.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import {
+  Table2,
+  Server,
+  SearchCode,
+  Terminal,
+  MoreHorizontal,
+  Database,
+  Shield,
+  Code2,
+} from "lucide-react";
+import { cn } from "@/lib/utils";
+
+const primaryTabs = [
+  { label: "Browser", icon: Table2, path: "browser" },
+  { label: "Cluster", icon: Server, path: "cluster" },
+  { label: "Query", icon: SearchCode, path: "query" },
+  { label: "Terminal", icon: Terminal, path: "terminal" },
+];
+
+const moreTabs = [
+  { label: "Indexes", icon: Database, path: "indexes" },
+  { label: "Admin", icon: Shield, path: "admin" },
+  { label: "UDFs", icon: Code2, path: "udfs" },
+];
+
+interface MobileNavProps {
+  connId: string;
+}
+
+export function MobileNav({ connId }: MobileNavProps) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const [moreOpen, setMoreOpen] = useState(false);
+
+  const handleClick = (path: string) => {
+    router.push(`/${path}/${connId}`);
+    setMoreOpen(false);
+  };
+
+  return (
+    <>
+      {/* More menu overlay */}
+      {moreOpen && (
+        <div className="fixed inset-0 z-40" onClick={() => setMoreOpen(false)}>
+          <div
+            className="bg-card border-border safe-bottom absolute right-2 bottom-16 z-50 rounded-lg border shadow-lg"
+            onClick={(e) => e.stopPropagation()}
+          >
+            {moreTabs.map((tab) => {
+              const isActive = pathname?.startsWith(`/${tab.path}/`);
+              return (
+                <button
+                  key={tab.path}
+                  onClick={() => handleClick(tab.path)}
+                  className={cn(
+                    "flex w-full items-center gap-3 px-4 py-3 text-sm transition-colors",
+                    isActive ? "text-accent" : "text-muted-foreground hover:text-foreground",
+                  )}
+                >
+                  <tab.icon className="h-4 w-4" />
+                  {tab.label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {/* Bottom nav bar */}
+      <nav className="bg-card/95 border-border fixed right-0 bottom-0 left-0 z-30 flex h-16 items-center justify-around border-t pb-[env(safe-area-inset-bottom)] backdrop-blur-sm md:hidden">
+        {primaryTabs.map((tab) => {
+          const isActive = pathname?.startsWith(`/${tab.path}/`);
+          return (
+            <button
+              key={tab.path}
+              onClick={() => handleClick(tab.path)}
+              className={cn(
+                "flex flex-col items-center gap-1 px-3 py-2 text-[10px] font-medium transition-colors",
+                isActive ? "text-accent" : "text-muted-foreground",
+              )}
+            >
+              <tab.icon className={cn("h-5 w-5", isActive && "text-accent")} />
+              {tab.label}
+            </button>
+          );
+        })}
+        <button
+          onClick={() => setMoreOpen(!moreOpen)}
+          className={cn(
+            "flex flex-col items-center gap-1 px-3 py-2 text-[10px] font-medium transition-colors",
+            moreOpen || moreTabs.some((t) => pathname?.startsWith(`/${t.path}/`))
+              ? "text-accent"
+              : "text-muted-foreground",
+          )}
+        >
+          <MoreHorizontal className="h-5 w-5" />
+          More
+        </button>
+      </nav>
+    </>
+  );
+}

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -87,11 +87,15 @@ const DialogContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTML
   ({ className, children, ...props }, ref) => {
     const { onClose } = React.useContext(DialogContext);
     return (
-      <div ref={ref} className={cn("modal-box relative", className)} {...props}>
+      <div
+        ref={ref}
+        className={cn("modal-box relative max-w-[calc(100vw-2rem)] sm:max-w-lg", className)}
+        {...props}
+      >
         {children}
         <button
           onClick={onClose}
-          className="btn btn-sm btn-circle btn-ghost absolute top-4 right-4"
+          className="btn btn-sm btn-circle btn-ghost absolute top-4 right-4 h-10 w-10 sm:h-8 sm:w-8"
           aria-label="Close"
         >
           <X className="h-4 w-4" />

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -4,7 +4,14 @@ import { cn } from "@/lib/utils";
 
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
   ({ className, type, ...props }, ref) => {
-    return <input type={type} className={cn("input w-full", className)} ref={ref} {...props} />;
+    return (
+      <input
+        type={type}
+        className={cn("input w-full text-base sm:text-sm", className)}
+        ref={ref}
+        {...props}
+      />
+    );
   },
 );
 Input.displayName = "Input";

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -7,7 +7,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"tex
     return (
       <textarea
         className={cn(
-          "border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[60px] w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-sm focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "border-input placeholder:text-muted-foreground focus-visible:ring-ring flex min-h-[60px] w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-sm focus-visible:ring-1 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50 sm:text-sm",
           className,
         )}
         ref={ref}

--- a/frontend/src/hooks/use-breakpoint.ts
+++ b/frontend/src/hooks/use-breakpoint.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+type Breakpoint = "mobile" | "tablet" | "desktop";
+
+interface BreakpointResult {
+  isMobile: boolean;
+  isTablet: boolean;
+  isDesktop: boolean;
+  breakpoint: Breakpoint;
+}
+
+export function useBreakpoint(): BreakpointResult {
+  const [breakpoint, setBreakpoint] = useState<Breakpoint>("desktop");
+
+  useEffect(() => {
+    const mqMobile = window.matchMedia("(max-width: 767px)");
+    const mqTablet = window.matchMedia("(min-width: 768px) and (max-width: 1023px)");
+
+    function update() {
+      if (mqMobile.matches) setBreakpoint("mobile");
+      else if (mqTablet.matches) setBreakpoint("tablet");
+      else setBreakpoint("desktop");
+    }
+
+    update();
+    mqMobile.addEventListener("change", update);
+    mqTablet.addEventListener("change", update);
+    return () => {
+      mqMobile.removeEventListener("change", update);
+      mqTablet.removeEventListener("change", update);
+    };
+  }, []);
+
+  return {
+    isMobile: breakpoint === "mobile",
+    isTablet: breakpoint === "tablet",
+    isDesktop: breakpoint === "desktop",
+    breakpoint,
+  };
+}

--- a/frontend/src/hooks/use-scroll-direction.ts
+++ b/frontend/src/hooks/use-scroll-direction.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useState, useEffect, useRef } from "react";
+
+type ScrollDirection = "up" | "down" | null;
+
+export function useScrollDirection(threshold = 10): ScrollDirection {
+  const [direction, setDirection] = useState<ScrollDirection>(null);
+  const lastY = useRef(0);
+  const ticking = useRef(false);
+
+  useEffect(() => {
+    lastY.current = window.scrollY;
+
+    function update() {
+      const currentY = window.scrollY;
+      const diff = currentY - lastY.current;
+
+      if (Math.abs(diff) >= threshold) {
+        setDirection(diff > 0 ? "down" : "up");
+        lastY.current = currentY;
+      }
+      ticking.current = false;
+    }
+
+    function onScroll() {
+      if (!ticking.current) {
+        requestAnimationFrame(update);
+        ticking.current = true;
+      }
+    }
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, [threshold]);
+
+  return direction;
+}

--- a/frontend/src/hooks/use-swipe.ts
+++ b/frontend/src/hooks/use-swipe.ts
@@ -1,0 +1,52 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+interface UseSwipeOptions {
+  onSwipeRight?: () => void;
+  onSwipeLeft?: () => void;
+  edgeThreshold?: number;
+  minDistance?: number;
+}
+
+export function useSwipe({
+  onSwipeRight,
+  onSwipeLeft,
+  edgeThreshold = 30,
+  minDistance = 60,
+}: UseSwipeOptions) {
+  const startX = useRef(0);
+  const startY = useRef(0);
+  const isEdgeSwipe = useRef(false);
+
+  useEffect(() => {
+    function handleTouchStart(e: TouchEvent) {
+      const touch = e.touches[0];
+      startX.current = touch.clientX;
+      startY.current = touch.clientY;
+      isEdgeSwipe.current = touch.clientX <= edgeThreshold;
+    }
+
+    function handleTouchEnd(e: TouchEvent) {
+      const touch = e.changedTouches[0];
+      const dx = touch.clientX - startX.current;
+      const dy = touch.clientY - startY.current;
+
+      // Only trigger if horizontal movement is dominant
+      if (Math.abs(dx) < minDistance || Math.abs(dy) > Math.abs(dx)) return;
+
+      if (dx > 0 && isEdgeSwipe.current && onSwipeRight) {
+        onSwipeRight();
+      } else if (dx < 0 && onSwipeLeft) {
+        onSwipeLeft();
+      }
+    }
+
+    document.addEventListener("touchstart", handleTouchStart, { passive: true });
+    document.addEventListener("touchend", handleTouchEnd, { passive: true });
+    return () => {
+      document.removeEventListener("touchstart", handleTouchStart);
+      document.removeEventListener("touchend", handleTouchEnd);
+    };
+  }, [onSwipeRight, onSwipeLeft, edgeThreshold, minDistance]);
+}

--- a/frontend/src/stores/ui-store.ts
+++ b/frontend/src/stores/ui-store.ts
@@ -7,10 +7,13 @@ interface UIState {
   theme: Theme;
   sidebarOpen: boolean;
   activeTab: string | null;
+  mobileNavOpen: boolean;
   setTheme: (theme: Theme) => void;
   toggleSidebar: () => void;
   setSidebarOpen: (open: boolean) => void;
   setActiveTab: (tab: string | null) => void;
+  setMobileNavOpen: (open: boolean) => void;
+  toggleMobileNav: () => void;
 }
 
 export const useUIStore = create<UIState>()(
@@ -19,10 +22,13 @@ export const useUIStore = create<UIState>()(
       theme: "system",
       sidebarOpen: true,
       activeTab: null,
+      mobileNavOpen: false,
       setTheme: (theme) => set({ theme }),
       toggleSidebar: () => set((state) => ({ sidebarOpen: !state.sidebarOpen })),
       setSidebarOpen: (open) => set({ sidebarOpen: open }),
       setActiveTab: (tab) => set({ activeTab: tab }),
+      setMobileNavOpen: (open) => set({ mobileNavOpen: open }),
+      toggleMobileNav: () => set((state) => ({ mobileNavOpen: !state.mobileNavOpen })),
     }),
     {
       name: "aerospike-py-admin-ui-settings",


### PR DESCRIPTION
## Summary
- **모바일 드로어 사이드바**: 고정 `w-56` 사이드바를 `<1024px`에서 fixed 드로어 + 백드롭 오버레이로 전환, 스와이프 제스처로 열기/닫기 지원
- **모바일 하단 네비게이션**: TabBar를 모바일에서 숨기고 `MobileNav` 하단 바(Browser, Cluster, Query, Terminal, More) 제공
- **Query 페이지 탭 전환**: 고정 `w-[380px]` 좌측 패널을 모바일에서 "Query Builder / Results" 탭 전환 UI로 대체, 쿼리 실행 후 자동 Results 탭 전환
- **Record Browser 카드 뷰**: 모바일에서 테이블 대신 카드 형태로 레코드 표시, 페이지네이션 prev/next 축소
- **터치 타겟 최적화**: `@media (pointer: coarse)` 기반 44px 최소 터치 타겟, 모바일 row-actions 항상 표시
- **iOS 줌 방지**: Input/Textarea에 `text-base sm:text-sm` 적용 (16px 이상에서 iOS가 줌하지 않음)
- **반응형 테이블 컬럼 숨김**: Admin(Whitelist, Quotas), Indexes(Set, State), UDFs(Hash) 컬럼 모바일 숨김
- **공통 컴포넌트 개선**: PageHeader 스택 레이아웃, StatCard/Dialog 크기 반응형, 차트 높이 단계적 확장

### 신규 파일 (5개)
- `src/hooks/use-breakpoint.ts` - 뷰포트 브레이크포인트 감지 훅
- `src/hooks/use-swipe.ts` - 화면 가장자리 스와이프 제스처
- `src/hooks/use-scroll-direction.ts` - 스크롤 방향 감지
- `src/components/layout/mobile-nav.tsx` - 모바일 하단 네비게이션
- `src/components/common/responsive-table.tsx` - 테이블/카드 전환 래퍼

### 수정 파일 (19개)
모든 주요 페이지(Query, Browser, Cluster, Admin, Indexes, Connection, Terminal, UDFs, Settings)와 레이아웃 컴포넌트(Sidebar, Header, AppLayout, TabBar), UI 컴포넌트(Input, Textarea, Dialog, PageHeader, StatCard)

## Test plan
- [ ] `npm run type-check` 통과 확인
- [ ] `npm run build` 정상 완료 확인
- [ ] `npm run lint` 통과 확인
- [ ] Chrome DevTools Device Mode로 iPhone SE(375px), iPhone 14(390px), iPad(768px) 테스트
- [ ] 데스크탑에서 기존 UI가 변경 없이 동작하는지 (회귀 없음)
- [ ] 모바일에서 사이드바 드로어 동작 + 백드롭 클릭 닫기
- [ ] 모바일 하단 네비게이션 탭 전환 + More 메뉴
- [ ] Query 페이지 모바일 탭 전환 + 쿼리 실행 후 자동 Results 전환
- [ ] Record Browser 모바일 카드 뷰 + 페이지네이션