### PR TITLE
fix: apply K8S_VERIFY_SSL to global k8s Configuration

### DIFF
--- a/backend/src/aerospike_cluster_manager_api/k8s_client.py
+++ b/backend/src/aerospike_cluster_manager_api/k8s_client.py
@@ -72,18 +72,16 @@ class K8sClient:
             from . import config as app_config
 
             if not app_config.K8S_VERIFY_SSL:
-                api_client = client.ApiClient()
-                api_client.configuration.verify_ssl = False
+                configuration = client.Configuration.get_default_copy()
+                configuration.verify_ssl = False
+                configuration.ssl_ca_cert = None
+                client.Configuration.set_default(configuration)
                 logger.warning("K8S_VERIFY_SSL=false — TLS certificate verification disabled")
-                self._custom_api = client.CustomObjectsApi(api_client)
-                self._core_api = client.CoreV1Api(api_client)
-                self._storage_api = client.StorageV1Api(api_client)
-                self._autoscaling_api = client.AutoscalingV2Api(api_client)
-            else:
-                self._custom_api = client.CustomObjectsApi()
-                self._core_api = client.CoreV1Api()
-                self._storage_api = client.StorageV1Api()
-                self._autoscaling_api = client.AutoscalingV2Api()
+
+            self._custom_api = client.CustomObjectsApi()
+            self._core_api = client.CoreV1Api()
+            self._storage_api = client.StorageV1Api()
+            self._autoscaling_api = client.AutoscalingV2Api()
             self._initialized = True
 
     # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Previous approach created a new ApiClient but `load_incluster_config()` already set `ssl_ca_cert` on the global Configuration, so the CA was still being used for verification.

Fix: modify `Configuration.get_default_copy()` directly — set `verify_ssl=False` and `ssl_ca_cert=None` on the global default so all ApiClient instances inherit it.

## Test plan
- [ ] Deploy to mdad1 cluster with `K8S_VERIFY_SSL=false` — `/api/k8s/clusters` should return 200