### PR TITLE
fix(frontend-renewal): use next-server directly to fix bundle5 crash (#230)

### DIFF
--- a/frontend-renewal/server.js
+++ b/frontend-renewal/server.js
@@ -1,10 +1,19 @@
 // Custom Next.js server: forwards /api/* to BACKEND_URL at runtime.
 // Replaces the standalone-generated server.js in the container, so BACKEND_URL
 // is read on container start instead of being baked at `next build` time.
+//
+// Production must NOT use `require("next")` — that entry pulls
+// `next/dist/server/config-utils.js` -> `next/dist/compiled/webpack/webpack.js`,
+// which Next.js standalone tracing intentionally omits, so the runtime image
+// would crash with `Cannot find module './bundle5'` on container start
+// (issue #230). Instead, we mirror the standalone-generated server.js by
+// instantiating `next/dist/server/next-server` directly and feeding it the
+// inlined config from `.next/required-server-files.json`.
 const http = require("http");
 const https = require("https");
+const path = require("path");
+const fs = require("fs");
 const { parse } = require("url");
-const next = require("next");
 
 const dev = process.env.NODE_ENV !== "production";
 const port = parseInt(process.env.PORT || "3100", 10);
@@ -21,9 +30,6 @@ try {
 const backendIsHttps = parsedBackend.protocol === "https:";
 const backendPort = parsedBackend.port || (backendIsHttps ? 443 : 80);
 const backendLib = backendIsHttps ? https : http;
-
-const app = next({ dev, hostname, port });
-const handle = app.getRequestHandler();
 
 function proxyApi(req, res) {
   const targetPath = req.url;
@@ -58,13 +64,42 @@ function proxyApi(req, res) {
   req.pipe(proxyReq);
 }
 
-app.prepare().then(() => {
+async function createNextHandler() {
+  if (dev) {
+    // Dev: full `next` package is available; webpack et al. are needed anyway.
+    const next = require("next");
+    const app = next({ dev: true, hostname, port });
+    await app.prepare();
+    return app.getRequestHandler();
+  }
+  // Production standalone: use `next-server` directly. Avoids
+  // `require("next")` -> webpack chain that's not in the standalone trace.
+  const requiredServerFilesPath = path.join(__dirname, ".next", "required-server-files.json");
+  const requiredServerFiles = JSON.parse(fs.readFileSync(requiredServerFilesPath, "utf8"));
+  process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = JSON.stringify(requiredServerFiles.config);
+  process.chdir(__dirname);
+
+  const NextServer = require("next/dist/server/next-server").default;
+  const app = new NextServer({
+    hostname,
+    port,
+    dir: __dirname,
+    dev: false,
+    customServer: false,
+    conf: requiredServerFiles.config,
+  });
+  await app.prepare();
+  return app.getRequestHandler();
+}
+
+(async () => {
+  const handler = await createNextHandler();
   const server = http.createServer((req, res) => {
     const parsedUrl = parse(req.url, true);
     if (parsedUrl.pathname && parsedUrl.pathname.startsWith("/api/")) {
       return proxyApi(req, res);
     }
-    return handle(req, res, parsedUrl);
+    return handler(req, res, parsedUrl);
   });
 
   server.keepAliveTimeout = 65_000;
@@ -74,4 +109,7 @@ app.prepare().then(() => {
     console.log(`> Ready on http://${hostname}:${port}`);
     console.log(`> Proxying /api/* -> ${backendUrl}`);
   });
+})().catch((err) => {
+  console.error("Fatal: failed to start server:", err);
+  process.exit(1);
 });


### PR DESCRIPTION
## Summary
Fix the v0.10.1 / v0.11.0 frontend-renewal image crashing on container start with \`Cannot find module './bundle5'\`.

## Root cause
The runtime BACKEND_URL fix introduced in #229 swapped the standalone-generated \`server.js\` for a custom one that called \`require(\"next\")\`. The \`next\` package entry transitively loads \`next/dist/compiled/webpack/webpack.js\`, and Next.js's standalone output tracing intentionally omits the webpack runtime bundles (\`bundle5.js\`, etc.) — so the moment the custom server tried to instantiate Next.js, the require failed.

## Fix
Mirror the standalone-generated \`server.js\`:
- Instantiate \`next/dist/server/next-server\` directly (this path *is* in the standalone trace).
- Feed it the inlined config from \`.next/required-server-files.json\` and set \`__NEXT_PRIVATE_STANDALONE_CONFIG\` so Next.js internals treat the process as a standalone runtime.
- Keep \`require(\"next\")\` for dev mode where the full package is available, so \`npm run dev\` is unchanged.

The /api/* runtime proxy logic is unchanged — \`BACKEND_URL\` is still resolved on container start.

## Test plan
- [x] \`node --check frontend-renewal/server.js\` — syntax OK
- [ ] CI build of \`Dockerfile.frontend-renewal\` succeeds
- [ ] Run the new image with \`-e BACKEND_URL=http://example.invalid:9999 -p 3100:3100\` and confirm it boots without the bundle5 crash
- [ ] Hit \`/\` (Next.js page) and \`/api/health\` (proxied to BACKEND_URL) — page renders, /api returns 502 (target unreachable, but reaches the proxy)

## Related
- Closes #230
- Refs #229 (the change that introduced the regression)