### PR TITLE
chore(deps): upgrade Node.js from 22 to 24 (Active LTS)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # =============================================================================
 # Stage 1: Frontend build
 # =============================================================================
-FROM node:22-alpine AS frontend-deps
+FROM node:24-alpine AS frontend-deps
 WORKDIR /app
 COPY frontend/package.json frontend/package-lock.json ./
 RUN npm ci
 
-FROM node:22-alpine AS frontend-builder
+FROM node:24-alpine AS frontend-builder
 WORKDIR /app
 COPY --from=frontend-deps /app/node_modules ./node_modules
 COPY frontend/ .
@@ -37,8 +37,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js 22
-RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - \
+# Install Node.js 24
+RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
- Upgrade Node.js from 22 (Maintenance LTS) to 24 (Active LTS) in Dockerfile
- Replaces Dependabot PR #17 which proposed Node.js 25 (non-LTS, EOL April 2026)
- Updates both build stages (`node:24-alpine`) and runtime (`setup_24.x`)

## Why Node 24 instead of 25?
- Node.js 25 is an odd-numbered release that will **never** receive LTS status
- Node.js 25 reaches end-of-life around April 2026 (2 months away)
- Node.js 24 is the current **Active LTS** with support until April 2028
- `node:25-alpine` has a known local storage SecurityError issue