### PR TITLE
refactor: migrate backend to native AsyncClient (aerospike-py 0.0.1)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.13"
 dependencies = [
-    "aerospike-py", # 항상 최신버전 사용
+    "aerospike-py>=0.0.1", # 안정 버전 이상 사용
     "asyncpg>=0.30.0",
     "fastapi>=0.115.0",
     "kubernetes>=31.0.0",

--- a/backend/src/aerospike_cluster_manager_api/client_manager.py
+++ b/backend/src/aerospike_cluster_manager_api/client_manager.py
@@ -1,15 +1,13 @@
-"""Aerospike client pool manager.
+"""Aerospike async client pool manager.
 
-Manages one Client per connection-id, with thread-safe caching and
-asyncio.to_thread() wrappers so callers never block the event loop.
+Manages one AsyncClient per connection-id, with asyncio.Lock()
+for safe concurrent access in the async event loop.
 """
 
 from __future__ import annotations
 
 import asyncio
 import contextlib
-import threading
-from collections.abc import Callable
 from typing import Any
 
 import aerospike_py
@@ -21,47 +19,11 @@ from aerospike_cluster_manager_api.utils import parse_host_port
 
 class ClientManager:
     def __init__(self) -> None:
-        self._clients: dict[str, aerospike_py.Client] = {}
-        self._lock = threading.Lock()
+        self._clients: dict[str, aerospike_py.AsyncClient] = {}
+        self._lock = asyncio.Lock()
 
-    # ------------------------------------------------------------------
-    # Internal sync helpers (blocking Aerospike operations only)
-    # ------------------------------------------------------------------
-
-    def _connect_sync(self, conn_id: str, config: dict[str, Any]) -> aerospike_py.Client:
-        """Create and connect an Aerospike client (blocking)."""
-        client = aerospike_py.client(config).connect()
-
-        with self._lock:
-            old = self._clients.get(conn_id)
-            if old is not None:
-                with contextlib.suppress(AerospikeError, OSError):
-                    old.close()
-            self._clients[conn_id] = client
-
-        return client
-
-    def _close_client_sync(self, conn_id: str) -> None:
-        with self._lock:
-            client = self._clients.pop(conn_id, None)
-        if client is not None:
-            with contextlib.suppress(AerospikeError, OSError):
-                client.close()
-
-    def _close_all_sync(self) -> None:
-        with self._lock:
-            clients = list(self._clients.values())
-            self._clients.clear()
-        for client in clients:
-            with contextlib.suppress(AerospikeError, OSError):
-                client.close()
-
-    # ------------------------------------------------------------------
-    # Async public API
-    # ------------------------------------------------------------------
-
-    async def get_client(self, conn_id: str) -> aerospike_py.Client:
-        with self._lock:
+    async def get_client(self, conn_id: str) -> aerospike_py.AsyncClient:
+        async with self._lock:
             client = self._clients.get(conn_id)
             if client is not None and client.is_connected():
                 return client
@@ -76,18 +38,32 @@ class ClientManager:
             as_config["user"] = profile.username
             as_config["password"] = profile.password
 
-        return await asyncio.to_thread(self._connect_sync, conn_id, as_config)
+        client = aerospike_py.AsyncClient(as_config)
+        await client.connect()
+
+        async with self._lock:
+            old = self._clients.get(conn_id)
+            if old is not None:
+                with contextlib.suppress(AerospikeError, OSError):
+                    await old.close()
+            self._clients[conn_id] = client
+
+        return client
 
     async def close_client(self, conn_id: str) -> None:
-        await asyncio.to_thread(self._close_client_sync, conn_id)
+        async with self._lock:
+            client = self._clients.pop(conn_id, None)
+        if client is not None:
+            with contextlib.suppress(AerospikeError, OSError):
+                await client.close()
 
     async def close_all(self) -> None:
-        await asyncio.to_thread(self._close_all_sync)
-
-    async def run(self, conn_id: str, fn: Callable[..., Any], *args: Any) -> Any:
-        """Get client for *conn_id* and execute ``fn(client, *args)`` in a thread."""
-        client = await self.get_client(conn_id)
-        return await asyncio.to_thread(fn, client, *args)
+        async with self._lock:
+            clients = list(self._clients.values())
+            self._clients.clear()
+        for client in clients:
+            with contextlib.suppress(AerospikeError, OSError):
+                await client.close()
 
 
 client_manager = ClientManager()

--- a/backend/src/aerospike_cluster_manager_api/converters.py
+++ b/backend/src/aerospike_cluster_manager_api/converters.py
@@ -1,23 +1,25 @@
-"""Convert raw Aerospike tuples to Pydantic models."""
+"""Convert Aerospike Record objects to Pydantic models."""
 
 from __future__ import annotations
 
 from typing import Any
 
+from aerospike_py import Record
+
 from aerospike_cluster_manager_api.models.record import AerospikeRecord, RecordKey, RecordMeta
 
 
-def raw_to_record(raw: tuple[tuple, dict, dict]) -> AerospikeRecord:
-    """Convert ``(key_tuple, meta_dict, bins_dict)`` to :class:`AerospikeRecord`.
+def record_to_model(rec: Record) -> AerospikeRecord:
+    """Convert an aerospike-py :class:`Record` to :class:`AerospikeRecord`.
 
-    key_tuple: ``(namespace, set, pk, digest_bytes)``
-    meta_dict: ``{"gen": int, "ttl": int}``
-    bins_dict: ``{bin_name: value, ...}``
+    ``Record`` is a NamedTuple with ``key``, ``meta``, and ``bins`` attributes.
+    ``key``: ``(namespace, set, pk, digest_bytes)``
+    ``meta``: ``{"gen": int, "ttl": int}``
+    ``bins``: ``{bin_name: value, ...}``
     """
-    key_tuple, meta, bins = raw
-
-    if key_tuple is None:
-        key_tuple = ()
+    key_tuple = rec.key if rec.key is not None else ()
+    meta: dict[str, Any] = rec.meta or {}
+    bins: dict[str, Any] = rec.bins or {}
 
     ns: str = key_tuple[0] if len(key_tuple) > 0 else ""
     set_name: str = key_tuple[1] if len(key_tuple) > 1 else ""
@@ -25,9 +27,6 @@ def raw_to_record(raw: tuple[tuple, dict, dict]) -> AerospikeRecord:
     digest: bytes | None = key_tuple[3] if len(key_tuple) > 3 else None
 
     digest_hex = digest.hex() if isinstance(digest, bytes | bytearray) else None
-
-    meta = meta or {}
-    bins = bins or {}
 
     return AerospikeRecord(
         key=RecordKey(

--- a/backend/src/aerospike_cluster_manager_api/dependencies.py
+++ b/backend/src/aerospike_cluster_manager_api/dependencies.py
@@ -22,8 +22,8 @@ async def _get_verified_connection(conn_id: str = Path()) -> str:
     return conn_id
 
 
-async def _get_client(conn_id: str = Depends(_get_verified_connection)) -> aerospike_py.Client:
-    """Resolve *conn_id* and return a cached Aerospike client."""
+async def _get_client(conn_id: str = Depends(_get_verified_connection)) -> aerospike_py.AsyncClient:
+    """Resolve *conn_id* and return a cached Aerospike async client."""
     try:
         return await client_manager.get_client(conn_id)
     except Exception as e:
@@ -37,5 +37,5 @@ async def _get_client(conn_id: str = Depends(_get_verified_connection)) -> aeros
 VerifiedConnId = Annotated[str, Depends(_get_verified_connection)]
 """Inject a verified connection id from the path."""
 
-AerospikeClient = Annotated[aerospike_py.Client, Depends(_get_client)]
-"""Inject a cached Aerospike client resolved from the path ``conn_id``."""
+AerospikeClient = Annotated[aerospike_py.AsyncClient, Depends(_get_client)]
+"""Inject a cached Aerospike async client resolved from the path ``conn_id``."""

--- a/backend/src/aerospike_cluster_manager_api/routers/admin_users.py
+++ b/backend/src/aerospike_cluster_manager_api/routers/admin_users.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 
 from aerospike_py.exception import AdminError, AerospikeError
@@ -17,22 +16,6 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/admin", tags=["admin-users"])
 
 
-def _query_users_sync(c) -> list[AerospikeUser]:
-    raw_users = c.admin_query_users_info()
-    users: list[AerospikeUser] = []
-    for info in raw_users:
-        users.append(
-            AerospikeUser(
-                username=info.get("user", ""),
-                roles=info.get("roles", []),
-                readQuota=info.get("read_quota", 0),
-                writeQuota=info.get("write_quota", 0),
-                connections=info.get("connections", 0),
-            )
-        )
-    return users
-
-
 @router.get(
     "/{conn_id}/users",
     summary="List users",
@@ -41,17 +24,25 @@ def _query_users_sync(c) -> list[AerospikeUser]:
 async def get_users(client: AerospikeClient) -> list[AerospikeUser]:
     """Retrieve all Aerospike users and their roles. Requires Enterprise Edition."""
     try:
-        return await asyncio.to_thread(_query_users_sync, client)
+        raw_users = await client.admin_query_users_info()
+        users: list[AerospikeUser] = []
+        for info in raw_users:
+            users.append(
+                AerospikeUser(
+                    username=info.get("user", ""),
+                    roles=info.get("roles", []),
+                    readQuota=info.get("read_quota", 0),
+                    writeQuota=info.get("write_quota", 0),
+                    connections=info.get("connections", 0),
+                )
+            )
+        return users
     except AdminError:
         raise HTTPException(status_code=403, detail=EE_MSG) from None
     except AerospikeError as e:
         if "security" in str(e).lower() or "not enabled" in str(e).lower() or "not supported" in str(e).lower():
             raise HTTPException(status_code=403, detail=EE_MSG) from None
         raise
-
-
-def _create_user_sync(c, username: str, password: str, roles: list[str]) -> None:
-    c.admin_create_user(username, password, roles)
 
 
 @router.post(
@@ -66,7 +57,7 @@ async def create_user(body: CreateUserRequest, client: AerospikeClient) -> Aeros
         raise HTTPException(status_code=400, detail="Missing required fields: username, password")
 
     try:
-        await asyncio.to_thread(_create_user_sync, client, body.username, body.password, body.roles or [])
+        await client.admin_create_user(body.username, body.password, body.roles or [])
     except AdminError:
         raise HTTPException(status_code=403, detail=EE_MSG) from None
 
@@ -77,10 +68,6 @@ async def create_user(body: CreateUserRequest, client: AerospikeClient) -> Aeros
         writeQuota=0,
         connections=0,
     )
-
-
-def _change_password_sync(c, username: str, password: str) -> None:
-    c.admin_change_password(username, password)
 
 
 @router.patch(
@@ -95,15 +82,11 @@ async def change_password(body: ChangePasswordRequest, client: AerospikeClient) 
         raise HTTPException(status_code=400, detail="Missing required fields: username, password")
 
     try:
-        await asyncio.to_thread(_change_password_sync, client, body.username, body.password)
+        await client.admin_change_password(body.username, body.password)
     except AdminError:
         raise HTTPException(status_code=403, detail=EE_MSG) from None
 
     return MessageResponse(message="Password updated")
-
-
-def _drop_user_sync(c, username: str) -> None:
-    c.admin_drop_user(username)
 
 
 @router.delete(
@@ -118,7 +101,7 @@ async def delete_user(
 ) -> Response:
     """Delete an Aerospike user by username. Requires Enterprise Edition."""
     try:
-        await asyncio.to_thread(_drop_user_sync, client, username)
+        await client.admin_drop_user(username)
     except AdminError:
         raise HTTPException(status_code=403, detail=EE_MSG) from None
 

--- a/backend/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/backend/src/aerospike_cluster_manager_api/routers/connections.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import contextlib
 import logging
 import uuid
@@ -81,20 +80,6 @@ async def update_connection(
     return conn
 
 
-def _health_sync(c) -> dict:
-    node_names = c.get_node_names()
-    ns_raw = c.info_random_node(INFO_NAMESPACES)
-    namespaces = parse_list(ns_raw)
-    build = c.info_random_node(INFO_BUILD).strip()
-    edition = c.info_random_node(INFO_EDITION).strip()
-    return {
-        "node_count": len(node_names),
-        "namespace_count": len(namespaces),
-        "build": build,
-        "edition": edition,
-    }
-
-
 @router.get(
     "/{conn_id}/health",
     summary="Check connection health",
@@ -103,35 +88,22 @@ def _health_sync(c) -> dict:
 async def get_connection_health(client: AerospikeClient) -> ConnectionStatus:
     """Check the health status of an Aerospike cluster connection."""
     try:
-        info = await asyncio.to_thread(_health_sync, client)
+        node_names = await client.get_node_names()
+        ns_raw = await client.info_random_node(INFO_NAMESPACES)
+        namespaces = parse_list(ns_raw)
+        build = (await client.info_random_node(INFO_BUILD)).strip()
+        edition = (await client.info_random_node(INFO_EDITION)).strip()
+
         return ConnectionStatus(
             connected=True,
-            nodeCount=info["node_count"],
-            namespaceCount=info["namespace_count"],
-            build=info["build"],
-            edition=info["edition"],
+            nodeCount=len(node_names),
+            namespaceCount=len(namespaces),
+            build=build,
+            edition=edition,
         )
     except Exception:
         logger.exception("Health check failed for connection")
         return ConnectionStatus(connected=False, nodeCount=0, namespaceCount=0)
-
-
-def _test_connect_sync(body: TestConnectionRequest) -> dict:
-    hosts = [parse_host_port(h, body.port) for h in body.hosts]
-
-    config: dict[str, Any] = {"hosts": hosts}
-    if body.username and body.password:
-        config["user"] = body.username
-        config["password"] = body.password
-
-    client = aerospike_py.client(config).connect()
-    try:
-        if not client.is_connected():
-            return {"success": False, "message": "Failed to connect"}
-        return {"success": True, "message": "Connected successfully"}
-    finally:
-        with contextlib.suppress(AerospikeError, OSError):
-            client.close()
 
 
 @router.post(
@@ -142,7 +114,22 @@ def _test_connect_sync(body: TestConnectionRequest) -> dict:
 async def test_connection(body: TestConnectionRequest) -> dict:
     """Test connectivity to an Aerospike cluster without saving the profile."""
     try:
-        return await asyncio.to_thread(_test_connect_sync, body)
+        hosts = [parse_host_port(h, body.port) for h in body.hosts]
+
+        config: dict[str, Any] = {"hosts": hosts}
+        if body.username and body.password:
+            config["user"] = body.username
+            config["password"] = body.password
+
+        client = aerospike_py.AsyncClient(config)
+        await client.connect()
+        try:
+            if not client.is_connected():
+                return {"success": False, "message": "Failed to connect"}
+            return {"success": True, "message": "Connected successfully"}
+        finally:
+            with contextlib.suppress(AerospikeError, OSError):
+                await client.close()
     except Exception as e:
         logger.exception("Test connection failed")
         return {"success": False, "message": str(e)}

--- a/backend/src/aerospike_cluster_manager_api/routers/metrics.py
+++ b/backend/src/aerospike_cluster_manager_api/routers/metrics.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 import random
 import time
@@ -46,113 +45,6 @@ _STATS_SUM_KEYS = frozenset({"client_connections"})
 _STATS_MIN_KEYS = frozenset({"uptime"})
 
 
-def _fetch_metrics_sync(c, conn_id: str) -> dict:
-    # Cluster-level statistics (aggregated across all nodes)
-    stats_all = c.info_all(INFO_STATISTICS)
-    stats = aggregate_node_kv(stats_all, keys_to_sum=_STATS_SUM_KEYS, keys_to_min=_STATS_MIN_KEYS)
-    uptime = safe_int(stats.get("uptime"))
-    client_connections = safe_int(stats.get("client_connections"))
-
-    # Namespace list
-    ns_raw = c.info_random_node(INFO_NAMESPACES)
-    ns_names = parse_list(ns_raw)
-
-    # Count total nodes for RF calculation
-    total_nodes = len(stats_all)
-
-    ts_points = 60
-    ns_metrics: list[NamespaceMetrics] = []
-    memory_series: list[MetricSeries] = []
-    device_series: list[MetricSeries] = []
-    total_read_reqs = 0
-    total_write_reqs = 0
-    total_read_success = 0
-    total_write_success = 0
-
-    for i, ns_name in enumerate(ns_names):
-        # Aggregate namespace stats from all nodes
-        ns_all = c.info_all(info_namespace(ns_name))
-        ns_stats = aggregate_node_kv(ns_all, keys_to_sum=NS_SUM_KEYS)
-
-        replication_factor = safe_int(ns_stats.get("replication-factor"), 1)
-        effective_rf = min(replication_factor, total_nodes) if total_nodes > 0 else 1
-
-        raw_objects = safe_int(ns_stats.get("objects"))
-        objects = raw_objects // effective_rf if effective_rf > 0 else raw_objects
-        memory_used = safe_int(ns_stats.get("memory_used_bytes"))
-        memory_total = safe_int(ns_stats.get("memory-size"))
-        device_used = safe_int(ns_stats.get("device_used_bytes"))
-        device_total = safe_int(ns_stats.get("device-total-bytes"))
-
-        read_reqs = safe_int(ns_stats.get("client_read_success")) + safe_int(ns_stats.get("client_read_error"))
-        write_reqs = safe_int(ns_stats.get("client_write_success")) + safe_int(ns_stats.get("client_write_error"))
-        read_success = safe_int(ns_stats.get("client_read_success"))
-        write_success = safe_int(ns_stats.get("client_write_success"))
-
-        total_read_reqs += read_reqs
-        total_write_reqs += write_reqs
-        total_read_success += read_success
-        total_write_success += write_success
-
-        ns_metrics.append(
-            NamespaceMetrics(
-                namespace=ns_name,
-                objects=objects,
-                memoryUsed=memory_used,
-                memoryTotal=memory_total,
-                deviceUsed=device_used,
-                deviceTotal=device_total,
-                readReqs=read_reqs,
-                writeReqs=write_reqs,
-                readSuccess=read_success,
-                writeSuccess=write_success,
-            )
-        )
-
-        color = _NS_COLORS[i % len(_NS_COLORS)]
-        mem_pct = (memory_used / memory_total * 100) if memory_total > 0 else 0
-        memory_series.append(
-            MetricSeries(
-                name=f"memory_{ns_name}",
-                label=f"{ns_name} memory",
-                data=_generate_time_series(ts_points, mem_pct),
-                color=color,
-            )
-        )
-
-        dev_pct = (device_used / device_total * 100) if device_total > 0 else 0
-        device_series.append(
-            MetricSeries(
-                name=f"device_{ns_name}",
-                label=f"{ns_name} device",
-                data=_generate_time_series(ts_points, dev_pct),
-                color=color,
-            )
-        )
-
-    # TPS: simulate from current stats
-    read_tps_base = max(total_read_success / max(uptime, 1), 1)
-    write_tps_base = max(total_write_success / max(uptime, 1), 1)
-
-    return {
-        "connectionId": conn_id,
-        "timestamp": int(time.time() * 1000),
-        "connected": True,
-        "uptime": uptime,
-        "clientConnections": client_connections,
-        "totalReadReqs": total_read_reqs,
-        "totalWriteReqs": total_write_reqs,
-        "totalReadSuccess": total_read_success,
-        "totalWriteSuccess": total_write_success,
-        "namespaces": ns_metrics,
-        "readTps": _generate_time_series(ts_points, read_tps_base),
-        "writeTps": _generate_time_series(ts_points, write_tps_base),
-        "connectionHistory": _generate_time_series(ts_points, float(client_connections)),
-        "memoryUsageByNs": memory_series,
-        "deviceUsageByNs": device_series,
-    }
-
-
 @router.get(
     "/{conn_id}",
     summary="Get cluster metrics",
@@ -161,8 +53,108 @@ def _fetch_metrics_sync(c, conn_id: str) -> dict:
 async def get_metrics(client: AerospikeClient, conn_id: VerifiedConnId) -> ClusterMetrics:
     """Retrieve cluster-wide metrics including TPS, memory, device usage, and per-namespace stats."""
     try:
-        data = await asyncio.to_thread(_fetch_metrics_sync, client, conn_id)
-        return ClusterMetrics(**data)
+        # Cluster-level statistics (aggregated across all nodes)
+        stats_all = await client.info_all(INFO_STATISTICS)
+        stats = aggregate_node_kv(stats_all, keys_to_sum=_STATS_SUM_KEYS, keys_to_min=_STATS_MIN_KEYS)
+        uptime = safe_int(stats.get("uptime"))
+        client_connections = safe_int(stats.get("client_connections"))
+
+        # Namespace list
+        ns_raw = await client.info_random_node(INFO_NAMESPACES)
+        ns_names = parse_list(ns_raw)
+
+        total_nodes = len(stats_all)
+
+        ts_points = 60
+        ns_metrics: list[NamespaceMetrics] = []
+        memory_series: list[MetricSeries] = []
+        device_series: list[MetricSeries] = []
+        total_read_reqs = 0
+        total_write_reqs = 0
+        total_read_success = 0
+        total_write_success = 0
+
+        for i, ns_name in enumerate(ns_names):
+            ns_all = await client.info_all(info_namespace(ns_name))
+            ns_stats = aggregate_node_kv(ns_all, keys_to_sum=NS_SUM_KEYS)
+
+            replication_factor = safe_int(ns_stats.get("replication-factor"), 1)
+            effective_rf = min(replication_factor, total_nodes) if total_nodes > 0 else 1
+
+            raw_objects = safe_int(ns_stats.get("objects"))
+            objects = raw_objects // effective_rf if effective_rf > 0 else raw_objects
+            memory_used = safe_int(ns_stats.get("memory_used_bytes"))
+            memory_total = safe_int(ns_stats.get("memory-size"))
+            device_used = safe_int(ns_stats.get("device_used_bytes"))
+            device_total = safe_int(ns_stats.get("device-total-bytes"))
+
+            read_reqs = safe_int(ns_stats.get("client_read_success")) + safe_int(ns_stats.get("client_read_error"))
+            write_reqs = safe_int(ns_stats.get("client_write_success")) + safe_int(ns_stats.get("client_write_error"))
+            read_success = safe_int(ns_stats.get("client_read_success"))
+            write_success = safe_int(ns_stats.get("client_write_success"))
+
+            total_read_reqs += read_reqs
+            total_write_reqs += write_reqs
+            total_read_success += read_success
+            total_write_success += write_success
+
+            ns_metrics.append(
+                NamespaceMetrics(
+                    namespace=ns_name,
+                    objects=objects,
+                    memoryUsed=memory_used,
+                    memoryTotal=memory_total,
+                    deviceUsed=device_used,
+                    deviceTotal=device_total,
+                    readReqs=read_reqs,
+                    writeReqs=write_reqs,
+                    readSuccess=read_success,
+                    writeSuccess=write_success,
+                )
+            )
+
+            color = _NS_COLORS[i % len(_NS_COLORS)]
+            mem_pct = (memory_used / memory_total * 100) if memory_total > 0 else 0
+            memory_series.append(
+                MetricSeries(
+                    name=f"memory_{ns_name}",
+                    label=f"{ns_name} memory",
+                    data=_generate_time_series(ts_points, mem_pct),
+                    color=color,
+                )
+            )
+
+            dev_pct = (device_used / device_total * 100) if device_total > 0 else 0
+            device_series.append(
+                MetricSeries(
+                    name=f"device_{ns_name}",
+                    label=f"{ns_name} device",
+                    data=_generate_time_series(ts_points, dev_pct),
+                    color=color,
+                )
+            )
+
+        # TPS: simulate from current stats
+        read_tps_base = max(total_read_success / max(uptime, 1), 1)
+        write_tps_base = max(total_write_success / max(uptime, 1), 1)
+
+        return ClusterMetrics(
+            connectionId=conn_id,
+            timestamp=int(time.time() * 1000),
+            connected=True,
+            uptime=uptime,
+            clientConnections=client_connections,
+            totalReadReqs=total_read_reqs,
+            totalWriteReqs=total_write_reqs,
+            totalReadSuccess=total_read_success,
+            totalWriteSuccess=total_write_success,
+            namespaces=ns_metrics,
+            readTps=_generate_time_series(ts_points, read_tps_base),
+            writeTps=_generate_time_series(ts_points, write_tps_base),
+            connectionHistory=_generate_time_series(ts_points, float(client_connections)),
+            memoryUsageByNs=memory_series,
+            deviceUsageByNs=device_series,
+        )
     except Exception:
         logger.exception("Failed to fetch metrics for connection '%s'", conn_id)
         return ClusterMetrics(

--- a/backend/src/aerospike_cluster_manager_api/routers/query.py
+++ b/backend/src/aerospike_cluster_manager_api/routers/query.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 import time
@@ -10,7 +9,7 @@ from aerospike_py.exception import RecordNotFound
 from fastapi import APIRouter
 
 from aerospike_cluster_manager_api.constants import MAX_QUERY_RECORDS, POLICY_QUERY, POLICY_READ
-from aerospike_cluster_manager_api.converters import raw_to_record
+from aerospike_cluster_manager_api.converters import record_to_model
 from aerospike_cluster_manager_api.dependencies import AerospikeClient
 from aerospike_cluster_manager_api.models.query import QueryPredicate, QueryRequest, QueryResponse
 from aerospike_cluster_manager_api.routers.records import _auto_detect_pk
@@ -38,37 +37,42 @@ def _build_predicate(pred: QueryPredicate) -> tuple[str, ...]:
     raise ValueError(f"Unknown predicate operator: {op}")
 
 
-def _execute_query_sync(c, body: QueryRequest) -> dict:
+@router.post(
+    "/{conn_id}",
+    summary="Execute query",
+    description="Execute a query against Aerospike using primary key lookup, predicate filter, or full scan.",
+)
+async def execute_query(body: QueryRequest, client: AerospikeClient) -> QueryResponse:
+    """Execute a query against Aerospike using primary key lookup, predicate filter, or full scan."""
     start_time = time.monotonic()
 
     if body.primaryKey:
         if not body.set:
             raise ValueError("Set is required for PK Query")
 
-        # Aerospike treats string "123" and int 123 as different keys
         pk = _auto_detect_pk(body.primaryKey)
 
         try:
-            raw_result = c.get((body.namespace, body.set, pk), policy=POLICY_READ)
+            raw_result = await client.get((body.namespace, body.set, pk), policy=POLICY_READ)
             raw_results = [raw_result]
         except RecordNotFound:
             raw_results = []
 
         elapsed_ms = int((time.monotonic() - start_time) * 1000)
-        records = [raw_to_record(r) for r in raw_results]
-        return {
-            "records": records,
-            "executionTimeMs": elapsed_ms,
-            "scannedRecords": len(records),
-            "returnedRecords": len(records),
-        }
+        records = [record_to_model(r) for r in raw_results]
+        return QueryResponse(
+            records=records,
+            executionTimeMs=elapsed_ms,
+            scannedRecords=len(records),
+            returnedRecords=len(records),
+        )
 
-    q = c.query(body.namespace, body.set or "")
+    q = client.query(body.namespace, body.set or "")
     if body.predicate:
         q.where(_build_predicate(body.predicate))
     if body.selectBins:
         q.select(*body.selectBins)
-    raw_results = q.results(POLICY_QUERY)
+    raw_results = await q.results(POLICY_QUERY)
 
     elapsed_ms = int((time.monotonic() - start_time) * 1000)
     scanned = len(raw_results)
@@ -78,22 +82,11 @@ def _execute_query_sync(c, body: QueryRequest) -> dict:
     if len(raw_results) > MAX_QUERY_RECORDS:
         raw_results = raw_results[:MAX_QUERY_RECORDS]
 
-    records = [raw_to_record(r) for r in raw_results]
+    records = [record_to_model(r) for r in raw_results]
 
-    return {
-        "records": records,
-        "executionTimeMs": elapsed_ms,
-        "scannedRecords": scanned,
-        "returnedRecords": len(records),
-    }
-
-
-@router.post(
-    "/{conn_id}",
-    summary="Execute query",
-    description="Execute a query against Aerospike using primary key lookup, predicate filter, or full scan.",
-)
-async def execute_query(body: QueryRequest, client: AerospikeClient) -> QueryResponse:
-    """Execute a query against Aerospike using primary key lookup, predicate filter, or full scan."""
-    result = await asyncio.to_thread(_execute_query_sync, client, body)
-    return QueryResponse(**result)
+    return QueryResponse(
+        records=records,
+        executionTimeMs=elapsed_ms,
+        scannedRecords=scanned,
+        returnedRecords=len(records),
+    )

--- a/backend/tests/test_converters.py
+++ b/backend/tests/test_converters.py
@@ -3,22 +3,25 @@
 from __future__ import annotations
 
 import pytest
+from aerospike_py import Record
 from pydantic import ValidationError
 
-from aerospike_cluster_manager_api.converters import raw_to_record
+from aerospike_cluster_manager_api.converters import record_to_model
 from aerospike_cluster_manager_api.models.record import AerospikeRecord
 
 
-class TestRawToRecord:
-    """Tests for the raw_to_record converter."""
+class TestRecordToModel:
+    """Tests for the record_to_model converter."""
 
     def test_full_record(self):
         """Complete key tuple, meta, and bins."""
-        key_tuple = ("test", "sample_set", "pk-1", b"\xde\xad\xbe\xef")
-        meta = {"gen": 3, "ttl": 86400}
-        bins = {"name": "Alice", "age": 30, "active": True}
+        rec = Record(
+            key=("test", "sample_set", "pk-1", b"\xde\xad\xbe\xef"),
+            meta={"gen": 3, "ttl": 86400},
+            bins={"name": "Alice", "age": 30, "active": True},
+        )
 
-        record = raw_to_record((key_tuple, meta, bins))
+        record = record_to_model(rec)
 
         assert isinstance(record, AerospikeRecord)
         assert record.key.namespace == "test"
@@ -30,37 +33,30 @@ class TestRawToRecord:
         assert record.bins == {"name": "Alice", "age": 30, "active": True}
 
     def test_integer_primary_key(self):
-        key_tuple = ("test", "myset", 42, b"\x01\x02")
-        meta = {"gen": 1, "ttl": 0}
-        bins = {"score": 100}
+        rec = Record(key=("test", "myset", 42, b"\x01\x02"), meta={"gen": 1, "ttl": 0}, bins={"score": 100})
 
-        record = raw_to_record((key_tuple, meta, bins))
+        record = record_to_model(rec)
 
         assert record.key.pk == "42"
 
     def test_empty_key_tuple(self):
         """Empty key tuple should raise ValidationError (namespace is required)."""
-        key_tuple = ()
-        meta = {"gen": 1, "ttl": 0}
-        bins = {"x": 1}
+        rec = Record(key=(), meta={"gen": 1, "ttl": 0}, bins={"x": 1})
 
         with pytest.raises(ValidationError, match="namespace"):
-            raw_to_record((key_tuple, meta, bins))
+            record_to_model(rec)
 
     def test_none_key_tuple(self):
         """None key tuple should raise ValidationError (namespace is required)."""
-        meta = {"gen": 1, "ttl": 0}
-        bins = {"x": 1}
+        rec = Record(key=None, meta={"gen": 1, "ttl": 0}, bins={"x": 1})
 
         with pytest.raises(ValidationError, match="namespace"):
-            raw_to_record((None, meta, bins))
+            record_to_model(rec)
 
     def test_partial_key_tuple_namespace_only(self):
-        key_tuple = ("test",)
-        meta = {"gen": 1, "ttl": 0}
-        bins = {}
+        rec = Record(key=("test",), meta={"gen": 1, "ttl": 0}, bins={})
 
-        record = raw_to_record((key_tuple, meta, bins))
+        record = record_to_model(rec)
 
         assert record.key.namespace == "test"
         assert record.key.set == ""
@@ -68,11 +64,9 @@ class TestRawToRecord:
         assert record.key.digest is None
 
     def test_partial_key_tuple_namespace_and_set(self):
-        key_tuple = ("test", "myset")
-        meta = {"gen": 1, "ttl": 0}
-        bins = {}
+        rec = Record(key=("test", "myset"), meta={"gen": 1, "ttl": 0}, bins={})
 
-        record = raw_to_record((key_tuple, meta, bins))
+        record = record_to_model(rec)
 
         assert record.key.namespace == "test"
         assert record.key.set == "myset"
@@ -80,11 +74,9 @@ class TestRawToRecord:
         assert record.key.digest is None
 
     def test_partial_key_tuple_no_digest(self):
-        key_tuple = ("test", "myset", "pk-1")
-        meta = {"gen": 1, "ttl": 0}
-        bins = {}
+        rec = Record(key=("test", "myset", "pk-1"), meta={"gen": 1, "ttl": 0}, bins={})
 
-        record = raw_to_record((key_tuple, meta, bins))
+        record = record_to_model(rec)
 
         assert record.key.namespace == "test"
         assert record.key.set == "myset"
@@ -93,27 +85,25 @@ class TestRawToRecord:
 
     def test_none_meta(self):
         """None meta dict should default to gen=0, ttl=0."""
-        key_tuple = ("test", "myset", "pk-1", b"\x00")
-        bins = {"a": 1}
+        rec = Record(key=("test", "myset", "pk-1", b"\x00"), meta=None, bins={"a": 1})
 
-        record = raw_to_record((key_tuple, None, bins))
+        record = record_to_model(rec)
 
         assert record.meta.generation == 0
         assert record.meta.ttl == 0
 
     def test_none_bins(self):
         """None bins dict should result in empty bins."""
-        key_tuple = ("test", "myset", "pk-1", b"\x00")
-        meta = {"gen": 2, "ttl": 100}
+        rec = Record(key=("test", "myset", "pk-1", b"\x00"), meta={"gen": 2, "ttl": 100}, bins=None)
 
-        record = raw_to_record((key_tuple, meta, None))
+        record = record_to_model(rec)
 
         assert record.bins == {}
 
     def test_none_meta_and_bins(self):
-        key_tuple = ("test", "myset", "pk-1", b"\x00")
+        rec = Record(key=("test", "myset", "pk-1", b"\x00"), meta=None, bins=None)
 
-        record = raw_to_record((key_tuple, None, None))
+        record = record_to_model(rec)
 
         assert record.meta.generation == 0
         assert record.meta.ttl == 0
@@ -121,99 +111,86 @@ class TestRawToRecord:
 
     def test_none_set_name_becomes_empty_string(self):
         """When set name is None in key tuple, it should become ''."""
-        key_tuple = ("test", None, "pk-1", b"\x00")
-        meta = {"gen": 1, "ttl": 0}
-        bins = {}
+        rec = Record(key=("test", None, "pk-1", b"\x00"), meta={"gen": 1, "ttl": 0}, bins={})
 
-        record = raw_to_record((key_tuple, meta, bins))
+        record = record_to_model(rec)
 
         assert record.key.set == ""
 
     def test_none_primary_key(self):
         """When pk is None in key tuple, it should become ''."""
-        key_tuple = ("test", "myset", None, b"\x00")
-        meta = {"gen": 1, "ttl": 0}
-        bins = {}
+        rec = Record(key=("test", "myset", None, b"\x00"), meta={"gen": 1, "ttl": 0}, bins={})
 
-        record = raw_to_record((key_tuple, meta, bins))
+        record = record_to_model(rec)
 
         assert record.key.pk == ""
 
     def test_bytearray_digest(self):
         """bytearray digest should be hex-encoded the same as bytes."""
-        key_tuple = ("test", "myset", "pk-1", bytearray(b"\xca\xfe"))
-        meta = {"gen": 1, "ttl": 0}
-        bins = {}
+        rec = Record(key=("test", "myset", "pk-1", bytearray(b"\xca\xfe")), meta={"gen": 1, "ttl": 0}, bins={})
 
-        record = raw_to_record((key_tuple, meta, bins))
+        record = record_to_model(rec)
 
         assert record.key.digest == "cafe"
 
     def test_non_bytes_digest_becomes_none(self):
         """If the digest field is not bytes/bytearray, digest should be None."""
-        key_tuple = ("test", "myset", "pk-1", "not-bytes")
-        meta = {"gen": 1, "ttl": 0}
-        bins = {}
+        rec = Record(key=("test", "myset", "pk-1", "not-bytes"), meta={"gen": 1, "ttl": 0}, bins={})
 
-        record = raw_to_record((key_tuple, meta, bins))
+        record = record_to_model(rec)
 
         assert record.key.digest is None
 
     def test_complex_bin_values(self):
         """Bins can contain lists, dicts, GeoJSON, etc."""
-        key_tuple = ("test", "myset", "pk-1", b"\x00")
-        meta = {"gen": 1, "ttl": 0}
-        bins = {
-            "tags": ["python", "aerospike"],
-            "metadata": {"source": "import", "version": 2},
-            "location": {"type": "Point", "coordinates": [127.0, 37.5]},
-            "score": 3.14,
-        }
+        rec = Record(
+            key=("test", "myset", "pk-1", b"\x00"),
+            meta={"gen": 1, "ttl": 0},
+            bins={
+                "tags": ["python", "aerospike"],
+                "metadata": {"source": "import", "version": 2},
+                "location": {"type": "Point", "coordinates": [127.0, 37.5]},
+                "score": 3.14,
+            },
+        )
 
-        record = raw_to_record((key_tuple, meta, bins))
+        record = record_to_model(rec)
 
         assert record.bins["tags"] == ["python", "aerospike"]
         assert record.bins["metadata"]["source"] == "import"
         assert record.bins["score"] == 3.14
 
     def test_empty_bins(self):
-        key_tuple = ("test", "myset", "pk-1", b"\x00")
-        meta = {"gen": 5, "ttl": 300}
-        bins = {}
+        rec = Record(key=("test", "myset", "pk-1", b"\x00"), meta={"gen": 5, "ttl": 300}, bins={})
 
-        record = raw_to_record((key_tuple, meta, bins))
+        record = record_to_model(rec)
 
         assert record.bins == {}
 
     def test_meta_missing_gen_key(self):
         """Meta dict without 'gen' key should default to 0."""
-        key_tuple = ("test", "myset", "pk-1", b"\x00")
-        meta = {"ttl": 100}
-        bins = {"x": 1}
+        rec = Record(key=("test", "myset", "pk-1", b"\x00"), meta={"ttl": 100}, bins={"x": 1})
 
-        record = raw_to_record((key_tuple, meta, bins))
+        record = record_to_model(rec)
 
         assert record.meta.generation == 0
         assert record.meta.ttl == 100
 
     def test_meta_missing_ttl_key(self):
         """Meta dict without 'ttl' key should default to 0."""
-        key_tuple = ("test", "myset", "pk-1", b"\x00")
-        meta = {"gen": 5}
-        bins = {"x": 1}
+        rec = Record(key=("test", "myset", "pk-1", b"\x00"), meta={"gen": 5}, bins={"x": 1})
 
-        record = raw_to_record((key_tuple, meta, bins))
+        record = record_to_model(rec)
 
         assert record.meta.generation == 5
         assert record.meta.ttl == 0
 
     def test_record_serializable(self):
         """The returned record should be JSON-serializable via Pydantic."""
-        key_tuple = ("test", "myset", "pk-1", b"\xab\xcd")
-        meta = {"gen": 2, "ttl": 500}
-        bins = {"name": "Bob", "count": 10}
-
-        record = raw_to_record((key_tuple, meta, bins))
+        rec = Record(
+            key=("test", "myset", "pk-1", b"\xab\xcd"), meta={"gen": 2, "ttl": 500}, bins={"name": "Bob", "count": 10}
+        )
+        record = record_to_model(rec)
         data = record.model_dump()
 
         assert data["key"]["namespace"] == "test"

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -3,23 +3,6 @@ revision = 3
 requires-python = ">=3.13"
 
 [[package]]
-name = "aerospike-py"
-version = "0.0.1a6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/68/c8/76d7ac330702d6fce74f57e2bd098c29e512b474d59a360b87e51bd4addb/aerospike_py-0.0.1a6.tar.gz", hash = "sha256:2853721f9b69659e0a0e77e60f1f5f9987119afeec3cf575e4b5c9df8dac5c82", size = 83651, upload-time = "2026-02-16T01:04:32.056Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/1f/dd974b96ef03e0d3df120a254913f2e773c5a02eaa82a1d1e62ac02e8c72/aerospike_py-0.0.1a6-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:72975fa5a400f74a67a93bcdeab70027029224c198486401224174994798edfc", size = 2704216, upload-time = "2026-02-16T01:04:16.25Z" },
-    { url = "https://files.pythonhosted.org/packages/00/de/aa5813ca865cd0271cb7660fb95d6952f6d1ce700e40eddb44e7a361dfe3/aerospike_py-0.0.1a6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:fae4f3ad849e44b29831783fa2834a52f141861cf74329d6af6a1f4ce7a4b1d2", size = 2518712, upload-time = "2026-02-16T01:04:17.573Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/3d/720b7c3bb785299fc3e219e4fbd8ff6118ab9fcccb71a289217c6106f4ba/aerospike_py-0.0.1a6-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:783b9316dadab9fa54d85e988a69f33c0b7814ab2feccaba7120122742daecb7", size = 2625321, upload-time = "2026-02-16T01:04:18.85Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/9e/3c8321f231c730eae48942b6fe62663c7604d11fa282c70c6be2f38ebe29/aerospike_py-0.0.1a6-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:d7741707494527b507df36fc295dee5827cda9a87fbd50c0bcb99ff68d7174ae", size = 2751445, upload-time = "2026-02-16T01:04:20.475Z" },
-    { url = "https://files.pythonhosted.org/packages/31/e6/c06c52bd43a8869cce83864faaa90bdfe5b3affeada62fe0865c451106e2/aerospike_py-0.0.1a6-cp313-cp313-win_amd64.whl", hash = "sha256:aca4ece9f326b6b0c0353e3287bc008e1a1bc5281716aac05c8d5584a076cb5c", size = 3169090, upload-time = "2026-02-16T01:04:21.851Z" },
-    { url = "https://files.pythonhosted.org/packages/37/c0/aef3ac4c136a6d792cc485d49192ec2666d364b6b0a30d056319a44434f5/aerospike_py-0.0.1a6-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:16efc22396303fcb3b01d4450787b069a19ce953d2ac3dbeb2373f1e931f7302", size = 2617662, upload-time = "2026-02-16T01:04:23.125Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/6d/be9e89d18af9a06b72af3259d5672184f169991527645cc729c67e93bbf5/aerospike_py-0.0.1a6-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:b389f45c03c66a778e2c6d4cd39df3337f47274a0c1eb2441bd56c73e66cebfc", size = 2626182, upload-time = "2026-02-16T01:04:25.161Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/62/932c513f59299f64397877ef09a012b647a9d0e21ccf233f8ca94d0eae0e/aerospike_py-0.0.1a6-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:390e08635837804c42b0c04cf03bd1cfdf169cc2d25141ee0ac296b89f120bb7", size = 2752942, upload-time = "2026-02-16T01:04:26.532Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/4c/3d287d2d8f9b3c3adf6239f0772a8a64dfdac7361ecb006d13bbd418d181/aerospike_py-0.0.1a6-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:1a4368046351463ae12c422c22233d4dd554fa88373931540b56b32dbbd4c42c", size = 2618026, upload-time = "2026-02-16T01:04:27.829Z" },
-]
-
-[[package]]
 name = "aerospike-cluster-manager-api"
 version = "0.1.0"
 source = { editable = "." }
@@ -43,7 +26,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aerospike-py" },
+    { name = "aerospike-py", specifier = ">=0.0.1" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "kubernetes", specifier = ">=31.0.0" },
@@ -58,6 +41,23 @@ dev = [
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "ruff", specifier = ">=0.15.1" },
     { name = "testcontainers", extras = ["postgres"], specifier = ">=4.0.0" },
+]
+
+[[package]]
+name = "aerospike-py"
+version = "0.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/eb/ec78274d5d3195dd8c498df0380dd29792275a1e13b14ae9d9d789b807e8/aerospike_py-0.0.1.tar.gz", hash = "sha256:78401406e502c8244c724125a43674fcb05e130a420db3bed5f49815ac4ec4da", size = 112999, upload-time = "2026-02-26T01:08:24.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/74/df/347248fc5d6a94b3d06f448f9374efb3535f2111e48be29d06fb40c0c573/aerospike_py-0.0.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:0a3b27c4349f300ae31871eaee635b066eef527360aef0905792014b2f9c894c", size = 2134878, upload-time = "2026-02-26T01:08:02.13Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/2e/69d183560ea3a5fc10ed9fe5129b1231f8dc4c360b14dd323947d06293cc/aerospike_py-0.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:0528c7a9c54162f1c9008b50f93c5af6166a2a6d3cbabca73151c5e5bea86bc0", size = 1933749, upload-time = "2026-02-26T01:08:04.052Z" },
+    { url = "https://files.pythonhosted.org/packages/21/00/493ff3f7196c079ce330d76cb78f24e8473fbcea8a509678b2dd3394a3c0/aerospike_py-0.0.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:0bc97c19cafac6362161c5f11796748c3f2a1700096c71d0facca9debf9cf995", size = 2132330, upload-time = "2026-02-26T01:08:05.743Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/8a/749411a10985e675d1cff423095185a973f44d96e0d7da1c2c06a1d270a9/aerospike_py-0.0.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:e41797d309eaec4dc1a2ef35ceec9fa697c4c2307e6457408dc61644d500d5e2", size = 2258398, upload-time = "2026-02-26T01:08:08.732Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e5/9c02b18b24d58aafc2700b1d356bd0710bb6d0bba7ac4ca808f71501000c/aerospike_py-0.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:c669c9d6ac343bc971f27ef8f836b16307b0c5d60bd4a30535accb5e13724776", size = 2077000, upload-time = "2026-02-26T01:08:10.695Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/d6/2a6e4dd9c413eef43b9fbfc917793bb7c7f2d52cb1dd0fd7e85353eb074f/aerospike_py-0.0.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:e0ddfd08c26fa32ea141f53144899bc8c07c20dacfcdb1b1170b1c11b46626a1", size = 2126893, upload-time = "2026-02-26T01:08:12.759Z" },
+    { url = "https://files.pythonhosted.org/packages/56/86/edcb94e7c64a8fce146dcc442c69077085c4ccad64535f9319a54b03a890/aerospike_py-0.0.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:db23f5100fad1dc2962f5f691b80aeaf116f057602b4ff5ba8ad46ee44aab3e1", size = 2129936, upload-time = "2026-02-26T01:08:14.86Z" },
+    { url = "https://files.pythonhosted.org/packages/54/b2/38c4d3fc86a93a38bd5ee4a7d72a23818c0946566d764a689b84a8b0e36e/aerospike_py-0.0.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:470c1e340f6e5a4175dae230e0d07e39acf38be35aa84027b86df49f97fe4583", size = 2257001, upload-time = "2026-02-26T01:08:16.466Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5c/c176fab8ad0b9314fa63c4862bcab63c54b1203aaa8f524a2f4c8e8ee558/aerospike_py-0.0.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:25a9a19825b0eb477b9543c2f95acc76d26d69cf80eb8a7a08521b6249873e30", size = 2125715, upload-time = "2026-02-26T01:08:18.358Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- **aerospike-py** `0.0.1a6` (alpha) → `0.0.1` (stable) 업그레이드
- Sync `Client` + `asyncio.to_thread()` 패턴을 **네이티브 `AsyncClient`**로 전환 (Tokio 기반, 2.2~2.4x async throughput 향상)
- 모든 라우터에서 `_*_sync()` 헬퍼 함수 제거, 엔드포인트에서 직접 `await client.*()` 호출
- `raw_to_record(tuple)` → `record_to_model(Record)` — Record NamedTuple 속성 접근으로 가독성 향상
- 순 **165줄 감소** (436 additions, 601 deletions)

### 변경 파일 (16개)
| 파일 | 변경 내용 |
|------|-----------|
| `pyproject.toml` | `aerospike-py>=0.0.1` 버전 핀 |
| `client_manager.py` | `Client` → `AsyncClient`, `threading.Lock` → `asyncio.Lock` |
| `dependencies.py` | 타입 alias `AsyncClient`로 변경 |
| `converters.py` | `Record` NamedTuple 속성 접근 방식으로 전환 |
| `routers/*.py` (10개) | `asyncio.to_thread()` 제거, 직접 `await` 호출 |
| `tests/test_converters.py` | `Record` NamedTuple 사용으로 업데이트 |

## Test plan
- [x] `uv run pytest` — 105개 테스트 전부 통과
- [x] `uv run ruff check src` — 린트 통과
- [x] `uv run ruff format src` — 포맷 통과
- [ ] `podman compose -f compose.dev.yaml up -d` → 로컬 E2E 테스트 (연결/클러스터/레코드 CRUD/쿼리/인덱스)