### PR TITLE
fix(browser): reload button bypasses client cache

### DIFF
--- a/frontend/src/app/browser/[connId]/[ns]/[set]/page.tsx
+++ b/frontend/src/app/browser/[connId]/[ns]/[set]/page.tsx
@@ -246,6 +246,7 @@ export default function BrowserPage({
       activeFilters,
       routeState.pageSize,
       routeState.primaryKey || undefined,
+      true, // force: bypass cache so Reload/write mutations always fetch fresh data
     );
   }, [
     activeFilters,

--- a/frontend/src/stores/browser-store.ts
+++ b/frontend/src/stores/browser-store.ts
@@ -71,6 +71,7 @@ interface BrowserState {
     filters?: FilterGroup,
     pageSize?: number,
     primaryKey?: string,
+    force?: boolean,
   ) => Promise<void>;
   putRecord: (
     connId: string,
@@ -131,21 +132,23 @@ export const useBrowserStore = create<BrowserState>()((set, get) => ({
     });
   },
 
-  fetchFilteredRecords: async (connId, ns, setName, filters, pageSize, primaryKey) => {
+  fetchFilteredRecords: async (connId, ns, setName, filters, pageSize, primaryKey, force) => {
     const ps = pageSize ?? get().pageSize;
     const cacheKey = buildCacheKey(connId, ns, setName, filters, ps, primaryKey);
-    const cached = get().recordCache.get(cacheKey);
-    if (cached) {
-      set({
-        records: cached.records,
-        total: cached.total,
-        pageSize: cached.pageSize,
-        hasMore: cached.hasMore,
-        totalEstimated: cached.totalEstimated,
-        executionTimeMs: cached.executionTimeMs,
-        scannedRecords: cached.scannedRecords,
-      });
-      return;
+    if (!force) {
+      const cached = get().recordCache.get(cacheKey);
+      if (cached) {
+        set({
+          records: cached.records,
+          total: cached.total,
+          pageSize: cached.pageSize,
+          hasMore: cached.hasMore,
+          totalEstimated: cached.totalEstimated,
+          executionTimeMs: cached.executionTimeMs,
+          scannedRecords: cached.scannedRecords,
+        });
+        return;
+      }
     }
 
     await withLoading(set, async () => {


### PR DESCRIPTION
## Summary
- Record browser Reload button was a no-op because `fetchFilteredRecords` returned cached data on matching query-key (same conn/ns/set/filters/pageSize/primaryKey)
- Add optional \`force\` flag to skip cache read; cache write still occurs so normal navigation stays fast
- \`refreshCurrentView\` now passes \`force=true\`, which also makes post-mutation refresh (putRecord/deleteRecord) always show fresh data

## Root Cause
\`frontend/src/stores/browser-store.ts\` — fetchFilteredRecords checks \`recordCache\` first via \`buildCacheKey(connId, ns, set, filters, pageSize, primaryKey)\`. Reload re-invokes with identical params → cache hit → returns without fetching.

## Test plan
- [x] Open Record Browser, click Reload — verify \`POST /api/records/filtered\` fires (DevTools Network) on every click
- [x] Insert a record via aql while on browser page → click Reload → new record appears
- [x] Existing unit tests in \`stores/__tests__/browser-store.test.ts\` still pass (force param is optional/backward-compatible)