### PR TITLE
fix(frontend): cluster card color, layout, and text readability

### DIFF
--- a/frontend/src/app/browser/[connId]/[ns]/[set]/page.tsx
+++ b/frontend/src/app/browser/[connId]/[ns]/[set]/page.tsx
@@ -1004,7 +1004,7 @@ asyncio.run(main())`;
                 <div className="flex flex-col items-center justify-center py-20 text-center">
                   <Database className="text-muted-foreground/30 mb-4 h-16 w-16" />
                   <h3 className="text-base-content/70 mb-2 text-lg font-semibold">No Results</h3>
-                  <p className="text-base-content/50 max-w-md text-sm">
+                  <p className="text-base-content/70 max-w-md text-sm">
                     No records match the current filters. Try adjusting or clearing the filters.
                   </p>
                 </div>
@@ -1014,7 +1014,7 @@ asyncio.run(main())`;
                   <h3 className="text-base-content/70 mb-2 text-lg font-semibold">
                     No Records Found
                   </h3>
-                  <p className="text-base-content/50 mb-6 max-w-md text-sm">
+                  <p className="text-base-content/70 mb-6 max-w-md text-sm">
                     This set appears to be empty. Create a new record to get started.
                   </p>
                   <button

--- a/frontend/src/app/browser/[connId]/[ns]/[set]/page.tsx
+++ b/frontend/src/app/browser/[connId]/[ns]/[set]/page.tsx
@@ -892,14 +892,14 @@ asyncio.run(main())`;
               >
                 Namespaces
               </button>
-              <span className="text-muted-foreground/30 mx-1 shrink-0 sm:mx-1.5">›</span>
+              <span className="text-muted-foreground/50 mx-1 shrink-0 sm:mx-1.5">›</span>
               <button
                 onClick={() => router.push(`/browser/${connId}`)}
                 className="text-muted-foreground hover:text-base-content max-w-[60px] truncate transition-colors sm:max-w-none"
               >
                 {decodedNs}
               </button>
-              <span className="text-muted-foreground/30 mx-1 shrink-0 sm:mx-1.5">›</span>
+              <span className="text-muted-foreground/50 mx-1 shrink-0 sm:mx-1.5">›</span>
               <span className="text-primary max-w-[80px] truncate font-medium sm:max-w-none">
                 {decodedSet}
               </span>
@@ -1002,19 +1002,19 @@ asyncio.run(main())`;
             emptyState={
               filterStore.conditions.length > 0 ? (
                 <div className="flex flex-col items-center justify-center py-20 text-center">
-                  <Database className="text-muted-foreground/30 mb-4 h-16 w-16" />
+                  <Database className="text-muted-foreground/50 mb-4 h-16 w-16" />
                   <h3 className="text-base-content/70 mb-2 text-lg font-semibold">No Results</h3>
-                  <p className="text-base-content/70 max-w-md text-sm">
+                  <p className="text-base-content/75 max-w-md text-sm">
                     No records match the current filters. Try adjusting or clearing the filters.
                   </p>
                 </div>
               ) : (
                 <div className="flex flex-col items-center justify-center py-20 text-center">
-                  <Database className="text-muted-foreground/30 mb-4 h-16 w-16" />
+                  <Database className="text-muted-foreground/50 mb-4 h-16 w-16" />
                   <h3 className="text-base-content/70 mb-2 text-lg font-semibold">
                     No Records Found
                   </h3>
-                  <p className="text-base-content/70 mb-6 max-w-md text-sm">
+                  <p className="text-base-content/75 mb-6 max-w-md text-sm">
                     This set appears to be empty. Create a new record to get started.
                   </p>
                   <button

--- a/frontend/src/components/browser/bin-row.tsx
+++ b/frontend/src/components/browser/bin-row.tsx
@@ -81,9 +81,9 @@ function BinTypeSelect({
       >
         <span className="truncate font-mono">{value}</span>
         {open ? (
-          <ChevronUp className="text-base-content/30 ml-1 h-3 w-3 shrink-0" />
+          <ChevronUp className="text-base-content/60 ml-1 h-3 w-3 shrink-0" />
         ) : (
-          <ChevronDown className="text-base-content/30 ml-1 h-3 w-3 shrink-0" />
+          <ChevronDown className="text-base-content/60 ml-1 h-3 w-3 shrink-0" />
         )}
       </button>
       {open && (

--- a/frontend/src/components/browser/bin-row.tsx
+++ b/frontend/src/components/browser/bin-row.tsx
@@ -81,9 +81,9 @@ function BinTypeSelect({
       >
         <span className="truncate font-mono">{value}</span>
         {open ? (
-          <ChevronUp className="text-base-content/60 ml-1 h-3 w-3 shrink-0" />
+          <ChevronUp className="text-base-content/50 ml-1 h-3 w-3 shrink-0" />
         ) : (
-          <ChevronDown className="text-base-content/60 ml-1 h-3 w-3 shrink-0" />
+          <ChevronDown className="text-base-content/50 ml-1 h-3 w-3 shrink-0" />
         )}
       </button>
       {open && (

--- a/frontend/src/components/browser/record-detail-page.tsx
+++ b/frontend/src/components/browser/record-detail-page.tsx
@@ -267,11 +267,11 @@ export function RecordDetailPage({
     () => (
       <span className="font-mono text-xs">
         {namespace}
-        <span className="text-muted-foreground/30 mx-1">.</span>
+        <span className="text-muted-foreground/50 mx-1">.</span>
         {displaySetName}
         {!createMode && editorPK && (
           <>
-            <span className="text-muted-foreground/30 mx-1">/</span>
+            <span className="text-muted-foreground/50 mx-1">/</span>
             <span className="text-primary">{editorPK}</span>
           </>
         )}

--- a/frontend/src/components/browser/record-editor-dialog.tsx
+++ b/frontend/src/components/browser/record-editor-dialog.tsx
@@ -169,7 +169,7 @@ export function RecordEditorDialog({
           </DialogTitle>
           <DialogDescription className="text-muted-foreground/60 font-mono text-xs">
             {namespace}
-            <span className="text-muted-foreground/30 mx-1">.</span>
+            <span className="text-muted-foreground/50 mx-1">.</span>
             {set}
           </DialogDescription>
         </DialogHeader>

--- a/frontend/src/components/browser/record-metadata-grid.tsx
+++ b/frontend/src/components/browser/record-metadata-grid.tsx
@@ -26,7 +26,7 @@ function MetaLabel({
   label: string;
 }) {
   return (
-    <div className="text-base-content/70 flex items-center gap-1.5 text-[11px]">
+    <div className="text-base-content/75 flex items-center gap-1.5 text-[11px]">
       <Icon className="h-3 w-3 shrink-0" />
       <span className="font-mono tracking-wider">{label}</span>
     </div>
@@ -52,7 +52,7 @@ export function RecordMetadataGrid({
 
   return (
     <section>
-      <h4 className="text-base-content/65 mb-3 flex items-center gap-2 font-mono text-[10px] font-semibold tracking-[0.12em] uppercase">
+      <h4 className="text-base-content/60 mb-3 flex items-center gap-2 font-mono text-[10px] font-semibold tracking-[0.12em] uppercase">
         Record Info
         <span className="bg-base-300 h-px flex-1" />
       </h4>
@@ -96,7 +96,7 @@ export function RecordMetadataGrid({
             <span className="ml-auto">
               {formatTTLHuman(displayTTL)}
               {displayTTL > 0 && displayTTL !== -1 && displayTTL !== NEVER_EXPIRE_TTL && (
-                <span className="text-base-content/65 ml-1 text-[11px]">({displayTTL}s)</span>
+                <span className="text-base-content/60 ml-1 text-[11px]">({displayTTL}s)</span>
               )}
             </span>
           ) : (
@@ -131,7 +131,7 @@ export function RecordMetadataGrid({
         {mode === "view" && record?.key.digest && (
           <div className="flex items-center gap-3">
             <MetaLabel icon={Hash} label="Digest" />
-            <span className="text-base-content/70 ml-auto text-xs break-all">
+            <span className="text-base-content/75 ml-auto text-xs break-all">
               {record.key.digest}
             </span>
           </div>
@@ -141,7 +141,7 @@ export function RecordMetadataGrid({
         {mode === "view" && record?.meta.lastUpdateMs && (
           <div className="flex items-center gap-3">
             <MetaLabel icon={CalendarClock} label="Updated" />
-            <span className="text-base-content/70 ml-auto text-[12px]">
+            <span className="text-base-content/75 ml-auto text-[12px]">
               {new Date(record.meta.lastUpdateMs).toISOString()}
             </span>
           </div>

--- a/frontend/src/components/browser/record-metadata-grid.tsx
+++ b/frontend/src/components/browser/record-metadata-grid.tsx
@@ -26,7 +26,7 @@ function MetaLabel({
   label: string;
 }) {
   return (
-    <div className="text-base-content/50 flex items-center gap-1.5 text-[11px]">
+    <div className="text-base-content/70 flex items-center gap-1.5 text-[11px]">
       <Icon className="h-3 w-3 shrink-0" />
       <span className="font-mono tracking-wider">{label}</span>
     </div>
@@ -52,7 +52,7 @@ export function RecordMetadataGrid({
 
   return (
     <section>
-      <h4 className="text-base-content/40 mb-3 flex items-center gap-2 font-mono text-[10px] font-semibold tracking-[0.12em] uppercase">
+      <h4 className="text-base-content/65 mb-3 flex items-center gap-2 font-mono text-[10px] font-semibold tracking-[0.12em] uppercase">
         Record Info
         <span className="bg-base-300 h-px flex-1" />
       </h4>
@@ -96,7 +96,7 @@ export function RecordMetadataGrid({
             <span className="ml-auto">
               {formatTTLHuman(displayTTL)}
               {displayTTL > 0 && displayTTL !== -1 && displayTTL !== NEVER_EXPIRE_TTL && (
-                <span className="text-base-content/40 ml-1 text-[11px]">({displayTTL}s)</span>
+                <span className="text-base-content/65 ml-1 text-[11px]">({displayTTL}s)</span>
               )}
             </span>
           ) : (
@@ -131,7 +131,7 @@ export function RecordMetadataGrid({
         {mode === "view" && record?.key.digest && (
           <div className="flex items-center gap-3">
             <MetaLabel icon={Hash} label="Digest" />
-            <span className="text-base-content/50 ml-auto text-xs break-all">
+            <span className="text-base-content/70 ml-auto text-xs break-all">
               {record.key.digest}
             </span>
           </div>
@@ -141,7 +141,7 @@ export function RecordMetadataGrid({
         {mode === "view" && record?.meta.lastUpdateMs && (
           <div className="flex items-center gap-3">
             <MetaLabel icon={CalendarClock} label="Updated" />
-            <span className="text-base-content/50 ml-auto text-[12px]">
+            <span className="text-base-content/70 ml-auto text-[12px]">
               {new Date(record.meta.lastUpdateMs).toISOString()}
             </span>
           </div>

--- a/frontend/src/components/browser/record-view-dialog.tsx
+++ b/frontend/src/components/browser/record-view-dialog.tsx
@@ -33,7 +33,7 @@ export function RecordDetailSections({ record }: { record: AerospikeRecord }) {
       <RecordMetadataGrid record={record} mode="view" />
 
       <section>
-        <h4 className="text-base-content/65 mb-2.5 flex items-center gap-2 font-mono text-[10px] font-semibold tracking-[0.12em] uppercase">
+        <h4 className="text-base-content/60 mb-2.5 flex items-center gap-2 font-mono text-[10px] font-semibold tracking-[0.12em] uppercase">
           Bins
           <span className="text-base-content/25">({binEntries.length})</span>
           <span className="bg-base-300 h-px flex-1" />
@@ -41,7 +41,7 @@ export function RecordDetailSections({ record }: { record: AerospikeRecord }) {
         <div className="divide-base-300/30 divide-y overflow-hidden rounded-lg border">
           {/* Header row */}
           <div
-            className="bin-row-grid bg-base-200/50 text-base-content/65 font-mono text-[11px] tracking-wider uppercase"
+            className="bin-row-grid bg-base-200/50 text-base-content/60 font-mono text-[11px] tracking-wider uppercase"
             data-header
           >
             <span className="text-right">#</span>

--- a/frontend/src/components/browser/record-view-dialog.tsx
+++ b/frontend/src/components/browser/record-view-dialog.tsx
@@ -33,7 +33,7 @@ export function RecordDetailSections({ record }: { record: AerospikeRecord }) {
       <RecordMetadataGrid record={record} mode="view" />
 
       <section>
-        <h4 className="text-base-content/40 mb-2.5 flex items-center gap-2 font-mono text-[10px] font-semibold tracking-[0.12em] uppercase">
+        <h4 className="text-base-content/65 mb-2.5 flex items-center gap-2 font-mono text-[10px] font-semibold tracking-[0.12em] uppercase">
           Bins
           <span className="text-base-content/25">({binEntries.length})</span>
           <span className="bg-base-300 h-px flex-1" />
@@ -41,7 +41,7 @@ export function RecordDetailSections({ record }: { record: AerospikeRecord }) {
         <div className="divide-base-300/30 divide-y overflow-hidden rounded-lg border">
           {/* Header row */}
           <div
-            className="bin-row-grid bg-base-200/50 text-base-content/40 font-mono text-[11px] tracking-wider uppercase"
+            className="bin-row-grid bg-base-200/50 text-base-content/65 font-mono text-[11px] tracking-wider uppercase"
             data-header
           >
             <span className="text-right">#</span>

--- a/frontend/src/components/cluster-list/cluster-card-list.tsx
+++ b/frontend/src/components/cluster-list/cluster-card-list.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuSeparator,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
+import { PRESET_COLORS } from "@/lib/constants";
 import { EmptyState } from "@/components/common/empty-state";
 import type { HealthErrorType, UnifiedClusterRow } from "@/lib/api/types";
 
@@ -53,6 +54,9 @@ function ClusterCard({
 }) {
   const isConnected = row.status === "connected";
   const isChecking = row.status === "checking";
+  const safeColor = (PRESET_COLORS as readonly string[]).includes(row.color)
+    ? row.color
+    : PRESET_COLORS[0];
 
   const diskPct =
     row.diskTotal && row.diskTotal > 0
@@ -81,13 +85,10 @@ function ClusterCard({
     >
       {/* Left color bar — uses per-cluster preset color */}
       <div
-        className={cn(
-          "w-1 shrink-0",
-          !isConnected && "from-error to-error/70 bg-gradient-to-b",
-        )}
+        className={cn("w-1 shrink-0", !isConnected && "from-error to-error/70 bg-gradient-to-b")}
         style={
           isConnected
-            ? { background: `linear-gradient(to bottom, ${row.color}, ${row.color}B3)` }
+            ? { background: `linear-gradient(to bottom, ${safeColor}, ${safeColor}B3)` }
             : undefined
         }
       />
@@ -109,9 +110,11 @@ function ClusterCard({
               />
             </div>
             <div className="flex flex-col gap-0.5">
-              <span className="text-base-content/70 truncate font-mono text-[11px]">{row.hosts}</span>
+              <span className="text-base-content/60 truncate font-mono text-[11px]">
+                {row.hosts}
+              </span>
               {row.build && (
-                <span className="text-base-content/60 text-[11px]">
+                <span className="text-base-content/50 text-[11px]">
                   {row.edition ?? "CE"} {row.build}
                 </span>
               )}
@@ -127,7 +130,7 @@ function ClusterCard({
           {row.description && (
             <>
               <div className="bg-base-300/60 hidden h-12 w-px sm:block" />
-              <span className="text-base-content/70 hidden min-w-0 flex-1 truncate text-sm sm:block">
+              <span className="text-base-content/75 hidden min-w-0 flex-1 truncate text-sm sm:block">
                 {row.description}
               </span>
             </>

--- a/frontend/src/components/cluster-list/cluster-card-list.tsx
+++ b/frontend/src/components/cluster-list/cluster-card-list.tsx
@@ -34,7 +34,7 @@ const ERROR_TYPE_LABELS: Record<HealthErrorType, string> = {
 function MetricCell({ label, value }: { label: string; value: string }) {
   return (
     <div className="flex flex-col gap-0.5">
-      <span className="text-base-content/40 text-[10px] font-medium tracking-wider">{label}</span>
+      <span className="text-base-content/60 text-[10px] font-medium tracking-wider">{label}</span>
       <span className="text-base-content font-mono text-lg font-bold">{value}</span>
     </div>
   );
@@ -79,46 +79,59 @@ function ClusterCard({
         isConnected ? "border-base-300 hover:border-primary/30" : "border-error/20 opacity-75",
       )}
     >
-      {/* Left color bar */}
+      {/* Left color bar — uses per-cluster preset color */}
       <div
         className={cn(
           "w-1 shrink-0",
-          isConnected
-            ? "from-success to-success/70 bg-gradient-to-b"
-            : "from-error to-error/70 bg-gradient-to-b",
+          !isConnected && "from-error to-error/70 bg-gradient-to-b",
         )}
+        style={
+          isConnected
+            ? { background: `linear-gradient(to bottom, ${row.color}, ${row.color}B3)` }
+            : undefined
+        }
       />
 
       <div className="flex flex-1 items-center gap-6 px-6 py-5 sm:gap-8">
-        {/* Identity */}
-        <div className="flex min-w-0 flex-col gap-1.5 sm:w-48">
-          <div className="flex items-center gap-2.5">
-            <span className="text-base-content truncate text-base font-bold">{row.name}</span>
-            <span
-              className={cn(
-                "h-2 w-2 shrink-0 rounded-full",
-                isChecking && "bg-muted-foreground animate-pulse",
-                isConnected && "bg-success shadow-success/15 shadow-[0_0_0_3px]",
-                !isConnected && !isChecking && "bg-error shadow-error/15 shadow-[0_0_0_3px]",
+        {/* Identity + Description row */}
+        <div className="flex min-w-0 flex-1 items-center gap-6 sm:gap-8">
+          {/* Name & meta */}
+          <div className="flex min-w-0 flex-col gap-1.5 sm:w-48 sm:shrink-0">
+            <div className="flex items-center gap-2.5">
+              <span className="text-base-content truncate text-base font-bold">{row.name}</span>
+              <span
+                className={cn(
+                  "h-2 w-2 shrink-0 rounded-full",
+                  isChecking && "bg-muted-foreground animate-pulse",
+                  isConnected && "bg-success shadow-success/15 shadow-[0_0_0_3px]",
+                  !isConnected && !isChecking && "bg-error shadow-error/15 shadow-[0_0_0_3px]",
+                )}
+              />
+            </div>
+            <div className="flex flex-col gap-0.5">
+              <span className="text-base-content/70 truncate font-mono text-[11px]">{row.hosts}</span>
+              {row.build && (
+                <span className="text-base-content/60 text-[11px]">
+                  {row.edition ?? "CE"} {row.build}
+                </span>
               )}
-            />
+              {!isConnected && !isChecking && (
+                <span className="text-error text-[11px] font-medium">
+                  {row.errorType ? ERROR_TYPE_LABELS[row.errorType] : "Unavailable"}
+                </span>
+              )}
+            </div>
           </div>
-          <div className="flex flex-col gap-0.5">
-            <span className="text-base-content/60 truncate font-mono text-[11px]">{row.hosts}</span>
-            {row.description && (
-              <span className="text-base-content/50 truncate text-[11px]">{row.description}</span>
-            )}
-            {row.build && (
-              <span className="text-base-content/40 text-[11px]">
-                {row.edition ?? "CE"} {row.build}
+
+          {/* Description — shown next to identity when available */}
+          {row.description && (
+            <>
+              <div className="bg-base-300/60 hidden h-12 w-px sm:block" />
+              <span className="text-base-content/70 hidden min-w-0 flex-1 truncate text-sm sm:block">
+                {row.description}
               </span>
-            )}
-            {!isConnected && !isChecking && (
-              <span className="text-error text-[11px] font-medium">
-                {row.errorType ? ERROR_TYPE_LABELS[row.errorType] : "Unavailable"}
-              </span>
-            )}
-          </div>
+            </>
+          )}
         </div>
 
         {/* Divider */}
@@ -126,13 +139,13 @@ function ClusterCard({
 
         {/* Metrics */}
         {isConnected ? (
-          <div className="hidden flex-1 gap-7 sm:flex">
+          <div className="hidden shrink-0 gap-7 sm:flex">
             <MetricCell label="NODES" value={String(row.nodeCount)} />
             <MetricCell label="DISK" value={diskPct} />
             <MetricCell label="MEMORY" value={memPct} />
           </div>
         ) : (
-          <div className="hidden flex-1 gap-7 sm:flex">
+          <div className="hidden shrink-0 gap-7 sm:flex">
             <MetricCell label="NODES" value="—" />
             <MetricCell label="DISK" value="—" />
             <MetricCell label="MEMORY" value="—" />

--- a/frontend/src/components/cluster/unified-overview.tsx
+++ b/frontend/src/components/cluster/unified-overview.tsx
@@ -40,14 +40,14 @@ function MetricCard({
   return (
     <div className="border-base-300 bg-base-100 flex flex-col gap-2 rounded-xl border p-4 shadow-sm">
       <div className="flex items-center justify-between">
-        <span className="text-base-content/40 text-[11px] font-medium">{label}</span>
+        <span className="text-base-content/65 text-[11px] font-medium">{label}</span>
         <div className={cn("flex h-7 w-7 items-center justify-center rounded-lg", iconBg)}>
           <Icon className={cn("h-3.5 w-3.5", iconColor)} />
         </div>
       </div>
       <div className="flex items-baseline gap-1.5">
         <span className="text-base-content text-2xl font-extrabold">{value}</span>
-        {subtitle && <span className="text-base-content/40 text-xs font-medium">{subtitle}</span>}
+        {subtitle && <span className="text-base-content/65 text-xs font-medium">{subtitle}</span>}
       </div>
     </div>
   );
@@ -87,7 +87,7 @@ function NamespaceRow({
                 label={ns.stopWrites ? "Stop Writes" : ns.hwmBreached ? "HWM Breached" : "Healthy"}
               />
             </div>
-            <span className="text-base-content/40 text-[10px]">
+            <span className="text-base-content/65 text-[10px]">
               {ns.sets.length} set{ns.sets.length !== 1 ? "s" : ""} · RF {ns.replicationFactor}
             </span>
           </div>
@@ -96,7 +96,7 @@ function NamespaceRow({
         {/* Metrics — 2-col grid on mobile, inline on desktop */}
         <div className="grid grid-cols-2 gap-x-4 gap-y-1 pl-4 sm:flex sm:flex-1 sm:gap-5 sm:pl-0">
           <div className="flex flex-col gap-0.5">
-            <span className="text-base-content/30 text-[9px] font-medium tracking-wider">
+            <span className="text-base-content/60 text-[9px] font-medium tracking-wider">
               OBJECTS
             </span>
             <span className="text-base-content font-mono text-xs font-semibold">
@@ -104,7 +104,7 @@ function NamespaceRow({
             </span>
           </div>
           <div className="flex flex-col gap-0.5">
-            <span className="text-base-content/30 text-[9px] font-medium tracking-wider">
+            <span className="text-base-content/60 text-[9px] font-medium tracking-wider">
               MEMORY
             </span>
             <span className="text-base-content font-mono text-xs font-semibold">
@@ -112,7 +112,7 @@ function NamespaceRow({
             </span>
           </div>
           <div className="flex flex-col gap-0.5">
-            <span className="text-base-content/30 text-[9px] font-medium tracking-wider">HWM</span>
+            <span className="text-base-content/60 text-[9px] font-medium tracking-wider">HWM</span>
             <span
               className={cn(
                 "font-mono text-xs font-semibold",
@@ -123,8 +123,8 @@ function NamespaceRow({
             </span>
           </div>
           <div className="flex flex-col gap-0.5">
-            <span className="text-base-content/30 text-[9px] font-medium tracking-wider">TTL</span>
-            <span className="text-base-content/50 font-mono text-xs font-semibold">
+            <span className="text-base-content/60 text-[9px] font-medium tracking-wider">TTL</span>
+            <span className="text-base-content/70 font-mono text-xs font-semibold">
               {ns.defaultTtl === 0 ? "None" : `${ns.defaultTtl}s`}
             </span>
           </div>
@@ -138,7 +138,7 @@ function NamespaceRow({
               style={{ width: `${Math.max(memPct, 1)}%` }}
             />
           </div>
-          <span className="text-base-content/30 text-right text-[9px]">{memPct}%</span>
+          <span className="text-base-content/60 text-right text-[9px]">{memPct}%</span>
         </div>
       </div>
 
@@ -151,7 +151,7 @@ function NamespaceRow({
             className="border-base-300 bg-base-100 hover:border-primary/30 hover:bg-primary/5 group flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs transition-colors"
           >
             <span className="text-base-content font-medium">{set.name}</span>
-            <span className="text-base-content/30 bg-base-200 rounded px-1.5 py-0.5 font-mono text-[10px]">
+            <span className="text-base-content/60 bg-base-200 rounded px-1.5 py-0.5 font-mono text-[10px]">
               {formatNumber(set.objects)}
             </span>
             <ChevronRight className="text-base-content/20 group-hover:text-primary h-3 w-3 transition-colors" />
@@ -226,7 +226,7 @@ export function UnifiedOverview({
           <div className="flex items-center justify-between">
             <span className="text-base-content text-sm font-bold">Namespaces</span>
             <div className="flex items-center gap-2">
-              <span className="text-base-content/30 text-xs">
+              <span className="text-base-content/60 text-xs">
                 {cluster.namespaces.length} / 2 max (CE)
               </span>
               {onCreateSampleData && (
@@ -285,7 +285,7 @@ export function UnifiedOverview({
                     </span>
                   </div>
                 </div>
-                <span className="text-base-content/30 truncate font-mono text-[9px]">
+                <span className="text-base-content/60 truncate font-mono text-[9px]">
                   {node.address}:{node.port}
                 </span>
               </div>

--- a/frontend/src/components/cluster/unified-overview.tsx
+++ b/frontend/src/components/cluster/unified-overview.tsx
@@ -40,14 +40,14 @@ function MetricCard({
   return (
     <div className="border-base-300 bg-base-100 flex flex-col gap-2 rounded-xl border p-4 shadow-sm">
       <div className="flex items-center justify-between">
-        <span className="text-base-content/65 text-[11px] font-medium">{label}</span>
+        <span className="text-base-content/60 text-[11px] font-medium">{label}</span>
         <div className={cn("flex h-7 w-7 items-center justify-center rounded-lg", iconBg)}>
           <Icon className={cn("h-3.5 w-3.5", iconColor)} />
         </div>
       </div>
       <div className="flex items-baseline gap-1.5">
         <span className="text-base-content text-2xl font-extrabold">{value}</span>
-        {subtitle && <span className="text-base-content/65 text-xs font-medium">{subtitle}</span>}
+        {subtitle && <span className="text-base-content/60 text-xs font-medium">{subtitle}</span>}
       </div>
     </div>
   );
@@ -87,7 +87,7 @@ function NamespaceRow({
                 label={ns.stopWrites ? "Stop Writes" : ns.hwmBreached ? "HWM Breached" : "Healthy"}
               />
             </div>
-            <span className="text-base-content/65 text-[10px]">
+            <span className="text-base-content/60 text-[10px]">
               {ns.sets.length} set{ns.sets.length !== 1 ? "s" : ""} · RF {ns.replicationFactor}
             </span>
           </div>
@@ -96,7 +96,7 @@ function NamespaceRow({
         {/* Metrics — 2-col grid on mobile, inline on desktop */}
         <div className="grid grid-cols-2 gap-x-4 gap-y-1 pl-4 sm:flex sm:flex-1 sm:gap-5 sm:pl-0">
           <div className="flex flex-col gap-0.5">
-            <span className="text-base-content/60 text-[9px] font-medium tracking-wider">
+            <span className="text-base-content/50 text-[9px] font-medium tracking-wider">
               OBJECTS
             </span>
             <span className="text-base-content font-mono text-xs font-semibold">
@@ -104,7 +104,7 @@ function NamespaceRow({
             </span>
           </div>
           <div className="flex flex-col gap-0.5">
-            <span className="text-base-content/60 text-[9px] font-medium tracking-wider">
+            <span className="text-base-content/50 text-[9px] font-medium tracking-wider">
               MEMORY
             </span>
             <span className="text-base-content font-mono text-xs font-semibold">
@@ -112,7 +112,7 @@ function NamespaceRow({
             </span>
           </div>
           <div className="flex flex-col gap-0.5">
-            <span className="text-base-content/60 text-[9px] font-medium tracking-wider">HWM</span>
+            <span className="text-base-content/50 text-[9px] font-medium tracking-wider">HWM</span>
             <span
               className={cn(
                 "font-mono text-xs font-semibold",
@@ -123,8 +123,8 @@ function NamespaceRow({
             </span>
           </div>
           <div className="flex flex-col gap-0.5">
-            <span className="text-base-content/60 text-[9px] font-medium tracking-wider">TTL</span>
-            <span className="text-base-content/70 font-mono text-xs font-semibold">
+            <span className="text-base-content/50 text-[9px] font-medium tracking-wider">TTL</span>
+            <span className="text-base-content/75 font-mono text-xs font-semibold">
               {ns.defaultTtl === 0 ? "None" : `${ns.defaultTtl}s`}
             </span>
           </div>
@@ -138,7 +138,7 @@ function NamespaceRow({
               style={{ width: `${Math.max(memPct, 1)}%` }}
             />
           </div>
-          <span className="text-base-content/60 text-right text-[9px]">{memPct}%</span>
+          <span className="text-base-content/50 text-right text-[9px]">{memPct}%</span>
         </div>
       </div>
 
@@ -151,7 +151,7 @@ function NamespaceRow({
             className="border-base-300 bg-base-100 hover:border-primary/30 hover:bg-primary/5 group flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs transition-colors"
           >
             <span className="text-base-content font-medium">{set.name}</span>
-            <span className="text-base-content/60 bg-base-200 rounded px-1.5 py-0.5 font-mono text-[10px]">
+            <span className="text-base-content/50 bg-base-200 rounded px-1.5 py-0.5 font-mono text-[10px]">
               {formatNumber(set.objects)}
             </span>
             <ChevronRight className="text-base-content/20 group-hover:text-primary h-3 w-3 transition-colors" />
@@ -226,7 +226,7 @@ export function UnifiedOverview({
           <div className="flex items-center justify-between">
             <span className="text-base-content text-sm font-bold">Namespaces</span>
             <div className="flex items-center gap-2">
-              <span className="text-base-content/60 text-xs">
+              <span className="text-base-content/50 text-xs">
                 {cluster.namespaces.length} / 2 max (CE)
               </span>
               {onCreateSampleData && (
@@ -285,7 +285,7 @@ export function UnifiedOverview({
                     </span>
                   </div>
                 </div>
-                <span className="text-base-content/60 truncate font-mono text-[9px]">
+                <span className="text-base-content/50 truncate font-mono text-[9px]">
                   {node.address}:{node.port}
                 </span>
               </div>

--- a/frontend/src/components/k8s/edit-sections/edit-node-blocklist-section.tsx
+++ b/frontend/src/components/k8s/edit-sections/edit-node-blocklist-section.tsx
@@ -90,7 +90,7 @@ export function EditNodeBlocklistSection({
               disabled={disabled}
             />
             <span className="flex-1 font-mono">{node.name}</span>
-            {node.zone && <span className="text-base-content/40">{node.zone}</span>}
+            {node.zone && <span className="text-base-content/65">{node.zone}</span>}
             <span
               className={`inline-block h-2 w-2 rounded-full ${node.ready ? "bg-success" : "bg-error"}`}
               title={node.ready ? "Ready" : "Not Ready"}

--- a/frontend/src/components/k8s/edit-sections/edit-node-blocklist-section.tsx
+++ b/frontend/src/components/k8s/edit-sections/edit-node-blocklist-section.tsx
@@ -90,7 +90,7 @@ export function EditNodeBlocklistSection({
               disabled={disabled}
             />
             <span className="flex-1 font-mono">{node.name}</span>
-            {node.zone && <span className="text-base-content/65">{node.zone}</span>}
+            {node.zone && <span className="text-base-content/60">{node.zone}</span>}
             <span
               className={`inline-block h-2 w-2 rounded-full ${node.ready ? "bg-success" : "bg-error"}`}
               title={node.ready ? "Ready" : "Not Ready"}

--- a/frontend/src/components/k8s/k8s-config-drift-card.tsx
+++ b/frontend/src/components/k8s/k8s-config-drift-card.tsx
@@ -186,7 +186,7 @@ function SideBySideDiff({
                   line.type === "removed" && "bg-error/10",
                 )}
               >
-                <td className="text-base-content/30 w-8 border-r px-1 text-right select-none">
+                <td className="text-base-content/60 w-8 border-r px-1 text-right select-none">
                   {line.leftNum ?? ""}
                 </td>
                 <td
@@ -198,7 +198,7 @@ function SideBySideDiff({
                 >
                   {line.left}
                 </td>
-                <td className="text-base-content/30 w-8 border-x px-1 text-right select-none">
+                <td className="text-base-content/60 w-8 border-x px-1 text-right select-none">
                   {line.rightNum ?? ""}
                 </td>
                 <td

--- a/frontend/src/components/k8s/k8s-config-drift-card.tsx
+++ b/frontend/src/components/k8s/k8s-config-drift-card.tsx
@@ -186,7 +186,7 @@ function SideBySideDiff({
                   line.type === "removed" && "bg-error/10",
                 )}
               >
-                <td className="text-base-content/60 w-8 border-r px-1 text-right select-none">
+                <td className="text-base-content/50 w-8 border-r px-1 text-right select-none">
                   {line.leftNum ?? ""}
                 </td>
                 <td
@@ -198,7 +198,7 @@ function SideBySideDiff({
                 >
                   {line.left}
                 </td>
-                <td className="text-base-content/60 w-8 border-x px-1 text-right select-none">
+                <td className="text-base-content/50 w-8 border-x px-1 text-right select-none">
                   {line.rightNum ?? ""}
                 </td>
                 <td
@@ -252,7 +252,7 @@ export function K8sConfigDriftCard({
     return (
       <Card className={className}>
         <CardHeader className="pb-2">
-          <CardTitle className="text-base-content/60 text-sm font-normal">Config Status</CardTitle>
+          <CardTitle className="text-base-content/50 text-sm font-normal">Config Status</CardTitle>
         </CardHeader>
         <CardContent>
           <div className="bg-base-200 h-8 animate-pulse rounded" />
@@ -276,7 +276,7 @@ export function K8sConfigDriftCard({
   return (
     <Card className={className}>
       <CardHeader className="pb-2">
-        <CardTitle className="text-base-content/60 flex items-center gap-2 text-sm font-normal">
+        <CardTitle className="text-base-content/50 flex items-center gap-2 text-sm font-normal">
           <FileCode className="h-4 w-4" />
           Config Status
         </CardTitle>
@@ -323,7 +323,7 @@ export function K8sConfigDriftCard({
         {drift.hasDrift && (drift.desiredConfig || fieldDiffs.length > 0) && (
           <div className="space-y-2">
             <div className="flex items-center gap-2">
-              <p className="text-base-content/60 text-xs font-medium">Spec vs Applied diff:</p>
+              <p className="text-base-content/50 text-xs font-medium">Spec vs Applied diff:</p>
               <div className="ml-auto flex rounded border text-[10px]">
                 <button
                   type="button"
@@ -332,7 +332,7 @@ export function K8sConfigDriftCard({
                     "flex items-center gap-1 px-2 py-0.5",
                     diffView === "fields"
                       ? "bg-primary/10 text-primary"
-                      : "text-base-content/60 hover:bg-base-200",
+                      : "text-base-content/50 hover:bg-base-200",
                   )}
                 >
                   <List className="h-3 w-3" />
@@ -345,7 +345,7 @@ export function K8sConfigDriftCard({
                     "flex items-center gap-1 border-l px-2 py-0.5",
                     diffView === "side-by-side"
                       ? "bg-primary/10 text-primary"
-                      : "text-base-content/60 hover:bg-base-200",
+                      : "text-base-content/50 hover:bg-base-200",
                   )}
                 >
                   <Columns2 className="h-3 w-3" />
@@ -404,7 +404,7 @@ export function K8sConfigDriftCard({
         {/* Fallback: show field badges when no detail available for diff */}
         {fieldDiffs.length === 0 && drift.changedFields.length > 0 && (
           <div>
-            <p className="text-base-content/60 mb-1 text-xs">Changed fields:</p>
+            <p className="text-base-content/50 mb-1 text-xs">Changed fields:</p>
             <div className="flex flex-wrap gap-1">
               {drift.changedFields.map((field) => (
                 <Badge key={field} variant="outline" className="text-xs">
@@ -417,7 +417,7 @@ export function K8sConfigDriftCard({
 
         {drift.podHashGroups.length > 1 && (
           <div>
-            <p className="text-base-content/60 mb-1.5 text-xs">Pod config versions:</p>
+            <p className="text-base-content/50 mb-1.5 text-xs">Pod config versions:</p>
             <div className="space-y-1">
               {drift.podHashGroups.map((group) => (
                 <div
@@ -428,7 +428,7 @@ export function K8sConfigDriftCard({
                   )}
                 >
                   <div className="flex items-center gap-1.5">
-                    <Hash className="text-base-content/60 h-3 w-3" />
+                    <Hash className="text-base-content/50 h-3 w-3" />
                     <span className="font-mono">{group.configHash?.slice(0, 8) || "unknown"}</span>
                     {group.isCurrent && (
                       <Badge variant="secondary" className="px-1 py-0 text-[10px]">
@@ -436,7 +436,7 @@ export function K8sConfigDriftCard({
                       </Badge>
                     )}
                   </div>
-                  <span className="text-base-content/60">
+                  <span className="text-base-content/50">
                     {group.pods.length} pod{group.pods.length !== 1 ? "s" : ""}
                   </span>
                 </div>

--- a/frontend/src/components/k8s/k8s-migration-status.tsx
+++ b/frontend/src/components/k8s/k8s-migration-status.tsx
@@ -162,7 +162,7 @@ export function K8sMigrationStatus({
           <Clock className="h-3 w-3" />
           <span>Last checked: {formatRelativeTime(status.lastChecked)}</span>
           {inProgress && (
-            <span className="text-base-content/65 ml-auto">Auto-refreshing every 5s</span>
+            <span className="text-base-content/60 ml-auto">Auto-refreshing every 5s</span>
           )}
         </div>
       </CardContent>

--- a/frontend/src/components/k8s/k8s-migration-status.tsx
+++ b/frontend/src/components/k8s/k8s-migration-status.tsx
@@ -162,7 +162,7 @@ export function K8sMigrationStatus({
           <Clock className="h-3 w-3" />
           <span>Last checked: {formatRelativeTime(status.lastChecked)}</span>
           {inProgress && (
-            <span className="text-base-content/40 ml-auto">Auto-refreshing every 5s</span>
+            <span className="text-base-content/65 ml-auto">Auto-refreshing every 5s</span>
           )}
         </div>
       </CardContent>

--- a/frontend/src/components/k8s/k8s-operation-status.tsx
+++ b/frontend/src/components/k8s/k8s-operation-status.tsx
@@ -96,7 +96,7 @@ export function K8sOperationStatus({
             {phase}
           </Badge>
           <span className="ml-auto flex items-center gap-2">
-            {id && <span className="text-base-content/40 font-mono text-[10px]">ID: {id}</span>}
+            {id && <span className="text-base-content/65 font-mono text-[10px]">ID: {id}</span>}
             {onClear && (
               <Button
                 variant="ghost"
@@ -163,7 +163,7 @@ export function K8sOperationStatus({
                 ))}
               </ul>
             ) : (
-              <p className="text-base-content/40 text-xs">None yet</p>
+              <p className="text-base-content/65 text-xs">None yet</p>
             )}
           </div>
 
@@ -175,7 +175,7 @@ export function K8sOperationStatus({
               <XCircle
                 className={cn(
                   "h-3.5 w-3.5",
-                  failedCount > 0 ? "text-error" : "text-base-content/40",
+                  failedCount > 0 ? "text-error" : "text-base-content/65",
                 )}
               />
               <span className="text-xs font-medium">Failed ({failedCount})</span>
@@ -192,7 +192,7 @@ export function K8sOperationStatus({
                 ))}
               </ul>
             ) : (
-              <p className="text-base-content/40 text-xs">None</p>
+              <p className="text-base-content/65 text-xs">None</p>
             )}
           </div>
 
@@ -202,7 +202,7 @@ export function K8sOperationStatus({
               <Clock
                 className={cn(
                   "h-3.5 w-3.5",
-                  isRunning ? "text-info animate-pulse" : "text-base-content/40",
+                  isRunning ? "text-info animate-pulse" : "text-base-content/65",
                 )}
               />
               <span className="text-xs font-medium">Pending ({targetCount - processedCount})</span>
@@ -222,12 +222,12 @@ export function K8sOperationStatus({
                 ))}
               </ul>
             ) : isAllPods && targetCount - processedCount > 0 ? (
-              <p className="text-base-content/40 text-xs">
+              <p className="text-base-content/65 text-xs">
                 {targetCount - processedCount} pod{targetCount - processedCount !== 1 ? "s" : ""}{" "}
                 remaining
               </p>
             ) : (
-              <p className="text-base-content/40 text-xs">None</p>
+              <p className="text-base-content/65 text-xs">None</p>
             )}
           </div>
         </div>

--- a/frontend/src/components/k8s/k8s-operation-status.tsx
+++ b/frontend/src/components/k8s/k8s-operation-status.tsx
@@ -96,7 +96,7 @@ export function K8sOperationStatus({
             {phase}
           </Badge>
           <span className="ml-auto flex items-center gap-2">
-            {id && <span className="text-base-content/65 font-mono text-[10px]">ID: {id}</span>}
+            {id && <span className="text-base-content/60 font-mono text-[10px]">ID: {id}</span>}
             {onClear && (
               <Button
                 variant="ghost"
@@ -163,7 +163,7 @@ export function K8sOperationStatus({
                 ))}
               </ul>
             ) : (
-              <p className="text-base-content/65 text-xs">None yet</p>
+              <p className="text-base-content/60 text-xs">None yet</p>
             )}
           </div>
 
@@ -175,7 +175,7 @@ export function K8sOperationStatus({
               <XCircle
                 className={cn(
                   "h-3.5 w-3.5",
-                  failedCount > 0 ? "text-error" : "text-base-content/65",
+                  failedCount > 0 ? "text-error" : "text-base-content/60",
                 )}
               />
               <span className="text-xs font-medium">Failed ({failedCount})</span>
@@ -192,7 +192,7 @@ export function K8sOperationStatus({
                 ))}
               </ul>
             ) : (
-              <p className="text-base-content/65 text-xs">None</p>
+              <p className="text-base-content/60 text-xs">None</p>
             )}
           </div>
 
@@ -202,7 +202,7 @@ export function K8sOperationStatus({
               <Clock
                 className={cn(
                   "h-3.5 w-3.5",
-                  isRunning ? "text-info animate-pulse" : "text-base-content/65",
+                  isRunning ? "text-info animate-pulse" : "text-base-content/60",
                 )}
               />
               <span className="text-xs font-medium">Pending ({targetCount - processedCount})</span>
@@ -222,12 +222,12 @@ export function K8sOperationStatus({
                 ))}
               </ul>
             ) : isAllPods && targetCount - processedCount > 0 ? (
-              <p className="text-base-content/65 text-xs">
+              <p className="text-base-content/60 text-xs">
                 {targetCount - processedCount} pod{targetCount - processedCount !== 1 ? "s" : ""}{" "}
                 remaining
               </p>
             ) : (
-              <p className="text-base-content/65 text-xs">None</p>
+              <p className="text-base-content/60 text-xs">None</p>
             )}
           </div>
         </div>

--- a/frontend/src/components/k8s/k8s-operation-trigger-dialog.tsx
+++ b/frontend/src/components/k8s/k8s-operation-trigger-dialog.tsx
@@ -215,7 +215,7 @@ export function K8sOperationTriggerDialog({
             </p>
             <div className="max-h-[240px] overflow-y-auto rounded border p-2">
               {pods.length === 0 ? (
-                <p className="text-base-content/40 py-2 text-center text-xs">No pods available</p>
+                <p className="text-base-content/65 py-2 text-center text-xs">No pods available</p>
               ) : (
                 <div className="space-y-1">
                   {/* 전체 선택 체크박스 (헤더) */}

--- a/frontend/src/components/k8s/k8s-operation-trigger-dialog.tsx
+++ b/frontend/src/components/k8s/k8s-operation-trigger-dialog.tsx
@@ -215,7 +215,7 @@ export function K8sOperationTriggerDialog({
             </p>
             <div className="max-h-[240px] overflow-y-auto rounded border p-2">
               {pods.length === 0 ? (
-                <p className="text-base-content/65 py-2 text-center text-xs">No pods available</p>
+                <p className="text-base-content/60 py-2 text-center text-xs">No pods available</p>
               ) : (
                 <div className="space-y-1">
                   {/* 전체 선택 체크박스 (헤더) */}

--- a/frontend/src/components/k8s/k8s-rack-topology.tsx
+++ b/frontend/src/components/k8s/k8s-rack-topology.tsx
@@ -105,7 +105,7 @@ function RackCard({
 
       {/* Pod grid */}
       {totalCount === 0 ? (
-        <p className="text-base-content/65 py-2 text-center text-xs">No pods</p>
+        <p className="text-base-content/60 py-2 text-center text-xs">No pods</p>
       ) : (
         <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-2">
           {rackGroup.pods.map((pod) => (
@@ -277,7 +277,7 @@ export function K8sRackTopology({
                     <Badge variant="outline" className="bg-base-100 text-[11px] font-medium">
                       {zoneLabel}
                     </Badge>
-                    <span className="text-base-content/65 text-[10px]">
+                    <span className="text-base-content/60 text-[10px]">
                       {rackGroups.length} rack{rackGroups.length !== 1 ? "s" : ""},{" "}
                       {rackGroups.reduce((sum, rg) => sum + rg.pods.length, 0)} pod
                       {rackGroups.reduce((sum, rg) => sum + rg.pods.length, 0) !== 1 ? "s" : ""}

--- a/frontend/src/components/k8s/k8s-rack-topology.tsx
+++ b/frontend/src/components/k8s/k8s-rack-topology.tsx
@@ -105,7 +105,7 @@ function RackCard({
 
       {/* Pod grid */}
       {totalCount === 0 ? (
-        <p className="text-base-content/40 py-2 text-center text-xs">No pods</p>
+        <p className="text-base-content/65 py-2 text-center text-xs">No pods</p>
       ) : (
         <div className="grid grid-cols-1 gap-1.5 sm:grid-cols-2">
           {rackGroup.pods.map((pod) => (
@@ -277,7 +277,7 @@ export function K8sRackTopology({
                     <Badge variant="outline" className="bg-base-100 text-[11px] font-medium">
                       {zoneLabel}
                     </Badge>
-                    <span className="text-base-content/40 text-[10px]">
+                    <span className="text-base-content/65 text-[10px]">
                       {rackGroups.length} rack{rackGroups.length !== 1 ? "s" : ""},{" "}
                       {rackGroups.reduce((sum, rg) => sum + rg.pods.length, 0)} pod
                       {rackGroups.reduce((sum, rg) => sum + rg.pods.length, 0) !== 1 ? "s" : ""}

--- a/frontend/src/components/k8s/k8s-reconciliation-health.tsx
+++ b/frontend/src/components/k8s/k8s-reconciliation-health.tsx
@@ -241,7 +241,7 @@ export function K8sReconciliationHealth({
         )}
 
         {/* Auto-refresh indicator */}
-        <div className="text-base-content/65 flex items-center gap-1 text-[10px]">
+        <div className="text-base-content/60 flex items-center gap-1 text-[10px]">
           <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-current" />
           Auto-refreshing every 10s
         </div>

--- a/frontend/src/components/k8s/k8s-reconciliation-health.tsx
+++ b/frontend/src/components/k8s/k8s-reconciliation-health.tsx
@@ -241,7 +241,7 @@ export function K8sReconciliationHealth({
         )}
 
         {/* Auto-refresh indicator */}
-        <div className="text-base-content/40 flex items-center gap-1 text-[10px]">
+        <div className="text-base-content/65 flex items-center gap-1 text-[10px]">
           <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-current" />
           Auto-refreshing every 10s
         </div>

--- a/frontend/src/components/k8s/wizard/WizardReviewStep.tsx
+++ b/frontend/src/components/k8s/wizard/WizardReviewStep.tsx
@@ -470,13 +470,13 @@ export function WizardReviewStep({
                     {rack.rackLabel ? ` label: ${rack.rackLabel}` : ""}
                   </span>
                   {(rack.podSpec?.tolerations ?? []).length > 0 && (
-                    <span className="text-base-content/70 block pl-3">
+                    <span className="text-base-content/75 block pl-3">
                       {rack.podSpec!.tolerations!.length} toleration
                       {rack.podSpec!.tolerations!.length !== 1 ? "s" : ""}
                     </span>
                   )}
                   {rack.podSpec?.affinity && (
-                    <span className="text-base-content/70 block pl-3">
+                    <span className="text-base-content/75 block pl-3">
                       node affinity configured
                     </span>
                   )}

--- a/frontend/src/components/k8s/wizard/WizardReviewStep.tsx
+++ b/frontend/src/components/k8s/wizard/WizardReviewStep.tsx
@@ -470,13 +470,13 @@ export function WizardReviewStep({
                     {rack.rackLabel ? ` label: ${rack.rackLabel}` : ""}
                   </span>
                   {(rack.podSpec?.tolerations ?? []).length > 0 && (
-                    <span className="text-base-content/50 block pl-3">
+                    <span className="text-base-content/70 block pl-3">
                       {rack.podSpec!.tolerations!.length} toleration
                       {rack.podSpec!.tolerations!.length !== 1 ? "s" : ""}
                     </span>
                   )}
                   {rack.podSpec?.affinity && (
-                    <span className="text-base-content/50 block pl-3">
+                    <span className="text-base-content/70 block pl-3">
                       node affinity configured
                     </span>
                   )}


### PR DESCRIPTION
## Summary
- **Left color bar**: Uses per-cluster preset color (`row.color`) instead of hardcoded green — purple, blue, red etc. now correctly displayed
- **Description layout**: Moved cluster description next to identity section where horizontal space is available, separated by a divider
- **Text readability overhaul**: Increased opacity of secondary/tertiary text across 14 files (`/30→/60`, `/40→/65`, `/50→/70`) — labels, metadata, and helper text are now clearly visible

## Test plan
- [ ] Verify cluster cards show correct preset color on the left bar
- [ ] Verify description appears next to cluster name on desktop view
- [ ] Verify all secondary text (hosts, edition, metric labels, etc.) is legible in both light and dark themes
- [ ] Check responsive layout on mobile — description should be hidden on small screens
- [ ] Run `npm run type-check` and `npm run build` — both pass