### PR TITLE
feat: improve record browser with bug fixes and batch_read code generation

### DIFF
--- a/frontend/src/stores/browser-store.ts
+++ b/frontend/src/stores/browser-store.ts
@@ -68,10 +68,8 @@ export const useBrowserStore = create<BrowserState>()((set, get) => ({
   putRecord: async (connId, data) => {
     try {
       await api.putRecord(connId, data);
-      const { selectedNamespace, selectedSet, page, pageSize } = get();
-      if (selectedNamespace && selectedSet) {
-        await get().fetchRecords(connId, selectedNamespace, selectedSet, page, pageSize);
-      }
+      const { page, pageSize } = get();
+      await get().fetchRecords(connId, data.key.namespace, data.key.set, page, pageSize);
     } catch (error) {
       set({ error: getErrorMessage(error) });
       throw error;


### PR DESCRIPTION
## Summary
- **Fix record list not refreshing after create**: `putRecord` in `browser-store.ts` now uses `data.key.namespace`/`data.key.set` directly for refetch instead of relying on `selectedNamespace`/`selectedSet` which were always `null`
- **Fix breadcrumbs**: Renamed "data" to "Namespaces" and made namespace label a clickable link navigating to `/browser/${connId}`
- **Preserve bin name case sensitivity**: Removed CSS `uppercase` class from dynamic bin column headers so "Name" and "NAME" display distinctly
- **Add batch_read code generation**: Added checkbox selection (header select-all + per-row) with a floating toolbar and dialog that generates a Python `aerospike.client.batch_read()` snippet with selected record keys

## Test plan
- [ ] Create a new record and verify the list refreshes immediately
- [ ] Click breadcrumb "Namespaces" and namespace name links to confirm navigation
- [ ] Verify bin column headers preserve original casing (e.g., "Name" vs "NAME")
- [ ] Select records via checkboxes, click "Generate batch_read", verify correct Python code with proper namespace/set/PKs
- [ ] Verify "Copy" button copies code to clipboard
- [ ] Confirm mobile card view checkboxes work correctly
- [ ] `npm run type-check` passes
- [ ] `npm run lint` passes