### PR TITLE
fix: replace bare except with specific types, remove redundant console.error

### DIFF
--- a/backend/src/aerospike_cluster_manager_api/routers/records.py
+++ b/backend/src/aerospike_cluster_manager_api/routers/records.py
@@ -4,7 +4,7 @@ import logging
 import time
 from typing import Any
 
-from aerospike_py.exception import RecordNotFound
+from aerospike_py.exception import AerospikeError, RecordNotFound
 from aerospike_py.types import WriteMeta
 from fastapi import APIRouter, HTTPException, Query
 from starlette.responses import Response
@@ -53,7 +53,7 @@ async def _get_set_object_count(client: Any, ns: str, set_name: str) -> int:
         for s in agg:
             if s["name"] == set_name:
                 return s["objects"]
-    except Exception:
+    except (AerospikeError, OSError):
         logger.debug("Failed to get set object count for %s.%s", ns, set_name, exc_info=True)
     return 0
 

--- a/frontend/src/app/k8s/clusters/[namespace]/[name]/page.tsx
+++ b/frontend/src/app/k8s/clusters/[namespace]/[name]/page.tsx
@@ -118,12 +118,10 @@ export default function K8sClusterDetailPage() {
 
     // Non-transitional phase: fetch once without starting a polling interval.
     Promise.all([
-      api.getK8sClusterEvents(namespace, name).catch((err) => {
-        console.error("Failed to fetch cluster events:", err);
+      api.getK8sClusterEvents(namespace, name).catch(() => {
         return useK8sClusterStore.getState().detailEvents;
       }),
-      api.getK8sClusterHealth(namespace, name).catch((err) => {
-        console.error("Failed to fetch cluster health:", err);
+      api.getK8sClusterHealth(namespace, name).catch(() => {
         return useK8sClusterStore.getState().detailHealth;
       }),
     ]).then(([events, health]) => {

--- a/frontend/src/components/k8s/k8s-cluster-wizard.tsx
+++ b/frontend/src/components/k8s/k8s-cluster-wizard.tsx
@@ -174,8 +174,7 @@ export function K8sClusterWizard() {
   // Fetch K8s nodes when on Advanced step (scratch mode only)
   useEffect(() => {
     if (!isTemplateMode && step === 3) {
-      fetchK8sNodes().catch((err) => {
-        console.error("Failed to fetch K8s nodes:", err);
+      fetchK8sNodes().catch(() => {
         useToastStore
           .getState()
           .addToast("error", "Failed to load node information for zone selection");


### PR DESCRIPTION
## Summary
- **records.py**: `except Exception` → `except (AerospikeError, OSError)` (코드베이스 기존 패턴과 일관)
- **page.tsx (k8s cluster detail)**: toast/fallback으로 이미 처리되는 에러의 중복 console.error 2개 제거
- **k8s-cluster-wizard.tsx**: toast로 이미 처리되는 에러의 중복 console.error 1개 제거

## Test plan
- [ ] `uv run pytest tests/ -v --tb=short` 백엔드 테스트 통과
- [ ] `npm run test` 프론트엔드 유닛 테스트 통과
- [ ] `npm run lint` ESLint 통과