### PR TITLE
fix(ci): tag CD reads main's cache; add workflow_dispatch; raise timeout

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -16,6 +16,7 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  workflow_dispatch:
 
 concurrency:
   group: cd-${{ github.ref }}
@@ -28,7 +29,7 @@ jobs:
   build-and-push:
     name: Build & Push (${{ matrix.name }})
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
       packages: write
@@ -91,5 +92,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: ${{ !startsWith(github.ref, 'refs/tags/') && format('type=gha,scope={0}', matrix.name) || '' }}
-          cache-to: ${{ !startsWith(github.ref, 'refs/tags/') && format('type=gha,mode=max,scope={0}', matrix.name) || '' }}
+          # Read main's cache for every event (tag, dispatch, branch). Without
+          # this, tag pushes do a cold multi-arch build via QEMU and the
+          # frontend-renewal job times out at 30 minutes (#239 release).
+          cache-from: type=gha,scope=${{ matrix.name }}
+          # Only main writes to the cache so tags don't churn it.
+          cache-to: ${{ github.ref == 'refs/heads/main' && format('type=gha,mode=max,scope={0}', matrix.name) || '' }}


### PR DESCRIPTION
## Summary

Tag-triggered CD on v0.11.5 timed out because frontend-renewal's multi-arch build did not reuse main's gha cache and could not finish a cold QEMU build inside the 30-minute job cap. Three changes:

1. `cache-from: type=gha,scope=<image>` is now always set, so tag pushes reuse the cache main wrote.
2. `cache-to` is gated on `github.ref == 'refs/heads/main'` so only main writes; tags read.
3. `workflow_dispatch` trigger added so the workflow can be re-run against a specific ref (e.g., to recover the missing v0.11.5 frontend-renewal image tag).
4. `timeout-minutes: 60` as a safety net for cold builds when the cache is empty.

## Test plan
- [x] YAML validates (no syntax errors).
- [ ] After merge: `gh workflow run cd.yaml --ref v0.11.5` and confirm all four images push `0.11.5` / `0.11` semver tags within ~3 minutes.