### PR TITLE
fix(backend): disable /api/redoc (loads from jsdelivr CDN, breaks in airgap)

### DIFF
--- a/backend/src/aerospike_cluster_manager_api/main.py
+++ b/backend/src/aerospike_cluster_manager_api/main.py
@@ -69,7 +69,12 @@ app = FastAPI(
     # /api/docs is served below from self-hosted swagger-ui assets so the docs
     # page works in airgap / firewalled clusters that can't reach jsdelivr (#234).
     docs_url=None,
-    redoc_url="/api/redoc",
+    # Redoc is disabled — FastAPI's default /api/redoc loads redoc.standalone.js
+    # from cdn.jsdelivr.net and there is no maintained Python package that
+    # vendors it. /api/docs (Swagger UI) covers the same use case and is
+    # self-hosted, so disabling redoc avoids the airgap footgun without losing
+    # API-explorer functionality. Re-enable + vendor JS at build time if needed.
+    redoc_url=None,
     openapi_url="/api/openapi.json",
     lifespan=lifespan,
 )


### PR DESCRIPTION
## Summary
Follow-up to #234 / #236. The Swagger UI page is now self-hosted, but \`/api/redoc\` still rendered blank in airgap clusters because FastAPI's default \`redoc_url\` loads \`redoc.standalone.js\` from \`cdn.jsdelivr.net\`. Disable it.

## Why disable instead of vendor
There's no maintained Python package that vendors \`redoc.standalone.js\` the way \`swagger-ui-bundle\` does for Swagger UI. The two viable paths were:

1. **Disable** — \`redoc_url=None\` (this PR). One line, zero maintenance, zero new build-time network egress.
2. **Vendor** — download \`redoc.standalone.js\` at Docker build time, mount it via \`StaticFiles\`, custom \`/api/redoc\` handler. More moving parts, build-time CDN egress, version drift surface.

\`/api/docs\` (Swagger UI, fixed in v0.11.3) covers the same OpenAPI-explorer use case, so disabling Redoc loses no user-facing functionality. If anyone wants Redoc back, the comment in \`main.py\` documents the vendor path.

## Test plan
- [x] \`python -m py_compile main.py\` — OK
- [x] \`uv run ruff check src\` / \`ruff format --check src\` — clean
- [ ] \`docker run -p 8000:8000 …backend:<this-PR>\` and confirm
  - \`curl /api/docs\` still works (200)
  - \`curl /api/redoc\` returns 404
  - \`curl /api/openapi.json\` still returns the spec (200)