### PR TITLE
feat: add PVC status, CR export/import, and force reconcile

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,9 @@ Common use cases include:
 | `POST` | `/api/k8s/clusters/{namespace}/{name}/hpa` | Create or update HPA (minReplicas, maxReplicas, CPU/memory targets) |
 | `DELETE` | `/api/k8s/clusters/{namespace}/{name}/hpa` | Delete HPA for a cluster |
 | `POST` | `/api/k8s/clusters/{namespace}/{name}/resync-template` | Trigger template resync via annotation |
+| `GET` | `/api/k8s/clusters/{namespace}/{name}/pvcs` | List PVCs associated with the cluster |
+| `POST` | `/api/k8s/clusters/{namespace}/{name}/force-reconcile` | Force re-reconciliation via annotation |
+| `POST` | `/api/k8s/clusters/import` | Import cluster from raw CR JSON |
 | `GET` | `/api/k8s/templates` | List all AerospikeClusterTemplate resources (cluster-scoped) |
 | `POST` | `/api/k8s/templates` | Create a new AerospikeClusterTemplate |
 | `GET` | `/api/k8s/templates/{name}` | Get template detail (spec, status, usedBy) |

--- a/backend/src/aerospike_cluster_manager_api/k8s_client.py
+++ b/backend/src/aerospike_cluster_manager_api/k8s_client.py
@@ -471,6 +471,45 @@ class K8sClient:
         except Exception as e:
             raise self._wrap_api_exception(e) from e
 
+    def _list_pvcs_sync(self, namespace: str, label_selector: str) -> list[dict[str, Any]]:
+        """List PersistentVolumeClaims filtered by label selector."""
+        logger.debug("_list_pvcs_sync(namespace=%s, label_selector=%s)", namespace, label_selector)
+        self._ensure_initialized()
+        try:
+            result = self._get_core_api().list_namespaced_persistent_volume_claim(
+                namespace=namespace,
+                label_selector=label_selector,
+                _request_timeout=_K8S_API_TIMEOUT,
+            )
+            pvcs = []
+            for pvc in result.items:
+                meta = pvc.metadata
+                spec = pvc.spec
+                status = pvc.status
+                capacity = status.capacity.get("storage", "") if status and status.capacity else ""
+                pvcs.append(
+                    {
+                        "name": meta.name if meta else "",
+                        "namespace": meta.namespace if meta else "",
+                        "storageClass": spec.storage_class_name if spec else "",
+                        "capacity": capacity,
+                        "requestedSize": (
+                            spec.resources.requests.get("storage", "")
+                            if spec and spec.resources and spec.resources.requests
+                            else ""
+                        ),
+                        "status": (status.phase or "Unknown") if status else "Unknown",
+                        "volumeName": spec.volume_name if spec else None,
+                        "accessModes": list(spec.access_modes or []) if spec else [],
+                        "volumeMode": spec.volume_mode if spec else None,
+                        "createdAt": meta.creation_timestamp.isoformat() if meta and meta.creation_timestamp else None,
+                        "labels": dict(meta.labels or {}) if meta else {},
+                    }
+                )
+            return pvcs
+        except Exception as e:
+            raise self._wrap_api_exception(e) from e
+
     def _read_pod_log_sync(
         self, namespace: str, pod_name: str, container: str | None = None, tail_lines: int = 500
     ) -> str:
@@ -545,6 +584,9 @@ class K8sClient:
 
     async def list_nodes(self) -> list[dict[str, Any]]:
         return await asyncio.to_thread(self._list_nodes_sync)
