### PR TITLE
fix: health check always returns 200, add GitHub link & sidebar polling

### DIFF
--- a/backend/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/backend/src/aerospike_cluster_manager_api/routers/connections.py
@@ -14,7 +14,7 @@ from starlette.responses import Response
 from aerospike_cluster_manager_api import db
 from aerospike_cluster_manager_api.client_manager import client_manager
 from aerospike_cluster_manager_api.constants import INFO_BUILD, INFO_EDITION, INFO_NAMESPACES
-from aerospike_cluster_manager_api.dependencies import AerospikeClient, _get_verified_connection
+from aerospike_cluster_manager_api.dependencies import _get_verified_connection
 from aerospike_cluster_manager_api.info_parser import parse_list
 from aerospike_cluster_manager_api.models.connection import (
     ConnectionProfile,
@@ -85,9 +85,14 @@ async def update_connection(
     summary="Check connection health",
     description="Check the health status of an Aerospike cluster connection.",
 )
-async def get_connection_health(client: AerospikeClient) -> ConnectionStatus:
-    """Check the health status of an Aerospike cluster connection."""
+async def get_connection_health(conn_id: str = Depends(_get_verified_connection)) -> ConnectionStatus:
+    """Check the health status of an Aerospike cluster connection.
+
+    Always returns HTTP 200. Uses ``connected: false`` to signal unreachable clusters
+    so that the frontend health indicator never mistakes a transient 503 for a permanent failure.
+    """
     try:
+        client = await client_manager.get_client(conn_id)
         node_names = await client.get_node_names()
         ns_raw = await client.info_random_node(INFO_NAMESPACES)
         namespaces = parse_list(ns_raw)
@@ -102,7 +107,7 @@ async def get_connection_health(client: AerospikeClient) -> ConnectionStatus:
             edition=edition,
         )
     except Exception:
-        logger.exception("Health check failed for connection")
+        logger.warning("Health check failed for connection '%s'", conn_id, exc_info=True)
         return ConnectionStatus(connected=False, nodeCount=0, namespaceCount=0)
 
 

--- a/frontend/src/components/layout/header.tsx
+++ b/frontend/src/components/layout/header.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import { Moon, Sun, Monitor, PanelLeft, Menu } from "lucide-react";
+import { Moon, Sun, Monitor, PanelLeft, Menu, Github } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -64,6 +64,26 @@ export function Header() {
       </div>
 
       <div className="flex items-center gap-0.5">
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="text-muted-foreground hover:text-foreground h-10 w-10 md:h-8 md:w-8"
+              aria-label="GitHub repository"
+              asChild
+            >
+              <a
+                href="https://github.com/KimSoungRyoul/aerospike-cluster-manager"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Github className="h-4 w-4" />
+              </a>
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom">GitHub Repository</TooltipContent>
+        </Tooltip>
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button

--- a/frontend/src/components/layout/sidebar.tsx
+++ b/frontend/src/components/layout/sidebar.tsx
@@ -124,6 +124,12 @@ function SidebarContent({ isMobileOrTablet }: { isMobileOrTablet: boolean }) {
         fetchAllHealth();
       })
       .catch((err) => console.error("Failed to load sidebar connections:", err));
+
+    const interval = setInterval(() => {
+      fetchAllHealth();
+    }, 30_000);
+
+    return () => clearInterval(interval);
   }, [fetchConnections, fetchAllHealth]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- **Backend**: `/health` 엔드포인트가 클러스터에 연결 불가 시 503 대신 항상 HTTP 200을 반환하도록 수정. `connected: false`로 상태 전달해 프론트엔드가 일시적 503을 영구 실패로 오해하지 않도록 함
- **Frontend (header)**: 상단 바 우측에 GitHub 저장소 바로가기 아이콘 링크 추가
- **Frontend (sidebar)**: 사이드바에서 30초마다 연결 헬스 상태를 자동 폴링하도록 interval 추가

## Test plan

- [ ] 연결 불가 클러스터의 health 엔드포인트가 HTTP 200 + `connected: false` 반환 확인
- [ ] 헤더 GitHub 아이콘 클릭 시 새 탭에서 저장소 열림 확인
- [ ] 사이드바 상태 표시가 30초마다 갱신되는 것 확인