### PR TITLE
fix: use CE 8 data_total_bytes for in-memory namespace stats

### DIFF
--- a/backend/src/aerospike_cluster_manager_api/constants.py
+++ b/backend/src/aerospike_cluster_manager_api/constants.py
@@ -51,6 +51,8 @@ NS_SUM_KEYS = frozenset(
         "tombstones",
         "memory_used_bytes",
         "memory-size",
+        "data_used_bytes",
+        "data_total_bytes",
         "device_used_bytes",
         "device-total-bytes",
         "client_read_success",

--- a/backend/src/aerospike_cluster_manager_api/routers/clusters.py
+++ b/backend/src/aerospike_cluster_manager_api/routers/clusters.py
@@ -116,8 +116,18 @@ async def get_cluster(client: AerospikeClient, conn_id: VerifiedConnId) -> Clust
         raw_objects = safe_int(ns_stats.get("objects"))
         unique_objects = raw_objects // effective_rf if effective_rf > 0 else raw_objects
 
-        memory_used = safe_int(ns_stats.get("memory_used_bytes"))
-        memory_total = safe_int(ns_stats.get("memory-size"))
+        # CE 8 uses unified data_used_bytes/data_total_bytes for both memory and device.
+        # Fall back to legacy memory_used_bytes/memory-size for older versions.
+        memory_used = (
+            safe_int(ns_stats.get("data_used_bytes"))
+            if "data_used_bytes" in ns_stats
+            else safe_int(ns_stats.get("memory_used_bytes"))
+        )
+        memory_total = (
+            safe_int(ns_stats.get("data_total_bytes"))
+            if "data_total_bytes" in ns_stats
+            else safe_int(ns_stats.get("memory-size"))
+        )
         device_used = safe_int(ns_stats.get("device_used_bytes"))
         device_total = safe_int(ns_stats.get("device-total-bytes"))
 

--- a/backend/src/aerospike_cluster_manager_api/services/metrics_service.py
+++ b/backend/src/aerospike_cluster_manager_api/services/metrics_service.py
@@ -120,8 +120,18 @@ async def build_cluster_metrics(client, conn_id: str) -> ClusterMetrics:
 
             raw_objects = safe_int(ns_stats.get("objects"))
             objects = raw_objects // effective_rf if effective_rf > 0 else raw_objects
-            memory_used = safe_int(ns_stats.get("memory_used_bytes"))
-            memory_total = safe_int(ns_stats.get("memory-size"))
+            # CE 8 uses unified data_used_bytes/data_total_bytes for both memory and device.
+            # Fall back to legacy memory_used_bytes/memory-size for older versions.
+            memory_used = (
+                safe_int(ns_stats.get("data_used_bytes"))
+                if "data_used_bytes" in ns_stats
+                else safe_int(ns_stats.get("memory_used_bytes"))
+            )
+            memory_total = (
+                safe_int(ns_stats.get("data_total_bytes"))
+                if "data_total_bytes" in ns_stats
+                else safe_int(ns_stats.get("memory-size"))
+            )
             device_used = safe_int(ns_stats.get("device_used_bytes"))
             device_total = safe_int(ns_stats.get("device-total-bytes"))
 


### PR DESCRIPTION
## Summary
`clusters.py` and `metrics_service.py` read `memory-size`/`memory_used_bytes` which don't exist in CE 8 in-memory namespaces. This returns `memoryTotal: 0`, crashing the Overview page.

Apply the same `data_total_bytes`/`data_used_bytes` fallback already used in `connections.py`.

## Test plan
- [ ] Overview page renders correctly for in-memory namespaces on CE 8
- [ ] Metrics charts show memory usage data