### PR TITLE
docs+fix: improve documentation and K8s API error handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,29 +22,35 @@ AEROSPIKE_PORT=3000
 # DATABASE_URL=postgresql://aerospike:aerospike@localhost:5432/aerospike_manager
 
 # ============================================
-# Backend
+# Backend & Frontend Ports
 # ============================================
 # Port the backend API server listens on
 BACKEND_PORT=8000
 
-# ============================================
-# Frontend
-# ============================================
 # Port the frontend server listens on (used in compose.yaml)
 FRONTEND_PORT=3100
 
-# ============================================
-# Backend Configuration
-# ============================================
-# Comma-separated list of allowed origins for CORS
-# Must include the frontend URL
+# Comma-separated list of allowed origins for CORS (must include the frontend URL)
 CORS_ORIGINS=http://localhost:3000,http://localhost:3100
+
+# ============================================
+# Database Connection Pool (PostgreSQL only)
+# ============================================
+# DB_POOL_MIN_SIZE=2
+# DB_POOL_MAX_SIZE=10
+# DB_COMMAND_TIMEOUT=30
 
 # ============================================
 # Kubernetes Management
 # ============================================
 # Enable K8s cluster management endpoints (requires in-cluster or kubeconfig access)
 K8S_MANAGEMENT_ENABLED=false
+
+# Kubernetes API request timeout in seconds
+# K8S_API_TIMEOUT=10
+
+# Pod log streaming timeout in seconds
+# K8S_LOG_TIMEOUT=30
 
 # ============================================
 # Logging

--- a/README.md
+++ b/README.md
@@ -779,15 +779,51 @@ pre-commit run --all-files
 
 ## Environment Variables
 
+All environment variables with their defaults and descriptions. See `backend/src/aerospike_cluster_manager_api/config.py` for the backend source of truth.
+
+### Aerospike Connection
+
 | Variable | Default | Description |
 |---|---|---|
-| `AEROSPIKE_HOST` | `aerospike` | Aerospike server host |
+| `AEROSPIKE_HOST` | `aerospike` | Aerospike server host (used in compose files for default connection) |
 | `AEROSPIKE_PORT` | `3000` | Aerospike service port |
-| `BACKEND_PORT` | `8000` | Backend API port |
-| `FRONTEND_PORT` | `3100` | Frontend port |
-| `CORS_ORIGINS` | `http://localhost:3100` | Allowed CORS origins |
-| `BACKEND_URL` | `http://localhost:8000` | Backend URL (frontend proxy target) |
+
+### Database
+
+| Variable | Default | Description |
+|---|---|---|
+| `SQLITE_PATH` | `./data/connections.db` | SQLite database file path. SQLite is the default backend -- no external database required |
+| `ENABLE_POSTGRES` | `false` | Set to `true` to use PostgreSQL instead of the default SQLite backend |
+| `DATABASE_URL` | `postgresql://aerospike:aerospike@localhost:5432/aerospike_manager` | PostgreSQL connection string (only used when `ENABLE_POSTGRES=true`) |
+| `DB_POOL_MIN_SIZE` | `2` | Minimum number of connections in the database connection pool |
+| `DB_POOL_MAX_SIZE` | `10` | Maximum number of connections in the database connection pool |
+| `DB_COMMAND_TIMEOUT` | `30` | SQL command execution timeout in seconds |
+
+### Kubernetes Management
+
+| Variable | Default | Description |
+|---|---|---|
 | `K8S_MANAGEMENT_ENABLED` | `false` | Enable K8s cluster management endpoints (requires in-cluster or kubeconfig access) |
+| `K8S_API_TIMEOUT` | `10` | Kubernetes API request timeout in seconds (applies to CRUD on CRDs, listing pods, nodes, etc.) |
+| `K8S_LOG_TIMEOUT` | `30` | Kubernetes pod log streaming timeout in seconds |
+
+### Network / Server
+
+| Variable | Default | Description |
+|---|---|---|
+| `CORS_ORIGINS` | `http://localhost:3000,http://localhost:3100` | Comma-separated list of allowed CORS origins (must include the frontend URL) |
+| `BACKEND_URL` | `http://localhost:8000` | Backend URL used by the frontend proxy |
+| `BACKEND_PORT` | `8000` | Backend API port (compose files) |
+| `FRONTEND_PORT` | `3100` | Frontend port (compose files) |
+| `HOST` | `0.0.0.0` | Backend bind address |
+| `PORT` | `8000` | Backend bind port |
+
+### Logging
+
+| Variable | Default | Description |
+|---|---|---|
+| `LOG_LEVEL` | `INFO` | Backend log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
+| `LOG_FORMAT` | `text` | Log output format: `text` for local dev, `json` for structured container logging |
 
 ## Production Deployment
 
