### PR TITLE
fix(records): resolve string-keyed records and fix Expiry column truncation

### DIFF
--- a/backend/src/aerospike_cluster_manager_api/models/query.py
+++ b/backend/src/aerospike_cluster_manager_api/models/query.py
@@ -23,6 +23,8 @@ class QueryRequest(BaseModel):
     expression: str | None = Field(default=None, max_length=4096)
     maxRecords: int | None = Field(default=None, ge=1, le=1_000_000)
     primaryKey: str | None = Field(default=None, max_length=1024)
+    # Particle type for primaryKey resolution. "auto" retries alternate type on NOT_FOUND.
+    pkType: Literal["auto", "string", "int", "bytes"] = "auto"
 
 
 class QueryResponse(BaseModel):
@@ -93,6 +95,8 @@ class FilteredQueryRequest(BaseModel):
     page: int = Field(default=1, ge=1)
     page_size: int = Field(default=25, ge=1, le=500, alias="pageSize")
     primary_key: str | None = Field(default=None, max_length=1024, alias="primaryKey")
+    # Particle type for primary_key resolution. "auto" retries alternate type on NOT_FOUND.
+    pk_type: Literal["auto", "string", "int", "bytes"] = Field(default="auto", alias="pkType")
 
 
 class FilteredQueryResponse(BaseModel):

--- a/backend/src/aerospike_cluster_manager_api/models/record.py
+++ b/backend/src/aerospike_cluster_manager_api/models/record.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 BinValue = Any
 
@@ -41,6 +41,12 @@ class RecordListResponse(BaseModel):
 
 
 class RecordWriteRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
     key: RecordKey
     bins: dict[str, BinValue]
     ttl: int | None = None
+    # Particle type to use when persisting ``key.pk``. "auto" preserves the
+    # legacy heuristic (numeric-string → INTEGER); use "string" to keep digit
+    # keys as STRING so subsequent reads can find them.
+    pk_type: Literal["auto", "string", "int", "bytes"] = Field(default="auto", alias="pkType")

--- a/backend/src/aerospike_cluster_manager_api/routers/query.py
+++ b/backend/src/aerospike_cluster_manager_api/routers/query.py
@@ -10,7 +10,7 @@ from aerospike_cluster_manager_api.constants import MAX_QUERY_RECORDS, POLICY_QU
 from aerospike_cluster_manager_api.converters import record_to_model
 from aerospike_cluster_manager_api.dependencies import AerospikeClient
 from aerospike_cluster_manager_api.models.query import QueryRequest, QueryResponse
-from aerospike_cluster_manager_api.utils import auto_detect_pk, build_predicate
+from aerospike_cluster_manager_api.utils import build_predicate, get_with_pk_fallback, resolve_pk
 
 logger = logging.getLogger(__name__)
 
@@ -30,10 +30,17 @@ async def execute_query(body: QueryRequest, client: AerospikeClient) -> QueryRes
         if not body.set:
             raise HTTPException(status_code=400, detail="Set is required for primary key lookup")
 
-        pk = auto_detect_pk(body.primaryKey)
-
+        # pk_type=auto retries the alternate particle type on NOT_FOUND so
+        # numeric-string keys are resolvable even when the heuristic guesses int.
+        resolved = resolve_pk(body.primaryKey, body.pkType)
         try:
-            raw_result = await client.get((body.namespace, body.set, pk), policy=POLICY_READ)
+            raw_result = await get_with_pk_fallback(
+                client,
+                (body.namespace, body.set, resolved),
+                body.primaryKey,
+                body.pkType,
+                POLICY_READ,
+            )
             raw_results = [raw_result]
         except RecordNotFound:
             raw_results = []

--- a/backend/src/aerospike_cluster_manager_api/routers/records.py
+++ b/backend/src/aerospike_cluster_manager_api/routers/records.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Any
+from typing import Any, Literal
 
 from aerospike_py.exception import AerospikeError, RecordNotFound
 from aerospike_py.types import WriteMeta
@@ -27,7 +27,11 @@ from aerospike_cluster_manager_api.models.record import (
     RecordListResponse,
     RecordWriteRequest,
 )
