### PR TITLE
feat(dev): local kind + ACKO dev workflow via `make run-local`

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,13 @@ K8S_MANAGEMENT_ENABLED=false
 # Pod log streaming timeout in seconds
 # K8S_LOG_TIMEOUT=30
 
+# --- Local dev against kind (make run-local) ---
+# After `make run-local`, point the backend at the kind cluster by setting:
+# K8S_MANAGEMENT_ENABLED=true
+# KUBECONFIG=${HOME}/.kube/config
+# The backend auto-loads the kubeconfig via load_kube_config() when not in-cluster,
+# and the `kind-kind` context created by run-local will be picked up.
+
 # ============================================
 # Security Headers
 # ============================================

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,11 @@
 # Usage: make <target>
 
 .PHONY: dev dev-up dev-down up down test test-backend test-frontend \
-        lint lint-backend lint-frontend type-check build pre-commit clean
+        lint lint-backend lint-frontend type-check build pre-commit clean \
+        run-local run-local-down run-local-ui run-local-ui-local-build \
+        kind-up kind-down kind-status \
+        acko-install acko-uninstall acko-verify \
+        build-ui-images
 
 # ---------------------------------------------------------------------------
 # Podman Compose — development (Aerospike only)
@@ -74,3 +78,50 @@ pre-commit:
 clean:
 	podman compose -f compose.yaml down 2>/dev/null || true
 	podman compose -f compose.dev.yaml down 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Local K8s / ACKO development (kind + cert-manager + ACKO operator)
+# ---------------------------------------------------------------------------
+# Single entry point for ACKO UI development. Boots kind (podman provider),
+# installs the ACKO operator, and starts Aerospike via compose.dev.yaml.
+# backend/frontend are NOT started automatically — run-local prints the
+# commands to paste into two separate terminals for hot-reload development.
+
+run-local:
+	bash scripts/local-dev/run-local.sh
+
+# Same as run-local, but also deploys the chart-bundled UI (backend + legacy
+# frontend + frontend-renewal) inside kind. Uses public ghcr images by default.
+run-local-ui:
+	ACKO_UI_ENABLED=true bash scripts/local-dev/run-local.sh
+
+# Variant that builds the 3 UI images from this repo's Dockerfiles and loads
+# them into kind (for testing uncommitted UI changes).
+run-local-ui-local-build:
+	ACKO_UI_ENABLED=true ACKO_UI_LOCAL_BUILD=true bash scripts/local-dev/run-local.sh
+
+run-local-down:
+	bash scripts/local-dev/run-local-down.sh
+
+build-ui-images:
+	bash scripts/local-dev/build-ui-images.sh
+
+kind-up:
+	bash scripts/local-dev/kind-up.sh
+
+kind-down:
+	bash scripts/local-dev/kind-down.sh
+
+kind-status:
+	kubectl cluster-info --context kind-kind
+	kubectl get nodes -L topology.kubernetes.io/zone --context kind-kind
+
+acko-install:
+	bash scripts/local-dev/acko-install.sh
+
+acko-uninstall:
+	bash scripts/local-dev/acko-uninstall.sh
+
+acko-verify:
+	kubectl get crd --context kind-kind | grep acko.io
+	kubectl -n aerospike-operator get pods --context kind-kind

--- a/README.md
+++ b/README.md
@@ -125,6 +125,24 @@ npm run dev                        # http://localhost:3000
 
 > The frontend dev server proxies `/api/*` requests to `http://localhost:8000`.
 
