### PR TITLE
fix: resolve frontend-to-backend API proxy ECONNREFUSED in Docker Compose

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,7 @@ FROM base AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-ARG BACKEND_URL=http://localhost:8000
+ARG BACKEND_URL=http://aerospike-py-admin-ui-backend:8000
 ENV BACKEND_URL=${BACKEND_URL}
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build


### PR DESCRIPTION
## Summary
- Change the `BACKEND_URL` build arg default in `frontend/Dockerfile` from `http://localhost:8000` to `http://aerospike-py-admin-ui-backend:8000`
- This ensures the Next.js rewrites proxy targets the correct backend container service name at build time

## Root Cause
Next.js `rewrites()` evaluates `process.env.BACKEND_URL` at **build time**. The Dockerfile had `ARG BACKEND_URL=http://localhost:8000` as default, which gets baked into the standalone build. Inside the frontend container, `localhost:8000` doesn't point to the backend container, causing `ECONNREFUSED` on all API calls.

## Test plan
- [ ] Run `podman compose up --build` and verify all `/api/*` requests succeed
- [ ] Verify `http://localhost:3100` loads data correctly
- [ ] Verify local development with `npm run dev` still works (uses env var, not Dockerfile)

Closes #27