-from aerospike_cluster_manager_api.utils import auto_detect_pk, build_predicate
+from aerospike_cluster_manager_api.utils import (
+    build_predicate,
+    get_with_pk_fallback,
+    resolve_pk,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -99,9 +103,17 @@ async def get_record_detail(
     ns: str = Query(..., min_length=1),
     set: str = Query(...),
     pk: str = Query(..., min_length=1),
+    pk_type: Literal["auto", "string", "int", "bytes"] = Query("auto"),
 ) -> AerospikeRecord:
-    """Retrieve a single record identified by namespace, set, and primary key."""
-    raw_result = await client.get((ns, set, auto_detect_pk(pk)), policy=POLICY_READ)
+    """Retrieve a single record identified by namespace, set, and primary key.
+
+    When ``pk_type='auto'`` (default), the lookup falls back to the alternate
+    particle type on NOT_FOUND — fixing the case where a numeric-string key
+    (e.g. ``"23404907"``) was stored as STRING but would otherwise be probed
+    as INTEGER. Pass an explicit ``pk_type`` to disable the fallback.
+    """
+    resolved = resolve_pk(pk, pk_type)
+    raw_result = await get_with_pk_fallback(client, (ns, set, resolved), pk, pk_type, POLICY_READ)
     return record_to_model(raw_result)
 
 
@@ -112,12 +124,18 @@ async def get_record_detail(
     description="Write a record to Aerospike with the specified key, bins, and optional TTL.",
 )
 async def put_record(body: RecordWriteRequest, client: AerospikeClient) -> AerospikeRecord:
-    """Write a record to Aerospike with the specified key, bins, and optional TTL."""
+    """Write a record to Aerospike with the specified key, bins, and optional TTL.
+
+    The key's particle type comes from ``body.key.pk_type`` ("auto" by default).
+    Writes do not fall back: the resolved type is what gets persisted on disk,
+    so callers that care should pass an explicit ``pk_type`` to avoid creating
+    a record under a particle type that subsequent reads can't find.
+    """
     k = body.key
     if not k.namespace or not k.set or not k.pk:
         raise HTTPException(status_code=400, detail="Missing required key fields: namespace, set, pk")
 
-    key_tuple = (k.namespace, k.set, auto_detect_pk(k.pk))
+    key_tuple = (k.namespace, k.set, resolve_pk(k.pk, body.pk_type))
 
     meta: WriteMeta | None = None
     if body.ttl is not None:
@@ -139,9 +157,16 @@ async def delete_record(
     ns: str = Query(..., min_length=1),
     set: str = Query(..., min_length=1),
     pk: str = Query(..., min_length=1),
+    pk_type: Literal["auto", "string", "int", "bytes"] = Query("auto"),
 ) -> Response:
-    """Delete a record identified by namespace, set, and primary key."""
-    await client.remove((ns, set, auto_detect_pk(pk)))
+    """Delete a record identified by namespace, set, and primary key.
+
+    Deletes do not fall back to the alternate type even in ``auto`` mode: a
+    delete that targets the wrong particle type would silently no-op (the
+    record at the *other* type stays put), and a fallback could mask that
+    fact. Pass an explicit ``pk_type`` to be sure of which record gets removed.
+    """
+    await client.remove((ns, set, resolve_pk(pk, pk_type)))
     return Response(status_code=204)
 
 
@@ -157,14 +182,22 @@ async def get_filtered_records(
     """Scan records with optional expression filters and pagination."""
     start_time = time.monotonic()
 
-    # PK lookup short-circuit
+    # PK lookup short-circuit. Falls back to the alternate particle type on
+    # NOT_FOUND when pk_type=auto so numeric-string keys (stored as STRING)
+    # are still found even though auto's heuristic resolves them as INTEGER.
     if body.primary_key:
         if not body.set:
             raise HTTPException(status_code=400, detail="Set is required for primary key lookup")
 
-        pk = auto_detect_pk(body.primary_key)
+        resolved = resolve_pk(body.primary_key, body.pk_type)
         try:
-            raw_result = await client.get((body.namespace, body.set, pk), policy=POLICY_READ)
+            raw_result = await get_with_pk_fallback(
+                client,
+                (body.namespace, body.set, resolved),
+                body.primary_key,
+                body.pk_type,
+                POLICY_READ,
+            )
             raw_results = [raw_result]
         except RecordNotFound:
             raw_results = []

--- a/backend/src/aerospike_cluster_manager_api/utils.py
+++ b/backend/src/aerospike_cluster_manager_api/utils.py
@@ -3,12 +3,18 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
+from aerospike_py.exception import RecordNotFound
 from fastapi import HTTPException
 
 if TYPE_CHECKING:
     from aerospike_cluster_manager_api.models.query import QueryPredicate
+
+
+# Explicit PK particle type selector. `auto` is a heuristic that tries the most
+# likely type then falls back — see resolve_pk / get_with_pk_fallback below.
+type PkType = Literal["auto", "string", "int", "bytes"]
 
 
 def build_predicate(pred: QueryPredicate) -> tuple[Any, ...]:
@@ -45,14 +51,42 @@ def parse_host_port(host_str: str, default_port: int) -> tuple[str, int]:
     return (host_str, default_port)
 
 
-def auto_detect_pk(pk: str) -> str | int:
-    """Convert PK to int only when the round-trip is lossless (no leading zeros).
+def resolve_pk(pk: str, pk_type: PkType = "auto") -> str | int | bytes:
+    """Resolve a string primary key into the Aerospike key value of the requested type.
 
-    "1"     -> 1    (integer key)
-    "00001" -> "00001"  (string key -- leading zeros preserved)
-    "-5"    -> -5   (negative integer key)
-    "abc"   -> "abc"  (string key)
+    Aerospike keys are digested as RIPEMD-160(set || particle_type_byte || key_bytes),
+    so the particle type must match how the record was originally written. If
+    the caller knows the type, they should pass it explicitly via ``pk_type``.
+
+    Behavior:
+        - "string": return ``pk`` as-is.
+        - "int":    return ``int(pk)`` (raises ValueError if not parseable).
+        - "bytes":  return ``bytes.fromhex(pk)`` (raises ValueError on invalid hex).
+        - "auto":   best-effort heuristic. Treats any digit-only PK (including
+                    negative) as an integer, preserving leading-zero strings. The
+                    heuristic is wrong for numeric-string keys, so callers that
+                    do reads should pair this with ``get_with_pk_fallback``.
+
+    See also ``get_with_pk_fallback`` for the read-side fallback that tries the
+    alternate type when ``auto`` picks wrong.
     """
+    if pk_type == "string":
+        return pk
+    if pk_type == "int":
+        try:
+            return int(pk)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=f"pk_type=int but pk is not an integer: {pk!r}") from exc
+    if pk_type == "bytes":
+        try:
+            return bytes.fromhex(pk)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=f"pk_type=bytes but pk is not valid hex: {pk!r}") from exc
+
+    # auto: preserve the original heuristic so that true INTEGER-keyed sets
+    # continue to work without requiring the caller to opt in. Read paths should
+    # wrap this with get_with_pk_fallback to recover the NOT_FOUND case where
+    # the heuristic guessed wrong.
     try:
         as_int = int(pk)
         if str(as_int) == pk:
@@ -60,3 +94,54 @@ def auto_detect_pk(pk: str) -> str | int:
     except ValueError:
         pass
     return pk
+
+
+# Backward-compat alias — existing callers keep working. Prefer ``resolve_pk``.
+def auto_detect_pk(pk: str) -> str | int:
+    """Deprecated: use ``resolve_pk(pk, pk_type='auto')`` instead."""
+    result = resolve_pk(pk, "auto")
+    # auto mode never returns bytes; cast to satisfy the narrower return type.
+    if isinstance(result, bytes):  # pragma: no cover — defensive, unreachable
+        raise TypeError("resolve_pk(auto) unexpectedly returned bytes")
+    return result
+
+
+async def get_with_pk_fallback(
+    client: Any,
+    key_tuple: tuple[str, str, str | int | bytes],
+    pk_raw: str,
+    pk_type: PkType,
+    policy: dict[str, Any],
+) -> Any:
+    """Read a record, retrying the alternate PK type if ``auto`` resolved wrong.
+
+    When ``pk_type == "auto"`` and the first attempt raises ``RecordNotFound``,
+    we retry with the alternate string/int particle type (whichever one the
+    heuristic did *not* pick). This makes the record browser work for both
+    INTEGER-keyed and STRING-keyed sets without the caller having to know
+    upfront which one the record was written with.
+
+    Explicit pk types (``string`` / ``int`` / ``bytes``) never fall back — if
+    the caller asserted a type, we propagate the NOT_FOUND as-is so the caller
+    knows the key is genuinely absent under that type.
+    """
+    try:
+        return await client.get(key_tuple, policy=policy)
+    except RecordNotFound:
+        if pk_type != "auto":
+            raise
+        # Heuristic picked one type; try the opposite. If the alternate type
+        # isn't applicable (e.g. non-numeric string can't become int), keep
+        # propagating the original RecordNotFound — never leak ValueError.
+        first = key_tuple[2]
+        alt: str | int | None = None
+        if isinstance(first, int):
+            alt = pk_raw  # retry as raw string
+        elif isinstance(first, str):
+            try:
+                alt = int(first)
+            except ValueError:
+                alt = None  # no integer alternative → fall through to re-raise
+        if alt is None:
+            raise
+        return await client.get((key_tuple[0], key_tuple[1], alt), policy=policy)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -157,6 +157,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -529,6 +530,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       },
@@ -577,6 +579,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.19.0"
       }
@@ -2020,6 +2023,7 @@
       "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright": "1.58.2"
       },
@@ -2873,7 +2877,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -2963,8 +2966,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3119,6 +3121,7 @@
       "integrity": "sha512-jp2P3tQMSxWugkCUKLRPVUpGaL5MVFwF8RDuSRztfwgN1wmqJeMSbKlnEtQqU8UrhTmzEmZdu2I6v2dpp7XIxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -3129,6 +3132,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3139,6 +3143,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3148,8 +3153,7 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -3660,6 +3664,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4068,6 +4073,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4607,7 +4613,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -4640,15 +4645,13 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dompurify": {
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.7.tgz",
       "integrity": "sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -4987,6 +4990,7 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5227,6 +5231,7 @@
       "integrity": "sha512-30ScMRHIAD33JJQkgfGW1t8CURZtjc2JpTrq5n2HFhOefbAhb7ucc7xJwdWcrEtqUIYJ73Nybpsggii6GtAHjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.2",
         "@typescript-eslint/types": "8.57.2",
@@ -5428,6 +5433,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -5832,6 +5838,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7371,7 +7378,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -7432,7 +7438,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -8068,6 +8073,7 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -8163,7 +8169,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -8179,7 +8184,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -8190,7 +8194,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -8203,8 +8206,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -8254,6 +8256,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8263,6 +8266,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -8274,13 +8278,15 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -8357,7 +8363,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -9306,6 +9313,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9524,6 +9532,7 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9681,6 +9690,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -9789,6 +9799,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9802,6 +9813,7 @@
       "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.1.2",
         "@vitest/mocker": "4.1.2",
@@ -10185,6 +10197,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/frontend/src/app/browser/[connId]/[ns]/[set]/page.tsx
+++ b/frontend/src/app/browser/[connId]/[ns]/[set]/page.tsx
@@ -629,7 +629,7 @@ asyncio.run(main())`;
       // TTL → Expiry
       {
         id: "ttl",
-        size: 120,
+        size: 140,
         header: () => (
           <span className="text-muted-foreground/60 font-mono text-[10px] font-semibold tracking-[0.1em] uppercase">
             Expiry
@@ -637,8 +637,14 @@ asyncio.run(main())`;
         ),
         cell: ({ row }) => {
           const ttl = row.original.meta.ttl;
+          // Cell shows short form (no seconds) to fit the narrow column without
+          // truncation; tooltip carries the full second-precision timestamp plus
+          // raw TTL for power users who want exact values.
           return (
-            <span className="text-muted-foreground/60 font-mono text-xs" title={`TTL: ${ttl}s`}>
+            <span
+              className="text-muted-foreground/60 font-mono text-xs"
+              title={`Expires: ${formatTTLAsExpiry(ttl, true)}  (TTL: ${ttl}s)`}
+            >
               {formatTTLAsExpiry(ttl)}
             </span>
           );
@@ -814,7 +820,10 @@ asyncio.run(main())`;
                     Gen:{" "}
                     <span className="text-base-content font-mono">{record.meta.generation}</span>
                   </span>
-                  <span className="text-muted-foreground" title={`TTL: ${record.meta.ttl}s`}>
+                  <span
+                    className="text-muted-foreground"
+                    title={`Expires: ${formatTTLAsExpiry(record.meta.ttl, true)}  (TTL: ${record.meta.ttl}s)`}
+                  >
                     Expiry:{" "}
                     <span className="text-base-content font-mono">
                       {formatTTLAsExpiry(record.meta.ttl)}

--- a/frontend/src/lib/__tests__/formatters.test.ts
+++ b/frontend/src/lib/__tests__/formatters.test.ts
@@ -109,14 +109,25 @@ describe("formatTTLAsExpiry", () => {
     expect(formatTTLAsExpiry(0)).toBe("Default");
   });
 
-  it("returns yyyy-mm-dd hh:mm:ss format for positive TTL", () => {
+  it("returns yyyy-mm-dd hh:mm format (no seconds) by default", () => {
     const result = formatTTLAsExpiry(3600);
+    expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/);
+  });
+
+  it("returns yyyy-mm-dd hh:mm:ss when includeSeconds=true", () => {
+    const result = formatTTLAsExpiry(3600, true);
     expect(result).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
   });
 
-  it("calculates correct expiry date", () => {
+  it("calculates correct expiry date (short form)", () => {
     vi.setSystemTime(new Date("2026-03-01T12:00:00"));
-    expect(formatTTLAsExpiry(86400)).toBe("2026-03-02 12:00:00");
+    expect(formatTTLAsExpiry(86400)).toBe("2026-03-02 12:00");
+    vi.useRealTimers();
+  });
+
+  it("calculates correct expiry date (long form)", () => {
+    vi.setSystemTime(new Date("2026-03-01T12:00:00"));
+    expect(formatTTLAsExpiry(86400, true)).toBe("2026-03-02 12:00:00");
     vi.useRealTimers();
   });
 });

--- a/frontend/src/lib/api/types/query.ts
+++ b/frontend/src/lib/api/types/query.ts
@@ -23,6 +23,7 @@ export interface QueryRequest {
   expression?: string; // raw JSON expression
   maxRecords?: number;
   primaryKey?: string;
+  pkType?: import("./records").PkType;
 }
 
 export interface QueryResponse {
@@ -77,6 +78,7 @@ export interface FilteredQueryRequest {
   page?: number;
   pageSize?: number;
   primaryKey?: string;
+  pkType?: import("./records").PkType;
 }
 
 export interface FilteredQueryResponse {

--- a/frontend/src/lib/api/types/records.ts
+++ b/frontend/src/lib/api/types/records.ts
@@ -41,10 +41,13 @@ export interface RecordListResponse {
   totalEstimated?: boolean;
 }
 
+export type PkType = "auto" | "string" | "int" | "bytes";
+
 export interface RecordWriteRequest {
   key: RecordKey;
   bins: Record<string, BinValue>;
   ttl?: number;
+  pkType?: PkType;
 }
 
 // === Bin Editor ===

--- a/frontend/src/lib/formatters.ts
+++ b/frontend/src/lib/formatters.ts
@@ -35,10 +35,14 @@ export function formatPercent(value: number, total: number): number {
 export const NEVER_EXPIRE_TTL = 4294967295; // 0xFFFFFFFF — Aerospike "never expires" sentinel
 
 /**
- * Convert TTL (seconds remaining) to an expiration datetime string (yyyy-mm-dd hh:mm:ss).
+ * Convert TTL (seconds remaining) to an expiration datetime.
  * Used in table views to show when a record expires.
+ *
+ * Returns a short form ("yyyy-mm-dd hh:mm", 16 chars) suited for a narrow
+ * column. Use ``includeSeconds=true`` for the long form ("yyyy-mm-dd hh:mm:ss",
+ * 19 chars) when displaying in a wider context (detail panels, tooltips).
  */
-export function formatTTLAsExpiry(ttl: number): string {
+export function formatTTLAsExpiry(ttl: number, includeSeconds = false): string {
   if (ttl === -1 || ttl === NEVER_EXPIRE_TTL) return "Never";
   if (ttl === 0) return "Default";
 
@@ -48,6 +52,9 @@ export function formatTTLAsExpiry(ttl: number): string {
   const d = String(expiry.getDate()).padStart(2, "0");
   const h = String(expiry.getHours()).padStart(2, "0");
   const mi = String(expiry.getMinutes()).padStart(2, "0");
+  if (!includeSeconds) {
+    return `${y}-${mo}-${d} ${h}:${mi}`;
+  }
   const s = String(expiry.getSeconds()).padStart(2, "0");
   return `${y}-${mo}-${d} ${h}:${mi}:${s}`;
 }


### PR DESCRIPTION
## Summary

- **Fixes #206** — record browser now finds records with string PKs that look like integers (e.g. `\"23404907\"` stored as STRING). Adds an explicit `pk_type` selector with read-side fallback for the `auto` mode.
- Fixes Expiry column always showing `...` — column was 120px but the formatter returned a 19-char timestamp. Format defaults to `yyyy-MM-dd HH:mm`, column bumped to 140px, full timestamp moved to tooltip.

## Why two fixes in one PR

Both surfaced while diagnosing the same record-browser session against a real production cluster, both touch the same code paths, and shipping them together avoids a half-fixed UX (you'd resolve a record but couldn't read its expiry).

## Behavior changes

### PK resolution (Option D — explicit + auto-fallback)

| `pk_type` | Behavior |
|-----------|----------|
| `auto` (default) | Legacy heuristic for first attempt; on `RecordNotFound`, retry with the alternate string/int particle type. Backward-compatible for int-keyed sets, fixes string-keyed digit sets. |
| `string` | Always treat PK as STRING. No fallback. |
| `int` | Always treat PK as INTEGER. No fallback. |
| `bytes` | Treat PK as hex-encoded BYTES. No fallback. |

- Reads (`GET /detail`, `POST /filter`, `POST /query`) — fallback enabled in `auto`.
- Writes (`POST /records`) — never fall back; the resolved type is what gets persisted.
- Deletes (`DELETE /records`) — never fall back; deleting under the wrong type would silently no-op the actual record.

### Expiry formatter

`formatTTLAsExpiry(ttl, includeSeconds=false)`:
- Default (`includeSeconds=false`) → `\"2026-04-20 20:30\"` (16 chars).
- `includeSeconds=true` → `\"2026-04-20 20:30:45\"` (19 chars). Used in tooltips for precision.

## Test plan

- [x] `cd backend && uv run pytest tests/` — 226 passed
- [x] `cd backend && uv run ruff check src/` — clean
- [x] `cd frontend && npm run test -- --run formatters` — 28 passed
- [x] `cd frontend && npm run type-check` — clean
- [x] `cd frontend && npx prettier --check ...` — clean
- [ ] Manual: open record browser on a set with STRING-typed numeric keys, confirm record loads (Option A: any set whose `aql> select ... where PK='123'` works but `PK=123` does not).
- [ ] Manual: confirm Expiry column shows full short-form timestamp without `...` and tooltip shows long-form.

## Related

- Issue: aerospike-ce-ecosystem/aerospike-cluster-manager#206
- The `package-lock.json` change is from `npm install` needed to bootstrap `node_modules` for running the formatter test suite — not a dependency change.