+### Local K8s / ACKO Development
+
+To exercise the K8s / ACKO UI (`/k8s/clusters`, `/k8s/templates`) against a real operator without deploying anything to a shared cluster, use `make run-local`:
+
+```bash
+make run-local          # kind (podman) + cert-manager + ACKO operator + Aerospike (compose.dev.yaml)
+```
+
+The command is idempotent and prints the exact backend/frontend start commands to run in separate terminals. It sets up:
+
+- kind cluster named `kind` → kubectl context `kind-kind` (1 control-plane + 3 workers with `topology.kubernetes.io/zone=zone-a/b/c`)
+- cert-manager and the ACKO operator via Helm (CRDs: `aerospikeclusters.acko.io`, `aerospikeclustertemplates.acko.io`)
+- Standalone Aerospike nodes on `localhost:14790/:14791/:14792` (for the non-K8s connection UI)
+
+Start the backend with `K8S_MANAGEMENT_ENABLED=true` and the frontend as usual; the backend's Kubernetes client picks up `~/.kube/config` automatically. Teardown with `make run-local-down`.
+
+Related targets: `make kind-up/down/status`, `make acko-install/uninstall/verify`.
+
 ## Features
 
 - **Connection Management** — Manage multiple Aerospike cluster connection profiles

--- a/kind-config.yaml
+++ b/kind-config.yaml
@@ -1,0 +1,16 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+name: kind
+networking:
+  apiServerAddress: 127.0.0.1
+nodes:
+  - role: control-plane
+  - role: worker
+    labels:
+      topology.kubernetes.io/zone: zone-a
+  - role: worker
+    labels:
+      topology.kubernetes.io/zone: zone-b
+  - role: worker
+    labels:
+      topology.kubernetes.io/zone: zone-c

