### PR TITLE
fix: runtime BACKEND_URL proxy + K8S_CA_FILE for K8s API SSL (#225)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,17 @@ K8S_MANAGEMENT_ENABLED=false
 # Pod log streaming timeout in seconds
 # K8S_LOG_TIMEOUT=30
 
+# Verify TLS certificate when calling the K8s API server (default: true).
+# Set to false to disable verification entirely (last resort).
+# K8S_VERIFY_SSL=true
+
+# Optional path to a custom CA bundle (PEM) used to verify the K8s API-server
+# certificate. Required on clusters whose API-server cert is signed by a CA
+# without the Authority Key Identifier extension — CPython 3.13+ rejects such
+# chains by default. Mount the CA via Helm `ui.backend.extraVolumes` and set
+# `ui.k8s.caFile` (chart value) which produces this env var.
+# K8S_CA_FILE=/etc/ssl/k8s/ca.crt
+
 # --- Local dev against kind (make run-local) ---
 # After `make run-local`, point the backend at the kind cluster by setting:
 # K8S_MANAGEMENT_ENABLED=true

--- a/Dockerfile.frontend-renewal
+++ b/Dockerfile.frontend-renewal
@@ -10,10 +10,8 @@ FROM node:22-alpine AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY frontend-renewal/ .
-# Next.js `rewrites()` is evaluated at build time and baked into routes-manifest.json.
-# BACKEND_URL must be set here to the Service DNS the frontend will use at runtime.
-ARG BACKEND_URL=http://aerospike-ce-kubernetes-operator-ui-backend:80
-ENV BACKEND_URL=${BACKEND_URL}
+# /api/* is proxied to BACKEND_URL at runtime by the custom server.js, so no
+# build-time BACKEND_URL is needed (and would silently override the runtime env).
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN npm run build
 
@@ -31,6 +29,9 @@ WORKDIR /app
 COPY --from=builder --chown=appuser:appuser /app/public ./public
 COPY --from=builder --chown=appuser:appuser /app/.next/standalone ./
 COPY --from=builder --chown=appuser:appuser /app/.next/static ./.next/static
+# Override the standalone-generated server.js with our custom one that
+# proxies /api/* to BACKEND_URL at runtime (uses node built-ins only).
+COPY --from=builder --chown=appuser:appuser /app/server.js ./server.js
 
 USER appuser
 

--- a/backend/src/aerospike_cluster_manager_api/config.py
+++ b/backend/src/aerospike_cluster_manager_api/config.py
@@ -49,6 +49,11 @@ AS_TEND_INTERVAL: int = _get_int("AS_TEND_INTERVAL", 1000)  # Cluster tend inter
 # Kubernetes API
 K8S_API_TIMEOUT: int = _get_int("K8S_API_TIMEOUT", 10)
 K8S_VERIFY_SSL: bool = os.getenv("K8S_VERIFY_SSL", "true").lower() in ("true", "1", "yes")
+# Optional path to a custom CA bundle for verifying the K8s API-server certificate.
+# When set (and K8S_VERIFY_SSL is true), overrides the default in-cluster CA bundle.
+# Required on clusters whose API-server cert is signed by a CA that lacks the
+# Authority Key Identifier extension — CPython 3.13+ rejects such chains by default.
+K8S_CA_FILE: str = os.getenv("K8S_CA_FILE", "")
 K8S_LOG_TIMEOUT: int = _get_int("K8S_LOG_TIMEOUT", 30)
 
 # SSE (Server-Sent Events) streaming

--- a/backend/src/aerospike_cluster_manager_api/k8s_client.py
+++ b/backend/src/aerospike_cluster_manager_api/k8s_client.py
@@ -77,6 +77,12 @@ class K8sClient:
                 configuration.ssl_ca_cert = None
                 client.Configuration.set_default(configuration)
                 logger.warning("K8S_VERIFY_SSL=false — TLS certificate verification disabled")
+            elif app_config.K8S_CA_FILE:
+                configuration = client.Configuration.get_default_copy()
+                configuration.verify_ssl = True
+                configuration.ssl_ca_cert = app_config.K8S_CA_FILE
+                client.Configuration.set_default(configuration)
+                logger.info("Using custom K8s API CA bundle: %s", app_config.K8S_CA_FILE)
 
             self._custom_api = client.CustomObjectsApi()
             self._core_api = client.CoreV1Api()

--- a/backend/src/aerospike_cluster_manager_api/k8s_client.py
+++ b/backend/src/aerospike_cluster_manager_api/k8s_client.py
@@ -80,7 +80,7 @@ class K8sClient:
             elif app_config.K8S_CA_FILE:
                 configuration = client.Configuration.get_default_copy()
                 configuration.verify_ssl = True
-                configuration.ssl_ca_cert = app_config.K8S_CA_FILE
+                configuration.ssl_ca_cert = app_config.K8S_CA_FILE  # type: ignore[reportAttributeAccessIssue]
                 client.Configuration.set_default(configuration)
                 logger.info("Using custom K8s API CA bundle: %s", app_config.K8S_CA_FILE)
 

--- a/frontend-renewal/next.config.mjs
+++ b/frontend-renewal/next.config.mjs
@@ -20,15 +20,10 @@ const nextConfig = {
       },
     ];
   },
