### PR TITLE
chore(gitignore): ignore Claude review state and hypothesis cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ Thumbs.db
 .AppleDouble
 .LSOverride
 .claude/
+
+# === Test / Agent caches ===
+.hypothesis/
+.claude/reviews/
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
## Summary
- Add `.hypothesis/` (hypothesis-python example database, auto-generated by property-based tests).
- Add `.claude/reviews/` and `.claude/scheduled_tasks.lock` (Claude Code agent runtime state).

The existing `# === Claude Code ===` block only ignores `.claude/settings.json` and `.claude/skills/playwright-cli/`; the `reviews/` directory and the `scheduled_tasks.lock` file from the agent runtime were slipping through.

`.DS_Store` is already ignored under `# === Common ===` — no change needed there.

## Test plan
- [x] `git status` is clean of these caches after the commit (only meaningful work-in-progress shows up)
- [x] Tracked files under `.claude/` (skills, settings outside `settings.json`) are unaffected — entries are surgical