### PR TITLE
fix(ui): real record detail + bin editor; wire sets page; native bool bins

### DIFF
--- a/backend/src/aerospike_cluster_manager_api/converters.py
+++ b/backend/src/aerospike_cluster_manager_api/converters.py
@@ -28,13 +28,21 @@ def record_to_model(rec: Record) -> AerospikeRecord:
 
     digest_hex = digest.hex() if isinstance(digest, bytes | bytearray) else None
 
-    # meta can be a RecordMetadata NamedTuple (gen, ttl) or a dict
+    # meta can be a RecordMetadata NamedTuple (gen, ttl, optional last_update_time) or a dict
+    last_update_ms: int | None = None
     if meta is not None and hasattr(meta, "gen"):
         gen = meta.gen
         ttl = meta.ttl
+        # aerospike-py may expose last_update_time or last_update_ms depending on version/read policy
+        raw_lut = getattr(meta, "last_update_time", None) or getattr(meta, "last_update_ms", None)
+        if isinstance(raw_lut, int) and raw_lut > 0:
+            last_update_ms = raw_lut
     elif isinstance(meta, dict):
         gen = meta.get("gen", 0)
         ttl = meta.get("ttl", 0)
+        raw_lut = meta.get("last_update_time") or meta.get("last_update_ms")
+        if isinstance(raw_lut, int) and raw_lut > 0:
+            last_update_ms = raw_lut
     else:
         gen = 0
         ttl = 0
@@ -49,6 +57,7 @@ def record_to_model(rec: Record) -> AerospikeRecord:
         meta=RecordMeta(
             generation=gen,
             ttl=ttl,
+            lastUpdateMs=last_update_ms,
         ),
         bins=bins,
     )

--- a/backend/src/aerospike_cluster_manager_api/sample_data_generator.py
+++ b/backend/src/aerospike_cluster_manager_api/sample_data_generator.py
@@ -54,8 +54,8 @@ def generate_record_bins(i: int) -> dict[str, Any]:
     dbl_dec_part = i % 100
     dbl_val = float(f"{dbl_int_part}.{dbl_dec_part}")
 
-    # bin_bool: Boolean as integer (0 or 1)
-    bool_val = i % 2
+    # bin_bool: actual Python bool (Aerospike CE 5.6+ supports native bool bins)
+    bool_val = bool(i % 2)
 
     # bin_list: mixed types [int, string, double, int]
     list_val = [int_val, color, dbl_val, i % 3]

--- a/frontend-renewal/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
+++ b/frontend-renewal/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
@@ -1,28 +1,411 @@
+"use client"
+
 import { Badge } from "@/components/Badge"
 import { Button } from "@/components/Button"
 import { Card } from "@/components/Card"
+import { Input } from "@/components/Input"
+import { Label } from "@/components/Label"
 import { clusterSections } from "@/app/siteConfig"
+import { ApiError } from "@/lib/api/client"
+import { deleteRecord, getRecordDetail, putRecord } from "@/lib/api/records"
+import type { AerospikeRecord, BinValue, PkType } from "@/lib/types/record"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useEffect, useMemo, useState } from "react"
 
 type PageProps = {
   params: { clusterId: string; namespace: string; set: string; key: string }
 }
 
-// Mirrors GET /api/connections/{connId}/records/{ns}/{set}/{key}
-type Bin = { name: string; type: string; value: string }
+// ---------------------------------------------------------------------------
+// Aerospike stores GeoJSON as a JSON string in a dedicated particle type, but the Python
+// backend currently returns it as a plain string. Detect the "type"/"coordinates" shape so
+// the UI surfaces it as GeoJSON rather than an opaque string.
+// ---------------------------------------------------------------------------
+const GEOJSON_TYPES = new Set([
+  "Point",
+  "LineString",
+  "Polygon",
+  "MultiPoint",
+  "MultiLineString",
+  "MultiPolygon",
+  "GeometryCollection",
+  "Feature",
+  "FeatureCollection",
+])
 
