### PR TITLE
feat: operator integration enhancements (revision, container securityContext, affinity)

### DIFF
--- a/backend/src/aerospike_cluster_manager_api/models/k8s/cluster.py
+++ b/backend/src/aerospike_cluster_manager_api/models/k8s/cluster.py
@@ -153,6 +153,11 @@ class CreateK8sClusterRequest(BaseModel):
     init_containers: list[SidecarConfig] | None = Field(
         default=None, alias="initContainers", description="Init containers to add to the pod"
     )
+    aerospike_container_security_context: dict[str, Any] | None = Field(
+        default=None,
+        alias="aerospikeContainerSecurityContext",
+        description="SecurityContext for the Aerospike container",
+    )
 
     model_config = {"populate_by_name": True}
 
@@ -220,6 +225,11 @@ class UpdateK8sClusterRequest(BaseModel):
     sidecars: list[SidecarConfig] | None = Field(default=None, description="Sidecar containers to add to the pod")
     init_containers: list[SidecarConfig] | None = Field(
         default=None, alias="initContainers", description="Init containers to add to the pod"
+    )
+    aerospike_container_security_context: dict[str, Any] | None = Field(
+        default=None,
+        alias="aerospikeContainerSecurityContext",
+        description="SecurityContext for the Aerospike container",
     )
 
     model_config = {"populate_by_name": True}

--- a/backend/src/aerospike_cluster_manager_api/models/k8s/scheduling.py
+++ b/backend/src/aerospike_cluster_manager_api/models/k8s/scheduling.py
@@ -195,6 +195,10 @@ class RackConfig(BaseModel):
         alias="podSpec",
         description="Rack-specific pod scheduling override (affinity, tolerations, nodeSelector)",
     )
+    revision: str | None = Field(
+        default=None,
+        description="Revision string for triggering rolling restart of a specific rack",
+    )
 
 
 class RackAwareConfig(BaseModel):

--- a/backend/src/aerospike_cluster_manager_api/services/k8s_service.py
+++ b/backend/src/aerospike_cluster_manager_api/services/k8s_service.py
@@ -110,6 +110,8 @@ def build_rack_list(racks: list[RackConfig]) -> list[dict[str, Any]]:
             r["aerospikeConfig"] = rack.aerospike_config
         if rack.storage and rack.storage.volumes:
             r["storage"] = {"volumes": rack.storage.volumes}
+        if rack.revision is not None:
+            r["revision"] = rack.revision
         if rack.pod_spec:
             pod_spec: dict[str, Any] = {}
             if rack.pod_spec.affinity:
@@ -159,6 +161,8 @@ def build_pod_scheduling(sched: PodSchedulingConfig) -> dict[str, Any]:
             meta["annotations"] = sched.metadata.annotations
         if meta:
             result["metadata"] = meta
+    if sched.affinity:
+        result["affinity"] = sched.affinity
     if sched.priority_class_name:
         result["priorityClassName"] = sched.priority_class_name
     return result
@@ -732,6 +736,12 @@ def build_cr(req: CreateK8sClusterRequest) -> dict[str, Any]:
         pod_spec["initContainers"] = _build_sidecar_list(req.init_containers)
         cr["spec"]["podSpec"] = pod_spec
 
+    # Aerospike container security context
+    if req.aerospike_container_security_context is not None:
+        pod_spec = cr["spec"].get("podSpec", {})
+        pod_spec.setdefault("aerospikeContainer", {})["securityContext"] = req.aerospike_container_security_context
+        cr["spec"]["podSpec"] = pod_spec
+
     return cr
 
 
@@ -1124,6 +1134,10 @@ def build_update_patch(body: UpdateK8sClusterRequest) -> dict[str, Any]:
     if body.init_containers is not None:
         pod_spec = patch["spec"].get("podSpec", {})
         pod_spec["initContainers"] = _build_sidecar_list(body.init_containers)
+        patch["spec"]["podSpec"] = pod_spec
+    if body.aerospike_container_security_context is not None:
+        pod_spec = patch["spec"].get("podSpec", {})
+        pod_spec.setdefault("aerospikeContainer", {})["securityContext"] = body.aerospike_container_security_context
         patch["spec"]["podSpec"] = pod_spec
     return patch
 

--- a/backend/tests/test_k8s_service_builders.py
+++ b/backend/tests/test_k8s_service_builders.py
@@ -116,6 +116,7 @@ class TestBuildRackConfigDict:
             aerospike_config=None,
             storage=None,
             pod_spec=None,
