### PR TITLE
fix: prevent dev dependency download at runtime

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@ set -e
 
 # Start backend (FastAPI)
 cd /app/backend
-uv run uvicorn aerospike_cluster_manager_api.main:app \
+uv run --no-dev uvicorn aerospike_cluster_manager_api.main:app \
     --host 0.0.0.0 --port 8000 &
 backend_pid=$!
 


### PR DESCRIPTION
## Summary
- `uv run` → `uv run --no-dev` in `entrypoint.sh`
- Prevents `ruff` download attempt at container startup in air-gapped environments

Closes #186

## Test plan
- [ ] Deploy to air-gapped K8s cluster (mdad1-n3r) — backend should start without PyPI access