### PR TITLE
fix: clear detailEvents and detailHealth on stopDetailPolling

### DIFF
--- a/frontend/src/stores/k8s-cluster-store.ts
+++ b/frontend/src/stores/k8s-cluster-store.ts
@@ -295,7 +295,7 @@ export const useK8sClusterStore = create<K8sClusterState>()((set, get) => {
         clearInterval(_k8sDetailIntervalId);
         _k8sDetailIntervalId = null;
       }
-      set({ consecutiveErrors: 0 });
+      set({ consecutiveErrors: 0, detailEvents: [], detailHealth: null });
     },
   };
 });


### PR DESCRIPTION
## Summary

- `stopDetailPolling`에서 `detailEvents: []`, `detailHealth: null` 초기화 추가

## Problem

PR #86 코드 리뷰에서 발견된 버그. 클러스터 간 이동 시 `stopDetailPolling`이 `consecutiveErrors`만 초기화하고 `detailEvents` / `detailHealth`는 유지하고 있었음. 결과적으로 이전 클러스터의 이벤트/헬스 데이터가 새 클러스터 페이지 로드 초기에 잠깐 노출됨.

## Fix

```ts
// before
set({ consecutiveErrors: 0 });

// after
set({ consecutiveErrors: 0, detailEvents: [], detailHealth: null });
```

## Test plan
- [x] TypeScript type-check passes
- [x] 513 unit tests pass
- [x] pre-commit hooks pass