+            revision=None,
         )
         rack_config = SimpleNamespace(
             racks=[rack],
@@ -138,6 +139,7 @@ class TestBuildRackConfigDict:
             aerospike_config=None,
             storage=None,
             pod_spec=None,
+            revision=None,
         )
         rack_config = SimpleNamespace(
             racks=[rack],
@@ -151,6 +153,28 @@ class TestBuildRackConfigDict:
         assert result["scaleDownBatchSize"] == 2
         assert result["maxIgnorablePods"] == 1
         assert result["rollingUpdateBatchSize"] == 3
+
+    def test_with_revision(self):
+        rack = SimpleNamespace(
+            id=1,
+            zone=None,
+            region=None,
+            rack_label=None,
+            node_name=None,
+            aerospike_config=None,
+            storage=None,
+            pod_spec=None,
+            revision="my-cluster-6b8f9c4d77",
+        )
+        rack_config = SimpleNamespace(
+            racks=[rack],
+            namespaces=None,
+            scale_down_batch_size=None,
+            max_ignorable_pods=None,
+            rolling_update_batch_size=None,
+        )
+        result = _build_rack_config_dict(rack_config)
+        assert result["racks"] == [{"id": 1, "revision": "my-cluster-6b8f9c4d77"}]
 
 
 class TestBuildServiceMetadataDict:

--- a/frontend/src/components/k8s/wizard/WizardAdvancedStep.tsx
+++ b/frontend/src/components/k8s/wizard/WizardAdvancedStep.tsx
@@ -12,6 +12,7 @@ import { WizardValidationPolicyStep } from "./advanced/validation-policy";
 import { WizardBandwidthStep } from "./advanced/bandwidth";
 import { WizardPodSecurityContextStep } from "./advanced/pod-security-context";
 import { WizardServiceMetadataStep } from "./advanced/service-metadata";
+import { ContainerSecurityContext } from "./advanced/container-security-context";
 import type { WizardAdvancedStepProps } from "./types";
 
 function WizardRackIDOverrideStep({
@@ -151,6 +152,10 @@ export function WizardAdvancedStep({
 
   const rackIDOverrideSummary = form.enableRackIDOverride ? "Enabled" : "Disabled";
 
+  const containerSecurityContextSummary = form.aerospikeContainerSecurityContext
+    ? "Configured"
+    : "Default";
+
   return (
     <div className="space-y-3">
       <p className="text-base-content/60 text-sm">
@@ -204,6 +209,13 @@ export function WizardAdvancedStep({
 
       <CollapsibleSection title="Rack ID Override" summary={rackIDOverrideSummary}>
         <WizardRackIDOverrideStep form={form} updateForm={updateForm} />
+      </CollapsibleSection>
+
+      <CollapsibleSection
+        title="Container Security Context"
+        summary={containerSecurityContextSummary}
+      >
+        <ContainerSecurityContext form={form} updateForm={updateForm} />
       </CollapsibleSection>
     </div>
   );

--- a/frontend/src/components/k8s/wizard/advanced/container-security-context.tsx
+++ b/frontend/src/components/k8s/wizard/advanced/container-security-context.tsx
@@ -1,0 +1,247 @@
+import { useState } from "react";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
+import type { CreateK8sClusterRequest } from "@/lib/api/types";
+
+interface ContainerSecurityContextProps {
+  form: CreateK8sClusterRequest;
+  updateForm: (updates: Partial<CreateK8sClusterRequest>) => void;
+}
+
+export function ContainerSecurityContext({ form, updateForm }: ContainerSecurityContextProps) {
+  const ctx = (form.aerospikeContainerSecurityContext ?? {}) as Record<string, unknown>;
+
+  const updateCtx = (updates: Record<string, unknown>) => {
+    const next = { ...ctx, ...updates };
+    // Remove keys with undefined values
+    const cleaned = Object.fromEntries(Object.entries(next).filter(([, v]) => v !== undefined));
+    updateForm({
+      aerospikeContainerSecurityContext: Object.keys(cleaned).length > 0 ? cleaned : undefined,
+    });
+  };
+
+  const [addCapInput, setAddCapInput] = useState("");
+  const [dropCapInput, setDropCapInput] = useState("");
+
+  const capabilities = (ctx.capabilities ?? {}) as {
+    add?: string[];
+    drop?: string[];
+  };
+
+  const updateCapabilities = (updates: { add?: string[]; drop?: string[] }) => {
+    const next = { ...capabilities, ...updates };
+    if (!next.add?.length && !next.drop?.length) {
+      updateCtx({ capabilities: undefined });
+    } else {
+      const cap: Record<string, string[]> = {};
+      if (next.add?.length) cap.add = next.add;
+      if (next.drop?.length) cap.drop = next.drop;
+      updateCtx({ capabilities: cap });
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <p className="text-muted-foreground text-sm">
+        Configure the security context for the Aerospike container. These settings control Linux
+        capabilities, user/group IDs, and privilege escalation.
+      </p>
+
+      {/* Run As User / Group */}
+      <div className="grid grid-cols-2 gap-3">
+        <div className="grid gap-1.5">
+          <Label htmlFor="sc-run-as-user" className="text-xs">
+            Run As User (UID)
+          </Label>
+          <Input
+            id="sc-run-as-user"
+            type="number"
+            value={ctx.runAsUser != null ? String(ctx.runAsUser) : ""}
+            onChange={(e) => {
+              const val = e.target.value.trim();
+              updateCtx({ runAsUser: val ? Number(val) : undefined });
+            }}
+            placeholder="e.g. 0"
+          />
+        </div>
+        <div className="grid gap-1.5">
+          <Label htmlFor="sc-run-as-group" className="text-xs">
+            Run As Group (GID)
+          </Label>
+          <Input
+            id="sc-run-as-group"
+            type="number"
+            value={ctx.runAsGroup != null ? String(ctx.runAsGroup) : ""}
+            onChange={(e) => {
+              const val = e.target.value.trim();
+              updateCtx({ runAsGroup: val ? Number(val) : undefined });
+            }}
+            placeholder="e.g. 0"
+          />
+        </div>
+      </div>
+
+      {/* Boolean flags */}
+      <div className="flex flex-wrap gap-4">
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="sc-privileged"
+            checked={(ctx.privileged as boolean) ?? false}
+            onCheckedChange={(checked) => {
+              updateCtx({ privileged: checked === true ? true : undefined });
+            }}
+          />
+          <Label htmlFor="sc-privileged" className="cursor-pointer text-xs">
+            Privileged
+          </Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="sc-read-only-root"
+            checked={(ctx.readOnlyRootFilesystem as boolean) ?? false}
+            onCheckedChange={(checked) => {
+              updateCtx({ readOnlyRootFilesystem: checked === true ? true : undefined });
+            }}
+          />
+          <Label htmlFor="sc-read-only-root" className="cursor-pointer text-xs">
+            Read-Only Root Filesystem
+          </Label>
+        </div>
+        <div className="flex items-center gap-2">
+          <Checkbox
+            id="sc-allow-priv-escalation"
+            checked={(ctx.allowPrivilegeEscalation as boolean) ?? false}
+            onCheckedChange={(checked) => {
+              updateCtx({ allowPrivilegeEscalation: checked === true ? true : undefined });
+            }}
+          />
+          <Label htmlFor="sc-allow-priv-escalation" className="cursor-pointer text-xs">
+            Allow Privilege Escalation
+          </Label>
+        </div>
+      </div>
+
+      {/* Capabilities */}
+      <div className="grid gap-3">
+        <Label className="text-sm font-semibold">Capabilities</Label>
+
+        {/* Add capabilities */}
+        <div className="grid gap-1.5">
+          <Label className="text-xs">Add</Label>
+          {(capabilities.add ?? []).length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {capabilities.add!.map((cap) => (
+                <span
+                  key={cap}
+                  className="bg-primary/10 text-primary inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs"
+                >
+                  {cap}
+                  <button
+                    type="button"
+                    onClick={() =>
+                      updateCapabilities({ add: capabilities.add!.filter((c) => c !== cap) })
+                    }
+                    className="hover:bg-primary/20 ml-0.5 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full"
+                  >
+                    &times;
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="flex gap-2">
+            <Input
+              value={addCapInput}
+              onChange={(e) => setAddCapInput(e.target.value.toUpperCase())}
+              placeholder="e.g. NET_ADMIN"
+              className="flex-1"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  const val = addCapInput.trim();
+                  if (val && !(capabilities.add ?? []).includes(val)) {
+                    updateCapabilities({ add: [...(capabilities.add ?? []), val] });
+                  }
+                  setAddCapInput("");
+                }
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => {
+                const val = addCapInput.trim();
+                if (val && !(capabilities.add ?? []).includes(val)) {
+                  updateCapabilities({ add: [...(capabilities.add ?? []), val] });
+                }
+                setAddCapInput("");
+              }}
+              disabled={!addCapInput.trim()}
+              className="bg-accent text-accent-foreground hover:bg-accent/80 rounded px-3 text-xs font-medium disabled:opacity-50"
+            >
+              Add
+            </button>
+          </div>
+        </div>
+
+        {/* Drop capabilities */}
+        <div className="grid gap-1.5">
+          <Label className="text-xs">Drop</Label>
+          {(capabilities.drop ?? []).length > 0 && (
+            <div className="flex flex-wrap gap-1">
+              {capabilities.drop!.map((cap) => (
+                <span
+                  key={cap}
+                  className="bg-destructive/10 text-destructive inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-xs"
+                >
+                  {cap}
+                  <button
+                    type="button"
+                    onClick={() =>
+                      updateCapabilities({ drop: capabilities.drop!.filter((c) => c !== cap) })
+                    }
+                    className="hover:bg-destructive/20 ml-0.5 inline-flex h-3.5 w-3.5 items-center justify-center rounded-full"
+                  >
+                    &times;
+                  </button>
+                </span>
+              ))}
+            </div>
+          )}
+          <div className="flex gap-2">
+            <Input
+              value={dropCapInput}
+              onChange={(e) => setDropCapInput(e.target.value.toUpperCase())}
+              placeholder="e.g. ALL"
+              className="flex-1"
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  const val = dropCapInput.trim();
+                  if (val && !(capabilities.drop ?? []).includes(val)) {
+                    updateCapabilities({ drop: [...(capabilities.drop ?? []), val] });
+                  }
+                  setDropCapInput("");
+                }
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => {
+                const val = dropCapInput.trim();
+                if (val && !(capabilities.drop ?? []).includes(val)) {
+                  updateCapabilities({ drop: [...(capabilities.drop ?? []), val] });
+                }
+                setDropCapInput("");
+              }}
+              disabled={!dropCapInput.trim()}
+              className="bg-accent text-accent-foreground hover:bg-accent/80 rounded px-3 text-xs font-medium disabled:opacity-50"
+            >
+              Add
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/api/types/k8s.ts
+++ b/frontend/src/lib/api/types/k8s.ts
@@ -501,6 +501,7 @@ export interface CreateK8sClusterRequest {
   podMetadata?: PodMetadataConfig;
   sidecars?: SidecarConfig[];
   initContainers?: SidecarConfig[];
+  aerospikeContainerSecurityContext?: Record<string, unknown>;
 }
 
 export interface UpdateK8sClusterRequest {
@@ -530,6 +531,7 @@ export interface UpdateK8sClusterRequest {
   podMetadata?: PodMetadataConfig;
   sidecars?: SidecarConfig[];
   initContainers?: SidecarConfig[];
+  aerospikeContainerSecurityContext?: Record<string, unknown>;
 }
 
 export interface ScaleK8sClusterRequest {


### PR DESCRIPTION
## Summary

- **RackConfig `revision` 필드 추가**: Operator CRD의 rack revision을 UI에서 설정할 수 있도록 모델, CR 빌더, wizard, edit dialog에 추가. Revision 변경 시 해당 랙의 모든 Pod가 순차적으로 재시작됩니다.
- **`aerospikeContainerSecurityContext` 지원**: Aerospike 컨테이너 전용 보안 설정 (runAsUser, runAsGroup, runAsNonRoot, readOnlyRootFilesystem, allowPrivilegeEscalation)을 Create/Update 모델 및 CR 빌더에 추가. Advanced wizard에 새로운 섹션 추가.
- **`affinity` 매핑 누락 수정**: `PodSchedulingConfig.affinity` 필드가 `build_pod_scheduling`에서 CR로 매핑되지 않던 버그 수정.
- **Docs 업데이트**: k8s-management.md에 새로운 기능 문서화.

## Changes

### Backend (Python)
- `models/k8s/scheduling.py`: `RackConfig`에 `revision` 필드 추가
- `models/k8s/cluster.py`: Create/Update request에 `aerospikeContainerSecurityContext` 필드 추가
- `services/k8s_service.py`: 
  - `build_rack_list()`에 revision 매핑 추가
  - `build_pod_scheduling()`에 affinity 매핑 추가
  - `build_cr()` / `build_update_patch()`에 aerospikeContainer.securityContext 매핑 추가

### Frontend (TypeScript/React)
- `lib/api/types/k8s.ts`: `RackConfig`, `CreateK8sClusterRequest`, `UpdateK8sClusterRequest` 타입 업데이트
- `wizard/WizardRackConfigStep.tsx`: Revision 입력 필드 추가
- `wizard/WizardAdvancedStep.tsx`: Aerospike Container Security Context 섹션 추가
- `wizard/advanced/container-security-context.tsx`: 새로운 컴포넌트
- `edit-sections/edit-rack-config-section.tsx`: Edit dialog에 revision 필드 추가

### Docs
- `docs/k8s-management.md`: Rack revision, container security context 문서화

## Test plan
- [ ] Backend: 기존 unit test 통과 확인
- [ ] Frontend: Wizard에서 rack revision 입력 후 클러스터 생성 테스트
- [ ] Frontend: Advanced 섹션에서 container security context 설정 테스트
- [ ] Edit dialog에서 rack revision 수정 테스트
- [ ] API: affinity가 포함된 pod scheduling으로 클러스터 생성 시 CR에 affinity 필드 반영 확인