### PR TITLE
feat: add K8S_VERIFY_SSL option for clusters with non-standard CA

### DIFF
--- a/backend/src/aerospike_cluster_manager_api/config.py
+++ b/backend/src/aerospike_cluster_manager_api/config.py
@@ -48,6 +48,7 @@ AS_TEND_INTERVAL: int = _get_int("AS_TEND_INTERVAL", 1000)  # Cluster tend inter
 
 # Kubernetes API
 K8S_API_TIMEOUT: int = _get_int("K8S_API_TIMEOUT", 10)
+K8S_VERIFY_SSL: bool = os.getenv("K8S_VERIFY_SSL", "true").lower() in ("true", "1", "yes")
 K8S_LOG_TIMEOUT: int = _get_int("K8S_LOG_TIMEOUT", 30)
 
 # SSE (Server-Sent Events) streaming

--- a/backend/src/aerospike_cluster_manager_api/k8s_client.py
+++ b/backend/src/aerospike_cluster_manager_api/k8s_client.py
@@ -69,10 +69,21 @@ class K8sClient:
                         "Unable to initialize Kubernetes client — no in-cluster config or valid kubeconfig found"
                     ) from e
 
-            self._custom_api = client.CustomObjectsApi()
-            self._core_api = client.CoreV1Api()
-            self._storage_api = client.StorageV1Api()
-            self._autoscaling_api = client.AutoscalingV2Api()
+            from . import config as app_config
+
+            if not app_config.K8S_VERIFY_SSL:
+                api_client = client.ApiClient()
+                api_client.configuration.verify_ssl = False
+                logger.warning("K8S_VERIFY_SSL=false — TLS certificate verification disabled")
+                self._custom_api = client.CustomObjectsApi(api_client)
+                self._core_api = client.CoreV1Api(api_client)
+                self._storage_api = client.StorageV1Api(api_client)
+                self._autoscaling_api = client.AutoscalingV2Api(api_client)
+            else:
+                self._custom_api = client.CustomObjectsApi()
+                self._core_api = client.CoreV1Api()
+                self._storage_api = client.StorageV1Api()
+                self._autoscaling_api = client.AutoscalingV2Api()
             self._initialized = True
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `K8S_VERIFY_SSL` env var (default `true`) to `config.py`
- When `false`, disables TLS certificate verification for K8s API client
- Fixes `SSL: CERTIFICATE_VERIFY_FAILED: Missing Authority Key Identifier` on some enterprise K8s clusters

## Test plan
- [ ] Deploy to mdad1 cluster with `K8S_VERIFY_SSL=false` — K8s management endpoints should work
- [ ] Default behavior unchanged (SSL verification enabled)