+
+    async def list_pvcs(self, namespace: str, label_selector: str) -> list[dict[str, Any]]:
+        return await asyncio.to_thread(self._list_pvcs_sync, namespace, label_selector)
 
     async def read_pod_log(
         self, namespace: str, pod_name: str, container: str | None = None, tail_lines: int = 500

--- a/backend/src/aerospike_cluster_manager_api/models/k8s/operations.py
+++ b/backend/src/aerospike_cluster_manager_api/models/k8s/operations.py
@@ -138,6 +138,32 @@ class ReconciliationHealthResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
 
+class PVCInfo(BaseModel):
+    """PersistentVolumeClaim info for cluster storage display."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str
+    namespace: str
+    storage_class: str | None = Field(None, alias="storageClass")
+    capacity: str = ""
+    requested_size: str = Field("", alias="requestedSize")
+    status: str = "Unknown"
+    volume_name: str | None = Field(None, alias="volumeName")
+    access_modes: list[str] = Field(default_factory=list, alias="accessModes")
+    volume_mode: str | None = Field(None, alias="volumeMode")
+    created_at: str | None = Field(None, alias="createdAt")
+
+
+class ImportClusterRequest(BaseModel):
+    """Request to import a cluster from raw CR YAML/JSON."""
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    cr: dict = Field(description="Raw AerospikeCluster CR as JSON object")
+    namespace: str | None = Field(None, description="Override namespace (uses CR metadata.namespace if omitted)")
+
+
 class NodeBlocklistRequest(BaseModel):
     node_names: list[str] = Field(default_factory=list, alias="nodeNames")
 

--- a/backend/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
+++ b/backend/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
@@ -26,6 +26,7 @@ from aerospike_cluster_manager_api.models.k8s_cluster import (
     CreateK8sTemplateRequest,
     HPAConfig,
     HPAResponse,
+    ImportClusterRequest,
     K8sClusterDetail,
     K8sClusterEvent,
     K8sClusterSummary,
@@ -34,6 +35,7 @@ from aerospike_cluster_manager_api.models.k8s_cluster import (
     MigrationStatusResponse,
     NodeBlocklistRequest,
     OperationRequest,
+    PVCInfo,
     ReconciliationHealthResponse,
     ReconciliationStatus,
     ScaleK8sClusterRequest,
@@ -251,6 +253,81 @@ async def get_k8s_cluster_yaml(
 
     item = await k8s_client.get_cluster(namespace, name)
     return {"yaml": clean_cr_for_export(item)}
+
+
+@router.get("/clusters/{namespace}/{name}/pvcs", summary="List PVCs for K8s Aerospike cluster")
+@_k8s_endpoint("list PVCs for Kubernetes cluster")
+async def list_k8s_cluster_pvcs(
+    namespace: str = _K8S_NAMESPACE,
+    name: str = _K8S_NAME,
+) -> list[PVCInfo]:
+    """List PersistentVolumeClaims associated with the cluster's StatefulSets."""
+
+    label_selector = f"app.kubernetes.io/instance={name}"
+    pvcs_raw = await k8s_client.list_pvcs(namespace, label_selector)
+    return [PVCInfo(**pvc) for pvc in pvcs_raw]
+
+
+@router.post(
+    "/clusters/{namespace}/{name}/force-reconcile",
+    summary="Force reconcile a drifted cluster",
+)
+@_k8s_endpoint("force reconcile Kubernetes cluster")
+async def force_reconcile_k8s_cluster(
+    namespace: str = _K8S_NAMESPACE,
+    name: str = _K8S_NAME,
+) -> K8sClusterSummary:
+    """Add a force-reconcile annotation to trigger the operator to re-reconcile."""
+
+    patch: dict[str, Any] = {
+        "metadata": {
+            "annotations": {
+                "acko.io/force-reconcile": datetime.now(UTC).isoformat(),
+            }
+        }
+    }
+    result = await k8s_client.patch_cluster(namespace, name, patch)
+    return extract_summary(result)
+
+
+@router.post("/clusters/import", status_code=201, summary="Import K8s Aerospike cluster from CR")
+@_k8s_endpoint("import Kubernetes cluster")
+async def import_k8s_cluster(body: ImportClusterRequest) -> K8sClusterSummary:
+    """Create a cluster from a raw AerospikeCluster CR (JSON/YAML)."""
+
+    cr = body.cr
+    metadata = cr.get("metadata", {})
+    cr_namespace = body.namespace or metadata.get("namespace")
+    if not cr_namespace:
+        raise HTTPException(status_code=400, detail="Namespace is required (set in CR metadata or request body)")
+
+    cr_name = metadata.get("name")
+    if not cr_name:
+        raise HTTPException(status_code=400, detail="CR metadata.name is required")
+
+    # Ensure correct apiVersion and kind
+    cr["apiVersion"] = "acko.io/v1alpha1"
+    cr["kind"] = "AerospikeCluster"
+    cr.setdefault("metadata", {})["namespace"] = cr_namespace
+
+    # Strip status and managed fields for clean import
+    cr.pop("status", None)
+    metadata = cr.get("metadata", {})
+    metadata.pop("resourceVersion", None)
+    metadata.pop("uid", None)
+    metadata.pop("creationTimestamp", None)
+    metadata.pop("generation", None)
+    metadata.pop("managedFields", None)
+
+    existing_namespaces = await k8s_client.list_namespaces()
+    if cr_namespace not in existing_namespaces:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Namespace '{cr_namespace}' does not exist. Available: {', '.join(sorted(existing_namespaces))}",
+        )
+
+    result = await k8s_client.create_cluster(cr_namespace, cr)
+    return extract_summary(result)
 
 
 @router.post("/clusters", status_code=201, summary="Create K8s Aerospike cluster")

