### PR TITLE
feat(records): map RustPanicError to HTTP 422 (#280)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 ]
 requires-python = ">=3.13"
 dependencies = [
-    "aerospike-py>=0.5.3",
+    "aerospike-py>=0.6.4",
     "aiosqlite>=0.21.0",
     "asyncpg>=0.30.0",
     "fastapi>=0.115.0",

--- a/backend/src/aerospike_cluster_manager_api/main.py
+++ b/backend/src/aerospike_cluster_manager_api/main.py
@@ -148,6 +148,9 @@ try:
         RecordExistsError,
         RecordGenerationError,
         RecordNotFound,
+        # RustPanicError ships in aerospike-py >0.5.3 (PR aerospike-py#301).
+        # Remove the type-ignore once the dep version is bumped.
+        RustPanicError,  # type: ignore[attr-defined]
         ServerError,
     )
 
@@ -201,6 +204,27 @@ try:
     async def _cluster_error(_req: Request, exc: ClusterError) -> JSONResponse:
         logger.exception("Aerospike cluster error")
         return JSONResponse(status_code=503, content={"detail": "Connection error: unable to reach Aerospike cluster"})
+
+    @app.exception_handler(RustPanicError)
+    async def _rust_panic(_req: Request, exc: RustPanicError) -> JSONResponse:
+        # aerospike-py #280: a record on the cluster carries a particle type
+        # the native client cannot decode (commonly PYTHON_BLOB / JAVA_BLOB
+        # legacy data). The native panic was caught and surfaced; the backend
+        # process is alive but this request can't complete because aerospike-
+        # core's stream cannot resume after the panic.
+        logger.warning("Native panic surfaced as RustPanicError: %s", exc)
+        return JSONResponse(
+            status_code=422,
+            content={
+                "detail": (
+                    "This record (or one in the result stream) contains a "
+                    "particle type the native client cannot decode "
+                    "(e.g. PYTHON_BLOB / JAVA_BLOB written by a legacy "
+                    "language-specific client). See aerospike-py issue #280."
+                ),
+                "error_kind": "rust_panic",
+            },
+        )
 
     @app.exception_handler(AerospikeError)
     async def _aerospike_error(_req: Request, exc: AerospikeError) -> JSONResponse:

--- a/backend/src/aerospike_cluster_manager_api/main.py
+++ b/backend/src/aerospike_cluster_manager_api/main.py
@@ -148,9 +148,7 @@ try:
         RecordExistsError,
         RecordGenerationError,
         RecordNotFound,
-        # RustPanicError ships in aerospike-py >0.5.3 (PR aerospike-py#301).
-        # Remove the type-ignore once the dep version is bumped.
-        RustPanicError,  # type: ignore[attr-defined]
+        RustPanicError,
         ServerError,
     )
 

--- a/backend/src/aerospike_cluster_manager_api/routers/records.py
+++ b/backend/src/aerospike_cluster_manager_api/routers/records.py
@@ -73,7 +73,15 @@ async def get_records(
     set: str = "",
     pageSize: int = Query(25, ge=1, le=500),
 ) -> RecordListResponse:
-    """Retrieve records from a namespace and set (limited by pageSize)."""
+    """Retrieve records from a namespace and set (limited by pageSize).
+
+    Note: if any record in the scan stream contains a particle type the native
+    client cannot decode (e.g. PYTHON_BLOB / JAVA_BLOB written by a legacy
+    language-specific client — see aerospike-py issue #280), the underlying
+    aerospike-core stream is broken at that record and the whole request
+    surfaces as HTTP 422 (``RustPanicError``). Per-record skipping is not
+    available without an aerospike-core fork.
+    """
     set_total = await _get_set_object_count(client, ns, set)
 
     limit = min(pageSize, MAX_QUERY_RECORDS)

--- a/backend/tests/test_records_router.py
+++ b/backend/tests/test_records_router.py
@@ -102,3 +102,34 @@ class TestGetRecordDetail:
 
         assert response.status_code == 404
         assert response.json() == {"detail": "Record not found"}
