### PR TITLE
fix(backend): unblock /api/docs by splitting Swagger UI bootstrap into external swagger-init.js

### DIFF
--- a/backend/src/aerospike_cluster_manager_api/main.py
+++ b/backend/src/aerospike_cluster_manager_api/main.py
@@ -6,7 +6,6 @@ from contextlib import asynccontextmanager
 
 from fastapi import APIRouter, FastAPI, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from slowapi import _rate_limit_exceeded_handler
@@ -88,16 +87,55 @@ app.mount(
 )
 
 
+# FastAPI's get_swagger_ui_html() emits an inline <script> that calls
+# SwaggerUIBundle({...}). Our CSP sets `script-src 'self'`, which blocks any
+# inline script and leaves /api/docs blank in the browser (#238). The custom
+# HTML below mirrors FastAPI's layout but moves the bootstrap call to the
+# external /api/docs/swagger-init.js route below, so the page renders under
+# strict CSP without weakening it for the rest of the API surface.
+_SWAGGER_UI_HTML = """\
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link type="text/css" rel="stylesheet" href="/api/docs/static/swagger-ui.css">
+<link rel="shortcut icon" href="/api/docs/static/favicon-32x32.png">
+<title>Aerospike Cluster Manager API - Swagger UI</title>
+</head>
+<body>
+<div id="swagger-ui"></div>
+<script src="/api/docs/static/swagger-ui-bundle.js"></script>
+<script src="/api/docs/swagger-init.js"></script>
+</body>
+</html>
+"""
+
+_SWAGGER_INIT_JS = """\
+window.ui = SwaggerUIBundle({
+    url: '/api/openapi.json',
+    dom_id: '#swagger-ui',
+    layout: 'BaseLayout',
+    deepLinking: true,
+    showExtensions: true,
+    showCommonExtensions: true,
+    presets: [
+        SwaggerUIBundle.presets.apis,
+        SwaggerUIBundle.SwaggerUIStandalonePreset,
+    ],
+});
+"""
+
+
 @app.get("/api/docs", include_in_schema=False)
 async def custom_swagger_ui() -> HTMLResponse:
-    """Self-hosted Swagger UI — replaces FastAPI's default cdn.jsdelivr.net version."""
-    return get_swagger_ui_html(
-        openapi_url=app.openapi_url or "/api/openapi.json",
-        title=f"{app.title} - Swagger UI",
-        swagger_js_url="/api/docs/static/swagger-ui-bundle.js",
-        swagger_css_url="/api/docs/static/swagger-ui.css",
-        swagger_favicon_url="/api/docs/static/favicon-32x32.png",
-    )
+    """Self-hosted Swagger UI with no inline scripts (CSP-compliant under script-src 'self', #238)."""
+    return HTMLResponse(content=_SWAGGER_UI_HTML)
+
+
+@app.get("/api/docs/swagger-init.js", include_in_schema=False)
+async def swagger_ui_init_js() -> Response:
+    """SwaggerUIBundle bootstrap — split into its own JS file so CSP `script-src 'self'` permits it (#238)."""
+    return Response(content=_SWAGGER_INIT_JS, media_type="application/javascript")
 
 
 app.state.limiter = limiter

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -65,6 +65,34 @@ async def test_csp_report_uri(init_test_db):
 
 
 # ---------------------------------------------------------------------------
+# Swagger UI is CSP-compliant under script-src 'self' (#238)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_swagger_docs_has_no_inline_script(client: AsyncClient):
+    """/api/docs must not emit inline <script> blocks — CSP `script-src 'self'` blocks them (#238)."""
+    resp = await client.get("/api/docs")
+    assert resp.status_code == 200
+    body = resp.text
+    # Strict CSP must still apply on the docs page itself.
+    assert "script-src 'self'" in resp.headers["Content-Security-Policy"]
+    # The bootstrap call must come from an external script, not an inline block.
+    assert "SwaggerUIBundle({" not in body
+    assert '<script src="/api/docs/swagger-init.js"></script>' in body
+    assert '<script src="/api/docs/static/swagger-ui-bundle.js"></script>' in body
+
+
+@pytest.mark.anyio
+async def test_swagger_init_js_is_served_with_js_mime(client: AsyncClient):
+    """The bootstrap script must be served as application/javascript so the browser executes it."""
+    resp = await client.get("/api/docs/swagger-init.js")
+    assert resp.status_code == 200
+    assert resp.headers["Content-Type"].startswith("application/javascript")
+    assert "SwaggerUIBundle({" in resp.text
+
+
+# ---------------------------------------------------------------------------
 # Proxy-aware rate limit key function
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- `/api/docs` rendered blank in the browser because FastAPI's `get_swagger_ui_html()` emits an inline `<script>SwaggerUIBundle({...})</script>` block that our CSP `script-src 'self'` blocks.
- Replace the helper with a small static HTML body that loads two same-origin scripts: the existing `swagger-ui-bundle.js` and a new `swagger-init.js` route serving the bootstrap call as `application/javascript`.
- CSP stays strict (`script-src 'self'`) — no `'unsafe-inline'`, no nonces, no per-route override.

Closes #238.

## Test plan
- [x] `uv run pytest tests/test_security_headers.py` — 11 passed (incl. 2 new tests)
- [x] `uv run pytest` — 229 passed, 1 unrelated warning
- [x] `uv run ruff check src tests && uv run ruff format src tests --check` — clean
- [x] Manual ASGI roundtrip: `/api/docs` returns 200 with no inline `SwaggerUIBundle({` and external `<script src="/api/docs/swagger-init.js">`; `/api/docs/swagger-init.js` returns 200 with `Content-Type: application/javascript`; `/api/docs/static/swagger-ui-bundle.js` still serves vendored asset.