--- a/docs/k8s-management.md
+++ b/docs/k8s-management.md
@@ -138,13 +138,19 @@ Change the cluster size (1-8 nodes for CE). The operator handles rolling scale-u
 ### Edit
 
 Modify running cluster settings with diff-based patching. The edit dialog supports all wizard fields plus:
-- **ACL (Access Control)** — Enable/disable ACL, manage roles with privileges and CIDR whitelists, manage users with K8s Secret-backed passwords
-- **Resources** — Configure CPU and memory requests/limits for Aerospike pods
+- **ACL (Access Control)** -- Enable/disable ACL, manage roles with privileges and CIDR whitelists, manage users with K8s Secret-backed passwords
+- **Resources** -- Configure CPU and memory requests/limits for Aerospike pods
 - Seeds Finder Services configuration
 - Sidecar and init container management
 - Security context configuration
 - Topology spread constraints
 - Service metadata
+
+### Export & Import
+
+**Export:** From the cluster detail page, click **Export** in the Spec section to download the cluster CR as a JSON file. The **Copy CR** button copies the YAML to clipboard.
+
+**Import:** From the cluster list page, click **Import CR** to create a cluster from an exported CR. Paste the JSON or upload a file. The import strips metadata fields (`uid`, `resourceVersion`, `managedFields`) for a clean import.
 
 ### HPA (Horizontal Pod Autoscaler)
 