--- a/scripts/local-dev/_common.sh
+++ b/scripts/local-dev/_common.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Shared helpers and environment defaults for local-dev scripts.
+# Source this file from other scripts: `source "$(dirname "$0")/_common.sh"`.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Environment defaults
+# ---------------------------------------------------------------------------
+# kind cluster is named `kind` so kubectl context becomes `kind-kind`.
+export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+export KIND_CONTEXT="kind-${KIND_CLUSTER_NAME}"
+export KIND_PROVIDER="${KIND_PROVIDER:-podman}"
+export KIND_EXPERIMENTAL_PROVIDER="${KIND_PROVIDER}"
+
+export CERT_MANAGER_NAMESPACE="${CERT_MANAGER_NAMESPACE:-cert-manager}"
+export CERT_MANAGER_VERSION="${CERT_MANAGER_VERSION:-v1.15.3}"
+
+export ACKO_NAMESPACE="${ACKO_NAMESPACE:-aerospike-operator}"
+# Release name MUST equal the chart name. The chart's fullname helper returns
+# the release name when it already contains the chart name, so UI resource
+# names match the BACKEND_URL baked into the frontend-renewal image at build
+# time (`http://aerospike-ce-kubernetes-operator-ui-backend:80`). A shorter
+# release name produces `aerospike-operator-aerospike-ce-kubernetes-operator-*`
+# which (a) breaks the baked BACKEND_URL and (b) exceeds the 63-char Service
+# name limit. See Dockerfile.frontend-renewal for the baked URL.
+export ACKO_RELEASE="${ACKO_RELEASE:-aerospike-ce-kubernetes-operator}"
+export ACKO_CRDS_RELEASE="${ACKO_CRDS_RELEASE:-aerospike-ce-kubernetes-operator-crds}"
+export ACKO_CHART_VERSION="${ACKO_CHART_VERSION:-0.1.2}"
+# Empty by default so the chart's natural naming wins. Set a non-empty value
+# only with ACKO_UI_LOCAL_BUILD=true + a matching --build-arg BACKEND_URL.
+export ACKO_FULLNAME_OVERRIDE="${ACKO_FULLNAME_OVERRIDE:-}"
+
+# UI (chart-bundled) — opt-in. When true, run-local passes ui.enabled=true and
+# the chart pulls the 3 images from ghcr (public). Override
+# ACKO_UI_LOCAL_BUILD=true to build images from this repo's Dockerfiles and
+# `kind load` them instead (useful for testing uncommitted UI changes).
+export ACKO_UI_ENABLED="${ACKO_UI_ENABLED:-false}"
+export ACKO_UI_LOCAL_BUILD="${ACKO_UI_LOCAL_BUILD:-false}"
+export ACKO_UI_IMAGE_TAG="${ACKO_UI_IMAGE_TAG:-latest}"
+export ACKO_UI_BACKEND_IMAGE="${ACKO_UI_BACKEND_IMAGE:-aerospike-cluster-manager-backend}"
+export ACKO_UI_FRONTEND_IMAGE="${ACKO_UI_FRONTEND_IMAGE:-aerospike-cluster-manager-frontend}"
+export ACKO_UI_FRONTEND_RENEWAL_IMAGE="${ACKO_UI_FRONTEND_RENEWAL_IMAGE:-aerospike-cluster-manager-frontend-renewal}"
+
+# Resolve repo root (scripts live at <repo>/scripts/local-dev/).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+export KIND_CONFIG_FILE="${KIND_CONFIG_FILE:-${REPO_ROOT}/kind-config.yaml}"
+
+# Sibling ACKO repo (required for local install).
+# Layout assumption: both repos cloned under a common parent directory
+#   <parent>/aerospike-cluster-manager
+#   <parent>/aerospike-ce-kubernetes-operator
+_sibling_charts_root="$(cd "${REPO_ROOT}/.." && pwd)/aerospike-ce-kubernetes-operator/charts"
+export ACKO_CHART_PATH="${ACKO_CHART_PATH:-${_sibling_charts_root}/aerospike-ce-kubernetes-operator}"
+export ACKO_CRDS_CHART_PATH="${ACKO_CRDS_CHART_PATH:-${_sibling_charts_root}/aerospike-ce-kubernetes-operator-crds}"
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+log()   { printf '\033[1;34m[*]\033[0m %s\n' "$*"; }
+ok()    { printf '\033[1;32m[\xe2\x9c\x93]\033[0m %s\n' "$*"; }
+warn()  { printf '\033[1;33m[!]\033[0m %s\n' "$*"; }
+err()   { printf '\033[1;31m[x]\033[0m %s\n' "$*" >&2; }
+die()   { err "$*"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Prerequisite checks
+# ---------------------------------------------------------------------------
+require_bin() {
+  local bin="$1"
+  local hint="${2:-}"
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    err "Missing required binary: $bin"
+    [[ -n "$hint" ]] && err "  $hint"
+    exit 1
+  fi
+}
+
+require_local_dev_bins() {
+  require_bin kind    "Install: https://kind.sigs.k8s.io/docs/user/quick-start/#installation"
+  require_bin kubectl "Install: https://kubernetes.io/docs/tasks/tools/"
+  require_bin helm    "Install: https://helm.sh/docs/intro/install/"
+  require_bin "${KIND_PROVIDER}" \
+    "Install: https://podman.io/docs/installation (or set KIND_PROVIDER=docker)"
+}
+
+# ---------------------------------------------------------------------------
+# kind helpers
+# ---------------------------------------------------------------------------
+kind_cluster_exists() {
+  kind get clusters 2>/dev/null | grep -qx "${KIND_CLUSTER_NAME}"
+}

--- a/scripts/local-dev/acko-install.sh
+++ b/scripts/local-dev/acko-install.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Install ACKO prerequisites and operator into the kind cluster.
+# All dependencies are installed as explicit prereqs (no subcharts):
+#   1. cert-manager      (jetstack/cert-manager)
+#   2. ACKO CRDs         (aerospike-ce-kubernetes-operator-crds, sibling chart)
+#   3. ACKO operator     (aerospike-ce-kubernetes-operator, sibling chart, crds.install=false)
+# Idempotent.
+set -euo pipefail
+source "$(cd "$(dirname "$0")" && pwd)/_common.sh"
+
+require_bin kubectl
+require_bin helm
+
+if ! kubectl config get-contexts -o name | grep -qx "${KIND_CONTEXT}"; then
+  die "kubectl context '${KIND_CONTEXT}' not found — run 'make kind-up' first"
+fi
+kubectl config use-context "${KIND_CONTEXT}" >/dev/null
+
+# ---------------------------------------------------------------------------
+# 1. cert-manager (ACKO admission webhook prerequisite)
+# ---------------------------------------------------------------------------
+if helm status cert-manager -n "${CERT_MANAGER_NAMESPACE}" >/dev/null 2>&1; then
+  ok "cert-manager already installed in namespace '${CERT_MANAGER_NAMESPACE}' — skipping"
+else
+  log "Adding jetstack helm repo..."
+  helm repo add jetstack https://charts.jetstack.io >/dev/null 2>&1 || true
+  helm repo update jetstack >/dev/null
+
+  log "Installing cert-manager ${CERT_MANAGER_VERSION}..."
+  helm install cert-manager jetstack/cert-manager \
+    --namespace "${CERT_MANAGER_NAMESPACE}" --create-namespace \
+    --version "${CERT_MANAGER_VERSION}" \
+    --set crds.enabled=true \
+    --wait --timeout=180s
+  ok "cert-manager ${CERT_MANAGER_VERSION} installed"
+fi
+
+log "Waiting for cert-manager deployments to be Available..."
+kubectl -n "${CERT_MANAGER_NAMESPACE}" wait --for=condition=Available \
+  deployment/cert-manager deployment/cert-manager-webhook deployment/cert-manager-cainjector \
+  --timeout=180s >/dev/null
+
+# ---------------------------------------------------------------------------
+# 2. ACKO CRDs (separate release — do NOT rely on the operator chart's subchart)
+# ---------------------------------------------------------------------------
+if [[ ! -f "${ACKO_CRDS_CHART_PATH}/Chart.yaml" ]]; then
+  die "ACKO CRDs chart not found at: ${ACKO_CRDS_CHART_PATH}
+Clone sibling repo: git clone https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator \\
+  $(cd "${REPO_ROOT}/.." && pwd)/aerospike-ce-kubernetes-operator
+Or set ACKO_CRDS_CHART_PATH to an alternate location."
+fi
+
+if helm status "${ACKO_CRDS_RELEASE}" -n "${ACKO_NAMESPACE}" >/dev/null 2>&1; then
+  ok "ACKO CRDs release '${ACKO_CRDS_RELEASE}' already installed in '${ACKO_NAMESPACE}' — skipping"
+else
+  log "Installing ACKO CRDs from ${ACKO_CRDS_CHART_PATH}"
+  # --take-ownership: when CRDs from a prior release still linger on the
+  # cluster (via helm.sh/resource-policy: keep) this flag lets the new release
+  # reclaim them instead of failing with "exists and cannot be imported".
+  helm install "${ACKO_CRDS_RELEASE}" "${ACKO_CRDS_CHART_PATH}" \
+    --namespace "${ACKO_NAMESPACE}" --create-namespace \
+    --take-ownership \
+    --wait --timeout=120s
+  ok "ACKO CRDs installed"
+fi
+
+for crd in aerospikeclusters.acko.io aerospikeclustertemplates.acko.io; do
+  if kubectl get crd "${crd}" >/dev/null 2>&1; then
+    ok "CRD present: ${crd}"
+  else
+    die "CRD missing after CRDs release install: ${crd}"
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# 3. ACKO operator (crds.install=false — CRDs were installed above)
+# ---------------------------------------------------------------------------
+if [[ ! -f "${ACKO_CHART_PATH}/Chart.yaml" ]]; then
+  die "ACKO operator chart not found at: ${ACKO_CHART_PATH}
+Clone sibling repo or set ACKO_CHART_PATH."
+fi
+
+_helm_args=(
+  --namespace "${ACKO_NAMESPACE}" --create-namespace
+  --set "crds.install=false"
+)
+if [[ -n "${ACKO_FULLNAME_OVERRIDE}" ]]; then
+  _helm_args+=(--set "fullnameOverride=${ACKO_FULLNAME_OVERRIDE}")
+fi
+
+if [[ "${ACKO_UI_ENABLED}" == "true" ]]; then
+  _helm_args+=(--set "ui.enabled=true")
+  if [[ "${ACKO_UI_LOCAL_BUILD}" == "true" ]]; then
+    log "UI mode: ui.enabled=true with locally-built images (tag: ${ACKO_UI_IMAGE_TAG}, pullPolicy=Never)"
+    _helm_args+=(
+      --set "ui.backend.image.repository=${ACKO_UI_BACKEND_IMAGE}"
+      --set "ui.backend.image.tag=${ACKO_UI_IMAGE_TAG}"
+      --set "ui.backend.image.pullPolicy=Never"
+      --set "ui.frontend.image.repository=${ACKO_UI_FRONTEND_IMAGE}"
+      --set "ui.frontend.image.tag=${ACKO_UI_IMAGE_TAG}"
+      --set "ui.frontend.image.pullPolicy=Never"
+      --set "ui.frontendRenewal.image.repository=${ACKO_UI_FRONTEND_RENEWAL_IMAGE}"
+      --set "ui.frontendRenewal.image.tag=${ACKO_UI_IMAGE_TAG}"
+      --set "ui.frontendRenewal.image.pullPolicy=Never"
+    )
+  else
+    log "UI mode: ui.enabled=true with chart-default images (ghcr.io, tag: latest)"
+  fi
+else
+  _helm_args+=(--set "ui.enabled=false")
+fi
+
+log "helm upgrade --install ${ACKO_RELEASE} ${ACKO_CHART_PATH}"
+helm upgrade --install "${ACKO_RELEASE}" "${ACKO_CHART_PATH}" \
+  "${_helm_args[@]}" --wait --timeout=600s
+ok "ACKO operator deployed"
+
+log "Waiting for ACKO operator deployments to be Available..."
+kubectl -n "${ACKO_NAMESPACE}" wait --for=condition=Available deployment \
+  --all --timeout=180s >/dev/null
+ok "ACKO operator is Ready"

--- a/scripts/local-dev/acko-uninstall.sh
+++ b/scripts/local-dev/acko-uninstall.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Uninstall ACKO operator + cert-manager from the kind cluster. Idempotent.
+set -euo pipefail
+source "$(cd "$(dirname "$0")" && pwd)/_common.sh"
+
+require_bin kubectl
+require_bin helm
+
+if ! kubectl config get-contexts -o name | grep -qx "${KIND_CONTEXT}"; then
+  warn "kubectl context '${KIND_CONTEXT}' not found — nothing to uninstall"
+  exit 0
+fi
+kubectl config use-context "${KIND_CONTEXT}" >/dev/null
+
+if helm status "${ACKO_RELEASE}" -n "${ACKO_NAMESPACE}" >/dev/null 2>&1; then
+  log "Uninstalling ACKO operator release '${ACKO_RELEASE}'..."
+  helm uninstall "${ACKO_RELEASE}" -n "${ACKO_NAMESPACE}"
+  ok "ACKO operator uninstalled"
+else
+  ok "ACKO operator release '${ACKO_RELEASE}' not present — skipping"
+fi
+
+if helm status "${ACKO_CRDS_RELEASE}" -n "${ACKO_NAMESPACE}" >/dev/null 2>&1; then
+  log "Uninstalling ACKO CRDs release '${ACKO_CRDS_RELEASE}'..."
+  helm uninstall "${ACKO_CRDS_RELEASE}" -n "${ACKO_NAMESPACE}"
+  ok "ACKO CRDs uninstalled (CRD objects retained via helm.sh/resource-policy: keep)"
+else
+  ok "ACKO CRDs release '${ACKO_CRDS_RELEASE}' not present — skipping"
+fi
+
+kubectl delete namespace "${ACKO_NAMESPACE}" --ignore-not-found --timeout=60s
+
+# Sweep orphan cluster-scoped admission webhook configs. These survive
+# `helm uninstall` if they carry a release name that no longer matches
+# (e.g., after changing fullnameOverride or ACKO_RELEASE between installs).
+# They cause every CR create to 500 with "service ...-webhook not found".
+log "Sweeping orphan admission webhook configurations for chart aerospike-ce-kubernetes-operator..."
+for kind in mutatingwebhookconfiguration validatingwebhookconfiguration; do
+  kubectl get "${kind}" \
+    -l "app.kubernetes.io/name=aerospike-ce-kubernetes-operator" \
+    -o name 2>/dev/null | while read -r res; do
+    log "  deleting ${res}"
+    kubectl delete "${res}" --ignore-not-found
+  done
+done
+ok "Orphan webhook configurations swept"
+
+if helm status cert-manager -n "${CERT_MANAGER_NAMESPACE}" >/dev/null 2>&1; then
+  log "Uninstalling cert-manager..."
+  helm uninstall cert-manager -n "${CERT_MANAGER_NAMESPACE}"
+  kubectl delete namespace "${CERT_MANAGER_NAMESPACE}" --ignore-not-found --timeout=60s
+  ok "cert-manager uninstalled"
+else
+  ok "cert-manager not present — skipping"
+fi

--- a/scripts/local-dev/build-ui-images.sh
+++ b/scripts/local-dev/build-ui-images.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Build the 3 Aerospike Cluster Manager UI images locally and load them into
+# the kind cluster. Used by run-local when ACKO_UI_ENABLED=true.
+#
+# Images produced (tag defaults to ${ACKO_UI_IMAGE_TAG}, default 'local'):
+#   - ${ACKO_UI_BACKEND_IMAGE}:${ACKO_UI_IMAGE_TAG}
+#   - ${ACKO_UI_FRONTEND_IMAGE}:${ACKO_UI_IMAGE_TAG}
+#   - ${ACKO_UI_FRONTEND_RENEWAL_IMAGE}:${ACKO_UI_IMAGE_TAG}
+set -euo pipefail
+source "$(cd "$(dirname "$0")" && pwd)/_common.sh"
+
+require_bin podman
+require_bin kind
+
+if ! kind_cluster_exists; then
+  die "kind cluster '${KIND_CLUSTER_NAME}' not found — run 'make kind-up' first"
+fi
+
+build_and_load() {
+  local image="$1"
+  local dockerfile="$2"
+  local tag="${ACKO_UI_IMAGE_TAG}"
+
+  log "Building ${image}:${tag} (dockerfile: ${dockerfile})..."
+  (cd "${REPO_ROOT}" && podman build -t "${image}:${tag}" -f "${dockerfile}" .)
+
+  log "Loading ${image}:${tag} into kind cluster '${KIND_CLUSTER_NAME}'..."
+  kind load docker-image "${image}:${tag}" --name "${KIND_CLUSTER_NAME}"
+  ok "${image}:${tag} loaded"
+}
+
+build_and_load "${ACKO_UI_BACKEND_IMAGE}"          "Dockerfile.backend"
+build_and_load "${ACKO_UI_FRONTEND_IMAGE}"         "Dockerfile.frontend"
+build_and_load "${ACKO_UI_FRONTEND_RENEWAL_IMAGE}" "Dockerfile.frontend-renewal"
+
+ok "All 3 UI images built and loaded into kind"

--- a/scripts/local-dev/kind-down.sh
+++ b/scripts/local-dev/kind-down.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Delete the local kind cluster. Idempotent.
+set -euo pipefail
+source "$(cd "$(dirname "$0")" && pwd)/_common.sh"
+
+require_bin kind
+require_bin "${KIND_PROVIDER}"
+
+if kind_cluster_exists; then
+  log "Deleting kind cluster '${KIND_CLUSTER_NAME}'..."
+  kind delete cluster --name "${KIND_CLUSTER_NAME}"
+  ok "kind cluster '${KIND_CLUSTER_NAME}' deleted"
+else
+  ok "kind cluster '${KIND_CLUSTER_NAME}' does not exist — nothing to do"
+fi

--- a/scripts/local-dev/kind-up.sh
+++ b/scripts/local-dev/kind-up.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Create a local kind cluster (podman provider by default). Idempotent.
+set -euo pipefail
+source "$(cd "$(dirname "$0")" && pwd)/_common.sh"
+
+require_local_dev_bins
+
+if [[ ! -f "${KIND_CONFIG_FILE}" ]]; then
+  die "kind config not found: ${KIND_CONFIG_FILE}"
+fi
+
+if kind_cluster_exists; then
+  ok "kind cluster '${KIND_CLUSTER_NAME}' already exists — skipping create"
+else
+  log "Creating kind cluster '${KIND_CLUSTER_NAME}' via ${KIND_PROVIDER}..."
+  kind create cluster --name "${KIND_CLUSTER_NAME}" --config "${KIND_CONFIG_FILE}"
+  ok "kind cluster created"
+fi
+
+log "Switching kubectl context to '${KIND_CONTEXT}'"
+kubectl config use-context "${KIND_CONTEXT}" >/dev/null
+
+log "Waiting for all nodes to be Ready..."
+kubectl wait --for=condition=Ready nodes --all --timeout=120s >/dev/null
+
+ok "kind cluster '${KIND_CLUSTER_NAME}' is ready (provider: ${KIND_PROVIDER}, context: ${KIND_CONTEXT})"
+kubectl get nodes -L topology.kubernetes.io/zone

--- a/scripts/local-dev/run-local-down.sh
+++ b/scripts/local-dev/run-local-down.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Teardown counterpart for run-local.sh. Removes Aerospike, ACKO, cert-manager, and kind.
+set -euo pipefail
+source "$(cd "$(dirname "$0")" && pwd)/_common.sh"
+
+log "[1/3] Stopping standalone Aerospike (compose.dev.yaml)..."
+if command -v podman >/dev/null 2>&1; then
+  (cd "${REPO_ROOT}" && podman compose -f compose.dev.yaml down) || warn "compose.dev.yaml down failed"
+else
+  warn "podman not found — skipping compose.dev.yaml teardown"
+fi
+
+log "[2/3] Uninstalling ACKO operator + cert-manager..."
+bash "${REPO_ROOT}/scripts/local-dev/acko-uninstall.sh" || warn "ACKO uninstall step reported an error"
+
+log "[3/3] Deleting kind cluster..."
+bash "${REPO_ROOT}/scripts/local-dev/kind-down.sh"
+
+ok "Teardown complete."

--- a/scripts/local-dev/run-local.sh
+++ b/scripts/local-dev/run-local.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Orchestrator: bootstrap the full local stack for ACKO UI development.
+#   1. kind cluster (podman provider)
+#   2. cert-manager + ACKO operator (helm)
+#   3. Standalone Aerospike (compose.dev.yaml) for non-K8s connection testing
+# backend/frontend are NOT started — instructions are printed for the developer.
+set -euo pipefail
+source "$(cd "$(dirname "$0")" && pwd)/_common.sh"
+
+require_local_dev_bins
+require_bin podman "Install: https://podman.io/docs/installation"
+
+log "[1/N] Bootstrapping kind cluster..."
+bash "${REPO_ROOT}/scripts/local-dev/kind-up.sh"
+
+if [[ "${ACKO_UI_ENABLED}" == "true" && "${ACKO_UI_LOCAL_BUILD}" == "true" ]]; then
+  log "[UI] Building and loading 3 UI images into kind (ACKO_UI_LOCAL_BUILD=true)..."
+  bash "${REPO_ROOT}/scripts/local-dev/build-ui-images.sh"
+fi
+
+log "[2/N] Installing cert-manager + ACKO operator (ui.enabled=${ACKO_UI_ENABLED})..."
+bash "${REPO_ROOT}/scripts/local-dev/acko-install.sh"
+
+log "[3/N] Starting standalone Aerospike via compose.dev.yaml..."
+(cd "${REPO_ROOT}" && podman compose -f compose.dev.yaml up -d)
+ok "Aerospike dev cluster up (localhost:14790/:14791/:14792)"
+
+cat <<EOF
+
+============================================================
+Local stack is ready.
+  kubectl context : ${KIND_CONTEXT}
+  ACKO operator   : ${ACKO_NAMESPACE}/${ACKO_RELEASE}
+  Aerospike seeds : localhost:14790, localhost:14791, localhost:14792
+  UI in cluster   : ${ACKO_UI_ENABLED} (local-build: ${ACKO_UI_LOCAL_BUILD})
+============================================================
+EOF
+
+if [[ "${ACKO_UI_ENABLED}" == "true" ]]; then
+  _ui_prefix="${ACKO_FULLNAME_OVERRIDE:-${ACKO_RELEASE}}"
+  cat <<EOF
+Port-forward the chart-bundled UI:
+
+  # frontend-renewal (Tremor rewrite)
+  kubectl port-forward -n ${ACKO_NAMESPACE} svc/${_ui_prefix}-ui-frontend-renewal 3100:3100
+
+  # legacy frontend
+  kubectl port-forward -n ${ACKO_NAMESPACE} svc/${_ui_prefix}-ui-frontend 3000:3000
+
+  # backend (if needed separately)
+  kubectl port-forward -n ${ACKO_NAMESPACE} svc/${_ui_prefix}-ui-backend 8000:80
+
+Then open http://localhost:3100/
+EOF
+else
+  cat <<EOF
+Next steps — open two terminals:
+
+  # Terminal A — backend
+  cd backend
+  K8S_MANAGEMENT_ENABLED=true \\
+  AEROSPIKE_HOST=localhost AEROSPIKE_PORT=14790 \\
+    uv run uvicorn aerospike_cluster_manager_api.main:app --reload
+
+  # Terminal B — frontend
+  cd frontend && npm run dev
+
+Then open http://localhost:3000/k8s/clusters
+EOF
+fi
+
+echo
+echo "Teardown: make run-local-down"


### PR DESCRIPTION
## Summary

- Single entry point (`make run-local`) that boots a local **kind** cluster (podman provider), installs **cert-manager** and the **ACKO** operator via Helm, and starts standalone Aerospike via `compose.dev.yaml` — removing the prior multi-step manual setup for exercising the K8s / ACKO UI.
- Adds 8 idempotent scripts under `scripts/local-dev/` plus companion Makefile targets (`run-local`, `run-local-ui`, `kind-up/down/status`, `acko-install/uninstall/verify`, `build-ui-images`).
- `kind-config.yaml` provisions 1 control-plane + 3 workers labeled `topology.kubernetes.io/zone=zone-a/b/c` so the rack-awareness UI has something to render against. `README.md` and `.env.example` document the `KUBECONFIG` / `K8S_MANAGEMENT_ENABLED=true` wiring the backend needs.

## Test plan

- [ ] `make run-local` on a clean machine (podman + kind installed) brings up `kind-kind` context, cert-manager, and ACKO operator, and the Aerospike dev compose stack.
- [ ] `kubectl get crd --context kind-kind | grep acko.io` shows `aerospikeclusters` and `aerospikeclustertemplates`.
- [ ] Backend started with `K8S_MANAGEMENT_ENABLED=true KUBECONFIG=~/.kube/config` can list clusters/templates from the kind cluster.
- [ ] `make run-local-down` tears everything down cleanly.
- [ ] `make run-local-ui` (and `run-local-ui-local-build`) deploys the chart-bundled UI into kind.