-const bins: Bin[] = [
-  { name: "email", type: "string", value: "alice@example.com" },
-  { name: "age", type: "integer", value: "29" },
-  { name: "is_active", type: "boolean", value: "true" },
-  { name: "tags", type: "list", value: '["early-access","beta"]' },
-  { name: "profile", type: "map", value: '{"plan":"pro","seats":5}' },
+type BinKind =
+  | "string"
+  | "integer"
+  | "double"
+  | "boolean"
+  | "list"
+  | "map"
+  | "geojson"
+  | "null"
+
+function looksLikeGeoJsonString(s: string): boolean {
+  const trimmed = s.trim()
+  if (!trimmed.startsWith("{") || !trimmed.endsWith("}")) return false
+  if (!trimmed.includes('"type"')) return false
+  try {
+    const parsed = JSON.parse(trimmed) as Record<string, unknown>
+    return (
+      typeof parsed.type === "string" &&
+      GEOJSON_TYPES.has(parsed.type) &&
+      ("coordinates" in parsed || "geometries" in parsed || "features" in parsed)
+    )
+  } catch {
+    return false
+  }
+}
+
+function detectBinType(value: unknown): BinKind {
+  if (value === null || value === undefined) return "null"
+  if (Array.isArray(value)) return "list"
+  if (typeof value === "boolean") return "boolean"
+  if (typeof value === "number")
+    return Number.isInteger(value) ? "integer" : "double"
+  if (typeof value === "string") {
+    return looksLikeGeoJsonString(value) ? "geojson" : "string"
+  }
+  if (typeof value === "object") {
+    const v = value as Record<string, unknown>
+    if (typeof v.type === "string" && GEOJSON_TYPES.has(v.type as string)) return "geojson"
+    return "map"
+  }
+  return "string"
+}
+
+function formatBinValue(value: unknown): string {
+  if (value === null || value === undefined) return "null"
+  if (typeof value === "string") {
+    if (looksLikeGeoJsonString(value)) {
+      try {
+        return JSON.stringify(JSON.parse(value), null, 2)
+      } catch {
+        return value
+      }
+    }
+    return value
+  }
+  if (typeof value === "number" || typeof value === "boolean") return String(value)
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+// Convert a bin value into the text we show inside the editor textarea.
+// Strings go in raw so the user doesn't have to deal with quoting; structured
+// types are pretty-printed JSON; geojson stays as a JSON object string.
+function binToDraft(value: unknown, kind: BinKind): string {
+  if (kind === "string") return (value as string) ?? ""
+  if (kind === "null") return "null"
+  if (kind === "geojson") {
+    if (typeof value === "string") {
+      try {
+        return JSON.stringify(JSON.parse(value), null, 2)
+      } catch {
+        return value
+      }
+    }
+    return JSON.stringify(value, null, 2)
+  }
+  return formatBinValue(value)
+}
+
+// Parse editor text back into a JS value honoring the chosen bin kind.
+// Throws on invalid input with a message the UI surfaces next to the field.
+function draftToBin(draft: string, kind: BinKind): BinValue {
+  switch (kind) {
+    case "null":
+      return null
+    case "string":
+      return draft
+    case "integer": {
+      const n = Number(draft.trim())
+      if (!Number.isFinite(n) || !Number.isInteger(n))
+        throw new Error("Not a valid integer")
+      return n
+    }
+    case "double": {
+      const n = Number(draft.trim())
+      if (!Number.isFinite(n)) throw new Error("Not a valid number")
+      return n
+    }
+    case "boolean": {
+      const t = draft.trim().toLowerCase()
+      if (t === "true") return true
+      if (t === "false") return false
+      throw new Error("Must be 'true' or 'false'")
+    }
+    case "list":
+    case "map": {
+      try {
+        return JSON.parse(draft) as BinValue
+      } catch (e) {
+        throw new Error(`Invalid JSON: ${e instanceof Error ? e.message : String(e)}`)
+      }
+    }
+    case "geojson": {
+      try {
+        const parsed = JSON.parse(draft) as Record<string, unknown>
+        if (
+          typeof parsed.type !== "string" ||
+          !GEOJSON_TYPES.has(parsed.type as string)
+        )
+          throw new Error("GeoJSON 'type' missing or unknown")
+        // Round-trip back to string form — that's what the backend expects.
+        return JSON.stringify(parsed)
+      } catch (e) {
+        throw new Error(`Invalid GeoJSON: ${e instanceof Error ? e.message : String(e)}`)
+      }
+    }
+  }
+}
+
+const TTL_NEVER_SENTINEL = 4_294_967_295
+
+function formatTtl(ttl: number | undefined): string {
+  if (ttl === undefined) return "—"
+  if (ttl === -1 || ttl === 0 || ttl === TTL_NEVER_SENTINEL) return "never"
+  if (ttl >= 86400) return `${Math.floor(ttl / 86400)}d ${Math.floor((ttl % 86400) / 3600)}h`
+  if (ttl >= 3600) return `${Math.floor(ttl / 3600)}h ${Math.floor((ttl % 3600) / 60)}m`
+  if (ttl >= 60) return `${Math.floor(ttl / 60)}m ${ttl % 60}s`
+  return `${ttl}s`
+}
+
+const CITRUSLEAF_EPOCH_MS = 1_262_304_000_000
+
+function formatLastUpdate(lastUpdateMs: number | undefined | null): string {
+  if (!lastUpdateMs) return "—"
+  const msSinceEpoch =
+    lastUpdateMs < 1_000_000_000_000
+      ? Math.floor(lastUpdateMs / 1_000_000) + CITRUSLEAF_EPOCH_MS
+      : lastUpdateMs
+  return new Date(msSinceEpoch).toLocaleString()
+}
+
+// ---------------------------------------------------------------------------
+// Draft model for the editor
+// ---------------------------------------------------------------------------
+interface BinDraft {
+  id: string
+  name: string
+  kind: BinKind
+  value: string
+}
+
+const BIN_KINDS: BinKind[] = [
+  "string",
+  "integer",
+  "double",
+  "boolean",
+  "list",
+  "map",
+  "geojson",
+  "null",
 ]
 
-const meta = { generation: 3, ttl: 2_592_000, lastUpdate: "2026-04-17T02:12:19Z" }
+function buildInitialDraft(record: AerospikeRecord): BinDraft[] {
+  return Object.entries(record.bins).map(([name, value], i) => {
+    const kind = detectBinType(value)
+    return { id: `bin-${i}-${name}`, name, kind, value: binToDraft(value, kind) }
+  })
+}
 
+// ---------------------------------------------------------------------------
+// Page
+// ---------------------------------------------------------------------------
 export default function RecordDetailPage({ params }: PageProps) {
+  const router = useRouter()
   const pk = decodeURIComponent(params.key)
+
+  const [record, setRecord] = useState<AerospikeRecord | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [deleting, setDeleting] = useState(false)
+
+  const [isEditing, setIsEditing] = useState(false)
+  const [drafts, setDrafts] = useState<BinDraft[]>([])
+  const [binErrors, setBinErrors] = useState<Record<string, string>>({})
+  const [ttlDraft, setTtlDraft] = useState<string>("")
+  const [saving, setSaving] = useState(false)
+
+  const loadRecord = (signal?: { cancelled: boolean }) => {
+    setIsLoading(true)
+    setError(null)
+    return getRecordDetail(params.clusterId, {
+      ns: params.namespace,
+      set: params.set,
+      pk,
+      pk_type: "auto" as PkType,
+    })
+      .then((r) => {
+        if (signal?.cancelled) return
+        setRecord(r)
+      })
+      .catch((err) => {
+        if (signal?.cancelled) return
+        if (err instanceof ApiError) setError(err.detail || err.message)
+        else if (err instanceof Error) setError(err.message)
+        else setError("Failed to load record")
+      })
+      .finally(() => {
+        if (!signal?.cancelled) setIsLoading(false)
+      })
+  }
+
+  useEffect(() => {
+    const signal = { cancelled: false }
+    loadRecord(signal)
+    return () => {
+      signal.cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [params.clusterId, params.namespace, params.set, pk])
+
+  const handleDelete = async () => {
+    if (!record) return
+    if (!window.confirm(`Delete record '${pk}'?`)) return
+    setDeleting(true)
+    try {
+      await deleteRecord(params.clusterId, {
+        ns: params.namespace,
+        set: params.set,
+        pk,
+        pk_type: "auto" as PkType,
+      })
+      router.push(clusterSections.set(params.clusterId, params.namespace, params.set))
+    } catch (err) {
+      if (err instanceof ApiError) setError(err.detail || err.message)
+      else if (err instanceof Error) setError(err.message)
+      else setError("Failed to delete record")
+      setDeleting(false)
+    }
+  }
+
+  const startEdit = () => {
+    if (!record) return
+    setDrafts(buildInitialDraft(record))
+    const ttl = record.meta.ttl
+    // When the record is set to "never expire", start with 0 (= keep TTL) so we don't force a new TTL on save.
+    setTtlDraft(
+      ttl === undefined || ttl === -1 || ttl === TTL_NEVER_SENTINEL ? "-1" : String(ttl),
+    )
+    setBinErrors({})
+    setIsEditing(true)
+  }
+
+  const cancelEdit = () => {
+    setIsEditing(false)
+    setDrafts([])
+    setBinErrors({})
+  }
+
+  const updateDraft = (id: string, patch: Partial<BinDraft>) => {
+    setDrafts((prev) => prev.map((d) => (d.id === id ? { ...d, ...patch } : d)))
+    // Clear the per-bin error as the user edits
+    if (patch.value !== undefined || patch.kind !== undefined) {
+      setBinErrors((prev) => {
+        const { [id]: _, ...rest } = prev
+        return rest
+      })
+    }
+  }
+
+  const addBin = () => {
+    const id = `bin-new-${Date.now()}`
+    setDrafts((prev) => [...prev, { id, name: "", kind: "string", value: "" }])
+  }
+
+  const removeBin = (id: string) => {
+    setDrafts((prev) => prev.filter((d) => d.id !== id))
+    setBinErrors((prev) => {
+      const { [id]: _, ...rest } = prev
+      return rest
+    })
+  }
+
+  const handleSave = async () => {
+    if (!record) return
+    setError(null)
+
+    // Validate bin names
+    const nextErrors: Record<string, string> = {}
+    const seenNames = new Set<string>()
+    for (const d of drafts) {
+      const n = d.name.trim()
+      if (!n) {
+        nextErrors[d.id] = "Bin name is required"
+        continue
+      }
+      if (seenNames.has(n)) {
+        nextErrors[d.id] = `Duplicate bin name '${n}'`
+        continue
+      }
+      seenNames.add(n)
+    }
+
+    // Parse each draft value in its chosen kind
+    const bins: Record<string, BinValue> = {}
+    for (const d of drafts) {
+      if (nextErrors[d.id]) continue
+      try {
+        bins[d.name.trim()] = draftToBin(d.value, d.kind)
+      } catch (e) {
+        nextErrors[d.id] = e instanceof Error ? e.message : String(e)
+      }
+    }
+
+    if (Object.keys(nextErrors).length > 0) {
+      setBinErrors(nextErrors)
+      return
+    }
+
+    let ttl: number | undefined
+    const t = ttlDraft.trim()
+    if (t !== "") {
+      const n = Number(t)
+      if (!Number.isInteger(n)) {
+        setError(
+          "TTL must be an integer (0 keep existing, -1 never expire, or seconds until expiry).",
+        )
+        return
+      }
+      ttl = n
+    }
+
+    setSaving(true)
+    try {
+      await putRecord(params.clusterId, {
+        key: { namespace: params.namespace, set: params.set, pk },
+        bins,
+        ttl,
+        pkType: "auto" as PkType,
+      })
+      setIsEditing(false)
+      setDrafts([])
+      await loadRecord()
+    } catch (err) {
+      if (err instanceof ApiError) setError(err.detail || err.message)
+      else if (err instanceof Error) setError(err.message)
+      else setError("Failed to save record")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const bins = record ? Object.entries(record.bins) : []
+  const meta = record?.meta
+  const binCount = isEditing ? drafts.length : bins.length
+  const hasValidationErrors = useMemo(
+    () => Object.keys(binErrors).length > 0,
+    [binErrors],
+  )
+
   return (
     <main className="flex flex-col gap-6">
       <nav
@@ -58,56 +441,231 @@ export default function RecordDetailPage({ params }: PageProps) {
           </h1>
         </div>
         <div className="flex gap-2">
-          <Button variant="secondary">Duplicate</Button>
-          <Button variant="destructive">Delete</Button>
-          <Button variant="primary">Save changes</Button>
+          {isEditing ? (
+            <>
+              <Button variant="secondary" onClick={cancelEdit} disabled={saving}>
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                onClick={handleSave}
+                isLoading={saving}
+                loadingText="Saving…"
+                disabled={saving || hasValidationErrors}
+              >
+                Save changes
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button
+                variant="secondary"
+                onClick={startEdit}
+                disabled={!record || deleting}
+              >
+                Edit
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={handleDelete}
+                isLoading={deleting}
+                loadingText="Deleting…"
+                disabled={!record || deleting}
+              >
+                Delete
+              </Button>
+            </>
+          )}
         </div>
       </header>
 
-      <Card className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-        <div>
-          <dt className="text-xs text-gray-500 dark:text-gray-500">Generation</dt>
-          <dd className="font-mono text-sm font-medium tabular-nums text-gray-900 dark:text-gray-50">
-            {meta.generation}
-          </dd>
+      {error && (
+        <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
+          {error}
         </div>
-        <div>
-          <dt className="text-xs text-gray-500 dark:text-gray-500">TTL</dt>
-          <dd className="font-mono text-sm font-medium tabular-nums text-gray-900 dark:text-gray-50">
-            {meta.ttl === -1 ? "never" : `${meta.ttl}s`}
-          </dd>
-        </div>
-        <div>
-          <dt className="text-xs text-gray-500 dark:text-gray-500">Last update</dt>
-          <dd className="font-mono text-sm font-medium text-gray-900 dark:text-gray-50">
-            {meta.lastUpdate}
-          </dd>
-        </div>
-        <div>
-          <dt className="text-xs text-gray-500 dark:text-gray-500">Bins</dt>
-          <dd className="font-mono text-sm font-medium tabular-nums text-gray-900 dark:text-gray-50">
-            {bins.length}
-          </dd>
-        </div>
-      </Card>
+      )}
 
-      <Card className="p-0">
-        <ul className="flex flex-col divide-y divide-gray-200 dark:divide-gray-800">
-          {bins.map((b) => (
-            <li key={b.name} className="flex flex-col gap-2 px-5 py-3 sm:flex-row sm:items-start">
-              <div className="min-w-40 sm:w-56">
-                <p className="font-mono text-sm font-semibold text-gray-900 dark:text-gray-50">
-                  {b.name}
-                </p>
-                <Badge variant="neutral">{b.type}</Badge>
+      {isLoading && !record ? (
+        <Card className="py-10 text-center text-sm text-gray-500 dark:text-gray-500">
+          Loading record…
+        </Card>
+      ) : !record ? (
+        <Card className="py-10 text-center text-sm text-gray-500 dark:text-gray-500">
+          Record not found.
+        </Card>
+      ) : (
+        <>
+          <Card className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+            <div>
+              <dt className="text-xs text-gray-500 dark:text-gray-500">Generation</dt>
+              <dd className="font-mono text-sm font-medium tabular-nums text-gray-900 dark:text-gray-50">
+                {meta?.generation ?? "—"}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gray-500 dark:text-gray-500">TTL</dt>
+              <dd className="font-mono text-sm font-medium tabular-nums text-gray-900 dark:text-gray-50">
+                {isEditing ? (
+                  <Input
+                    value={ttlDraft}
+                    onChange={(e) => setTtlDraft(e.target.value)}
+                    placeholder="-1 never, 0 keep, >0 seconds"
+                    className="h-7 w-40 text-xs"
+                  />
+                ) : (
+                  formatTtl(meta?.ttl)
+                )}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gray-500 dark:text-gray-500">Last update</dt>
+              <dd
+                className="font-mono text-sm font-medium text-gray-900 dark:text-gray-50"
+                title={
+                  meta && !meta.lastUpdateMs
+                    ? "aerospike-py RecordMetadata exposes only (gen, ttl); last_update_time is not surfaced."
+                    : undefined
+                }
+              >
+                {formatLastUpdate(meta?.lastUpdateMs)}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs text-gray-500 dark:text-gray-500">Bins</dt>
+              <dd className="font-mono text-sm font-medium tabular-nums text-gray-900 dark:text-gray-50">
+                {binCount}
+              </dd>
+            </div>
+          </Card>
+
+          <Card className="p-0">
+            <ul className="flex flex-col divide-y divide-gray-200 dark:divide-gray-800">
+              {isEditing ? (
+                drafts.length === 0 ? (
+                  <li className="px-5 py-6 text-center text-sm text-gray-500 dark:text-gray-500">
+                    No bins yet — use <strong>Add bin</strong> below.
+                  </li>
+                ) : (
+                  drafts.map((d) => (
+                    <li key={d.id} className="flex flex-col gap-2 px-5 py-3">
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-start">
+                        <div className="flex min-w-40 flex-col gap-1.5 sm:w-56">
+                          <Label htmlFor={`${d.id}-name`}>Bin name</Label>
+                          <Input
+                            id={`${d.id}-name`}
+                            value={d.name}
+                            onChange={(e) => updateDraft(d.id, { name: e.target.value })}
+                            placeholder="bin_name"
+                          />
+                          <Label htmlFor={`${d.id}-type`}>Type</Label>
+                          <select
+                            id={`${d.id}-type`}
+                            value={d.kind}
+                            onChange={(e) =>
+                              updateDraft(d.id, { kind: e.target.value as BinKind })
+                            }
+                            className="h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+                          >
+                            {BIN_KINDS.map((k) => (
+                              <option key={k} value={k}>
+                                {k}
+                              </option>
+                            ))}
+                          </select>
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            className="text-xs text-red-600 hover:text-red-700"
+                            onClick={() => removeBin(d.id)}
+                          >
+                            Remove bin
+                          </Button>
+                        </div>
+                        <div className="flex-1">
+                          {d.kind === "boolean" ? (
+                            <select
+                              value={d.value || "false"}
+                              onChange={(e) => updateDraft(d.id, { value: e.target.value })}
+                              className="h-9 w-full rounded-md border border-gray-300 bg-white px-3 font-mono text-xs text-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+                            >
+                              <option value="true">true</option>
+                              <option value="false">false</option>
+                            </select>
+                          ) : d.kind === "null" ? (
+                            <div className="rounded bg-gray-50 p-3 font-mono text-xs text-gray-500 dark:bg-gray-900 dark:text-gray-400">
+                              null
+                            </div>
+                          ) : d.kind === "string" || d.kind === "integer" || d.kind === "double" ? (
+                            <Input
+                              value={d.value}
+                              onChange={(e) => updateDraft(d.id, { value: e.target.value })}
+                              className="font-mono"
+                              placeholder={
+                                d.kind === "string"
+                                  ? "hello"
+                                  : d.kind === "integer"
+                                    ? "42"
+                                    : "3.14"
+                              }
+                            />
+                          ) : (
+                            <textarea
+                              value={d.value}
+                              onChange={(e) => updateDraft(d.id, { value: e.target.value })}
+                              rows={d.kind === "geojson" ? 6 : 8}
+                              className="w-full rounded-md border border-gray-300 bg-white p-3 font-mono text-xs text-gray-800 dark:border-gray-700 dark:bg-gray-950 dark:text-gray-200"
+                              placeholder={
+                                d.kind === "list"
+                                  ? '[1, "two", 3.0]'
+                                  : d.kind === "map"
+                                    ? '{"key": "value"}'
+                                    : '{"type":"Point","coordinates":[0,0]}'
+                              }
+                            />
+                          )}
+                          {binErrors[d.id] && (
+                            <p className="mt-1 text-xs text-red-600 dark:text-red-400">
+                              {binErrors[d.id]}
+                            </p>
+                          )}
+                        </div>
+                      </div>
+                    </li>
+                  ))
+                )
+              ) : bins.length === 0 ? (
+                <li className="px-5 py-6 text-center text-sm text-gray-500 dark:text-gray-500">
+                  This record has no bins.
+                </li>
+              ) : (
+                bins.map(([name, value]) => (
+                  <li
+                    key={name}
+                    className="flex flex-col gap-2 px-5 py-3 sm:flex-row sm:items-start"
+                  >
+                    <div className="min-w-40 sm:w-56">
+                      <p className="font-mono text-sm font-semibold text-gray-900 dark:text-gray-50">
+                        {name}
+                      </p>
+                      <Badge variant="neutral">{detectBinType(value)}</Badge>
+                    </div>
+                    <pre className="flex-1 overflow-x-auto whitespace-pre-wrap break-all rounded bg-gray-50 p-3 font-mono text-xs text-gray-800 dark:bg-gray-900 dark:text-gray-200">
+                      {formatBinValue(value)}
+                    </pre>
+                  </li>
+                ))
+              )}
+            </ul>
+            {isEditing && (
+              <div className="border-t border-gray-200 px-5 py-3 dark:border-gray-800">
+                <Button type="button" variant="secondary" onClick={addBin}>
+                  + Add bin
+                </Button>
               </div>
-              <pre className="flex-1 overflow-x-auto whitespace-pre-wrap break-all rounded bg-gray-50 p-3 font-mono text-xs text-gray-800 dark:bg-gray-900 dark:text-gray-200">
-                {b.value}
-              </pre>
-            </li>
-          ))}
-        </ul>
-      </Card>
+            )}
+          </Card>
+        </>
+      )}
     </main>
   )
 }

--- a/frontend-renewal/src/app/(main)/clusters/[clusterId]/sets/page.tsx
+++ b/frontend-renewal/src/app/(main)/clusters/[clusterId]/sets/page.tsx
@@ -4,6 +4,8 @@ import { Badge } from "@/components/Badge"
 import { Button } from "@/components/Button"
 import { Card } from "@/components/Card"
 import { Input } from "@/components/Input"
+import { CreateSampleDataDialog } from "@/components/dialogs/CreateSampleDataDialog"
+import { CreateSetDialog } from "@/components/dialogs/CreateSetDialog"
 import { clusterSections } from "@/app/siteConfig"
 import { useCluster } from "@/hooks/use-cluster"
 import type { NamespaceInfo, SetInfo } from "@/lib/types/cluster"
@@ -46,8 +48,11 @@ function nsStatusLabel(ns: NamespaceInfo): string {
 export default function SetsPage({ params }: PageProps) {
   const cluster = useCluster(params.clusterId)
   const [filter, setFilter] = useState("")
+  const [sampleOpen, setSampleOpen] = useState(false)
+  const [createSetNs, setCreateSetNs] = useState<string | null>(null)
 
   const namespaces = useMemo(() => cluster.data?.namespaces ?? [], [cluster.data])
+  const nsNames = useMemo(() => namespaces.map((n) => n.name), [namespaces])
 
   const filtered = useMemo(() => {
     const q = filter.trim().toLowerCase()
@@ -78,7 +83,13 @@ export default function SetsPage({ params }: PageProps) {
           <span className="text-xs text-gray-500 dark:text-gray-500">
             {namespaces.length} / 2 max <span className="font-medium">(CE)</span>
           </span>
-          <Button variant="secondary">Sample data</Button>
+          <Button
+            variant="secondary"
+            onClick={() => setSampleOpen(true)}
+            disabled={nsNames.length === 0}
+          >
+            Sample data
+          </Button>
         </div>
       </header>
 
@@ -105,10 +116,33 @@ export default function SetsPage({ params }: PageProps) {
       ) : (
         <div className="flex flex-col gap-4">
           {filtered.map((ns) => (
-            <NamespaceCard key={ns.name} ns={ns} clusterId={params.clusterId} />
+            <NamespaceCard
+              key={ns.name}
+              ns={ns}
+              clusterId={params.clusterId}
+              onCreateSet={() => setCreateSetNs(ns.name)}
+            />
           ))}
         </div>
       )}
+
+      <CreateSampleDataDialog
+        open={sampleOpen}
+        onOpenChange={setSampleOpen}
+        connId={params.clusterId}
+        namespaces={nsNames}
+        onSuccess={() => cluster.refetch?.()}
+      />
+      <CreateSetDialog
+        open={createSetNs !== null}
+        onOpenChange={(o) => !o && setCreateSetNs(null)}
+        connId={params.clusterId}
+        namespace={createSetNs ?? ""}
+        onSuccess={() => {
+          setCreateSetNs(null)
+          cluster.refetch?.()
+        }}
+      />
     </main>
   )
 }
@@ -116,9 +150,11 @@ export default function SetsPage({ params }: PageProps) {
 function NamespaceCard({
   ns,
   clusterId,
+  onCreateSet,
 }: {
   ns: NamespaceInfo
   clusterId: string
+  onCreateSet: () => void
 }) {
   const severity = nsSeverity(ns)
   const accent =
@@ -205,6 +241,8 @@ function NamespaceCard({
           <SetChip key={s.name} clusterId={clusterId} namespace={ns.name} set={s} />
         ))}
         <button
+          type="button"
+          onClick={onCreateSet}
           className={cx(
             "inline-flex items-center gap-1 rounded-md border border-dashed border-indigo-300 px-2.5 py-1.5 text-xs font-medium text-indigo-600 transition",
             "hover:border-indigo-400 hover:bg-indigo-50 dark:border-indigo-900/60 dark:text-indigo-400 dark:hover:bg-indigo-950/30",

--- a/frontend-renewal/src/components/dialogs/CreateSampleDataDialog.tsx
+++ b/frontend-renewal/src/components/dialogs/CreateSampleDataDialog.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import React from "react";
+
+import { Button } from "@/components/Button";
+import { Checkbox } from "@/components/Checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/Dialog";
+import { Input } from "@/components/Input";
+import { Label } from "@/components/Label";
+import { ApiError } from "@/lib/api/client";
+import { createSampleData } from "@/lib/api/sample-data";
+
+const MAX_RECORDS = 10_000;
+
+interface CreateSampleDataDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  connId: string;
+  namespaces: string[];
+  defaultNamespace?: string;
+  onSuccess?: (summary: {
+    recordsCreated: number;
+    indexesCreated: number;
+    indexesSkipped: number;
+    elapsedMs: number;
+  }) => void;
+}
+
+export function CreateSampleDataDialog({
+  open,
+  onOpenChange,
+  connId,
+  namespaces,
+  defaultNamespace,
+  onSuccess,
+}: CreateSampleDataDialogProps) {
+  const [namespace, setNamespace] = React.useState(
+    defaultNamespace ?? namespaces[0] ?? "",
+  );
+  const [setName, setSetName] = React.useState("sample_set");
+  const [recordCount, setRecordCount] = React.useState("1234");
+  const [createIndexes, setCreateIndexes] = React.useState(true);
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    setNamespace(defaultNamespace ?? namespaces[0] ?? "");
+    setSetName("sample_set");
+    setRecordCount("1234");
+    setCreateIndexes(true);
+    setError(null);
+  }, [open, defaultNamespace, namespaces]);
+
+  const handleSubmit = async () => {
+    setError(null);
+    if (!namespace) {
+      setError("Namespace is required");
+      return;
+    }
+    const name = setName.trim();
+    if (!name) {
+      setError("Set name is required");
+      return;
+    }
+    const count = Number.parseInt(recordCount, 10);
+    if (!Number.isFinite(count) || count < 1 || count > MAX_RECORDS) {
+      setError(`Record count must be between 1 and ${MAX_RECORDS.toLocaleString()}`);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const result = await createSampleData(connId, {
+        namespace,
+        setName: name,
+        recordCount: count,
+        createIndexes,
+      });
+      onOpenChange(false);
+      onSuccess?.({
+        recordsCreated: result.recordsCreated,
+        indexesCreated: result.indexesCreated.length,
+        indexesSkipped: result.indexesSkipped.length,
+        elapsedMs: result.elapsedMs,
+      });
+    } catch (err) {
+      if (err instanceof ApiError) setError(err.detail || err.message);
+      else if (err instanceof Error) setError(err.message);
+      else setError("Failed to create sample data");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[95vw] sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>Create Sample Data</DialogTitle>
+          <DialogDescription>
+            Generate sample records with varied bin types (int / string / double / bool / list /
+            map / geojson) for testing and exploration.
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && (
+          <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        <div className="flex flex-col gap-4 py-2">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="sd-namespace">Namespace</Label>
+            <select
+              id="sd-namespace"
+              value={namespace}
+              onChange={(e) => setNamespace(e.target.value)}
+              className="h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+            >
+              <option value="">Select namespace</option>
+              {namespaces.map((ns) => (
+                <option key={ns} value={ns}>
+                  {ns}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="sd-set">Set Name</Label>
+            <Input
+              id="sd-set"
+              value={setName}
+              onChange={(e) => setSetName(e.target.value)}
+              placeholder="sample_set"
+            />
+          </div>
+
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="sd-count">
+              Record Count{" "}
+              <span className="text-xs text-gray-500">
+                (1 ~ {MAX_RECORDS.toLocaleString()})
+              </span>
+            </Label>
+            <Input
+              id="sd-count"
+              type="number"
+              min={1}
+              max={MAX_RECORDS}
+              value={recordCount}
+              onChange={(e) => setRecordCount(e.target.value)}
+            />
+          </div>
+
+          <label className="flex items-center gap-2">
+            <Checkbox
+              id="sd-indexes"
+              checked={createIndexes}
+              onCheckedChange={(v) => setCreateIndexes(v === true)}
+            />
+            <Label htmlFor="sd-indexes" className="cursor-pointer text-sm">
+              Create secondary indexes (5 indexes on int/str/double/bool/geojson bins)
+            </Label>
+          </label>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            disabled={loading}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSubmit} isLoading={loading} loadingText="Creating…">
+            Create Sample Data
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend-renewal/src/components/dialogs/CreateSetDialog.tsx
+++ b/frontend-renewal/src/components/dialogs/CreateSetDialog.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import React from "react";
+
+import { Button } from "@/components/Button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/Dialog";
+import { Input } from "@/components/Input";
+import { Label } from "@/components/Label";
+import { ApiError } from "@/lib/api/client";
+import { putRecord } from "@/lib/api/records";
+
+/**
+ * Aerospike sets are created implicitly when a record with a new `set` value is written.
+ * This dialog collects the set name and a seed record (primary key + one bin) and POSTs
+ * it through the normal record write endpoint — after the write completes, the set exists
+ * and the user returns to the set list with a refreshed cluster view.
+ */
+interface CreateSetDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  connId: string;
+  namespace: string;
+  onSuccess?: (setName: string) => void;
+}
+
+export function CreateSetDialog({
+  open,
+  onOpenChange,
+  connId,
+  namespace,
+  onSuccess,
+}: CreateSetDialogProps) {
+  const [setName, setSetName] = React.useState("");
+  const [pk, setPk] = React.useState("");
+  const [binName, setBinName] = React.useState("value");
+  const [binValue, setBinValue] = React.useState("");
+  const [loading, setLoading] = React.useState(false);
+  const [error, setError] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (!open) return;
+    setSetName("");
+    setPk("");
+    setBinName("value");
+    setBinValue("");
+    setError(null);
+  }, [open]);
+
+  const handleSubmit = async () => {
+    setError(null);
+    const set = setName.trim();
+    if (!set) return setError("Set name is required");
+    const primaryKey = pk.trim();
+    if (!primaryKey) return setError("Primary key is required");
+    const bin = binName.trim();
+    if (!bin) return setError("Bin name is required");
+
+    setLoading(true);
+    try {
+      await putRecord(connId, {
+        key: { namespace, set, pk: primaryKey },
+        bins: { [bin]: binValue },
+      });
+      onOpenChange(false);
+      onSuccess?.(set);
+    } catch (err) {
+      if (err instanceof ApiError) setError(err.detail || err.message);
+      else if (err instanceof Error) setError(err.message);
+      else setError("Failed to create set");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[95vw] sm:max-w-[480px]">
+        <DialogHeader>
+          <DialogTitle>Create set in {namespace}</DialogTitle>
+          <DialogDescription>
+            Aerospike creates sets implicitly when the first record is written. Provide a set
+            name and a seed record below — the set will appear after the write succeeds.
+          </DialogDescription>
+        </DialogHeader>
+
+        {error && (
+          <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
+            {error}
+          </div>
+        )}
+
+        <div className="flex flex-col gap-4 py-2">
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="cs-name">Set Name</Label>
+            <Input
+              id="cs-name"
+              value={setName}
+              onChange={(e) => setSetName(e.target.value)}
+              placeholder="my_set"
+              autoFocus
+            />
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="cs-pk">Primary Key (for the seed record)</Label>
+            <Input
+              id="cs-pk"
+              value={pk}
+              onChange={(e) => setPk(e.target.value)}
+              placeholder="record-1"
+            />
+          </div>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-2">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="cs-bin-name">Bin Name</Label>
+              <Input
+                id="cs-bin-name"
+                value={binName}
+                onChange={(e) => setBinName(e.target.value)}
+                placeholder="value"
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="cs-bin-value">Bin Value</Label>
+              <Input
+                id="cs-bin-value"
+                value={binValue}
+                onChange={(e) => setBinValue(e.target.value)}
+                placeholder="hello"
+              />
+            </div>
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="secondary"
+            onClick={() => onOpenChange(false)}
+            disabled={loading}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSubmit} isLoading={loading} loadingText="Creating…">
+            Create Set
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend-renewal/src/lib/api/sample-data.ts
+++ b/frontend-renewal/src/lib/api/sample-data.ts
@@ -1,0 +1,20 @@
+/**
+ * Sample data generator — POST /api/sample-data/{conn_id}
+ *
+ * Bulk-writes synthetic records with varied bin types (int/str/double/bool/list/map/geojson)
+ * and optionally creates matching secondary indexes. Useful for populating a fresh cluster
+ * or exploring the record browser without hand-crafting data.
+ */
+
+import type {
+  CreateSampleDataRequest,
+  CreateSampleDataResponse,
+} from "../types/sample-data";
+import { apiPost } from "./client";
+
+export function createSampleData(
+  connId: string,
+  data: CreateSampleDataRequest,
+): Promise<CreateSampleDataResponse> {
+  return apiPost(`/sample-data/${encodeURIComponent(connId)}`, data, { timeoutMs: 60_000 });
+}

--- a/frontend-renewal/src/lib/types/sample-data.ts
+++ b/frontend-renewal/src/lib/types/sample-data.ts
@@ -1,0 +1,13 @@
+export interface CreateSampleDataRequest {
+  namespace: string;
+  setName?: string;
+  recordCount?: number;
+  createIndexes?: boolean;
+}
+
+export interface CreateSampleDataResponse {
+  recordsCreated: number;
+  indexesCreated: string[];
+  indexesSkipped: string[];
+  elapsedMs: number;
+}


### PR DESCRIPTION
## Summary

- **Record detail** (`frontend-renewal`): replace the 5-bin mock (email/age/…) with a live `GET /api/records/{connId}/detail`, and add an inline bin editor (per-bin name/type with the right widget per type, validation, Add/Remove bin, TTL editor). Save posts via `POST /api/records/{connId}`.
- **Sets page** (`frontend-renewal`): wire the previously-placeholder **Sample data** button to `CreateSampleDataDialog → POST /api/sample-data/{connId}`, and the per-namespace **+ Create set** chip to `CreateSetDialog` (Aerospike creates sets on first write, so it writes a seed record via `POST /api/records/{connId}`).
- **Aerospike-specific display**: GeoJSON strings detected by shape and rendered with a `geojson` badge + pretty-print; TTL `uint32_max`/`0`/`-1` sentinels translated to `never`; remaining values rendered as `Nd Nh` / `Nh Nm` / `Nm Ns` / `Ns`.
- **Backend**: `sample_data_generator.bin_bool` now stores a native Python `bool` (Aerospike `BOOLEAN` particle), not `0/1 INTEGER`. Existing records need to be regenerated via the Sample data dialog to pick up the new type.
- **Backend (future-proof)**: `converters.record_to_model` best-effort reads `meta.last_update_time` / `meta.last_update_ms` via `hasattr`/`getattr`; aerospike-py 0.5.3 doesn't expose them yet (tracked in aerospike-py#292), so `lastUpdateMs` stays `null` for now and the UI shows a tooltip explaining why.

## Background

This was commit `e0eb7d7` originally slated to land with PR #208, but PR #208 was merged at its prior HEAD (`1d01883`) so this work was left behind. Recovered from local reflog as `d02d4aa` and rebased on current `origin/main`.

## Test plan

- [ ] Open a record on the renewal UI — bin count + values match what aql shows.
- [ ] Edit a bin (each type), Save, reload — edits persist.
- [ ] Edit TTL with `-1` / `0` / a positive seconds value — each behaves per Aerospike semantics.
- [ ] Sets page: `Sample data` creates records + indexes. `+ Create set` seeds a record, set appears in the list.
- [ ] `bin_bool` stored via the new seed path shows as `true`/`false` (BOOLEAN) in aql, not `0`/`1`.