### PR TITLE
fix: replace crypto.randomUUID with HTTP-safe fallback

### DIFF
--- a/frontend/src/lib/bin-utils.ts
+++ b/frontend/src/lib/bin-utils.ts
@@ -1,5 +1,6 @@
 import type { AerospikeRecord, BinValue, BinEntry } from "@/lib/api/types";
 import type { BinType } from "@/lib/constants";
+import { uuid } from "@/lib/utils";
 
 export function parseBinValue(value: string, type: BinType): BinValue {
   switch (type) {
@@ -48,12 +49,12 @@ export function serializeBinValue(value: BinValue): string {
 }
 
 export function createEmptyBinEntry(): BinEntry {
-  return { id: crypto.randomUUID(), name: "", value: "", type: "string" };
+  return { id: uuid(), name: "", value: "", type: "string" };
 }
 
 export function buildBinEntriesFromRecord(record: AerospikeRecord): BinEntry[] {
   return Object.entries(record.bins).map(([name, value]) => ({
-    id: crypto.randomUUID(),
+    id: uuid(),
     name,
     value: serializeBinValue(value),
     type: detectBinType(value),

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -20,3 +20,24 @@ export function getErrorMessage(err: unknown): string {
 export function staggerDelay(index: number, step = 0.05): CSSProperties {
   return { animationDelay: `${index * step}s`, animationFillMode: "backwards" };
 }
+
+/**
+ * Generate a UUID v4 string.
+ * crypto.randomUUID() is only available in secure contexts (HTTPS/localhost).
+ * This fallback uses crypto.getRandomValues() which works over plain HTTP.
+ */
+export function uuid(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  const bytes = new Uint8Array(16);
+  if (typeof crypto !== "undefined" && typeof crypto.getRandomValues === "function") {
+    crypto.getRandomValues(bytes);
+  } else {
+    for (let i = 0; i < bytes.length; i++) bytes[i] = Math.floor(Math.random() * 256);
+  }
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const h = [...bytes].map((b) => b.toString(16).padStart(2, "0")).join("");
+  return `${h.slice(0, 8)}-${h.slice(8, 12)}-${h.slice(12, 16)}-${h.slice(16, 20)}-${h.slice(20)}`;
+}

--- a/frontend/src/stores/filter-store.ts
+++ b/frontend/src/stores/filter-store.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import type { BinDataType, FilterCondition, FilterGroup, FilterOperator } from "@/lib/api/types";
 import { FILTER_OPERATORS_BY_TYPE } from "@/lib/constants";
+import { uuid } from "@/lib/utils";
 
 interface FilterState {
   conditions: FilterCondition[];
@@ -26,7 +27,7 @@ export const useFilterStore = create<FilterState>()((set, get) => ({
     const operators = FILTER_OPERATORS_BY_TYPE[binType];
     const defaultOp = operators[0]?.value ?? ("eq" as FilterOperator);
     const condition: FilterCondition = {
-      id: crypto.randomUUID(),
+      id: uuid(),
       bin,
       operator: defaultOp,
       binType,


### PR DESCRIPTION
## Problem
`crypto.randomUUID()` throws `TypeError` in non-secure contexts (plain HTTP). This crashes the browser page when accessing the UI via HTTP LoadBalancer in corporate networks.

## Fix
Add `uuid()` helper in `utils.ts` using `crypto.getRandomValues()` (works over HTTP). Replace all direct `crypto.randomUUID()` calls in `bin-utils.ts` and `filter-store.ts`.

## Test plan
- [ ] Access UI over plain HTTP — record browser page should load without errors
- [ ] HTTPS access still works (uses native randomUUID when available)