-  async rewrites() {
-    const backendUrl = process.env.BACKEND_URL ?? "http://localhost:8000";
-    return [
-      {
-        source: "/api/:path*",
-        destination: `${backendUrl}/api/:path*`,
-      },
-    ];
-  },
+  // /api/* is proxied to BACKEND_URL at runtime by ./server.js (Next.js
+  // `rewrites()` would otherwise be evaluated at `next build` time and bake
+  // BACKEND_URL into the routes manifest, breaking any release whose
+  // backend Service hostname differs from the build-time value).
 };
 
 export default nextConfig;

--- a/frontend-renewal/package.json
+++ b/frontend-renewal/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev -p 3100",
+    "dev": "node server.js",
     "build": "next build",
-    "start": "next start -p 3100",
+    "start": "NODE_ENV=production node server.js",
     "lint": "next lint",
     "type-check": "tsc --noEmit",
     "format": "prettier --write .",

--- a/frontend-renewal/server.js
+++ b/frontend-renewal/server.js
@@ -1,0 +1,77 @@
+// Custom Next.js server: forwards /api/* to BACKEND_URL at runtime.
+// Replaces the standalone-generated server.js in the container, so BACKEND_URL
+// is read on container start instead of being baked at `next build` time.
+const http = require("http");
+const https = require("https");
+const { parse } = require("url");
+const next = require("next");
+
+const dev = process.env.NODE_ENV !== "production";
+const port = parseInt(process.env.PORT || "3100", 10);
+const hostname = process.env.HOSTNAME || "0.0.0.0";
+const backendUrl = process.env.BACKEND_URL || "http://localhost:8000";
+
+let parsedBackend;
+try {
+  parsedBackend = new URL(backendUrl);
+} catch (err) {
+  console.error(`Invalid BACKEND_URL=${backendUrl}: ${err.message}`);
+  process.exit(1);
+}
+const backendIsHttps = parsedBackend.protocol === "https:";
+const backendPort = parsedBackend.port || (backendIsHttps ? 443 : 80);
+const backendLib = backendIsHttps ? https : http;
+
+const app = next({ dev, hostname, port });
+const handle = app.getRequestHandler();
+
+function proxyApi(req, res) {
+  const targetPath = req.url;
+  const headers = { ...req.headers };
+  delete headers.host;
+
+  const proxyReq = backendLib.request(
+    {
+      hostname: parsedBackend.hostname,
+      port: backendPort,
+      path: targetPath,
+      method: req.method,
+      headers,
+    },
+    (proxyRes) => {
+      res.writeHead(proxyRes.statusCode || 502, proxyRes.headers);
+      proxyRes.pipe(res);
+    },
+  );
+
+  proxyReq.on("error", (err) => {
+    console.error(`[proxy] ${req.method} ${targetPath} -> ${backendUrl} failed: ${err.message}`);
+    if (!res.headersSent) {
+      res.writeHead(502, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Bad gateway", target: backendUrl }));
+    } else {
+      res.end();
+    }
+  });
+
+  req.on("aborted", () => proxyReq.destroy());
+  req.pipe(proxyReq);
+}
+
+app.prepare().then(() => {
+  const server = http.createServer((req, res) => {
+    const parsedUrl = parse(req.url, true);
+    if (parsedUrl.pathname && parsedUrl.pathname.startsWith("/api/")) {
+      return proxyApi(req, res);
+    }
+    return handle(req, res, parsedUrl);
+  });
+
+  server.keepAliveTimeout = 65_000;
+  server.headersTimeout = 66_000;
+
+  server.listen(port, hostname, () => {
+    console.log(`> Ready on http://${hostname}:${port}`);
+    console.log(`> Proxying /api/* -> ${backendUrl}`);
+  });
+});


### PR DESCRIPTION
## Summary
- **frontend-renewal**: replaces the build-time `BACKEND_URL` baked into Next.js `routes-manifest.json` with a runtime proxy in a custom `server.js` (Node `http`/`https` built-ins, no extra deps). `BACKEND_URL` is now read on container start; `fullnameOverride` no longer requires the chart name to be `aerospike-ce-kubernetes-operator`.
- **backend**: adds `K8S_CA_FILE` env var so the K8s API client can verify the API-server cert against a custom CA bundle (alongside the existing `K8S_VERIFY_SSL=false` escape hatch).
- `dev`/`start` scripts both use `server.js` so dev and prod share one proxy implementation.

## Background
Upstream operator issue aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator#225 reports two footguns:

1. The `frontend-renewal` image hard-coded the backend hostname into the Next.js routes manifest at build time. Even though the operator chart's ConfigMap correctly injects `BACKEND_URL` at runtime, the standalone server never re-read it, so `fullnameOverride` deviations produced `getaddrinfo ENOTFOUND ...-ui-backend` and 500s on any backend-backed page.
2. CPython ≥ 3.13 became strict about Authority Key Identifier extension verification (python/cpython#110524). On clusters whose API-server cert is signed by an internal CA without AKI, every backend → K8s API call fails with `SSL: CERTIFICATE_VERIFY_FAILED — Missing Authority Key Identifier`. The image only supported `K8S_VERIFY_SSL=false`, which corp policy often forbids.

## Changes
- `frontend-renewal/server.js` (new) — custom Next.js server that forwards `/api/*` to `process.env.BACKEND_URL` at runtime. SSE/streaming-friendly (uses `req.pipe` / `res.pipe`).
- `frontend-renewal/next.config.mjs` — removes the build-time `rewrites()` block.
- `frontend-renewal/package.json` — `dev`/`start` scripts run `server.js`.
- `Dockerfile.frontend-renewal` — drops the build-time `ARG BACKEND_URL`; runtime stage overrides the standalone-generated `server.js` with the custom one.
- `backend/.../config.py` — adds `K8S_CA_FILE` env var.
- `backend/.../k8s_client.py` — extends the SSL branch: `K8S_VERIFY_SSL=false` → bypass / `K8S_CA_FILE` → custom CA / default in-cluster CA.
- `.env.example` — documents `K8S_VERIFY_SSL`, `K8S_CA_FILE`.

## Test plan
- [x] `node --check frontend-renewal/server.js` — syntax OK
- [x] `python -m py_compile backend/src/aerospike_cluster_manager_api/config.py k8s_client.py` — OK
- [ ] Local container build + run with `BACKEND_URL=http://example.invalid:9999`: confirm logs show the custom target + `/api/*` returns 502 (target unreachable), proving runtime resolution
- [ ] Deploy via the paired operator chart PR (aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator#226) with `fullnameOverride: acko-short` and confirm `/clusters` works
- [ ] On a cluster with AKI-less internal CA: set `K8S_CA_FILE=/etc/ssl/k8s/ca.crt`, mount the secret, confirm backend logs `Using custom K8s API CA bundle` and `/api/k8s/clusters` returns 200

## Related
- Operator chart PR (paired): aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator#226 (will bump submodule pointer + image tag once this PR lands)
- Refs aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator#225