### PR TITLE
feat: add pod-level selection to operation trigger dialog

### DIFF
--- a/frontend/src/app/k8s/clusters/[namespace]/[name]/page.tsx
+++ b/frontend/src/app/k8s/clusters/[namespace]/[name]/page.tsx
@@ -34,7 +34,7 @@ import { K8sReconciliationHealth } from "@/components/k8s/k8s-reconciliation-hea
 import { K8sMigrationStatus } from "@/components/k8s/k8s-migration-status";
 import { K8sOperationStatus } from "@/components/k8s/k8s-operation-status";
 import { K8sRackTopology } from "@/components/k8s/k8s-rack-topology";
-import { ConfirmDialog } from "@/components/common/confirm-dialog";
+import { K8sOperationTriggerDialog } from "@/components/k8s/k8s-operation-trigger-dialog";
 import { useK8sClusterStore } from "@/stores/k8s-cluster-store";
 import { useToastStore } from "@/stores/toast-store";
 import { cn, getErrorMessage } from "@/lib/utils";
@@ -75,7 +75,6 @@ export default function K8sClusterDetailPage() {
     scaleCluster,
     deleteCluster,
     updateCluster,
-    triggerOperation,
     resyncTemplate,
     pauseCluster,
     resumeCluster,
@@ -92,8 +91,10 @@ export default function K8sClusterDetailPage() {
   const [resyncing, setResyncing] = useState(false);
   const [selectedPods, setSelectedPods] = useState<string[]>([]);
   const [templateSpecOpen, setTemplateSpecOpen] = useState(false);
-  const [warmRestartConfirmOpen, setWarmRestartConfirmOpen] = useState(false);
-  const [podRestartConfirmOpen, setPodRestartConfirmOpen] = useState(false);
+  const [operationDialogOpen, setOperationDialogOpen] = useState(false);
+  const [operationDialogKind, setOperationDialogKind] = useState<"WarmRestart" | "PodRestart">(
+    "WarmRestart",
+  );
   const [pendingPodsExpanded, setPendingPodsExpanded] = useState(false);
   const [migrationStatus, setMigrationStatus] = useState<MigrationStatus | null>(null);
 
@@ -215,7 +216,10 @@ export default function K8sClusterDetailPage() {
               variant="warning"
               size="sm"
               disabled={loading}
-              onClick={() => setWarmRestartConfirmOpen(true)}
+              onClick={() => {
+                setOperationDialogKind("WarmRestart");
+                setOperationDialogOpen(true);
+              }}
             >
               Warm Restart
             </Button>
@@ -223,7 +227,10 @@ export default function K8sClusterDetailPage() {
               variant="warning"
               size="sm"
               disabled={loading}
-              onClick={() => setPodRestartConfirmOpen(true)}
+              onClick={() => {
+                setOperationDialogKind("PodRestart");
+                setOperationDialogOpen(true);
+              }}
             >
               Pod Restart
             </Button>
@@ -818,62 +825,17 @@ export default function K8sClusterDetailPage() {
         clusterName={name}
       />
 
-      <ConfirmDialog
-        open={warmRestartConfirmOpen}
-        onOpenChange={setWarmRestartConfirmOpen}
-        title="Confirm Warm Restart"
-        description={
-          selectedPods.length > 0
-            ? `This will warm-restart ${selectedPods.length} selected pod(s). The operation applies configuration changes without a full pod restart but may briefly affect ongoing requests.`
-            : "This will warm-restart all pods in the cluster. The operation applies configuration changes without a full pod restart but may briefly affect ongoing requests."
-        }
-        confirmLabel="Warm Restart"
-        onConfirm={async () => {
-          try {
-            const pods = selectedPods.length > 0 ? selectedPods : undefined;
-            await triggerOperation(namespace, name, "WarmRestart", pods);
-            useToastStore
-              .getState()
-              .addToast(
-                "success",
-                pods
-                  ? `Warm restart initiated for ${pods.length} pod(s)`
-                  : "Warm restart initiated",
-              );
-            setSelectedPods([]);
-          } catch (err) {
-            useToastStore.getState().addToast("error", getErrorMessage(err));
-          }
-        }}
-      />
-
-      <ConfirmDialog
-        open={podRestartConfirmOpen}
-        onOpenChange={setPodRestartConfirmOpen}
-        title="Confirm Pod Restart"
-        description={
-          selectedPods.length > 0
-            ? `This will restart ${selectedPods.length} selected pod(s). Pods will be deleted and recreated, which is disruptive and will temporarily reduce cluster capacity.`
-            : "This will restart all pods in the cluster. Pods will be deleted and recreated one by one, which is disruptive and will temporarily reduce cluster capacity."
-        }
-        confirmLabel="Pod Restart"
-        variant="destructive"
-        onConfirm={async () => {
-          try {
-            const pods = selectedPods.length > 0 ? selectedPods : undefined;
-            await triggerOperation(namespace, name, "PodRestart", pods);
-            useToastStore
-              .getState()
-              .addToast(
-                "success",
-                pods
-                  ? `Pod restart initiated for ${pods.length} pod(s)`
-                  : "Pod restart initiated for all pods",
-              );
-            setSelectedPods([]);
-          } catch (err) {
-            useToastStore.getState().addToast("error", getErrorMessage(err));
-          }
+      <K8sOperationTriggerDialog
+        open={operationDialogOpen}
+        onOpenChange={setOperationDialogOpen}
+        namespace={namespace}
+        clusterName={name}
+        pods={selectedCluster.pods}
+        initialSelectedPods={selectedPods}
+        initialKind={operationDialogKind}
+        onSuccess={() => {
+          setSelectedPods([]);
+          fetchCluster(namespace, name);
         }}
       />
     </div>

--- a/frontend/src/components/k8s/k8s-operation-trigger-dialog.tsx
+++ b/frontend/src/components/k8s/k8s-operation-trigger-dialog.tsx
@@ -1,9 +1,11 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Select,
   SelectContent,
@@ -12,7 +14,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { FormDialog } from "@/components/common/form-dialog";
-import { K8sPodTable } from "@/components/k8s/k8s-pod-table";
 import { getErrorMessage } from "@/lib/utils";
 import { api } from "@/lib/api/client";
 import { CheckCircle, AlertTriangle } from "lucide-react";
@@ -26,6 +27,10 @@ interface K8sOperationTriggerDialogProps {
   namespace: string;
   clusterName: string;
   pods: K8sPodStatus[];
+  /** 클러스터 상세 페이지 테이블에서 미리 선택된 Pod 목록 */
+  initialSelectedPods?: string[];
+  /** 다이얼로그를 열 때 기본 오퍼레이션 타입 */
+  initialKind?: OperationKind;
   onSuccess?: () => void;
 }
 
@@ -35,9 +40,11 @@ export function K8sOperationTriggerDialog({
   namespace,
   clusterName,
   pods,
+  initialSelectedPods = [],
+  initialKind = "WarmRestart",
   onSuccess,
 }: K8sOperationTriggerDialogProps) {
-  const [kind, setKind] = useState<OperationKind>("WarmRestart");
+  const [kind, setKind] = useState<OperationKind>(initialKind);
   const [selectedPods, setSelectedPods] = useState<string[]>([]);
   const [operationId, setOperationId] = useState("");
   const [loading, setLoading] = useState(false);
@@ -45,16 +52,41 @@ export function K8sOperationTriggerDialog({
   const [step, setStep] = useState<"configure" | "confirm" | "result">("configure");
   const [resultMessage, setResultMessage] = useState<string | null>(null);
 
+  // 다이얼로그 열릴 때 상태 초기화
   useEffect(() => {
     if (open) {
-      setKind("WarmRestart");
-      setSelectedPods([]);
+      setKind(initialKind);
+      setSelectedPods(initialSelectedPods);
       setOperationId("");
       setError(null);
       setStep("configure");
       setResultMessage(null);
     }
-  }, [open]);
+  }, [open, initialKind, initialSelectedPods]);
+
+  // 전체 선택 / 해제 여부 계산
+  const allSelected = useMemo(
+    () => pods.length > 0 && selectedPods.length === pods.length,
+    [pods.length, selectedPods.length],
+  );
+  const someSelected = useMemo(
+    () => selectedPods.length > 0 && selectedPods.length < pods.length,
+    [pods.length, selectedPods.length],
+  );
+
+  const handleToggleAll = () => {
+    if (allSelected) {
+      setSelectedPods([]);
+    } else {
+      setSelectedPods(pods.map((p) => p.name));
+    }
+  };
+
+  const handleTogglePod = (podName: string) => {
+    setSelectedPods((prev) =>
+      prev.includes(podName) ? prev.filter((n) => n !== podName) : [...prev, podName],
+    );
+  };
 
   const handleNext = () => {
     if (step === "configure") {
@@ -76,13 +108,13 @@ export function K8sOperationTriggerDialog({
         const request: OperationRequest = {
           kind,
           ...(operationId.trim() ? { id: operationId.trim() } : {}),
-          ...(kind === "PodRestart" && selectedPods.length > 0 ? { podList: selectedPods } : {}),
+          ...(selectedPods.length > 0 ? { podList: selectedPods } : {}),
         };
 
         await api.triggerK8sClusterOperation(namespace, clusterName, request);
-        setResultMessage(
-          `${kind === "WarmRestart" ? "Warm restart" : "Pod restart"} operation triggered successfully.`,
-        );
+        const kindLabel = kind === "WarmRestart" ? "Warm restart" : "Pod restart";
+        const targetLabel = selectedPods.length > 0 ? `${selectedPods.length} pod(s)` : "all pods";
+        setResultMessage(`${kindLabel} operation triggered successfully for ${targetLabel}.`);
         setStep("result");
         onSuccess?.();
       } catch (err) {
@@ -124,7 +156,7 @@ export function K8sOperationTriggerDialog({
     >
       {step === "configure" && (
         <div className="space-y-4">
-          {/* Operation type selector */}
+          {/* Operation type 선택 */}
           <div className="grid gap-2">
             <Label htmlFor="op-kind">Operation Type</Label>
             <Select value={kind} onValueChange={(v) => setKind(v as OperationKind)}>
@@ -133,7 +165,7 @@ export function K8sOperationTriggerDialog({
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="WarmRestart">Warm Restart (rolling, no data loss)</SelectItem>
-                <SelectItem value="PodRestart">Pod Restart (select specific pods)</SelectItem>
+                <SelectItem value="PodRestart">Pod Restart (delete and recreate pods)</SelectItem>
               </SelectContent>
             </Select>
           </div>
@@ -150,36 +182,91 @@ export function K8sOperationTriggerDialog({
             />
           </div>
 
-          {/* Pod selection for PodRestart */}
-          {kind === "PodRestart" && (
-            <div className="space-y-2">
-              <Label>Select Pods to Restart</Label>
-              <p className="text-base-content/60 text-xs">
-                Choose one or more pods. If none are selected, all pods will be restarted.
-              </p>
-              <div className="max-h-[300px] overflow-y-auto rounded border p-2">
-                <K8sPodTable
-                  pods={pods}
-                  selectable
-                  selectedPods={selectedPods}
-                  onSelectionChange={setSelectedPods}
-                />
-              </div>
-              {selectedPods.length > 0 && (
-                <p className="text-xs text-amber-600">
-                  {selectedPods.length} pod{selectedPods.length !== 1 ? "s" : ""} selected for
-                  restart
-                </p>
+          {/* Pod 선택 영역 */}
+          <div className="space-y-2">
+            <div className="flex items-center justify-between">
+              <Label>Target Pods</Label>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-7 px-2 text-xs"
+                onClick={handleToggleAll}
+              >
+                {allSelected ? "Deselect All" : "Select All"}
+              </Button>
+            </div>
+            <p className="text-base-content/60 text-xs">
+              Choose specific pods for the operation. If none are selected, the operation applies to
+              all pods (cluster-wide).
+            </p>
+            <div className="max-h-[240px] overflow-y-auto rounded border p-2">
+              {pods.length === 0 ? (
+                <p className="text-base-content/40 py-2 text-center text-xs">No pods available</p>
+              ) : (
+                <div className="space-y-1">
+                  {/* 전체 선택 체크박스 (헤더) */}
+                  <label className="bg-base-200/50 flex cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-sm font-medium">
+                    <Checkbox
+                      checked={allSelected}
+                      ref={(el) => {
+                        if (el) el.indeterminate = someSelected;
+                      }}
+                      onCheckedChange={handleToggleAll}
+                      aria-label="Select all pods"
+                    />
+                    <span className="text-base-content/80 text-xs">All Pods ({pods.length})</span>
+                  </label>
+                  {/* 개별 Pod 체크박스 */}
+                  {pods.map((pod) => (
+                    <label
+                      key={pod.name}
+                      className="hover:bg-base-200/30 flex cursor-pointer items-center gap-2 rounded px-2 py-1 transition-colors"
+                    >
+                      <Checkbox
+                        checked={selectedPods.includes(pod.name)}
+                        onCheckedChange={() => handleTogglePod(pod.name)}
+                        aria-label={`Select ${pod.name}`}
+                      />
+                      <span className="flex-1 truncate font-mono text-xs">{pod.name}</span>
+                      <Badge
+                        variant="outline"
+                        className={
+                          pod.isReady
+                            ? "bg-success/10 text-success border-success/20 text-[10px]"
+                            : "bg-warning/10 text-warning border-warning/20 text-[10px]"
+                        }
+                      >
+                        {pod.isReady ? "Ready" : "NotReady"}
+                      </Badge>
+                    </label>
+                  ))}
+                </div>
               )}
             </div>
-          )}
+            {selectedPods.length > 0 && (
+              <p className="text-xs text-amber-600">
+                {selectedPods.length} pod{selectedPods.length !== 1 ? "s" : ""} selected for{" "}
+                {kind === "WarmRestart" ? "warm restart" : "restart"}
+              </p>
+            )}
+          </div>
 
+          {/* 오퍼레이션 타입별 안내 */}
           {kind === "WarmRestart" && (
             <div className="bg-info/5 border-info/20 rounded border p-3">
               <p className="text-info text-xs">
-                Warm restart performs a rolling restart of all pods in the cluster. Each pod is
-                restarted one at a time, waiting for the previous pod to become ready before
-                proceeding. This operation does not cause data loss.
+                Warm restart applies configuration changes without a full pod restart. Each pod is
+                restarted one at a time in a rolling manner. This operation does not cause data
+                loss.
+              </p>
+            </div>
+          )}
+          {kind === "PodRestart" && (
+            <div className="rounded border border-amber-500/10 bg-amber-500/5 p-3">
+              <p className="text-xs text-amber-600">
+                Pod restart deletes and recreates pods. This is more disruptive than a warm restart
+                and will temporarily reduce cluster capacity while pods are being recreated.
               </p>
             </div>
           )}
@@ -226,22 +313,30 @@ export function K8sOperationTriggerDialog({
             <div className="flex items-center justify-between text-sm">
               <span className="text-base-content/60">Target Pods:</span>
               <span className="text-xs">
-                {kind === "PodRestart" && selectedPods.length > 0
+                {selectedPods.length > 0
                   ? `${selectedPods.length} selected`
-                  : "All pods"}
+                  : "All pods (cluster-wide)"}
               </span>
             </div>
           </div>
 
-          {kind === "PodRestart" && selectedPods.length > 0 && (
+          {selectedPods.length > 0 && (
             <div>
               <p className="text-base-content/60 mb-1 text-xs">Selected pods:</p>
               <div className="flex flex-wrap gap-1">
-                {selectedPods.map((pod) => (
-                  <Badge key={pod} variant="outline" className="font-mono text-[11px]">
-                    {pod}
-                  </Badge>
-                ))}
+                {selectedPods.map((podName) => {
+                  const pod = pods.find((p) => p.name === podName);
+                  return (
+                    <Badge key={podName} variant="outline" className="gap-1 font-mono text-[11px]">
+                      {podName}
+                      {pod && (
+                        <span className={pod.isReady ? "text-green-500" : "text-amber-500"}>
+                          {pod.isReady ? "\u2713" : "\u26A0"}
+                        </span>
+                      )}
+                    </Badge>
+                  );
+                })}
               </div>
             </div>
           )}


### PR DESCRIPTION
## Summary
- WarmRestart/PodRestart 작업 시 특정 Pod를 선택할 수 있는 기능 추가
- Operation trigger dialog에 Pod 체크박스, Select All/Deselect All 토글, Pod 상태 배지 추가
- 클러스터 상세 페이지의 Pod 테이블에서 선택한 Pod가 dialog에 사전 선택됨

## Changes

### Frontend
- **`k8s-operation-trigger-dialog.tsx`**: Pod 선택 UI 추가 (체크박스, 상태 배지, Select All/Deselect All)
- **`page.tsx` (cluster detail)**: 기존 2개의 ConfirmDialog를 단일 K8sOperationTriggerDialog로 통합, initialSelectedPods/initialKind 전달

### Backend
- 변경 없음 (기존 `OperationRequest.podList` 필드가 이미 지원)

## Test plan
- [ ] Operation dialog 열기 → Pod 목록이 체크박스와 함께 표시됨
- [ ] Select All → 모든 Pod 선택, Deselect All → 모두 해제
- [ ] Pod 테이블에서 Pod 선택 후 Operation 버튼 → 해당 Pod가 사전 선택됨
- [ ] Pod 선택 상태에서 실행 → `podList`에 선택된 Pod만 포함
- [ ] Pod 미선택 상태에서 실행 → 클러스터 전체 작업 (podList 없음)