@@ -812,20 +848,11 @@ podman run -d \
 
 A built-in health check (`/api/health`) is configured with a 10-second interval and 15-second start period.
 
-### Environment Variables for Production
+### Production Environment
 
-| Variable | Default | Description |
-|---|---|---|
-| `SQLITE_PATH` | `/app/data/connections.db` | SQLite database file path (default backend) |
-| `ENABLE_POSTGRES` | `false` | Use PostgreSQL instead of SQLite |
-| `DATABASE_URL` | `postgresql://aerospike:aerospike@localhost:5432/aerospike_manager` | PostgreSQL connection string (only used when `ENABLE_POSTGRES=true`) |
-| `HOST` | `0.0.0.0` | Backend bind address |
-| `PORT` | `8000` | Backend bind port |
-| `CORS_ORIGINS` | `http://localhost:3000` | Comma-separated list of allowed CORS origins |
-| `BACKEND_URL` | `http://localhost:8000` | Backend URL used by the frontend proxy |
-| `K8S_MANAGEMENT_ENABLED` | `false` | Enable Kubernetes cluster management endpoints (requires in-cluster or kubeconfig access) |
-| `LOG_LEVEL` | `INFO` | Backend log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-| `LOG_FORMAT` | `text` | Log output format (`text` or `json` for structured logging) |
+For production, configure the environment variables listed in the [Environment Variables](#environment-variables) section above. Key settings to review: `CORS_ORIGINS` (must match your domain), `LOG_FORMAT` (set to `json` for structured logging), and `K8S_MANAGEMENT_ENABLED` (set to `true` when deploying inside Kubernetes).
+
+Inside the container, `SQLITE_PATH` defaults to `/app/data/connections.db`. Mount a volume to `/app/data` to persist data across container restarts.
 
 ### Database Setup
 

--- a/backend/src/aerospike_cluster_manager_api/k8s_client.py
+++ b/backend/src/aerospike_cluster_manager_api/k8s_client.py
@@ -106,9 +106,13 @@ class K8sClient:
 
         if isinstance(e, ApiException):
             msg = (str(e.body) if e.body else "")[:2000]
-            return K8sApiError(
-                status=int(e.status) if e.status is not None else 500, reason=e.reason or "", message=msg
-            )
+            raw_status = int(e.status) if e.status is not None else 500
+            status = raw_status if raw_status else 500
+            if raw_status == 0 or "timeout" in (e.reason or "").lower():
+                status = 408
+            return K8sApiError(status=status, reason=e.reason or "", message=msg)
+        if isinstance(e, (TimeoutError, OSError)) and "timed out" in str(e).lower():
+            return K8sApiError(status=408, reason="RequestTimeout", message="Kubernetes API request timed out")
         logger.error("Unexpected error in K8s operation: %s", e, exc_info=True)
         return K8sApiError(status=500, reason="InternalError", message="Internal server error")
 

--- a/backend/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
+++ b/backend/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
@@ -12,7 +12,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response
 from pydantic import BaseModel
 
 from aerospike_cluster_manager_api import config, db
@@ -83,7 +83,7 @@ class DeleteResponse(BaseModel):
 
 def _map_k8s_error(e: K8sApiError) -> HTTPException:
     """Map K8sApiError status codes to appropriate HTTPException responses."""
-    status_map = {404: 404, 409: 409, 422: 422, 403: 403, 401: 401}
+    status_map = {400: 400, 401: 401, 403: 403, 404: 404, 408: 408, 409: 409, 422: 422, 429: 429, 503: 503}
     http_status = status_map.get(e.status, 500)
     return HTTPException(status_code=http_status, detail=e.message or e.reason)
 
@@ -463,16 +463,19 @@ async def get_k8s_cluster_hpa(
     return extract_hpa_response(raw)
 
 
-@router.post(
-    "/clusters/{namespace}/{name}/hpa", status_code=201, summary="Create or update HPA for K8s Aerospike cluster"
-)
+@router.post("/clusters/{namespace}/{name}/hpa", summary="Create or update HPA for K8s Aerospike cluster")
 @_k8s_endpoint("create/update HPA for Kubernetes cluster")
 async def create_or_update_k8s_cluster_hpa(
+    response: Response,
     body: HPAConfig,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> HPAResponse:
 
+    if body.cpu_target_percent is None and body.memory_target_percent is None:
+        raise HTTPException(
+            status_code=400, detail="At least one of cpu_target_percent or memory_target_percent is required"
+        )
     # Check if HPA already exists — update if so, create if not
     try:
         await k8s_client.get_hpa(namespace, name)
@@ -484,6 +487,7 @@ async def create_or_update_k8s_cluster_hpa(
             body.cpu_target_percent,
             body.memory_target_percent,
         )
+        response.status_code = 200
     except K8sApiError as e:
         if e.status == 404:
             raw = await k8s_client.create_hpa(
@@ -494,6 +498,7 @@ async def create_or_update_k8s_cluster_hpa(
                 body.cpu_target_percent,
                 body.memory_target_percent,
             )
+            response.status_code = 201
         else:
             raise
     return extract_hpa_response(raw)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -79,7 +79,7 @@ The Aerospike Cluster Manager is a web-based GUI that provides two primary capab
 - All K8s API calls are wrapped with `asyncio.to_thread()` to avoid blocking the FastAPI event loop.
 - The `K8sClient` singleton (`k8s_client.py`) manages the Kubernetes API connection, automatically loading either in-cluster config or kubeconfig.
 - The `k8s_service.py` module contains business logic for building CRD specs, extracting summaries, computing config drift, and categorizing events.
-- **PostgreSQL** stores connection profiles and application state.
+- **SQLite** (default) or **PostgreSQL** (opt-in) stores connection profiles and application state.
 
 ### Aerospike CE Kubernetes Operator
 
@@ -176,6 +176,39 @@ This deploys the Cluster Manager as a Deployment with:
 - Environment variables preconfigured for in-cluster operation
 - Configurable database pool and Kubernetes API timeout settings
 
+## Database Backend
+
+The Aerospike Cluster Manager supports two database backends for persisting connection profiles and application state.
+
+### SQLite (Default)
+
+SQLite is the default database backend. It requires no external service and works out of the box. The backend creates the database file automatically on first startup.
+
+- **WAL mode** is enabled for better read concurrency. Multiple readers can access the database simultaneously while a single writer holds a lock, making it suitable for typical single-instance deployments.
+- **File path** is configurable via the `SQLITE_PATH` environment variable (default: `./data/connections.db`).
+- No additional container or service is needed, simplifying deployment.
+
+### PostgreSQL (Opt-in)
+
+PostgreSQL can be enabled by setting `ENABLE_POSTGRES=true` and providing a `DATABASE_URL` connection string. This is recommended for high-availability or multi-instance deployments.
+
+```bash
+ENABLE_POSTGRES=true
+DATABASE_URL=postgresql://user:password@host:5432/aerospike_manager
+```
+
+The PostgreSQL connection pool is configurable via `DB_POOL_MIN_SIZE`, `DB_POOL_MAX_SIZE`, and `DB_COMMAND_TIMEOUT` environment variables (see [Environment Configuration](#environment-configuration) below).
+
+### Choosing Between SQLite and PostgreSQL
+
+| Scenario | Recommended Backend |
+|----------|-------------------|
+| Single-instance deployment (standalone container, local dev) | SQLite |
+| High-availability with multiple replicas | PostgreSQL |
+| Kubernetes deployment with a single backend pod | SQLite |
+| Kubernetes deployment with horizontal scaling | PostgreSQL |
+| Minimal infrastructure / quick start | SQLite |
+
 ## Environment Configuration
 
 ### Core Settings
@@ -183,7 +216,9 @@ This deploys the Cluster Manager as a Deployment with:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `K8S_MANAGEMENT_ENABLED` | `false` | Master switch for all K8s management features. Set to `true` when running inside a Kubernetes cluster. |
-| `DATABASE_URL` | `postgresql://...@localhost:5432/aerospike_manager` | PostgreSQL connection string for persisting connection profiles. |
+| `SQLITE_PATH` | `./data/connections.db` | File path for the SQLite database (used when `ENABLE_POSTGRES` is `false`). |
+| `ENABLE_POSTGRES` | `false` | Set to `true` to use PostgreSQL instead of the default SQLite backend. |
+| `DATABASE_URL` | `postgresql://...@localhost:5432/aerospike_manager` | PostgreSQL connection string (only used when `ENABLE_POSTGRES=true`). |
 | `CORS_ORIGINS` | `http://localhost:3000,http://localhost:3100` | Comma-separated allowed CORS origins. Must include the frontend URL. |
 | `LOG_LEVEL` | `INFO` | Backend log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`). |
 | `LOG_FORMAT` | `text` | Log format: `text` for local dev, `json` for structured container logging. |

--- a/docs/k8s-management.md
+++ b/docs/k8s-management.md
@@ -257,27 +257,15 @@ Displays rack distribution and data migration status across the cluster. The hea
 
 ### Migration Status Monitoring
 
-The migration status card provides real-time visibility into Aerospike data migration:
+The migration status card provides real-time visibility into Aerospike data migration, particularly useful during scale-down operations, rolling restarts, and initial cluster provisioning.
 
-- **Overall status** -- Whether migration is in progress, and total remaining partitions across the cluster.
-- **Per-pod breakdown** -- Each pod shows its individual migrating partition count, making it easy to identify which pods still have data in transit.
+- **Overall status** -- Whether migration is in progress, and total remaining partitions aggregated across all nodes in the cluster.
+- **Per-pod breakdown** -- Each pod shows its individual migrating partition count in the pod table, making it easy to identify which nodes still have data in transit.
+- **Auto-refresh** -- The migration view refreshes automatically while migration is active (every 5 seconds), stopping once all partitions have settled.
+- **Integrated views** -- Migration progress is surfaced in both the pod table and the rack topology view, so you can correlate partition movement with rack placement.
 - **Last checked** -- Timestamp of when the migration status was last polled.
 
 The migration status is fetched from the `GET /api/k8s/clusters/{namespace}/{name}/migration-status` endpoint, which reads the `status.migrationStatus` field from the AerospikeCluster CR.
-
-Migration status is particularly useful during:
-- Scale-down operations (waiting for data to migrate off departing pods).
-- Rolling restarts (tracking data rebalancing after each pod restart).
-- Initial cluster provisioning (watching data distribution across new pods).
-
-### Migration Status Monitoring
-
-The cluster detail page shows real-time migration progress when the cluster is in a `WaitingForMigration` phase (e.g., after scaling or a rolling restart):
-
-- **Remaining partition count** -- Aggregated across all nodes, showing how many partitions still need to migrate.
-- **Per-pod migration breakdown** -- Each pod's individual remaining partition count is displayed in the pod table, making it easy to identify which nodes are still migrating.
-- **Auto-refresh** -- The migration view refreshes automatically while migration is active (every 5 seconds), stopping once all partitions have settled.
-- **Integrated views** -- Migration progress is surfaced in both the pod table and the rack topology view, so you can correlate partition movement with rack placement.
 
 ### Pod Health Tracking
 
@@ -332,12 +320,14 @@ Events auto-refresh during transitional phases and support category filtering.
 
 ### Configuration Drift Detection
 
-Compares the desired spec (what you declared) against the applied spec (what the operator last reconciled) and detects configuration drift. The UI presents:
+Compares the desired spec (what you declared) against the applied spec (what the operator last reconciled) and detects configuration drift. This is useful after editing a cluster to see whether the operator has fully applied the changes, or to identify partial rollout states where some pods are running the new config and others are still on the old one.
+
+The UI presents:
 
 - **Sync status badge** -- "In Sync" (green) or "Drift Detected" (amber) at the top of the card.
 - **Changed fields list** -- Each field that differs is listed with its path.
 - **Visual diff view** -- For every changed field the card shows the desired value (marked with `+`) and the applied value (marked with `-`) side-by-side, using color-coded formatting (`added`, `removed`, `changed`).
-- **Pod hash groups** -- Pods are grouped by their `configHash` and `podSpecHash`. The group matching the current desired hash is marked as "current"; pods in other groups have diverged and need a rolling restart.
+- **Pod hash groups** -- Pods are grouped by their `configHash` and `podSpecHash`. Each pod reports its current config hash in the pod status table. The group matching the current desired hash is marked as "current"; pods in other groups have diverged and need a rolling restart to pick up the new configuration.
 - **Desired & applied config snapshots** -- The full desired and applied config objects are available for inspection when the backend returns them.
 
 The drift data is fetched from `GET /api/k8s/clusters/{namespace}/{name}/config-drift`.
@@ -374,6 +364,8 @@ The card displays:
 - **Operator version** -- The version of the operator managing this cluster.
 - **Manual reset button** -- Clears the circuit breaker state to force an immediate reconcile.
 - **Auto-refresh** -- The card polls every 10 seconds to keep the health status current.
+
+The reconciliation health data is fetched from `GET /api/k8s/clusters/{namespace}/{name}/reconciliation-health`.
 
 ### Template Sync Status
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -260,6 +260,91 @@ See the [Architecture Guide](./architecture.md) for a complete RBAC configuratio
 
 3. **Connection leaks** -- If the backend is crashing and restarting, stale connections may accumulate. Restart PostgreSQL or configure idle connection cleanup in `pg_hba.conf`.
 
+## SQLite Issues
+
+### SQLite file permission errors
+
+**Symptoms:** Backend fails to start with "unable to open database file" or "readonly database" errors.
+
+**Possible causes and solutions:**
+
+1. **Directory does not exist** -- The parent directory for the SQLite file must exist. The backend does not create parent directories automatically.
+   ```bash
+   mkdir -p ./data
+   ```
+
+2. **Incorrect ownership in container** -- When running in a container, the volume mount must be writable by the container user. For Podman, use the `:U` flag to remap ownership:
+   ```bash
+   podman run -v ~/.aerospike-cluster-manager:/app/data:U ...
+   ```
+
+3. **Read-only filesystem** -- Ensure the volume is not mounted as read-only. Check your compose file or `podman run` command for `:ro` flags on the data volume.
+
+### WAL mode lock issues
+
+**Symptoms:** Backend logs show "database is locked" errors under concurrent access.
+
+**Possible causes and solutions:**
+
+1. **Network filesystem** -- SQLite WAL mode does not work reliably on network filesystems (NFS, CIFS, SMB). Use a local filesystem for the SQLite database file, or switch to PostgreSQL for shared storage.
+
+2. **Multiple processes** -- SQLite supports a single writer at a time. If multiple backend processes are writing simultaneously (e.g., multiple Gunicorn workers), consider either reducing to a single worker or switching to PostgreSQL.
+
+3. **Stale lock file** -- If the backend crashed while holding a write lock, a `-wal` or `-shm` file may be left behind. These are normally cleaned up on the next connection. If the database remains locked, stop all backend processes and delete the `-wal` and `-shm` files alongside the database file, then restart.
+
+## PostgreSQL Connection Pool Exhaustion
+
+### Backend becomes unresponsive under load (PostgreSQL)
+
+**Symptoms:** API requests hang or return 500 errors. Backend logs show "connection pool exhausted" or "too many connections" messages.
+
+**Possible causes and solutions:**
+
+1. **Pool too small** -- The default pool max size is 10 connections. Under high concurrency, this may be insufficient. Increase `DB_POOL_MAX_SIZE`:
+   ```bash
+   DB_POOL_MAX_SIZE=20
+   ```
+
+2. **Long-running queries** -- Queries that exceed `DB_COMMAND_TIMEOUT` (default: 30 seconds) are cancelled but may hold connections briefly. Investigate slow queries in PostgreSQL logs.
+
+3. **Connection leaks** -- If the backend crashes and restarts repeatedly, stale connections may accumulate in PostgreSQL. Monitor active connections:
+   ```sql
+   SELECT count(*) FROM pg_stat_activity WHERE datname = 'aerospike_manager';
+   ```
+
+4. **PostgreSQL max_connections limit** -- The PostgreSQL server itself has a `max_connections` limit (default: 100). Ensure `DB_POOL_MAX_SIZE` multiplied by the number of backend replicas does not exceed this limit.
+
+## Database Migration (SQLite to PostgreSQL)
+
+### Migrating from SQLite to PostgreSQL
+
+When scaling from a single-instance deployment to a multi-replica setup, you may need to migrate data from SQLite to PostgreSQL.
+
+**Steps:**
+
+1. **Export data from SQLite** -- Use the SQLite CLI to dump connection profiles:
+   ```bash
+   sqlite3 ./data/connections.db ".dump connections" > connections_dump.sql
+   ```
+
+2. **Create the PostgreSQL database** -- Ensure the target database exists:
+   ```bash
+   psql -h <host> -U <user> -c "CREATE DATABASE aerospike_manager;"
+   ```
+
+3. **Start the backend with PostgreSQL** -- Set `ENABLE_POSTGRES=true` and `DATABASE_URL` to point to the new database. The backend will create the required tables on startup.
+
+4. **Re-create connection profiles** -- Connection profiles can be re-created via the UI or by importing a previously exported JSON backup. The SQLite and PostgreSQL schemas are identical, but SQL dialect differences (e.g., autoincrement syntax) make direct SQL import unreliable. Using the application-level import/export feature is the safest approach.
+
+### Migrating from PostgreSQL to SQLite
+
+To simplify a deployment by removing the PostgreSQL dependency:
+
+1. Export connection profiles from the UI using the export feature.
+2. Stop the backend and remove the `ENABLE_POSTGRES` and `DATABASE_URL` environment variables (or set `ENABLE_POSTGRES=false`).
+3. Restart the backend -- it will create a fresh SQLite database.
+4. Import the connection profiles via the UI.
+
 ## General Tips
 
 - **Check backend logs** -- The backend logs detailed error information. Set `LOG_LEVEL=DEBUG` for verbose output.

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -522,6 +522,22 @@ export const api = {
       { method: "DELETE" },
     ),
 
+  // K8s Reconciliation Health
+  getK8sReconciliationHealth: (namespace: string, name: string) =>
+    request<import("./types").ReconciliationHealthResponse>(
+      `/api/k8s/clusters/${encodePathSegment(namespace)}/${encodePathSegment(name)}/reconciliation-health`,
+    ),
+
+  // K8s Node Blocklist
+  updateK8sClusterNodeBlocklist: (namespace: string, name: string, nodeNames: string[]) =>
+    request<import("./types").K8sClusterSummary>(
+      `/api/k8s/clusters/${encodePathSegment(namespace)}/${encodePathSegment(name)}/node-blocklist`,
+      {
+        method: "PATCH",
+        body: JSON.stringify({ nodeNames }),
+      },
+    ),
+
   // K8s Cluster Operations
   triggerK8sClusterOperation: (
     namespace: string,


### PR DESCRIPTION
## Summary
- Comprehensive documentation improvements across 5 files
- K8s API error handling and validation fixes in backend
- Missing frontend API method additions

## Documentation Changes
- **README.md**: Added comprehensive environment variables reference (16 vars, 5 categories)
- **architecture.md**: Added SQLite/PostgreSQL database backend comparison and configuration docs
- **k8s-management.md**: Fixed duplicate "Migration Status Monitoring" section, improved config drift and reconciliation health docs
- **troubleshooting.md**: Added 4 new sections (SQLite issues, PostgreSQL pool exhaustion, DB migration guides)
- **.env.example**: Consolidated sections, added missing env vars (DB_POOL_*, K8S_*_TIMEOUT)

## Code Fixes
- **k8s_clusters.py**: Expanded error status code mapping (add 400, 408, 429, 503); HPA returns 200 for update / 201 for create (was always 201); HPA validation requires at least one metric target
- **k8s_client.py**: Improved timeout detection (K8s API status=0, TimeoutError, OSError with "timed out")
- **client.ts**: Added `getK8sReconciliationHealth` and `updateK8sClusterNodeBlocklist` API methods

## Test plan
- [ ] Backend unit tests pass (`make test-backend`)
- [ ] Frontend lint/type check passes (`make lint-frontend`)
- [ ] Verify HPA create returns 201, update returns 200
- [ ] Verify HPA without metrics returns 400
- [ ] Verify K8s error mapping for 408/429/503 status codes
- [ ] Review documentation for accuracy