### PR TITLE
feat: add seeds finder services UI and template topology spread constraints

### DIFF
--- a/frontend/src/components/k8s/k8s-edit-dialog.tsx
+++ b/frontend/src/components/k8s/k8s-edit-dialog.tsx
@@ -43,6 +43,8 @@ import type {
   VolumeWipeMethod,
   TopologySpreadConstraintConfig,
   PodSecurityContextConfig,
+  SeedsFinderServicesConfig,
+  LoadBalancerSpec,
 } from "@/lib/api/types";
 
 interface K8sEditDialogProps {
@@ -114,6 +116,9 @@ export function K8sEditDialog({ open, onOpenChange, cluster, onSave }: K8sEditDi
   const [storageVolumes, setStorageVolumes] = useState<VolumeSpec[]>([]);
   const [storageCleanupThreads, setStorageCleanupThreads] = useState<number | undefined>(undefined);
   const [storageDeleteLocalOnRestart, setStorageDeleteLocalOnRestart] = useState(false);
+  // Seeds Finder Services
+  const [seedsFinderServices, setSeedsFinderServices] =
+    useState<SeedsFinderServicesConfig | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [configError, setConfigError] = useState<string | null>(null);
@@ -278,6 +283,9 @@ export function K8sEditDialog({ open, onOpenChange, cluster, onSave }: K8sEditDi
   const initialStorageDeleteLocalOnRestart = Boolean(
     (specStorage as Record<string, unknown> | undefined)?.deleteLocalStorageOnRestart,
   );
+  // Seeds Finder Services initial values
+  const initialSeedsFinderServices: SeedsFinderServicesConfig | null =
+    cluster.spec?.seedsFinderServices ?? null;
   const initialAerospikeConfig = useMemo(
     () => cluster.spec?.aerospikeConfig ?? {},
     [cluster.spec?.aerospikeConfig],
@@ -337,6 +345,15 @@ export function K8sEditDialog({ open, onOpenChange, cluster, onSave }: K8sEditDi
       setStorageVolumes(initialStorageVolumes.map((v) => ({ ...v })));
       setStorageCleanupThreads(initialStorageCleanupThreads);
       setStorageDeleteLocalOnRestart(initialStorageDeleteLocalOnRestart);
+      setSeedsFinderServices(
+        initialSeedsFinderServices
+          ? {
+              loadBalancer: initialSeedsFinderServices.loadBalancer
+                ? { ...initialSeedsFinderServices.loadBalancer }
+                : undefined,
+            }
+          : null,
+      );
       setError(null);
       setConfigError(null);
     }
@@ -387,6 +404,7 @@ export function K8sEditDialog({ open, onOpenChange, cluster, onSave }: K8sEditDi
     initialStorageVolumes,
     initialStorageCleanupThreads,
     initialStorageDeleteLocalOnRestart,
+    initialSeedsFinderServices,
   ]);
 
   // Validate JSON on every keystroke
@@ -449,7 +467,8 @@ export function K8sEditDialog({ open, onOpenChange, cluster, onSave }: K8sEditDi
     enableRackIDOverride !== initialEnableRackIDOverride ||
     JSON.stringify(storageVolumes) !== JSON.stringify(initialStorageVolumes) ||
     storageCleanupThreads !== initialStorageCleanupThreads ||
-    storageDeleteLocalOnRestart !== initialStorageDeleteLocalOnRestart;
+    storageDeleteLocalOnRestart !== initialStorageDeleteLocalOnRestart ||
+    JSON.stringify(seedsFinderServices) !== JSON.stringify(initialSeedsFinderServices);
 
   const handleSave = async () => {
     setLoading(true);
@@ -651,6 +670,13 @@ export function K8sEditDialog({ open, onOpenChange, cluster, onSave }: K8sEditDi
           ...(storageCleanupThreads ? { cleanupThreads: storageCleanupThreads } : {}),
           ...(storageDeleteLocalOnRestart ? { deleteLocalStorageOnRestart: true } : {}),
         };
+      }
+
+      // Seeds Finder Services
+      if (
+        JSON.stringify(seedsFinderServices) !== JSON.stringify(initialSeedsFinderServices)
+      ) {
+        data.seedsFinderServices = seedsFinderServices ?? undefined;
       }
 
       await onSave(data);
@@ -1604,6 +1630,58 @@ export function K8sEditDialog({ open, onOpenChange, cluster, onSave }: K8sEditDi
                 }}
                 disabled={loading}
               />
+            </div>
+          </EditCollapsible>
+
+          {/* Seeds Finder Services */}
+          <EditCollapsible
+            title="Seeds Finder Services"
+            summary={
+              seedsFinderServices?.loadBalancer
+                ? `LB port ${seedsFinderServices.loadBalancer.port}/${seedsFinderServices.loadBalancer.targetPort}`
+                : "Disabled"
+            }
+          >
+            <div className="space-y-3">
+              <p className="text-base-content/60 text-[10px]">
+                Configure a LoadBalancer service for external seed discovery.
+              </p>
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label
+                    htmlFor="edit-seeds-finder-lb"
+                    className="cursor-pointer text-xs"
+                  >
+                    Enable Seeds Finder LoadBalancer
+                  </Label>
+                  <p className="text-base-content/60 text-[10px]">
+                    Required for multi-cluster topologies or external client access.
+                  </p>
+                </div>
+                <Switch
+                  id="edit-seeds-finder-lb"
+                  checked={seedsFinderServices?.loadBalancer != null}
+                  onCheckedChange={(checked) => {
+                    if (checked) {
+                      setSeedsFinderServices({
+                        loadBalancer: { port: 3000, targetPort: 3000 },
+                      });
+                    } else {
+                      setSeedsFinderServices(null);
+                    }
+                    setError(null);
+                  }}
+                  disabled={loading}
+                />
+              </div>
+              {seedsFinderServices?.loadBalancer && (
+                <EditSeedsFinderLBSection
+                  lb={seedsFinderServices.loadBalancer}
+                  onChange={(lb) => setSeedsFinderServices({ loadBalancer: lb })}
+                  loading={loading}
+                  setError={setError}
+                />
+              )}
             </div>
           </EditCollapsible>
 
@@ -3276,6 +3354,187 @@ function EditSupGroupInput({
       >
         <Plus className="mr-0.5 h-3 w-3" /> Add
       </Button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Seeds Finder LoadBalancer Section for Edit Dialog
+// ---------------------------------------------------------------------------
+
+function EditSeedsFinderLBSection({
+  lb,
+  onChange,
+  loading,
+  setError,
+}: {
+  lb: LoadBalancerSpec;
+  onChange: (lb: LoadBalancerSpec) => void;
+  loading: boolean;
+  setError: (e: string | null) => void;
+}) {
+  const patch = (updates: Partial<LoadBalancerSpec>) => {
+    onChange({ ...lb, ...updates });
+    setError(null);
+  };
+
+  const [newCidr, setNewCidr] = useState("");
+
+  const isValidCIDR = (v: string): boolean => {
+    const match = v.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\/(\d{1,2})$/);
+    if (!match) return false;
+    const octets = [match[1], match[2], match[3], match[4]].map(Number);
+    const prefix = Number(match[5]);
+    return octets.every((o) => o >= 0 && o <= 255) && prefix >= 0 && prefix <= 32;
+  };
+
+  const addCidr = () => {
+    const v = newCidr.trim();
+    if (!v || !isValidCIDR(v)) return;
+    const current = lb.loadBalancerSourceRanges ?? [];
+    if (!current.includes(v)) {
+      patch({ loadBalancerSourceRanges: [...current, v] });
+    }
+    setNewCidr("");
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="grid grid-cols-2 gap-3">
+        <div className="grid gap-1">
+          <Label htmlFor="edit-sfs-port" className="text-[10px]">
+            Service Port
+          </Label>
+          <Input
+            id="edit-sfs-port"
+            type="number"
+            min={1}
+            max={65535}
+            value={lb.port}
+            onChange={(e) => patch({ port: parseInt(e.target.value) || 3000 })}
+            className="h-7 text-[10px]"
+            disabled={loading}
+          />
+        </div>
+        <div className="grid gap-1">
+          <Label htmlFor="edit-sfs-target-port" className="text-[10px]">
+            Target Port
+          </Label>
+          <Input
+            id="edit-sfs-target-port"
+            type="number"
+            min={1}
+            max={65535}
+            value={lb.targetPort}
+            onChange={(e) => patch({ targetPort: parseInt(e.target.value) || 3000 })}
+            className="h-7 text-[10px]"
+            disabled={loading}
+          />
+        </div>
+      </div>
+      <div className="grid gap-1">
+        <Label htmlFor="edit-sfs-traffic-policy" className="text-[10px]">
+          External Traffic Policy
+        </Label>
+        <Select
+          value={lb.externalTrafficPolicy ?? "Cluster"}
+          onChange={(e) =>
+            patch({ externalTrafficPolicy: e.target.value as "Cluster" | "Local" })
+          }
+          id="edit-sfs-traffic-policy"
+          className="h-7 text-[10px]"
+          disabled={loading}
+        >
+          <option value="Cluster">Cluster (default)</option>
+          <option value="Local">Local</option>
+        </Select>
+      </div>
+
+      {/* Annotations */}
+      <div className="grid gap-1.5">
+        <Label className="text-[10px] font-semibold">Annotations</Label>
+        <p className="text-base-content/60 text-[10px]">
+          Cloud-specific LoadBalancer annotations.
+        </p>
+        <EditKvEditor
+          value={lb.annotations}
+          onChange={(v) => patch({ annotations: v })}
+          keyPlaceholder="e.g. service.beta.kubernetes.io/aws-load-balancer-type"
+          valuePlaceholder="e.g. nlb"
+          disabled={loading}
+        />
+      </div>
+
+      {/* Labels */}
+      <div className="grid gap-1.5">
+        <Label className="text-[10px] font-semibold">Labels</Label>
+        <EditKvEditor
+          value={lb.labels}
+          onChange={(v) => patch({ labels: v })}
+          keyPlaceholder="label key"
+          valuePlaceholder="value"
+          disabled={loading}
+        />
+      </div>
+
+      {/* Source Ranges */}
+      <div className="grid gap-1.5">
+        <Label className="text-[10px] font-semibold">Load Balancer Source Ranges</Label>
+        <p className="text-base-content/60 text-[10px]">
+          Restrict access by specifying allowed CIDR ranges.
+        </p>
+        {(lb.loadBalancerSourceRanges ?? []).length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {lb.loadBalancerSourceRanges!.map((cidr) => (
+              <span
+                key={cidr}
+                className="bg-accent/10 text-accent inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[10px] font-medium"
+              >
+                {cidr}
+                <button
+                  type="button"
+                  onClick={() => {
+                    patch({
+                      loadBalancerSourceRanges: (lb.loadBalancerSourceRanges ?? []).filter(
+                        (c) => c !== cidr,
+                      ),
+                    });
+                  }}
+                  className="hover:bg-accent/20 ml-0.5 inline-flex h-3 w-3 items-center justify-center rounded-full"
+                  disabled={loading}
+                >
+                  <X className="h-2 w-2" />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+        <div className="flex gap-1.5">
+          <Input
+            value={newCidr}
+            onChange={(e) => setNewCidr(e.target.value)}
+            placeholder="e.g. 10.0.0.0/8"
+            className="h-7 text-[10px]"
+            disabled={loading}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                addCidr();
+              }
+            }}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-7 shrink-0 text-[10px]"
+            onClick={addCidr}
+            disabled={loading || !newCidr.trim() || !isValidCIDR(newCidr.trim())}
+          >
+            <Plus className="mr-0.5 h-3 w-3" /> Add
+          </Button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/k8s/k8s-template-edit-dialog.tsx
+++ b/frontend/src/components/k8s/k8s-template-edit-dialog.tsx
@@ -21,7 +21,12 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select";
-import type { K8sTemplateDetail, UpdateK8sTemplateRequest } from "@/lib/api/types";
+import { Plus, X } from "lucide-react";
+import type {
+  K8sTemplateDetail,
+  UpdateK8sTemplateRequest,
+  TopologySpreadConstraintConfig,
+} from "@/lib/api/types";
 
 interface K8sTemplateEditDialogProps {
   open: boolean;
@@ -56,6 +61,10 @@ export function K8sTemplateEditDialog({
   const [heartbeatTimeout, setHeartbeatTimeout] = useState<number | undefined>(undefined);
   // Rack config
   const [maxRacksPerNode, setMaxRacksPerNode] = useState<number | undefined>(undefined);
+  // Topology Spread Constraints
+  const [topologySpreadConstraints, setTopologySpreadConstraints] = useState<
+    TopologySpreadConstraintConfig[]
+  >([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -84,6 +93,8 @@ export function K8sTemplateEditDialog({
     networkConfig?.heartbeatTimeout != null ? Number(networkConfig.heartbeatTimeout) : undefined;
   const initialMaxRacksPerNode =
     rackConfigSpec?.maxRacksPerNode != null ? Number(rackConfigSpec.maxRacksPerNode) : undefined;
+  const initialTopologySpreadConstraints: TopologySpreadConstraintConfig[] =
+    (scheduling?.topologySpreadConstraints as TopologySpreadConstraintConfig[] | undefined) ?? [];
 
   // Reset form on open
   useEffect(() => {
@@ -103,6 +114,7 @@ export function K8sTemplateEditDialog({
       setHeartbeatInterval(initialHeartbeatInterval);
       setHeartbeatTimeout(initialHeartbeatTimeout);
       setMaxRacksPerNode(initialMaxRacksPerNode);
+      setTopologySpreadConstraints(initialTopologySpreadConstraints.map((t) => ({ ...t })));
       setError(null);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -124,7 +136,9 @@ export function K8sTemplateEditDialog({
       heartbeatMode !== initialHeartbeatMode ||
       heartbeatInterval !== initialHeartbeatInterval ||
       heartbeatTimeout !== initialHeartbeatTimeout ||
-      maxRacksPerNode !== initialMaxRacksPerNode
+      maxRacksPerNode !== initialMaxRacksPerNode ||
+      JSON.stringify(topologySpreadConstraints) !==
+        JSON.stringify(initialTopologySpreadConstraints)
     );
   }, [
     description,
@@ -157,6 +171,8 @@ export function K8sTemplateEditDialog({
     initialHeartbeatInterval,
     initialHeartbeatTimeout,
     initialMaxRacksPerNode,
+    topologySpreadConstraints,
+    initialTopologySpreadConstraints,
   ]);
 
   const handleSave = async () => {
@@ -170,16 +186,22 @@ export function K8sTemplateEditDialog({
       if (size !== initialSize) data.size = size;
 
       // Scheduling
-      if (
+      const schedulingChanged =
         antiAffinity !== initialAntiAffinity ||
-        podManagementPolicy !== initialPodManagementPolicy
-      ) {
+        podManagementPolicy !== initialPodManagementPolicy ||
+        JSON.stringify(topologySpreadConstraints) !==
+          JSON.stringify(initialTopologySpreadConstraints);
+      if (schedulingChanged) {
         data.scheduling = {};
         if (antiAffinity) {
           data.scheduling.podAntiAffinityLevel = antiAffinity as "none" | "preferred" | "required";
         }
         if (podManagementPolicy) {
           data.scheduling.podManagementPolicy = podManagementPolicy as "OrderedReady" | "Parallel";
+        }
+        if (topologySpreadConstraints.length > 0) {
+          data.scheduling.topologySpreadConstraints =
+            topologySpreadConstraints as unknown as Record<string, unknown>[];
         }
       }
 
@@ -453,6 +475,132 @@ export function K8sTemplateEditDialog({
             <p className="text-muted-foreground text-xs">
               Maximum number of racks per Kubernetes node. Leave empty for no limit.
             </p>
+          </div>
+
+          {/* Topology Spread Constraints */}
+          <div className="space-y-2">
+            <Label className="font-semibold">Topology Spread Constraints</Label>
+            <p className="text-muted-foreground text-xs">
+              Control how pods are spread across topology domains (zones, nodes, etc.).
+            </p>
+            {topologySpreadConstraints.map((tsc, idx) => (
+              <div key={idx} className="space-y-2 rounded border p-2">
+                <div className="flex items-center justify-between">
+                  <span className="text-xs font-medium">Constraint #{idx + 1}</span>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setTopologySpreadConstraints(
+                        topologySpreadConstraints.filter((_, i) => i !== idx),
+                      );
+                    }}
+                    className="text-muted-foreground hover:text-destructive p-1"
+                    title="Remove constraint"
+                  >
+                    <X className="h-4 w-4" />
+                  </button>
+                </div>
+                <div className="grid grid-cols-3 gap-2">
+                  <div className="grid gap-1">
+                    <Label className="text-xs">Max Skew</Label>
+                    <Input
+                      type="number"
+                      min={1}
+                      value={tsc.maxSkew}
+                      onChange={(e) => {
+                        const next = [...topologySpreadConstraints];
+                        next[idx] = { ...next[idx], maxSkew: parseInt(e.target.value) || 1 };
+                        setTopologySpreadConstraints(next);
+                      }}
+                    />
+                  </div>
+                  <div className="grid gap-1">
+                    <Label className="text-xs">Topology Key</Label>
+                    <Select
+                      value={tsc.topologyKey}
+                      onChange={(e) => {
+                        const next = [...topologySpreadConstraints];
+                        next[idx] = { ...next[idx], topologyKey: e.target.value };
+                        setTopologySpreadConstraints(next);
+                      }}
+                    >
+                      <option value="topology.kubernetes.io/zone">
+                        topology.kubernetes.io/zone
+                      </option>
+                      <option value="kubernetes.io/hostname">kubernetes.io/hostname</option>
+                      <option value="topology.kubernetes.io/region">
+                        topology.kubernetes.io/region
+                      </option>
+                    </Select>
+                  </div>
+                  <div className="grid gap-1">
+                    <Label className="text-xs">When Unsatisfiable</Label>
+                    <Select
+                      value={tsc.whenUnsatisfiable}
+                      onChange={(e) => {
+                        const next = [...topologySpreadConstraints];
+                        next[idx] = {
+                          ...next[idx],
+                          whenUnsatisfiable: e.target.value as "DoNotSchedule" | "ScheduleAnyway",
+                        };
+                        setTopologySpreadConstraints(next);
+                      }}
+                    >
+                      <option value="DoNotSchedule">DoNotSchedule</option>
+                      <option value="ScheduleAnyway">ScheduleAnyway</option>
+                    </Select>
+                  </div>
+                </div>
+                <div className="grid gap-1">
+                  <Label className="text-xs">
+                    Label Selector (optional, key=value comma-separated)
+                  </Label>
+                  <Input
+                    value={
+                      tsc.labelSelector
+                        ? Object.entries(tsc.labelSelector)
+                            .map(([k, v]) => `${k}=${v}`)
+                            .join(", ")
+                        : ""
+                    }
+                    onChange={(e) => {
+                      const entries = e.target.value
+                        .split(",")
+                        .map((s) => s.trim())
+                        .filter(Boolean);
+                      const labels: Record<string, string> = {};
+                      for (const entry of entries) {
+                        const [k, v] = entry.split("=").map((s) => s.trim());
+                        if (k && v) labels[k] = v;
+                      }
+                      const next = [...topologySpreadConstraints];
+                      next[idx] = {
+                        ...next[idx],
+                        labelSelector: Object.keys(labels).length > 0 ? labels : undefined,
+                      };
+                      setTopologySpreadConstraints(next);
+                    }}
+                    placeholder="e.g. app=aerospike, env=prod"
+                  />
+                </div>
+              </div>
+            ))}
+            <button
+              type="button"
+              onClick={() => {
+                setTopologySpreadConstraints([
+                  ...topologySpreadConstraints,
+                  {
+                    maxSkew: 1,
+                    topologyKey: "topology.kubernetes.io/zone",
+                    whenUnsatisfiable: "DoNotSchedule",
+                  },
+                ]);
+              }}
+              className="text-primary hover:text-primary/80 flex items-center gap-1 text-xs font-medium"
+            >
+              <Plus className="h-3.5 w-3.5" /> Add Topology Spread Constraint
+            </button>
           </div>
         </div>
 

--- a/frontend/src/components/k8s/wizard/WizardReviewStep.tsx
+++ b/frontend/src/components/k8s/wizard/WizardReviewStep.tsx
@@ -666,6 +666,21 @@ export function WizardReviewStep({
           </>
         )}
 
+        {form.seedsFinderServices?.loadBalancer && (
+          <>
+            <span className="text-base-content/60">Seeds Finder LB</span>
+            <span className="font-medium">
+              Port {form.seedsFinderServices.loadBalancer.port}
+              {" / "}
+              {form.seedsFinderServices.loadBalancer.targetPort}
+              {form.seedsFinderServices.loadBalancer.externalTrafficPolicy &&
+              form.seedsFinderServices.loadBalancer.externalTrafficPolicy !== "Cluster"
+                ? ` (${form.seedsFinderServices.loadBalancer.externalTrafficPolicy})`
+                : ""}
+            </span>
+          </>
+        )}
+
         {(form.storage?.localStorageClasses ?? []).length > 0 && (
           <>
             <span className="text-muted-foreground">Local Storage Classes</span>


### PR DESCRIPTION
## Summary
- **Seeds Finder Services UI**: Edit dialog에 LoadBalancer 기반 Seeds Finder Services 설정 추가 (포트, 외부 트래픽 정책, 어노테이션, 라벨, 소스 레인지). Review step에도 표시 추가.
- **Template Topology Spread Constraints**: Template edit dialog에 topology spread constraints 설정 UI 추가 (maxSkew, topologyKey, whenUnsatisfiable, labelSelector).

## Changes
- `frontend/src/components/k8s/k8s-edit-dialog.tsx` — Seeds Finder Services 편집 섹션 + `EditSeedsFinderLBSection` 컴포넌트
- `frontend/src/components/k8s/k8s-template-edit-dialog.tsx` — Topology Spread Constraints 편집 UI
- `frontend/src/components/k8s/wizard/WizardReviewStep.tsx` — Seeds Finder LB 요약 표시

## Test plan
- [ ] Seeds Finder Services: Edit dialog에서 LoadBalancer 토글 on/off, 포트/정책 설정, 어노테이션/라벨 추가/삭제 확인
- [ ] Template Topology: Template edit dialog에서 constraint 추가/삭제, maxSkew/topologyKey/whenUnsatisfiable/labelSelector 설정 확인
- [ ] 기존 기능 regression 없음 확인