### PR TITLE
improve: input validation, security hardening, and UX polish

### DIFF
--- a/backend/src/aerospike_py_admin_ui_api/client_manager.py
+++ b/backend/src/aerospike_py_admin_ui_api/client_manager.py
@@ -16,6 +16,7 @@ import aerospike_py
 from aerospike_py.exception import AerospikeError
 
 from aerospike_py_admin_ui_api import db
+from aerospike_py_admin_ui_api.utils import parse_host_port
 
 
 class ClientManager:
@@ -37,16 +38,7 @@ class ClientManager:
         if profile is None:
             raise ValueError(f"Connection profile '{conn_id}' not found")
 
-        hosts = []
-        for h in profile.hosts:
-            if ":" in h:
-                host, port_str = h.rsplit(":", 1)
-                try:
-                    hosts.append((host, int(port_str)))
-                except ValueError:
-                    hosts.append((h, profile.port))
-            else:
-                hosts.append((h, profile.port))
+        hosts = [parse_host_port(h, profile.port) for h in profile.hosts]
         config: dict[str, Any] = {"hosts": hosts}
         if profile.username and profile.password:
             config["user"] = profile.username

--- a/backend/src/aerospike_py_admin_ui_api/models/admin.py
+++ b/backend/src/aerospike_py_admin_ui_api/models/admin.py
@@ -4,9 +4,9 @@ from pydantic import BaseModel, Field
 
 
 class Privilege(BaseModel):
-    code: str
-    namespace: str | None = None
-    set: str | None = None
+    code: str = Field(min_length=1, max_length=63)
+    namespace: str | None = Field(default=None, max_length=31)
+    set: str | None = Field(default=None, max_length=63)
 
 
 class AerospikeUser(BaseModel):
@@ -18,14 +18,14 @@ class AerospikeUser(BaseModel):
 
 
 class CreateUserRequest(BaseModel):
-    username: str = Field(min_length=1)
-    password: str = Field(min_length=1)
+    username: str = Field(min_length=1, max_length=63)
+    password: str = Field(min_length=1, max_length=255)
     roles: list[str] | None = None
 
 
 class ChangePasswordRequest(BaseModel):
-    username: str = Field(min_length=1)
-    password: str = Field(min_length=1)
+    username: str = Field(min_length=1, max_length=63)
+    password: str = Field(min_length=1, max_length=255)
 
 
 class AerospikeRole(BaseModel):
@@ -37,7 +37,7 @@ class AerospikeRole(BaseModel):
 
 
 class CreateRoleRequest(BaseModel):
-    name: str
+    name: str = Field(min_length=1, max_length=63)
     privileges: list[Privilege]
     whitelist: list[str] | None = None
     readQuota: int | None = None

--- a/backend/src/aerospike_py_admin_ui_api/models/index.py
+++ b/backend/src/aerospike_py_admin_ui_api/models/index.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class SecondaryIndex(BaseModel):
@@ -15,8 +15,8 @@ class SecondaryIndex(BaseModel):
 
 
 class CreateIndexRequest(BaseModel):
-    namespace: str
-    set: str
-    bin: str
-    name: str
+    namespace: str = Field(min_length=1, max_length=31)
+    set: str = Field(min_length=1, max_length=63)
+    bin: str = Field(min_length=1, max_length=15)
+    name: str = Field(min_length=1, max_length=255)
     type: Literal["numeric", "string", "geo2dsphere"]

--- a/backend/src/aerospike_py_admin_ui_api/models/query.py
+++ b/backend/src/aerospike_py_admin_ui_api/models/query.py
@@ -8,20 +8,20 @@ from .record import AerospikeRecord, BinValue
 
 
 class QueryPredicate(BaseModel):
-    bin: str = Field(min_length=1)
+    bin: str = Field(min_length=1, max_length=15)
     operator: Literal["equals", "between", "contains", "geo_within_region", "geo_contains_point"]
     value: BinValue
     value2: BinValue | None = None
 
 
 class QueryRequest(BaseModel):
-    namespace: str = Field(min_length=1)
-    set: str | None = None
+    namespace: str = Field(min_length=1, max_length=31)
+    set: str | None = Field(default=None, max_length=63)
     predicate: QueryPredicate | None = None
     selectBins: list[str] | None = None
-    expression: str | None = None
+    expression: str | None = Field(default=None, max_length=4096)
     maxRecords: int | None = Field(default=None, ge=1, le=1_000_000)
-    primaryKey: str | None = None
+    primaryKey: str | None = Field(default=None, max_length=1024)
 
 
 class QueryResponse(BaseModel):

--- a/backend/src/aerospike_py_admin_ui_api/models/record.py
+++ b/backend/src/aerospike_py_admin_ui_api/models/record.py
@@ -13,9 +13,9 @@ class GeoJSON(BaseModel):
 
 
 class RecordKey(BaseModel):
-    namespace: str
-    set: str = ""
-    pk: str = ""
+    namespace: str = Field(min_length=1, max_length=31)
+    set: str = Field(default="", max_length=63)
+    pk: str = Field(default="", max_length=1024)
     digest: str | None = None
 
 