+
+    async def test_rust_panic_returns_422(self, client: AsyncClient):
+        """aerospike-py #280: a record with a particle type the native client
+        cannot decode (e.g. PYTHON_BLOB / JAVA_BLOB legacy data) surfaces as
+        ``RustPanicError``. The global handler maps it to HTTP 422 so the UI
+        can show a "this record needs a legacy client" hint instead of crashing
+        the page."""
+        from aerospike_py.exception import RustPanicError
+
+        mock_client = AsyncMock()
+        mock_client.get = AsyncMock(side_effect=RustPanicError("Rust panic in `AsyncClient.get`: unreachable code"))
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            response = await client.get(
+                "/api/records/conn-test/detail",
+                params={"ns": "test", "set": "demo", "pk": "legacy_blob"},
+            )
+
+        assert response.status_code == 422
+        body = response.json()
+        assert body["error_kind"] == "rust_panic"
+        assert "particle type" in body["detail"]

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -36,7 +36,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aerospike-py", specifier = ">=0.5.3" },
+    { name = "aerospike-py", specifier = ">=0.6.4" },
     { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
@@ -60,19 +60,21 @@ dev = [
 
 [[package]]
 name = "aerospike-py"
-version = "0.5.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a0/36/13ec9fd2c295ea22c2d5ad4904441f84882d4c4a51e417eb9a5f1ff297ec/aerospike_py-0.5.3.tar.gz", hash = "sha256:0deab4429b34a6aadde63405634276c8aee4f548d997049e030b76746bf5fd28", size = 140179, upload-time = "2026-04-13T03:52:02.866Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/74/0c6d4dbc7bc63b19c2ba31c538f5a3ea3ce92b5f31af2245633684224d53/aerospike_py-0.6.4.tar.gz", hash = "sha256:16c49cee908af59cb234c83f63080628d542c8a033f6f2e93a1e9f48fe7b5b44", size = 149801, upload-time = "2026-04-25T13:50:39.16Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/f7/3ef8e2c30f9088e9f3f2256ea32b831f5315e4042c0e81ddb8727a4c3053/aerospike_py-0.5.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:391d28445a83e1c5930eafc544f9a952e6d9270b487e37ce64c15292c1c580fb", size = 2217067, upload-time = "2026-04-13T03:51:45.804Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/a4/7b11c53fb9fa206aeccca98ca144874cf0b2870597c1faab27f5e4dfc14b/aerospike_py-0.5.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dc62685e2b0fd6decbc47282105d2d66b40c93b75623d2010be97b73b196add3", size = 2010964, upload-time = "2026-04-13T03:51:47.105Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/0e/eee571f5e7d77a9d76aa9b595d7aa9c4e8cd7df35f222e96f109bc2e22a4/aerospike_py-0.5.3-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:6b06c37b19f0430c6fd5da804deea1b9fa63fe73a2c69cfed3a5713915cebdad", size = 2227703, upload-time = "2026-04-13T03:51:48.565Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/f3/8541ee5a0e7c78d4d7f765e3392b5823473783abdd28c288387139aa44df/aerospike_py-0.5.3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:3e49845ed28a7432309c493c630a5899af170cbb0dce652ff14ec50fbbc3915f", size = 2341223, upload-time = "2026-04-13T03:51:50.199Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/67/d51b36574049cb30f7b47a6596b310364ce47a77559ddb772fccf49fa0d4/aerospike_py-0.5.3-cp313-cp313-win_amd64.whl", hash = "sha256:cc9410ab49f5e60b5808b20e9163301703ed8ba337eab7f895e86b48218ec142", size = 2162380, upload-time = "2026-04-13T03:51:51.919Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/9c/93c2fccaed5b3043632c4d4509b88ed288305b1166156f2caaf40ed0dfb9/aerospike_py-0.5.3-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:82d4a6dfc3735166f810f83f4a69c7cea258a58dd4dc8d2688881b600fecc4bc", size = 2224708, upload-time = "2026-04-13T03:51:53.463Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/4c/57578e7773dfc4d3dbe03a81d05110eada7a7c1fd36d3eef239029c24a89/aerospike_py-0.5.3-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:172efe85f81f9b52e79a6e110b8067b250ffd7c97ee3f057f10934fbbaa31f1b", size = 2227207, upload-time = "2026-04-13T03:51:54.959Z" },
-    { url = "https://files.pythonhosted.org/packages/79/e7/63d5293873a679ec1f6222ef88f6f7699b08f0f1dd509e03156e3a0c03e7/aerospike_py-0.5.3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e8ab42fb9255f4284055b04b626f320240e26e340310b8e8366c0e25bab9e4dd", size = 2342888, upload-time = "2026-04-13T03:51:56.693Z" },
-    { url = "https://files.pythonhosted.org/packages/19/05/6b74271258dfe7b0200adcb82e812d40a34170a33f3158961351b123cb0f/aerospike_py-0.5.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:8e7858c8f1b33bd673830b1d178e1d84579add9f5eb8251ab4028d340ad4c266", size = 2217965, upload-time = "2026-04-13T03:51:58.066Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/0f/c11c9337dcbe1d4bd5ccb7eac3a37ef6677c1cf78c931e6b462d81e808ce/aerospike_py-0.6.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:abc4d7a254788c81d6f966d6bd14e0279940ff7aa3d7f50aaa43283e9bf65ebb", size = 2839986, upload-time = "2026-04-25T13:50:12.76Z" },
+    { url = "https://files.pythonhosted.org/packages/91/be/81fc90f5ead2fced3bcc4699fe80917046d37faac691467aa5c5bb628b6a/aerospike_py-0.6.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7f277f93edbd16eb7a28435a54d4662315a204c7aa4660f91168fd149b23bfd3", size = 2690169, upload-time = "2026-04-25T13:50:15.187Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f2/af456694aa62622fb43fa15437e3b1e496ffa227b460a28c9c64412cbcea/aerospike_py-0.6.4-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:162b2df8fd823d39f04ed3c3c72879664ecf022373d918928e15170a27f62901", size = 2803107, upload-time = "2026-04-25T13:50:17.355Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/c8/d97ceb3560217a06c0decec5e4179279d7ae43e52deaa0c5dbbad9442ce5/aerospike_py-0.6.4-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:d91a93728f904d4d30309ea6f10e15bf8700ced856be3d0e9dd16cbb0c1ac48c", size = 2905424, upload-time = "2026-04-25T13:50:19.408Z" },
+    { url = "https://files.pythonhosted.org/packages/80/90/26bb79e3aa7658e807dffa6de0c710dbdc0561784fc04bf4b228865c2313/aerospike_py-0.6.4-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7ae7319f6efe80ad67abbe41fd12ffccbcd21a2eb67d16437bc045d024339db7", size = 2792976, upload-time = "2026-04-25T13:50:21.5Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/71/90020baca12edb611b535b9f6bd9c5493be268ed6858671a325754a111db/aerospike_py-0.6.4-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:6b30459ff4d7e4169b5deee10a1b5b35bb456331089827fab181b43b0d341dc0", size = 2803754, upload-time = "2026-04-25T13:50:23.357Z" },
+    { url = "https://files.pythonhosted.org/packages/38/b5/1180d21a757638ba927107a65eabc687e94cc35f65f4a5a23047d0e124cf/aerospike_py-0.6.4-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:8031649065cb5a790c7499bf4472516f6cb06291d2d61e7ec88e6d050da9aeba", size = 2908117, upload-time = "2026-04-25T13:50:25.125Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/40/f932a6f0a25689f446ee44318f6aeb4c37ce3d4610644678afb734444b14/aerospike_py-0.6.4-cp314-cp314-win_amd64.whl", hash = "sha256:57e4151dcd80dfdafd2d3875ee349aee572233afd3a1709dabb6dbe5d03d6bfe", size = 3349768, upload-time = "2026-04-25T13:50:27.296Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a5/3f94533ddbcc83c448eba7a378bd21f008941ee6327af24cc6cd96dbd161/aerospike_py-0.6.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:1ea0014c39a2431c57d45ec481e0100d4cc7dbc87a7af5b4dd2f115359fc1c4d", size = 2830603, upload-time = "2026-04-25T13:50:29.102Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/20/500a5b1ff5d151890282a00f9d6b830ef5b2d18b24c05aa8a99e26314594/aerospike_py-0.6.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:83f69745bf0ea0209019b536a255b65384591484d09ad0f3240e2d0823ff9478", size = 2681164, upload-time = "2026-04-25T13:50:31.08Z" },
+    { url = "https://files.pythonhosted.org/packages/09/d0/63e51159eb79575825a32b1a8d4760ea41ad9b0c574cf5a140696e83dd4f/aerospike_py-0.6.4-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:5d54d35bd55a41c090d4abf2b317b5609d565f2c873be26c0ec7a1d939b804d8", size = 2794422, upload-time = "2026-04-25T13:50:32.921Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds a global FastAPI exception handler mapping `aerospike_py.RustPanicError` (subclass of `ClientError`, ships in aerospike-py **0.6.4**) to HTTP **422** with `{"error_kind": "rust_panic", "detail": ...}`. Closes the cluster-manager-side follow-up for [aerospike-py#280](https://github.com/aerospike-ce-ecosystem/aerospike-py/issues/280).
- Documents on `get_records()` that aerospike-core's scan/query stream cannot resume after a record-level panic — a single legacy-blob record still fails the whole list endpoint with 422 (per-record skipping would require an aerospike-core fork; out of scope).
- Bumps `aerospike-py>=0.5.3` → `>=0.6.4` so the new `RustPanicError` symbol is available.

## Background
On brownfield clusters, records written by older language-specific Aerospike clients can land on the wire with non-standard particle types (PYTHON_BLOB, JAVA_BLOB, etc.). `aerospike-core 2.0.0`'s `bytes_to_particle()` panicked with `unreachable!()` on those types and aerospike-py's `panic = "abort"` killed the Python process — every record-browse in cluster-manager that touched such a set restarted the backend pod. [aerospike-py#301](https://github.com/aerospike-ce-ecosystem/aerospike-py/pull/301) (now released as 0.6.4) catches the panic and surfaces it as `RustPanicError`. This PR teaches the API how to render it.

## Test plan
- [x] `uv sync` pulls `aerospike-py==0.6.4` from PyPI
- [x] `uv run pytest tests/` — **255 passed** (including new `test_rust_panic_returns_422`)
- [x] Backend startup against `compose.dev.yaml` (3-node Aerospike on `14790`-`14792`) → `GET /api/health` returns `200 {"status":"ok"}`, `RustPanicError` import resolves cleanly (no pyright `# type: ignore` needed)
- [ ] **Manual smoke** (legacy-blob seed required):
    1. `make dev-up`
    2. Seed a PYTHON_BLOB / JAVA_BLOB record via a legacy language client (Java client or `aerospike-client-python <= 11.x` with auto-pickle)
    3. `cd backend && uv run uvicorn aerospike_cluster_manager_api.main:app --reload`
    4. `curl /api/records/CONN/detail?ns=...&set=...&pk=legacy_record` → expect HTTP 422 with `{"error_kind": "rust_panic", ...}`, backend process must remain alive

## Commits
1. `086eb47` — `feat(records): map RustPanicError to HTTP 422 (#280)` — global handler + records router docstring + unit test (with temporary `# type: ignore` while aerospike-py 0.6.4 was unreleased)
2. `ee07b5e` — `chore(deps): bump aerospike-py to 0.6.4 for RustPanicError (#280)` — dep bump + drop type-ignore + lockfile refresh