### PR TITLE
fix(backend): CSP_ENABLED toggle — let operators escape the swagger-init.js indirection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,12 @@ K8S_MANAGEMENT_ENABLED=false
 # CSP report URI for Content-Security-Policy violations
 # CSP_REPORT_URI=
 
+# Emit the in-app Content-Security-Policy header. Disable when an upstream
+# layer (ingress/WAF) owns CSP, or when you want /api/docs to use FastAPI's
+# default Swagger UI from CDN (jsdelivr swagger-ui 5.x, full OpenAPI 3.1
+# support — see issue #241). Default true.
+# CSP_ENABLED=true
+
 # Comma-separated list of trusted reverse-proxy IPs for X-Forwarded-For support
 # TRUSTED_PROXIES=10.0.0.1,10.0.0.2
 

--- a/backend/src/aerospike_cluster_manager_api/config.py
+++ b/backend/src/aerospike_cluster_manager_api/config.py
@@ -34,6 +34,12 @@ K8S_MANAGEMENT_ENABLED: bool = os.getenv("K8S_MANAGEMENT_ENABLED", "false").lowe
 # Security headers
 ENABLE_HSTS: bool = os.getenv("ENABLE_HSTS", "false").lower() in ("true", "1", "yes")
 CSP_REPORT_URI: str = os.getenv("CSP_REPORT_URI", "")
+# When disabled, the in-app Content-Security-Policy header is not emitted and
+# /api/docs falls back to FastAPI's default helper (CDN swagger-ui 5.x with
+# inline bootstrap). Operators with an upstream layer enforcing CSP, or those
+# whose browsers have unrestricted internet egress, can turn this off to lift
+# the swagger-init.js indirection and render OpenAPI 3.1 specs directly (#241).
+CSP_ENABLED: bool = os.getenv("CSP_ENABLED", "true").lower() in ("true", "1", "yes")
 
 # Trusted reverse-proxy addresses for X-Forwarded-For support
 TRUSTED_PROXIES: list[str] = [p.strip() for p in os.getenv("TRUSTED_PROXIES", "").split(",") if p.strip()]

--- a/backend/src/aerospike_cluster_manager_api/main.py
+++ b/backend/src/aerospike_cluster_manager_api/main.py
@@ -6,6 +6,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import APIRouter, FastAPI, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.openapi.docs import get_swagger_ui_html
 from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from slowapi import _rate_limit_exceeded_handler
@@ -128,7 +129,23 @@ window.ui = SwaggerUIBundle({
 
 @app.get("/api/docs", include_in_schema=False)
 async def custom_swagger_ui() -> HTMLResponse:
-    """Self-hosted Swagger UI with no inline scripts (CSP-compliant under script-src 'self', #238)."""
+    """Swagger UI page.
+
+    With CSP_ENABLED=true (default): self-hosted assets + external
+    swagger-init.js so the page renders under strict `script-src 'self'`
+    (#238). The vendored swagger-ui is 4.15.5 and does not parse OpenAPI 3.1.
+
+    With CSP_ENABLED=false: FastAPI's default helper which loads swagger-ui
+    5.x from cdn.jsdelivr.net — full OpenAPI 3.1 support and no init.js
+    indirection (#241). Browsers fetch the assets directly, so this works
+    whenever the operator's workstation has internet egress, regardless of
+    whether the cluster's pods do.
+    """
+    if not config.CSP_ENABLED:
+        return get_swagger_ui_html(
+            openapi_url=app.openapi_url or "/api/openapi.json",
+            title=f"{app.title} - Swagger UI",
+        )
     return HTMLResponse(content=_SWAGGER_UI_HTML)
 
 
@@ -187,14 +204,16 @@ async def security_headers_middleware(request: Request, call_next: RequestRespon
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
     response.headers["Permissions-Policy"] = "camera=(), microphone=(), geolocation=()"
 
-    csp = (
-        "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'"
-    )
-    if config.CSP_REPORT_URI:
-        sanitized_uri = config.CSP_REPORT_URI.split(";")[0].strip()
-        if sanitized_uri:
-            csp += f"; report-uri {sanitized_uri}"
-    response.headers["Content-Security-Policy"] = csp
+    if config.CSP_ENABLED:
+        csp = (
+            "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; "
+            "img-src 'self' data:; font-src 'self'"
+        )
+        if config.CSP_REPORT_URI:
+            sanitized_uri = config.CSP_REPORT_URI.split(";")[0].strip()
+            if sanitized_uri:
+                csp += f"; report-uri {sanitized_uri}"
+        response.headers["Content-Security-Policy"] = csp
 
     if config.ENABLE_HSTS:
         response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains"

--- a/backend/tests/test_security_headers.py
+++ b/backend/tests/test_security_headers.py
@@ -93,6 +93,30 @@ async def test_swagger_init_js_is_served_with_js_mime(client: AsyncClient):
 
 
 # ---------------------------------------------------------------------------
+# CSP_ENABLED toggle — disables in-app CSP and falls /api/docs back to FastAPI
+# default (CDN swagger-ui 5.x with inline init, full OpenAPI 3.1 support, #241)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_csp_disabled_strips_header_and_uses_cdn_docs(init_test_db):
+    """With CSP_ENABLED=false, no CSP header is emitted and /api/docs uses FastAPI's CDN-backed default."""
+    with patch("aerospike_cluster_manager_api.config.CSP_ENABLED", False):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            health = await ac.get("/api/health")
+            assert "Content-Security-Policy" not in health.headers
+
+            docs = await ac.get("/api/docs")
+            assert docs.status_code == 200
+            body = docs.text
+            # FastAPI default loads swagger-ui from jsdelivr CDN.
+            assert "cdn.jsdelivr.net/npm/swagger-ui-dist" in body
+            # And uses the inline bootstrap call (which our CSP would have blocked).
+            assert "SwaggerUIBundle({" in body
+
+
+# ---------------------------------------------------------------------------
 # Proxy-aware rate limit key function
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

The swagger-init.js + self-hosted-assets dance from v0.11.5 (#238) only existed because our own `security_headers_middleware` enforces `script-src 'self'` and FastAPI's `get_swagger_ui_html()` emits an inline `<script>`. The CDN is fetched by the operator's **browser**, not the pod, so the binding constraint was always our in-app CSP — not network egress.

Add `CSP_ENABLED` env var (default `true`, current behavior unchanged):

- `true`: strict CSP + self-hosted swagger-ui 4.15.5 + external `swagger-init.js`. Same as v0.11.5.
- `false`: no `Content-Security-Policy` header; `/api/docs` falls back to FastAPI's default `get_swagger_ui_html()` which loads swagger-ui **5.x** from cdn.jsdelivr.net. Browsers with internet egress get full **OpenAPI 3.1 rendering** and skip the indirection. Operators with an upstream layer (ingress/WAF) owning CSP can also use this to delegate the policy.

Closes #241.

## Test plan
- [x] `uv run pytest tests/test_security_headers.py` — 12 passed (incl. 1 new for the toggle off path).
- [x] `uv run pytest` — 230 passed.
- [x] `uv run ruff check src tests && uv run ruff format src tests --check` — clean.
- [x] Manual ASGI roundtrip:
  - default → CSP set, body has external init.js, no jsdelivr, no inline `SwaggerUIBundle({`.
  - `CSP_ENABLED=false` → no CSP header, body has jsdelivr URL + inline `SwaggerUIBundle({`.