@@ -335,6 +341,19 @@ Compares the desired spec (what you declared) against the applied spec (what the
 - **Desired & applied config snapshots** -- The full desired and applied config objects are available for inspection when the backend returns them.
 
 The drift data is fetched from `GET /api/k8s/clusters/{namespace}/{name}/config-drift`.
+
+When drift is detected, the **Force Reconcile** button triggers a re-reconciliation by annotating the CR with `acko.io/force-reconcile`. This is useful when the operator has applied a config but the status hasn't been updated yet.
+
+### PVC / Storage Status
+
+The PVC status panel lists all PersistentVolumeClaims associated with the cluster's StatefulSets. For each PVC:
+- **Status badge** -- Bound (green), Pending (amber), Released (blue), or Failed (red)
+- **Capacity** -- Provisioned storage capacity
+- **Storage Class** -- The Kubernetes StorageClass used
+- **Access Modes** -- ReadWriteOnce, ReadWriteMany, etc.
+- **Volume Name** -- The bound PersistentVolume name
+
+The data is fetched from `GET /api/k8s/clusters/{namespace}/{name}/pvcs`.
 
 ### Reconciliation Health Dashboard
 

--- a/frontend/src/app/k8s/clusters/[namespace]/[name]/page.tsx
+++ b/frontend/src/app/k8s/clusters/[namespace]/[name]/page.tsx
@@ -15,6 +15,7 @@ import {
   AlertTriangle,
   Copy,
   Gauge,
+  Download,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -35,6 +36,7 @@ import { K8sMigrationStatus } from "@/components/k8s/k8s-migration-status";
 import { K8sOperationStatus } from "@/components/k8s/k8s-operation-status";
 import { K8sRackTopology } from "@/components/k8s/k8s-rack-topology";
 import { K8sOperationTriggerDialog } from "@/components/k8s/k8s-operation-trigger-dialog";
+import { K8sPVCStatus } from "@/components/k8s/k8s-pvc-status";
 import { PauseResumeButton } from "@/components/k8s/pause-resume-button";
 import { useK8sClusterStore } from "@/stores/k8s-cluster-store";
 import { useToastStore } from "@/stores/toast-store";
@@ -433,6 +435,9 @@ export default function K8sClusterDetailPage() {
         migrationStatus={migrationStatus}
       />
 
+      {/* PVC / Storage Status */}
+      <K8sPVCStatus namespace={namespace} name={name} />
+
       {/* Status Dashboard: Pending Restart Pods, Last Reconcile, Operator Version */}
       {(selectedCluster.pendingRestartPods.length > 0 ||
         selectedCluster.lastReconcileTime ||
@@ -636,22 +641,47 @@ export default function K8sClusterDetailPage() {
         <CardHeader>
           <CardTitle className="flex items-center justify-between">
             Spec
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={async () => {
-                try {
-                  const result = await api.getK8sClusterYaml(namespace, name);
-                  await navigator.clipboard.writeText(JSON.stringify(result.yaml, null, 2));
-                  useToastStore.getState().addToast("success", "CR YAML copied to clipboard");
-                } catch (err) {
-                  useToastStore.getState().addToast("error", getErrorMessage(err));
-                }
-              }}
-            >
-              <Copy className="mr-2 h-3 w-3" />
-              Copy CR
-            </Button>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={async () => {
+                  try {
+                    const result = await api.getK8sClusterYaml(namespace, name);
+                    await navigator.clipboard.writeText(JSON.stringify(result.yaml, null, 2));
+                    useToastStore.getState().addToast("success", "CR YAML copied to clipboard");
+                  } catch (err) {
+                    useToastStore.getState().addToast("error", getErrorMessage(err));
+                  }
+                }}
+              >
+                <Copy className="mr-2 h-3 w-3" />
+                Copy CR
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={async () => {
+                  try {
+                    const result = await api.getK8sClusterYaml(namespace, name);
+                    const json = JSON.stringify(result.yaml, null, 2);
+                    const blob = new Blob([json], { type: "application/json" });
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement("a");
+                    a.href = url;
+                    a.download = `${name}.${namespace}.json`;
+                    a.click();
+                    URL.revokeObjectURL(url);
+                    useToastStore.getState().addToast("success", "CR exported");
+                  } catch (err) {
+                    useToastStore.getState().addToast("error", getErrorMessage(err));
+                  }
+                }}
+              >
+                <Download className="mr-2 h-3 w-3" />
+                Export
+              </Button>
+            </div>
           </CardTitle>
         </CardHeader>
         <CardContent>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { Plus, Boxes, Loader2, Wifi, WifiOff, Check } from "lucide-react";
+import { Plus, Boxes, Loader2, Wifi, WifiOff, Check, Upload } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -20,6 +20,7 @@ import { InlineAlert } from "@/components/common/inline-alert";
 import { LoadingButton } from "@/components/common/loading-button";
 import { PageHeader } from "@/components/common/page-header";
 import { ClusterListTable } from "@/components/cluster-list/cluster-list-table";
+import { K8sImportDialog } from "@/components/k8s/k8s-import-dialog";
 import { useConnectionStore } from "@/stores/connection-store";
 import { useClusterListStore } from "@/stores/cluster-list-store";
 import { useK8sClusterStore } from "@/stores/k8s-cluster-store";
@@ -66,6 +67,7 @@ export default function ConnectionsPage() {
   } | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<UnifiedClusterRow | null>(null);
   const [deleting, setDeleting] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
 
   useEffect(() => {
     // Populate connection-store so openEditDialog can access full connection data
@@ -219,10 +221,16 @@ export default function ConnectionsPage() {
         actions={
           <>
             {k8sAvailable && (
-              <Button variant="info" onClick={() => router.push("/k8s/clusters/new")}>
-                <Boxes className="mr-2 h-4 w-4 sm:mr-2" />
-                <span className="hidden sm:inline">Create Cluster</span>
-              </Button>
+              <>
+                <Button variant="info" onClick={() => router.push("/k8s/clusters/new")}>
+                  <Boxes className="mr-2 h-4 w-4 sm:mr-2" />
+                  <span className="hidden sm:inline">Create Cluster</span>
+                </Button>
+                <Button variant="outline" onClick={() => setImportOpen(true)}>
+                  <Upload className="mr-2 h-4 w-4 sm:mr-2" />
+                  <span className="hidden sm:inline">Import CR</span>
+                </Button>
+              </>
             )}
             <Button variant="success" onClick={openCreateDialog}>
               <Plus className="mr-2 h-4 w-4 sm:mr-2" />
@@ -392,6 +400,16 @@ export default function ConnectionsPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Import Dialog */}
+      <K8sImportDialog
+        open={importOpen}
+        onOpenChange={setImportOpen}
+        onSuccess={async () => {
+          await fetchAll();
+          fetchAllHealth();
+        }}
+      />
 
       {/* Delete Confirmation */}
       <ConfirmDialog

--- a/frontend/src/components/k8s/k8s-config-drift-card.tsx
+++ b/frontend/src/components/k8s/k8s-config-drift-card.tsx
@@ -3,9 +3,11 @@
 import { useEffect, useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { CheckCircle, AlertTriangle, FileCode, Hash, Minus, Plus } from "lucide-react";
-import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { CheckCircle, AlertTriangle, FileCode, Hash, Minus, Plus, RotateCcw } from "lucide-react";
+import { cn, getErrorMessage } from "@/lib/utils";
 import { api } from "@/lib/api/client";
+import { useToastStore } from "@/stores/toast-store";
 import type { ConfigDriftResponse, K8sClusterDetail } from "@/lib/api/types";
 
 interface K8sConfigDriftCardProps {
@@ -66,6 +68,7 @@ export function K8sConfigDriftCard({
 }: K8sConfigDriftCardProps) {
   const [drift, setDrift] = useState<ConfigDriftResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const [reconciling, setReconciling] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -124,12 +127,29 @@ export function K8sConfigDriftCard({
             <>
               <AlertTriangle className="h-4 w-4 text-amber-500" />
               <span className="text-sm font-medium text-amber-600">Config Drift Detected</span>
-              <Badge
-                variant="outline"
-                className="ml-auto border-amber-500/30 text-[10px] text-amber-600"
-              >
+              <Badge variant="outline" className="border-amber-500/30 text-[10px] text-amber-600">
                 {drift.changedFields.length} field{drift.changedFields.length !== 1 ? "s" : ""}
               </Badge>
+              <Button
+                variant="outline"
+                size="sm"
+                className="ml-auto h-7 gap-1 text-xs"
+                disabled={reconciling}
+                onClick={async () => {
+                  setReconciling(true);
+                  try {
+                    await api.forceReconcileK8sCluster(namespace, name);
+                    useToastStore.getState().addToast("success", "Force reconcile triggered");
+                  } catch (err) {
+                    useToastStore.getState().addToast("error", getErrorMessage(err));
+                  } finally {
+                    setReconciling(false);
+                  }
+                }}
+              >
+                <RotateCcw className={cn("h-3 w-3", reconciling && "animate-spin")} />
+                Force Reconcile
+              </Button>
             </>
           ) : (
             <>

--- a/frontend/src/components/k8s/k8s-import-dialog.tsx
+++ b/frontend/src/components/k8s/k8s-import-dialog.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { Upload } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
+import { api } from "@/lib/api/client";
+import { getErrorMessage } from "@/lib/utils";
+import { useToastStore } from "@/stores/toast-store";
+
+interface K8sImportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess?: () => void;
+}
+
+export function K8sImportDialog({ open, onOpenChange, onSuccess }: K8sImportDialogProps) {
+  const [yamlText, setYamlText] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [preview, setPreview] = useState<{ name: string; namespace: string; size: number } | null>(
+    null,
+  );
+
+  const parseYaml = useCallback((text: string) => {
+    try {
+      const parsed = JSON.parse(text);
+      const meta = parsed.metadata || {};
+      setPreview({
+        name: meta.name || "(unknown)",
+        namespace: meta.namespace || "default",
+        size: parsed.spec?.size || 0,
+      });
+      return parsed;
+    } catch {
+      // Try simple YAML-like parsing for basic cases
+      setPreview(null);
+      return null;
+    }
+  }, []);
+
+  const handleFileUpload = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = (event) => {
+        const text = event.target?.result as string;
+        setYamlText(text);
+        parseYaml(text);
+      };
+      reader.readAsText(file);
+    },
+    [parseYaml],
+  );
+
+  const handleImport = async () => {
+    if (!yamlText.trim()) return;
+    setLoading(true);
+    try {
+      let cr: Record<string, unknown>;
+      try {
+        cr = JSON.parse(yamlText);
+      } catch {
+        useToastStore
+          .getState()
+          .addToast("error", "Invalid JSON format. Please paste the CR as JSON.");
+        setLoading(false);
+        return;
+      }
+      await api.importK8sCluster({ cr });
+      useToastStore.getState().addToast("success", "Cluster imported successfully");
+      onOpenChange(false);
+      setYamlText("");
+      setPreview(null);
+      onSuccess?.();
+    } catch (err) {
+      useToastStore.getState().addToast("error", getErrorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Upload className="h-5 w-5" />
+            Import Cluster from CR
+          </DialogTitle>
+          <DialogDescription>
+            Paste an AerospikeCluster CR (JSON) or upload a file to create a cluster.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div>
+            <Label htmlFor="cr-file">Upload CR file</Label>
+            <input
+              id="cr-file"
+              type="file"
+              accept=".json,.yaml,.yml"
+              onChange={handleFileUpload}
+              className="file-input file-input-bordered mt-1 w-full text-sm"
+            />
+          </div>
+
+          <div>
+            <Label htmlFor="cr-text">Or paste CR JSON</Label>
+            <textarea
+              id="cr-text"
+              value={yamlText}
+              onChange={(e) => {
+                setYamlText(e.target.value);
+                parseYaml(e.target.value);
+              }}
+              placeholder='{"apiVersion": "acko.io/v1alpha1", "kind": "AerospikeCluster", ...}'
+              rows={12}
+              className="bg-base-200 mt-1 w-full rounded-lg border p-3 font-mono text-xs"
+            />
+          </div>
+
+          {preview && (
+            <div className="bg-base-200 rounded-lg p-3 text-sm">
+              <p className="font-medium">Preview:</p>
+              <div className="text-base-content/60 mt-1 grid grid-cols-3 gap-2 text-xs">
+                <div>
+                  <span className="font-medium">Name:</span> {preview.name}
+                </div>
+                <div>
+                  <span className="font-medium">Namespace:</span> {preview.namespace}
+                </div>
+                <div>
+                  <span className="font-medium">Size:</span> {preview.size}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={() => onOpenChange(false)} disabled={loading}>
+            Cancel
+          </Button>
+          <Button onClick={handleImport} disabled={loading || !yamlText.trim()}>
+            {loading ? "Importing..." : "Import Cluster"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/k8s/k8s-pvc-status.tsx
+++ b/frontend/src/components/k8s/k8s-pvc-status.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { HardDrive } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { api } from "@/lib/api/client";
+import type { PVCInfo } from "@/lib/api/types";
+
+interface K8sPVCStatusProps {
+  namespace: string;
+  name: string;
+  className?: string;
+}
+
+function statusColor(status: string) {
+  switch (status) {
+    case "Bound":
+      return "bg-success/10 text-success border-success/20";
+    case "Pending":
+      return "bg-warning/10 text-warning border-warning/20";
+    case "Released":
+      return "bg-info/10 text-info border-info/20";
+    case "Failed":
+      return "bg-error/10 text-error border-error/20";
+    default:
+      return "bg-base-200 text-base-content/60 border-base-300";
+  }
+}
+
+export function K8sPVCStatus({ namespace, name, className }: K8sPVCStatusProps) {
+  const [pvcs, setPvcs] = useState<PVCInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getK8sClusterPVCs(namespace, name)
+      .then((data) => {
+        if (!cancelled) setPvcs(data);
+      })
+      .catch(() => {
+        if (!cancelled) setPvcs([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [namespace, name]);
+
+  if (loading) {
+    return (
+      <Card className={className}>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-base-content/60 flex items-center gap-2 text-sm font-normal">
+            <HardDrive className="h-4 w-4" />
+            Storage (PVCs)
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="bg-base-200 h-8 animate-pulse rounded" />
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (pvcs.length === 0) return null;
+
+  const boundCount = pvcs.filter((p) => p.status === "Bound").length;
+
+  return (
+    <Card className={className}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-base-content/60 flex items-center gap-2 text-sm font-normal">
+          <HardDrive className="h-4 w-4" />
+          Storage (PVCs)
+          <Badge variant="outline" className="ml-auto text-[10px]">
+            {boundCount}/{pvcs.length} Bound
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-base-content/60 border-b text-left text-xs">
+                <th className="pr-4 pb-2 font-medium">Name</th>
+                <th className="pr-4 pb-2 font-medium">Status</th>
+                <th className="pr-4 pb-2 font-medium">Capacity</th>
+                <th className="pr-4 pb-2 font-medium">Storage Class</th>
+                <th className="pr-4 pb-2 font-medium">Access Modes</th>
+                <th className="pb-2 font-medium">Volume</th>
+              </tr>
+            </thead>
+            <tbody>
+              {pvcs.map((pvc) => (
+                <tr key={pvc.name} className="border-b last:border-b-0">
+                  <td className="py-2 pr-4 font-mono text-xs">{pvc.name}</td>
+                  <td className="py-2 pr-4">
+                    <Badge variant="outline" className={cn("text-[10px]", statusColor(pvc.status))}>
+                      {pvc.status}
+                    </Badge>
+                  </td>
+                  <td className="py-2 pr-4 font-mono text-xs">
+                    {pvc.capacity || pvc.requestedSize || "-"}
+                  </td>
+                  <td className="py-2 pr-4 text-xs">{pvc.storageClass || "-"}</td>
+                  <td className="py-2 pr-4 text-xs">{pvc.accessModes.join(", ") || "-"}</td>
+                  <td
+                    className="max-w-[160px] truncate py-2 font-mono text-xs"
+                    title={pvc.volumeName || ""}
+                  >
+                    {pvc.volumeName || "-"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -532,4 +532,24 @@ export const api = {
       `/api/k8s/clusters/${encodePathSegment(namespace)}/${encodePathSegment(name)}/operations`,
       { method: "POST", body: JSON.stringify(data) },
     ),
+
+  // K8s Cluster PVCs
+  getK8sClusterPVCs: (namespace: string, name: string) =>
+    request<import("./types").PVCInfo[]>(
+      `/api/k8s/clusters/${encodePathSegment(namespace)}/${encodePathSegment(name)}/pvcs`,
+    ),
+
+  // K8s Force Reconcile
+  forceReconcileK8sCluster: (namespace: string, name: string) =>
+    request<import("./types").K8sClusterSummary>(
+      `/api/k8s/clusters/${encodePathSegment(namespace)}/${encodePathSegment(name)}/force-reconcile`,
+      { method: "POST" },
+    ),
+
+  // K8s Cluster Import
+  importK8sCluster: (data: import("./types").ImportClusterRequest) =>
+    request<import("./types").K8sClusterSummary>("/api/k8s/clusters/import", {
+      method: "POST",
+      body: JSON.stringify(data),
+    }),
 };

--- a/frontend/src/lib/api/types/k8s.ts
+++ b/frontend/src/lib/api/types/k8s.ts
@@ -720,6 +720,26 @@ export interface HPAResponse {
   status: HPAStatus;
 }
 
+// === PVC (PersistentVolumeClaim) Status ===
+export interface PVCInfo {
+  name: string;
+  namespace: string;
+  storageClass: string | null;
+  capacity: string;
+  requestedSize: string;
+  status: "Pending" | "Bound" | "Released" | "Failed" | string;
+  volumeName: string | null;
+  accessModes: string[];
+  volumeMode: string | null;
+  createdAt: string | null;
+}
+
+// === Import Cluster ===
+export interface ImportClusterRequest {
+  cr: Record<string, unknown>;
+  namespace?: string;
+}
+
 // === AerospikeCluster Spec (typed subset of the CRD spec) ===
 export interface AerospikeNetworkPolicySpec {
   accessType?: string;


### PR DESCRIPTION
## Summary
- **PVC Status Panel**: New storage status section on cluster detail page showing all PVCs with status badges (Bound/Pending/Released/Failed), capacity, storage class, access modes, and volume names
- **Export CR**: Download cluster CR as JSON file from the cluster detail page
- **Import CR**: Create clusters from exported CR JSON via a new Import dialog on the cluster list page (supports file upload and text paste)
- **Force Reconcile**: Trigger re-reconciliation from the config drift card by annotating the CR with `acko.io/force-reconcile`

### Backend
- `GET /api/k8s/clusters/{ns}/{name}/pvcs` — List PVCs by label selector
- `POST /api/k8s/clusters/{ns}/{name}/force-reconcile` — Annotate CR to trigger reconcile
- `POST /api/k8s/clusters/import` — Create cluster from raw CR JSON

### Frontend
- `K8sPVCStatus` component with status badges and storage details
- `K8sImportDialog` component with file upload, JSON preview, and validation
- Force Reconcile button integrated into `K8sConfigDriftCard`
- Export button added to cluster detail spec section

## Test plan
- [ ] Verify PVC status panel renders correctly for clusters with PV storage
- [ ] Test CR export downloads valid JSON
- [ ] Test CR import with valid and invalid JSON inputs
- [ ] Test Force Reconcile button updates annotation and triggers reconcile
- [ ] Verify TypeScript type-check passes (`npm run type-check`)
- [ ] Verify all existing tests pass (`npm run test`)