--- a/backend/src/aerospike_py_admin_ui_api/models/terminal.py
+++ b/backend/src/aerospike_py_admin_ui_api/models/terminal.py
@@ -12,4 +12,4 @@ class TerminalCommand(BaseModel):
 
 
 class TerminalRequest(BaseModel):
-    command: str = Field(min_length=1)
+    command: str = Field(min_length=1, max_length=4096)

--- a/backend/src/aerospike_py_admin_ui_api/routers/connections.py
+++ b/backend/src/aerospike_py_admin_ui_api/routers/connections.py
@@ -24,6 +24,7 @@ from aerospike_py_admin_ui_api.models.connection import (
     TestConnectionRequest,
     UpdateConnectionRequest,
 )
+from aerospike_py_admin_ui_api.utils import parse_host_port
 
 logger = logging.getLogger(__name__)
 
@@ -116,16 +117,7 @@ async def get_connection_health(client: AerospikeClient) -> ConnectionStatus:
 
 
 def _test_connect_sync(body: TestConnectionRequest) -> dict:
-    hosts: list[tuple[str, int]] = []
-    for h in body.hosts:
-        if ":" in h:
-            host, port_str = h.rsplit(":", 1)
-            try:
-                hosts.append((host, int(port_str)))
-            except ValueError:
-                hosts.append((h, body.port))
-        else:
-            hosts.append((h, body.port))
+    hosts = [parse_host_port(h, body.port) for h in body.hosts]
 
     config: dict[str, Any] = {"hosts": hosts}
     if body.username and body.password:

--- a/backend/src/aerospike_py_admin_ui_api/utils.py
+++ b/backend/src/aerospike_py_admin_ui_api/utils.py
@@ -1,0 +1,14 @@
+"""Shared utility functions."""
+
+from __future__ import annotations
+
+
+def parse_host_port(host_str: str, default_port: int) -> tuple[str, int]:
+    """Parse a host string that may contain an optional ':port' suffix."""
+    if ":" in host_str:
+        host, port_str = host_str.rsplit(":", 1)
+        try:
+            return (host, int(port_str))
+        except ValueError:
+            return (host_str, default_port)
+    return (host_str, default_port)

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -93,6 +93,7 @@ export default function ConnectionsPage() {
   } | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<ConnectionProfile | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [exportConfirmOpen, setExportConfirmOpen] = useState(false);
 
   useEffect(() => {
     fetchConnections()
@@ -189,8 +190,7 @@ export default function ConnectionsPage() {
     }
   };
 
-  const handleExport = useCallback(() => {
-    if (!window.confirm("Export connections? Passwords will NOT be included for security.")) return;
+  const doExport = useCallback(() => {
     const data = connections.map(({ name, hosts, port, color, username }) => ({
       name,
       hosts,
@@ -207,8 +207,12 @@ export default function ConnectionsPage() {
     a.download = "aerospike-connections.json";
     a.click();
     URL.revokeObjectURL(url);
-    toast.success("Connections exported (passwords excluded)");
+    toast.success("Connections exported");
   }, [connections]);
+
+  const handleExport = useCallback(() => {
+    setExportConfirmOpen(true);
+  }, []);
 
   const handleImport = useCallback(() => {
     const input = document.createElement("input");
@@ -585,6 +589,17 @@ export default function ConnectionsPage() {
         variant="destructive"
         onConfirm={handleDelete}
         loading={deleting}
+      />
+
+      {/* Export Confirmation */}
+      <ConfirmDialog
+        open={exportConfirmOpen}
+        onOpenChange={setExportConfirmOpen}
+        title="Export Connections"
+        description="Export connections? Passwords will NOT be included for security."
+        confirmLabel="Export"
+        variant="default"
+        onConfirm={doExport}
       />
     </div>
   );

--- a/frontend/src/components/k8s/k8s-cluster-wizard.tsx
+++ b/frontend/src/components/k8s/k8s-cluster-wizard.tsx
@@ -158,7 +158,7 @@ export function K8sClusterWizard() {
     } catch (err) {
       const msg = getErrorMessage(err);
       setCreationError(msg);
-      toast.error(msg);
+      toast.error("Failed to create cluster");
     } finally {
       setCreating(false);
     }


### PR DESCRIPTION
## Summary
- **Backend**: Add `max_length` constraints to all Pydantic models using Aerospike CE actual limits (namespace: 31, set: 63, bin: 15, username: 63, terminal command: 4096) to prevent unbounded input attacks
- **Backend**: Extract duplicated host:port parsing logic from `client_manager.py` and `connections.py` into shared `utils.py`
- **Frontend**: Replace `window.confirm()` with `ConfirmDialog` component for connection export (UX consistency)
- **Frontend**: Improve K8s cluster wizard error display — show generic toast, keep detailed error in InlineAlert

## Test plan
- [ ] Verify backend rejects inputs exceeding max_length constraints (e.g., namespace > 31 chars)
- [ ] Verify connection test and client creation still work with host:port parsing via shared utility
- [ ] Verify export confirmation dialog appears and functions correctly
- [ ] Verify K8s cluster creation error shows short toast + detailed InlineAlert
- [ ] Run `ruff check` and `ruff format` — passes
- [ ] Run `npm run lint` and `npm run type-check` — passes