### PR TITLE
feat(frontend-renewal): record-browser filter toolbar + sidebar polish

### DIFF
--- a/frontend-renewal/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
+++ b/frontend-renewal/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
@@ -3,7 +3,6 @@
 import { Badge } from "@/components/Badge"
 import { Button } from "@/components/Button"
 import { Card } from "@/components/Card"
-import { Input } from "@/components/Input"
 import {
   Table,
   TableBody,
@@ -13,10 +12,28 @@ import {
   TableRoot,
   TableRow,
 } from "@/components/Table"
+import {
+  draftHasFilters,
+  draftToFilterConditions,
+  emptyFilterDraft,
+  RecordFilters,
+  type FilterDraft,
+} from "@/components/browser/RecordFilters"
 import { clusterSections } from "@/app/siteConfig"
-import { listRecords } from "@/lib/api/records"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/Select"
+import { listIndexes } from "@/lib/api/indexes"
+import { filterRecords } from "@/lib/api/records"
+import type { BinDataType } from "@/lib/types/query"
+import type { SecondaryIndex } from "@/lib/types/index"
 import type { AerospikeRecord } from "@/lib/types/record"
 import { cx } from "@/lib/utils"
+import { RiRefreshLine, RiTimerLine } from "@remixicon/react"
 import Link from "next/link"
 import { useCallback, useEffect, useMemo, useState } from "react"
 
@@ -24,6 +41,23 @@ type PageProps = { params: { clusterId: string; namespace: string; set: string }
 
 // TTL sentinel for namespaces without default-ttl (uint32 max).
 const TTL_NO_EXPIRY = 4_294_967_295
+
+const PAGE_SIZE_OPTIONS = [25, 50, 100] as const
+const DEFAULT_PAGE_SIZE = 50
+
+function formatRowCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`
+  return String(n)
+}
+
+interface QueryMeta {
+  total: number
+  totalEstimated: boolean
+  executionTimeMs: number
+}
+
+const EMPTY_META: QueryMeta = { total: 0, totalEstimated: false, executionTimeMs: 0 }
 
 function formatTtl(ttl: number): string {
   if (!Number.isFinite(ttl) || ttl === TTL_NO_EXPIRY || ttl <= 0) return "never"
@@ -98,33 +132,81 @@ function renderBin(v: unknown, name: string): React.ReactNode {
   return <span className="font-mono text-xs text-gray-900 dark:text-gray-50">{s}</span>
 }
 
+function indexTypeToBinDataType(idx: SecondaryIndex): BinDataType {
+  if (idx.type === "numeric") return "integer"
+  if (idx.type === "geo2dsphere") return "geo"
+  return "string"
+}
+
 export default function RecordBrowserPage({ params }: PageProps) {
   const [records, setRecords] = useState<AerospikeRecord[] | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
-  const [pkFilter, setPkFilter] = useState("")
+  const [indexes, setIndexes] = useState<SecondaryIndex[]>([])
+  const [pageSize, setPageSize] = useState<number>(DEFAULT_PAGE_SIZE)
+  const [meta, setMeta] = useState<QueryMeta>(EMPTY_META)
 
-  const load = useCallback(async () => {
-    setLoading(true)
-    setError(null)
-    try {
-      const resp = await listRecords(params.clusterId, {
-        ns: params.namespace,
-        set: params.set,
-        pageSize: 50,
-      })
-      setRecords(resp.records)
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-      setRecords(null)
-    } finally {
-      setLoading(false)
-    }
-  }, [params.clusterId, params.namespace, params.set])
+  // Draft = what the user is composing in the toolbar.
+  // Applied = what the most recent fetch used.
+  const [draft, setDraft] = useState<FilterDraft>(emptyFilterDraft)
+  const [applied, setApplied] = useState<FilterDraft>(emptyFilterDraft)
 
+  const runFetch = useCallback(
+    async (target: FilterDraft, size: number) => {
+      setLoading(true)
+      setError(null)
+      try {
+        const pk = target.pk.trim()
+        const filters = draftToFilterConditions(target)
+        const resp = await filterRecords(params.clusterId, {
+          namespace: params.namespace,
+          set: params.set,
+          pageSize: size,
+          primaryKey: pk || null,
+          filters: filters ?? null,
+        })
+        setRecords(resp.records)
+        setMeta({
+          total: resp.total,
+          totalEstimated: resp.totalEstimated,
+          executionTimeMs: resp.executionTimeMs,
+        })
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err))
+        setRecords(null)
+        setMeta(EMPTY_META)
+      } finally {
+        setLoading(false)
+      }
+    },
+    [params.clusterId, params.namespace, params.set],
+  )
+
+  // Initial load + reload on set change.
   useEffect(() => {
-    void load()
-  }, [load])
+    const blank = emptyFilterDraft()
+    setDraft(blank)
+    setApplied(blank)
+    void runFetch(blank, pageSize)
+    // Intentionally omit pageSize from deps — we only want to reset on set
+    // change, not on every limit change (that's handled by handlePageSize).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runFetch])
+
+  // Load secondary indexes once per connection.
+  useEffect(() => {
+    let cancelled = false
+    listIndexes(params.clusterId)
+      .then((data) => {
+        if (!cancelled) setIndexes(data)
+      })
+      .catch(() => {
+        if (!cancelled) setIndexes([])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [params.clusterId])
 
   const binColumns = useMemo(() => {
     const names = new Set<string>()
@@ -132,12 +214,50 @@ export default function RecordBrowserPage({ params }: PageProps) {
     return Array.from(names).sort()
   }, [records])
 
-  const filtered = useMemo(() => {
-    if (!records) return []
-    const q = pkFilter.trim().toLowerCase()
-    if (!q) return records
-    return records.filter((r) => (r.key.pk ?? "").toLowerCase().includes(q))
-  }, [records, pkFilter])
+  // Only bins with a ready secondary index on this ns/set are filterable.
+  const availableBins = useMemo(() => {
+    const byBin = new Map<string, SecondaryIndex>()
+    for (const idx of indexes) {
+      if (
+        idx.namespace === params.namespace &&
+        idx.set === params.set &&
+        idx.state === "ready"
+      ) {
+        byBin.set(idx.bin, idx)
+      }
+    }
+    return Array.from(byBin.entries())
+      .sort(([a], [b]) => a.localeCompare(b))
+      .map(([name, idx]) => ({ name, type: indexTypeToBinDataType(idx) }))
+  }, [indexes, params.namespace, params.set])
+
+  const dirty = useMemo(() => !draftEquals(draft, applied), [draft, applied])
+
+  const handleApply = useCallback(() => {
+    setApplied(draft)
+    void runFetch(draft, pageSize)
+  }, [draft, pageSize, runFetch])
+
+  const handleClear = useCallback(() => {
+    const blank = emptyFilterDraft()
+    setDraft(blank)
+    setApplied(blank)
+    void runFetch(blank, pageSize)
+  }, [pageSize, runFetch])
+
+  const handleRefresh = useCallback(() => {
+    void runFetch(applied, pageSize)
+  }, [applied, pageSize, runFetch])
+
+  const handlePageSize = useCallback(
+    (next: number) => {
+      setPageSize(next)
+      void runFetch(applied, next)
+    },
+    [applied, runFetch],
+  )
+
+  const appliedFilterCount = applied.conditions.length + (applied.pk.trim() ? 1 : 0)
 
   return (
     <main className="flex flex-col gap-6">
@@ -167,29 +287,50 @@ export default function RecordBrowserPage({ params }: PageProps) {
           </h1>
           <p className="mt-1 text-sm text-gray-500 dark:text-gray-500">
             {records
-              ? `${filtered.length} of ${records.length} records shown`
+              ? appliedFilterCount > 0
+                ? `${records.length} records shown · ${appliedFilterCount} filter${appliedFilterCount === 1 ? "" : "s"} active`
+                : `${records.length} records shown`
               : loading
                 ? "Loading…"
                 : "—"}
           </p>
         </div>
         <div className="flex gap-2">
-          <Button variant="secondary" onClick={() => void load()} isLoading={loading}>
-            Refresh
+          <Button
+            variant="secondary"
+            onClick={handleRefresh}
+            disabled={loading}
+            aria-label="Refresh records"
+            title="Refresh records"
+            className="h-9 w-9 p-0"
+          >
+            <RiRefreshLine
+              className={cx("size-4", loading && "animate-spin")}
+              aria-hidden="true"
+            />
           </Button>
           <Button variant="primary">New record</Button>
         </div>
       </header>
 
-      <div className="flex flex-wrap items-center gap-2">
-        <Input
-          type="search"
-          value={pkFilter}
-          onChange={(e) => setPkFilter(e.target.value)}
-          placeholder="Primary key contains..."
-          className="sm:w-72"
-        />
-      </div>
+      <RecordFilters
+        availableBins={availableBins}
+        draft={draft}
+        onChange={setDraft}
+        onApply={handleApply}
+        onClear={handleClear}
+        loading={loading}
+        dirty={dirty}
+        trailing={
+          <StatusBar
+            records={records}
+            meta={meta}
+            pageSize={pageSize}
+            onPageSizeChange={handlePageSize}
+            loading={loading}
+          />
+        }
+      />
 
       {error && (
         <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
@@ -220,19 +361,19 @@ export default function RecordBrowserPage({ params }: PageProps) {
             <TableBody>
               {loading && !records ? (
                 <RecordSkeleton cols={Math.max(binColumns.length, 4) + 4} />
-              ) : filtered.length === 0 ? (
+              ) : !records || records.length === 0 ? (
                 <TableRow>
                   <TableCell
                     colSpan={binColumns.length + 4}
                     className="py-8 text-center text-sm text-gray-500 dark:text-gray-500"
                   >
-                    {records && records.length > 0
-                      ? "No records match the filter."
+                    {draftHasFilters(applied)
+                      ? "No records match the applied filters."
                       : "No records in this set."}
                   </TableCell>
                 </TableRow>
               ) : (
-                filtered.map((r) => (
+                records.map((r) => (
                   <TableRow key={r.key.digest ?? r.key.pk}>
                     <TableCell
                       className={cx(
@@ -285,6 +426,66 @@ export default function RecordBrowserPage({ params }: PageProps) {
   )
 }
 
+function StatusBar({
+  records,
+  meta,
+  pageSize,
+  onPageSizeChange,
+  loading,
+}: {
+  records: AerospikeRecord[] | null
+  meta: QueryMeta
+  pageSize: number
+  onPageSizeChange: (next: number) => void
+  loading: boolean
+}) {
+  const returned = records?.length ?? 0
+  return (
+    <div className="flex flex-wrap items-center gap-3 text-xs">
+      {meta.executionTimeMs > 0 && (
+        <span className="inline-flex items-center gap-1 rounded bg-emerald-50 px-1.5 py-0.5 font-mono text-[11px] font-semibold tabular-nums text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400">
+          <RiTimerLine className="size-3" aria-hidden="true" />
+          {meta.executionTimeMs}ms
+        </span>
+      )}
+
+      <span className="h-3.5 w-px bg-gray-200 dark:bg-gray-800" aria-hidden="true" />
+
+      <span className="font-mono tabular-nums text-gray-500 dark:text-gray-400">
+        <span className="font-semibold text-gray-900 dark:text-gray-50">{returned}</span>
+        <span className="mx-1 opacity-60">of</span>
+        <span className="font-semibold text-gray-900 dark:text-gray-50">
+          {meta.totalEstimated ? "~" : ""}
+          {formatRowCount(meta.total)}
+        </span>
+        <span className="ml-1 opacity-60">rows</span>
+      </span>
+
+      <span className="h-3.5 w-px bg-gray-200 dark:bg-gray-800" aria-hidden="true" />
+
+      <div className="flex items-center gap-1.5">
+        <span className="text-[11px] font-medium text-gray-500 dark:text-gray-500">Limit</span>
+        <Select
+          value={String(pageSize)}
+          onValueChange={(v) => onPageSizeChange(parseInt(v, 10))}
+          disabled={loading}
+        >
+          <SelectTrigger className="h-7 w-[72px] px-2 text-xs">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {PAGE_SIZE_OPTIONS.map((n) => (
+              <SelectItem key={n} value={String(n)}>
+                {n}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  )
+}
+
 function RecordSkeleton({ cols }: { cols: number }) {
   return (
     <>
@@ -299,4 +500,24 @@ function RecordSkeleton({ cols }: { cols: number }) {
       ))}
     </>
   )
+}
+
+function draftEquals(a: FilterDraft, b: FilterDraft): boolean {
+  if (a.pk !== b.pk) return false
+  if (a.logic !== b.logic) return false
+  if (a.conditions.length !== b.conditions.length) return false
+  for (let i = 0; i < a.conditions.length; i++) {
+    const x = a.conditions[i]
+    const y = b.conditions[i]
+    if (
+      x.bin !== y.bin ||
+      x.operator !== y.operator ||
+      x.binType !== y.binType ||
+      x.value !== y.value ||
+      x.value2 !== y.value2
+    ) {
+      return false
+    }
+  }
+  return true
 }

--- a/frontend-renewal/src/components/browser/RecordFilters.tsx
+++ b/frontend-renewal/src/components/browser/RecordFilters.tsx
@@ -1,0 +1,571 @@
+"use client"
+
+import {
+  RiAddLine,
+  RiCloseLine,
+  RiDatabase2Line,
+  RiSearchLine,
+} from "@remixicon/react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+
+import { Button } from "@/components/Button"
+import { Input } from "@/components/Input"
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/Popover"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/Select"
+import {
+  DUAL_VALUE_OPERATORS,
+  FILTER_OPERATORS_BY_TYPE,
+  NO_VALUE_OPERATORS,
+  operatorLabel,
+} from "@/lib/filter-operators"
+import type { BinDataType, FilterCondition, FilterOperator } from "@/lib/types/query"
+import type { BinValue } from "@/lib/types/record"
+import { cx } from "@/lib/utils"
+
+export interface FilterDraftCondition extends FilterCondition {
+  id: string
+  binType: BinDataType
+}
+
+export interface FilterDraft {
+  pk: string
+  logic: "and" | "or"
+  conditions: FilterDraftCondition[]
+}
+
+export function emptyFilterDraft(): FilterDraft {
+  return { pk: "", logic: "and", conditions: [] }
+}
+
+export function draftHasFilters(draft: FilterDraft): boolean {
+  return draft.conditions.length > 0 || draft.pk.trim().length > 0
+}
+
+/** Strip the client-side `id` field before sending to the backend. */
+export function draftToFilterConditions(
+  draft: FilterDraft,
+): { logic: "and" | "or"; conditions: FilterCondition[] } | undefined {
+  if (draft.conditions.length === 0) return undefined
+  return {
+    logic: draft.logic,
+    conditions: draft.conditions.map(({ id: _id, ...rest }) => rest),
+  }
+}
+
+function uuid(): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
+    return crypto.randomUUID()
+  }
+  return `fc-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+}
+
+const TYPE_BADGE_COLORS: Record<BinDataType, string> = {
+  integer: "text-blue-600 dark:text-blue-400",
+  float: "text-cyan-600 dark:text-cyan-400",
+  string: "text-emerald-600 dark:text-emerald-400",
+  bool: "text-amber-600 dark:text-amber-400",
+  geo: "text-rose-600 dark:text-rose-400",
+  list: "text-violet-600 dark:text-violet-400",
+  map: "text-orange-600 dark:text-orange-400",
+}
+
+export interface RecordFiltersProps {
+  /** Bins that have a ready secondary index on this ns/set. */
+  availableBins: Array<{ name: string; type: BinDataType }>
+  draft: FilterDraft
+  onChange: (draft: FilterDraft) => void
+  onApply: () => void
+  onClear: () => void
+  loading?: boolean
+  /** True when the draft differs from what was last applied. */
+  dirty?: boolean
+  /** Optional content rendered right-aligned on the same toolbar row. */
+  trailing?: React.ReactNode
+}
+
+export function RecordFilters({
+  availableBins,
+  draft,
+  onChange,
+  onApply,
+  onClear,
+  loading,
+  dirty,
+  trailing,
+}: RecordFiltersProps) {
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const [editingId, setEditingId] = useState<string | null>(null)
+
+  const updatePk = useCallback(
+    (pk: string) => onChange({ ...draft, pk }),
+    [draft, onChange],
+  )
+
+  const addCondition = useCallback(
+    (binName: string, binType: BinDataType) => {
+      const operators = FILTER_OPERATORS_BY_TYPE[binType]
+      const defaultOp = operators[0]?.value ?? ("eq" as FilterOperator)
+      const cond: FilterDraftCondition = {
+        id: uuid(),
+        bin: binName,
+        operator: defaultOp,
+        binType,
+      }
+      onChange({ ...draft, conditions: [...draft.conditions, cond] })
+      setEditingId(cond.id)
+      setPickerOpen(false)
+    },
+    [draft, onChange],
+  )
+
+  const updateCondition = useCallback(
+    (id: string, updates: Partial<Omit<FilterDraftCondition, "id">>) => {
+      onChange({
+        ...draft,
+        conditions: draft.conditions.map((c) => (c.id === id ? { ...c, ...updates } : c)),
+      })
+    },
+    [draft, onChange],
+  )
+
+  const removeCondition = useCallback(
+    (id: string) => {
+      onChange({
+        ...draft,
+        conditions: draft.conditions.filter((c) => c.id !== id),
+      })
+      if (editingId === id) setEditingId(null)
+    },
+    [draft, editingId, onChange],
+  )
+
+  const toggleLogic = useCallback(() => {
+    onChange({ ...draft, logic: draft.logic === "and" ? "or" : "and" })
+  }, [draft, onChange])
+
+  const handleApplyKey = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === "Enter") {
+        e.preventDefault()
+        onApply()
+      }
+    },
+    [onApply],
+  )
+
+  const hasDraft = draftHasFilters(draft)
+  const canApply = !loading && dirty !== false
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        {/* PK lookup */}
+        <div className="flex min-w-[240px] items-center gap-1">
+          <span className="font-mono text-[10px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-500">
+            PK
+          </span>
+          <Input
+            type="search"
+            value={draft.pk}
+            onChange={(e) => updatePk(e.target.value)}
+            onKeyDown={handleApplyKey}
+            placeholder="Primary key..."
+            className="sm:w-60"
+          />
+        </div>
+
+        <span className="mx-0.5 hidden h-5 w-px bg-gray-200 dark:bg-gray-800 sm:block" />
+
+        {/* Add filter picker */}
+        <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className={cx(
+                "inline-flex h-8 items-center gap-1 rounded-md border border-dashed px-2.5 text-xs transition-colors",
+                "border-gray-300 text-gray-500 hover:border-gray-400 hover:bg-gray-50 hover:text-gray-900",
+                "dark:border-gray-700 dark:text-gray-400 dark:hover:border-gray-600 dark:hover:bg-gray-900 dark:hover:text-gray-50",
+              )}
+              title={
+                availableBins.length === 0
+                  ? "No secondary indexes found — create an index to enable filtering"
+                  : `${availableBins.length} indexed bin(s) available`
+              }
+            >
+              {availableBins.length > 0 ? (
+                <RiAddLine className="size-3.5" aria-hidden="true" />
+              ) : (
+                <RiDatabase2Line className="size-3.5" aria-hidden="true" />
+              )}
+              <span>Add filter</span>
+              {availableBins.length > 0 && (
+                <span className="ml-1 rounded-full bg-indigo-100 px-1.5 text-[10px] font-medium tabular-nums text-indigo-700 dark:bg-indigo-950/60 dark:text-indigo-300">
+                  {availableBins.length}
+                </span>
+              )}
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="start" side="bottom" className="w-[240px] p-0">
+            <BinPicker bins={availableBins} onSelect={addCondition} />
+          </PopoverContent>
+        </Popover>
+
+        {/* Condition chips */}
+        {draft.conditions.map((cond, idx) => (
+          <ConditionChip
+            key={cond.id}
+            condition={cond}
+            editing={editingId === cond.id}
+            onOpenChange={(open) => setEditingId(open ? cond.id : null)}
+            onChange={(updates) => updateCondition(cond.id, updates)}
+            onRemove={() => removeCondition(cond.id)}
+            leadingLogic={idx > 0 ? draft.logic : undefined}
+            onToggleLogic={idx > 0 ? toggleLogic : undefined}
+          />
+        ))}
+
+        <Button
+          variant="primary"
+          onClick={onApply}
+          isLoading={loading}
+          disabled={!canApply}
+          className="h-8 gap-1 px-3 text-xs"
+        >
+          <RiSearchLine className="size-3.5" aria-hidden="true" />
+          Search
+        </Button>
+
+        {hasDraft && (
+          <button
+            type="button"
+            onClick={onClear}
+            className="inline-flex h-8 items-center gap-1 rounded-md px-2 text-xs text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-gray-50"
+          >
+            <RiCloseLine className="size-3" aria-hidden="true" />
+            <span>Clear</span>
+          </button>
+        )}
+
+        {trailing && (
+          <div className="ml-auto flex flex-wrap items-center gap-3">{trailing}</div>
+        )}
+      </div>
+
+      {availableBins.length === 0 && (
+        <p className="text-[11px] text-gray-500 dark:text-gray-500">
+          Bin filters require a ready secondary index on this namespace/set. Use the
+          Indexes tab to create one. Primary-key lookup above works without an index.
+        </p>
+      )}
+    </div>
+  )
+}
+
+/* ───────────────── Bin picker popover ───────────────── */
+
+function BinPicker({
+  bins,
+  onSelect,
+}: {
+  bins: Array<{ name: string; type: BinDataType }>
+  onSelect: (name: string, type: BinDataType) => void
+}) {
+  const [query, setQuery] = useState("")
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    inputRef.current?.focus()
+  }, [])
+
+  const filtered = useMemo(() => {
+    if (!query.trim()) return bins
+    const q = query.toLowerCase()
+    return bins.filter((b) => b.name.toLowerCase().includes(q))
+  }, [bins, query])
+
+  return (
+    <div className="text-xs">
+      <div className="flex items-center gap-2 border-b border-gray-200 px-3 py-2 dark:border-gray-800">
+        <RiSearchLine className="size-3.5 shrink-0 text-gray-400" aria-hidden="true" />
+        <input
+          ref={inputRef}
+          type="text"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Filter by..."
+          className="w-full bg-transparent text-xs outline-none placeholder:text-gray-400 dark:placeholder:text-gray-600"
+        />
+      </div>
+
+      <div className="flex items-center gap-1.5 border-b border-gray-200 px-3 py-1.5 dark:border-gray-800">
+        <RiDatabase2Line className="size-3 text-amber-500" aria-hidden="true" />
+        <span className="text-[10px] text-gray-500 dark:text-gray-500">
+          Secondary Index required
+        </span>
+      </div>
+
+      <div className="max-h-[240px] overflow-auto py-1">
+        {bins.length === 0 ? (
+          <div className="space-y-1 px-3 py-4 text-center">
+            <p className="text-gray-500 dark:text-gray-500">No indexed bins found</p>
+            <p className="text-[10px] text-gray-400 dark:text-gray-600">
+              Create a secondary index on the Indexes tab to enable filtering.
+            </p>
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="px-3 py-4 text-center text-gray-500 dark:text-gray-500">
+            No matching bins
+          </div>
+        ) : (
+          filtered.map((bin) => (
+            <button
+              key={bin.name}
+              type="button"
+              onClick={() => onSelect(bin.name, bin.type)}
+              className="flex w-full items-center gap-2 px-3 py-1.5 text-left transition-colors hover:bg-gray-100 dark:hover:bg-gray-900"
+            >
+              <span className={cx("font-mono text-[11px]", TYPE_BADGE_COLORS[bin.type])}>
+                #
+              </span>
+              <span className="truncate font-mono text-[12px] text-gray-900 dark:text-gray-50">
+                {bin.name}
+              </span>
+              <span className="ml-auto text-[10px] text-gray-400 dark:text-gray-600">
+                {bin.type}
+              </span>
+            </button>
+          ))
+        )}
+      </div>
+    </div>
+  )
+}
+
+/* ───────────────── Condition chip + editor ───────────────── */
+
+function formatChipValue(c: FilterDraftCondition): string {
+  if (NO_VALUE_OPERATORS.includes(c.operator)) return ""
+  if (c.operator === "between" && c.value != null && c.value2 != null) {
+    return `${String(c.value)} ~ ${String(c.value2)}`
+  }
+  if (c.value == null) return "…"
+  const s = String(c.value)
+  return s.length > 20 ? `${s.slice(0, 20)}…` : s
+}
+
+interface ConditionChipProps {
+  condition: FilterDraftCondition
+  editing: boolean
+  onOpenChange: (open: boolean) => void
+  onChange: (updates: Partial<Omit<FilterDraftCondition, "id">>) => void
+  onRemove: () => void
+  leadingLogic?: "and" | "or"
+  onToggleLogic?: () => void
+}
+
+function ConditionChip({
+  condition,
+  editing,
+  onOpenChange,
+  onChange,
+  onRemove,
+  leadingLogic,
+  onToggleLogic,
+}: ConditionChipProps) {
+  const label = operatorLabel(condition.operator, condition.binType)
+  const valStr = formatChipValue(condition)
+
+  return (
+    <div className="flex items-center gap-1.5">
+      {leadingLogic && (
+        <button
+          type="button"
+          onClick={onToggleLogic}
+          title={`Switch to ${leadingLogic === "and" ? "OR" : "AND"} logic`}
+          className="inline-flex h-6 items-center rounded bg-gray-100 px-1.5 font-mono text-[10px] font-semibold uppercase tracking-wider text-gray-600 hover:bg-gray-200 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-gray-800"
+        >
+          {leadingLogic}
+        </button>
+      )}
+      <Popover open={editing} onOpenChange={onOpenChange}>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            className={cx(
+              "inline-flex h-8 items-center gap-1.5 rounded-md border px-2 text-xs transition-colors",
+              "border-gray-300 bg-gray-50 text-gray-900 hover:bg-gray-100",
+              "dark:border-gray-700 dark:bg-gray-900 dark:text-gray-50 dark:hover:bg-gray-800",
+            )}
+          >
+            <span className={cx("font-mono", TYPE_BADGE_COLORS[condition.binType])}>
+              {condition.bin}
+            </span>
+            <span className="text-gray-500 dark:text-gray-500">{label}</span>
+            {valStr && (
+              <span className="max-w-[140px] truncate font-mono text-[11px]">{valStr}</span>
+            )}
+            <span
+              role="button"
+              tabIndex={0}
+              onClick={(e) => {
+                e.stopPropagation()
+                onRemove()
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault()
+                  e.stopPropagation()
+                  onRemove()
+                }
+              }}
+              className="ml-0.5 inline-flex size-4 items-center justify-center rounded-sm text-gray-400 hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-gray-700 dark:hover:text-gray-50"
+              aria-label={`Remove ${condition.bin} filter`}
+            >
+              <RiCloseLine className="size-3" aria-hidden="true" />
+            </span>
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="start" side="bottom" className="w-[280px] p-3">
+          <ConditionEditor
+            condition={condition}
+            onChange={onChange}
+            onApply={() => onOpenChange(false)}
+          />
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}
+
+function parseInputValue(raw: string, binType: BinDataType): BinValue {
+  if (binType === "integer") {
+    const n = parseInt(raw, 10)
+    return Number.isNaN(n) ? raw : n
+  }
+  if (binType === "float") {
+    const n = parseFloat(raw)
+    return Number.isNaN(n) ? raw : n
+  }
+  return raw
+}
+
+function ConditionEditor({
+  condition,
+  onChange,
+  onApply,
+}: {
+  condition: FilterDraftCondition
+  onChange: (updates: Partial<Omit<FilterDraftCondition, "id">>) => void
+  onApply: () => void
+}) {
+  const operators = FILTER_OPERATORS_BY_TYPE[condition.binType] ?? []
+  const needsValue = !NO_VALUE_OPERATORS.includes(condition.operator)
+  const needsValue2 = DUAL_VALUE_OPERATORS.includes(condition.operator)
+  const isGeo = condition.operator === "geo_within" || condition.operator === "geo_contains"
+
+  const [val, setVal] = useState(condition.value != null ? String(condition.value) : "")
+  const [val2, setVal2] = useState(condition.value2 != null ? String(condition.value2) : "")
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (needsValue) inputRef.current?.focus()
+  }, [needsValue])
+
+  const commit = useCallback(() => {
+    const updates: Partial<Omit<FilterDraftCondition, "id">> = {}
+    if (needsValue) {
+      updates.value = isGeo ? val : parseInputValue(val, condition.binType)
+    } else {
+      updates.value = null
+    }
+    if (needsValue2) {
+      updates.value2 = parseInputValue(val2, condition.binType)
+    } else {
+      updates.value2 = null
+    }
+    onChange(updates)
+    onApply()
+  }, [condition.binType, isGeo, needsValue, needsValue2, onApply, onChange, val, val2])
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      e.preventDefault()
+      commit()
+    }
+  }
+
+  const numberType =
+    condition.binType === "integer" || condition.binType === "float" ? "number" : "text"
+
+  return (
+    <div className="space-y-2.5">
+      <div className="font-mono text-xs text-gray-700 dark:text-gray-300">{condition.bin}</div>
+
+      <Select
+        value={condition.operator}
+        onValueChange={(v) => onChange({ operator: v as FilterOperator })}
+      >
+        <SelectTrigger className="h-8 text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {operators.map((op) => (
+            <SelectItem key={op.value} value={op.value}>
+              {op.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      {needsValue && !isGeo && (
+        <Input
+          ref={inputRef}
+          type={numberType}
+          value={val}
+          onChange={(e) => setVal(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder={condition.operator === "regex" ? "Pattern..." : "Value..."}
+          className={condition.operator === "regex" ? "font-mono" : ""}
+        />
+      )}
+
+      {needsValue2 && (
+        <Input
+          type={numberType}
+          value={val2}
+          onChange={(e) => setVal2(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder="Upper bound..."
+        />
+      )}
+
+      {isGeo && (
+        <textarea
+          value={val}
+          onChange={(e) => setVal(e.target.value)}
+          placeholder='{"type":"AeroCircle","coordinates":[[lng,lat],radius]}'
+          className="min-h-[80px] w-full rounded-md border border-gray-300 bg-white p-2 font-mono text-xs outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 dark:border-gray-800 dark:bg-gray-950 dark:focus:border-indigo-700 dark:focus:ring-indigo-700/30"
+        />
+      )}
+
+      <div className="flex items-center justify-end gap-2 pt-1">
+        <Button
+          variant="ghost"
+          className="h-7 px-2 text-xs"
+          onClick={() => onApply()}
+        >
+          Cancel
+        </Button>
+        <Button variant="primary" className="h-7 px-2 text-xs" onClick={commit}>
+          Apply
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/frontend-renewal/src/components/ui/navigation/ClusterTabs.tsx
+++ b/frontend-renewal/src/components/ui/navigation/ClusterTabs.tsx
@@ -52,8 +52,13 @@ export function ClusterTabs({ clusterId }: Props) {
   return (
     <TabNavigation>
       {tabs.map((t) => (
-        <TabNavigationLink key={t.href} asChild active={isActive(t.href, t.exact)}>
-          <Link href={t.href} className="inline-flex items-center gap-2">
+        <TabNavigationLink
+          key={t.href}
+          asChild
+          active={isActive(t.href, t.exact)}
+          className="gap-2"
+        >
+          <Link href={t.href}>
             <t.icon className="size-4 shrink-0" aria-hidden="true" />
             {t.label}
           </Link>

--- a/frontend-renewal/src/components/ui/navigation/Sidebar.tsx
+++ b/frontend-renewal/src/components/ui/navigation/Sidebar.tsx
@@ -13,7 +13,9 @@ import { getCluster } from "@/lib/api/clusters"
 import type { ConnectionProfileResponse } from "@/lib/types/connection"
 import type { K8sClusterSummary } from "@/lib/types/k8s"
 import { cx, focusRing } from "@/lib/utils"
+import * as AccordionPrimitives from "@radix-ui/react-accordion"
 import {
+  RiArrowDownSLine,
   RiBox3Line,
   RiCodeSSlashLine,
   RiDatabase2Line,
@@ -117,7 +119,7 @@ export function Sidebar() {
       {/* sidebar (lg+) */}
       <nav className="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
         <aside className="flex grow flex-col gap-y-4 overflow-y-auto border-r border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-950">
-          <BrandCard />
+          <BrandCard active={pathname === "/clusters"} />
 
           <nav aria-label="core navigation" className="flex flex-1 flex-col">
             <Accordion
@@ -155,20 +157,6 @@ export function Sidebar() {
                     No clusters yet
                   </span>
                 )}
-
-                <Link
-                  href="/clusters"
-                  className={cx(
-                    "mt-0.5 flex items-center gap-x-2.5 rounded-md py-1.5 pl-2 pr-2 text-sm font-medium transition",
-                    pathname === "/clusters"
-                      ? "text-indigo-600 dark:text-indigo-400"
-                      : "text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 hover:dark:bg-gray-900 hover:dark:text-gray-50",
-                    focusRing,
-                  )}
-                >
-                  <RiStackLine className="size-4 shrink-0" aria-hidden="true" />
-                  All clusters
-                </Link>
               </GroupSection>
 
               <GroupSection value="acko" icon={RiBox3Line} label="ACKO">
@@ -207,12 +195,17 @@ export function Sidebar() {
   )
 }
 
-function BrandCard() {
+function BrandCard({ active }: { active?: boolean }) {
   return (
     <Link
       href="/clusters"
+      aria-label="All clusters"
+      title="All clusters"
       className={cx(
-        "flex items-center gap-3 rounded-md px-2 py-1.5 transition hover:bg-gray-50 dark:hover:bg-gray-900",
+        "flex items-center gap-3 rounded-md px-2 py-1.5 transition",
+        active
+          ? "bg-indigo-50 dark:bg-indigo-950/40"
+          : "hover:bg-gray-50 dark:hover:bg-gray-900",
         focusRing,
       )}
     >
@@ -224,7 +217,12 @@ function BrandCard() {
         className="size-9 shrink-0 rounded-lg"
       />
       <div className="min-w-0 leading-tight">
-        <p className="truncate text-sm font-semibold text-gray-900 dark:text-gray-50">
+        <p
+          className={cx(
+            "truncate text-sm font-semibold",
+            active ? "text-indigo-700 dark:text-indigo-300" : "text-gray-900 dark:text-gray-50",
+          )}
+        >
           Aerospike
         </p>
         <p className="truncate text-xs text-gray-500 dark:text-gray-400">Cluster Manager</p>
@@ -279,27 +277,53 @@ function ClusterNode({
   const expandedNamespaces = cluster.namespaces
     .filter((ns) => pathname.includes(`/clusters/${cluster.id}/sets/${ns.name}`))
     .map((ns) => ns.name)
+  // Backend prepends "[K8s] " to connection names auto-created for ACKO
+  // clusters. The ACKO badge already signals K8s origin, so drop the prefix
+  // for display to avoid visual duplication (and give the name more width).
+  const displayName =
+    cluster.managedBy === "ACKO"
+      ? cluster.name.replace(/^\[K8s\]\s*/, "")
+      : cluster.name
 
   return (
     <AccordionItem value={cluster.id} className="border-none">
-      <AccordionTrigger
+      <AccordionPrimitives.Header
         className={cx(
-          "rounded-md px-2 py-1.5 hover:bg-gray-100 hover:dark:bg-gray-900",
+          "flex items-center rounded-md pr-1 hover:bg-gray-100 hover:dark:bg-gray-900",
           clusterActive
             ? "text-indigo-600 dark:text-indigo-400"
             : "text-gray-700 dark:text-gray-400",
         )}
       >
-        <span className="flex items-center gap-2 text-sm font-medium">
-          <RiStackLine className="size-4" aria-hidden="true" />
-          <span className="font-mono">{cluster.name}</span>
+        <Link
+          href={`/clusters/${cluster.id}`}
+          title={cluster.name}
+          className={cx(
+            "flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium",
+            focusRing,
+          )}
+        >
+          <RiStackLine className="size-4 shrink-0" aria-hidden="true" />
+          <span className="min-w-0 flex-1 truncate font-mono">{displayName}</span>
           {cluster.managedBy === "ACKO" && (
-            <span className="rounded bg-indigo-50 px-1.5 text-[10px] font-semibold uppercase tracking-wider text-indigo-600 dark:bg-indigo-950/40 dark:text-indigo-400">
+            <span className="shrink-0 rounded bg-indigo-50 px-1.5 text-[10px] font-semibold uppercase tracking-wider text-indigo-600 dark:bg-indigo-950/40 dark:text-indigo-400">
               ACKO
             </span>
           )}
-        </span>
-      </AccordionTrigger>
+        </Link>
+        <AccordionPrimitives.Trigger
+          aria-label={`Toggle ${displayName} namespaces`}
+          className={cx(
+            "group/chev flex size-6 shrink-0 items-center justify-center rounded-md text-gray-400 hover:bg-gray-200 hover:text-gray-900 dark:text-gray-500 hover:dark:bg-gray-800 hover:dark:text-gray-50",
+            focusRing,
+          )}
+        >
+          <RiArrowDownSLine
+            className="size-4 transition-transform duration-150 group-data-[state=open]/chev:rotate-180"
+            aria-hidden="true"
+          />
+        </AccordionPrimitives.Trigger>
+      </AccordionPrimitives.Header>
       <AccordionContent className="pt-1">
         <ul className="flex flex-col gap-0.5">
           {cluster.namespaces.length === 0 && (

--- a/frontend-renewal/src/lib/filter-operators.ts
+++ b/frontend-renewal/src/lib/filter-operators.ts
@@ -1,0 +1,77 @@
+/**
+ * Filter operator metadata mirrored from the original frontend/ constants.
+ * Used by the record-browser filter toolbar to render operator selects,
+ * decide which value inputs to show, and render filter chips.
+ */
+
+import type { BinDataType, FilterOperator } from "./types/query"
+
+export interface FilterOperatorOption {
+  value: FilterOperator
+  label: string
+}
+
+export const FILTER_OPERATORS_BY_TYPE: Record<BinDataType, FilterOperatorOption[]> = {
+  integer: [
+    { value: "eq", label: "=" },
+    { value: "ne", label: "≠" },
+    { value: "gt", label: ">" },
+    { value: "ge", label: "≥" },
+    { value: "lt", label: "<" },
+    { value: "le", label: "≤" },
+    { value: "between", label: "Between" },
+    { value: "exists", label: "Exists" },
+    { value: "not_exists", label: "Not Exists" },
+  ],
+  float: [
+    { value: "eq", label: "=" },
+    { value: "ne", label: "≠" },
+    { value: "gt", label: ">" },
+    { value: "ge", label: "≥" },
+    { value: "lt", label: "<" },
+    { value: "le", label: "≤" },
+    { value: "between", label: "Between" },
+    { value: "exists", label: "Exists" },
+    { value: "not_exists", label: "Not Exists" },
+  ],
+  string: [
+    { value: "eq", label: "Equals" },
+    { value: "ne", label: "Not Equals" },
+    { value: "contains", label: "Contains" },
+    { value: "not_contains", label: "Not Contains" },
+    { value: "regex", label: "Regex" },
+    { value: "exists", label: "Exists" },
+    { value: "not_exists", label: "Not Exists" },
+  ],
+  bool: [
+    { value: "is_true", label: "Is True" },
+    { value: "is_false", label: "Is False" },
+    { value: "exists", label: "Exists" },
+  ],
+  geo: [
+    { value: "geo_within", label: "Within Region" },
+    { value: "geo_contains", label: "Contains Point" },
+    { value: "exists", label: "Exists" },
+  ],
+  list: [
+    { value: "exists", label: "Exists" },
+    { value: "not_exists", label: "Not Exists" },
+  ],
+  map: [
+    { value: "exists", label: "Exists" },
+    { value: "not_exists", label: "Not Exists" },
+  ],
+}
+
+export const NO_VALUE_OPERATORS: FilterOperator[] = [
+  "exists",
+  "not_exists",
+  "is_true",
+  "is_false",
+]
+
+export const DUAL_VALUE_OPERATORS: FilterOperator[] = ["between"]
+
+export function operatorLabel(op: FilterOperator, binType: BinDataType): string {
+  return FILTER_OPERATORS_BY_TYPE[binType]?.find((o) => o.value === op)?.label ?? op
+}


### PR DESCRIPTION
## Summary

- **Record browser filter toolbar** on `/clusters/:id/sets/:ns/:set`: PK input plus per-condition chips scoped to bins that have a ready secondary index. Search is the only trigger for a new fetch — no live query on every keystroke.
- **Inline status bar** next to Search: execution time · returned-of-total rows · Limit selector (25/50/100) that refetches with the currently applied filters.
- **Sidebar polish**: brand/logo is the All-clusters entry (duplicate link removed), cluster-name click → overview with a separate chevron-only toggle, drop the backend's auto `[K8s] ` prefix for ACKO-managed clusters.
- **UX details**: icon-only Refresh button whose icon spins without shifting width; tab icon/label spacing.

## Test plan
- [ ] Fresh load of `/clusters/:id/sets/test/sample_set` renders 50 rows and Search is disabled (draft == applied).
- [ ] Add-filter popover lists only bins with a ready sindex; picking a bin + value + Apply adds a chip but fires no request until Search is clicked.
- [ ] Search fires `POST /api/records/:id/filter`; status bar shows `{ms} · {n} of ~{total} rows`.
- [ ] Changing Limit refetches with currently applied filters.
- [ ] Refresh icon spins during load without the button width changing.
- [ ] Clicking the cluster name in the sidebar navigates to overview; the chevron expands the namespaces list independently.
- [ ] Sidebar shows `ui-demo-2` (no `[K8s]` prefix) with the ACKO badge.