### PR TITLE
fix: add ACL validation and sanitize empty resources in edit dialog

### DIFF
--- a/frontend/src/components/k8s/k8s-edit-dialog.tsx
+++ b/frontend/src/components/k8s/k8s-edit-dialog.tsx
@@ -24,6 +24,7 @@ import type {
   NetworkAccessType,
   BandwidthConfig,
 } from "@/lib/api/types";
+import { validateACLConfig } from "@/lib/validations/k8s-acl";
 import { useEditDialogState } from "./hooks/use-edit-dialog-state";
 import {
   EditAclSection,
@@ -274,12 +275,24 @@ export function K8sEditDialog({ open, onOpenChange, cluster, onSave }: K8sEditDi
 
       // ACL
       if (JSON.stringify(state.aclConfig) !== JSON.stringify(initials.aclConfig)) {
+        if (state.aclConfig) {
+          const aclError = validateACLConfig(state.aclConfig);
+          if (aclError) {
+            patchState({ error: aclError });
+            return;
+          }
+        }
         data.acl = state.aclConfig ?? undefined;
       }
 
-      // Resources
+      // Resources — strip empty strings to avoid backend validation errors
       if (JSON.stringify(state.resources) !== JSON.stringify(initials.resources)) {
-        data.resources = state.resources ?? undefined;
+        const r = state.resources;
+        if (r && (r.requests.cpu || r.requests.memory || r.limits.cpu || r.limits.memory)) {
+          data.resources = r;
+        } else {
+          data.resources = undefined;
+        }
       }
 
       await onSave(data);


### PR DESCRIPTION
## Summary
- Wire existing `validateACLConfig()` into the edit dialog save flow — catches missing admin user, duplicate role/user names, and invalid privileges **before** the API call
- Sanitize empty-string resource values (CPU/memory) to `undefined` to prevent backend Pydantic 422 validation errors

Follow-up fix for issues found in PR #133 code review.

## Test plan
- [ ] Open edit dialog, enable ACL without admin user → verify inline error message
- [ ] Open edit dialog, clear all resource fields → verify save succeeds (sends undefined, not empty strings)
- [ ] Verify TypeScript type-check passes