### PR TITLE
fix(local-dev): podman/kind compatibility for build-ui-images.sh

### DIFF
--- a/scripts/local-dev/_common.sh
+++ b/scripts/local-dev/_common.sh
@@ -38,8 +38,14 @@ export ACKO_FULLNAME_OVERRIDE="${ACKO_FULLNAME_OVERRIDE:-}"
 export ACKO_UI_ENABLED="${ACKO_UI_ENABLED:-false}"
 export ACKO_UI_LOCAL_BUILD="${ACKO_UI_LOCAL_BUILD:-false}"
 export ACKO_UI_IMAGE_TAG="${ACKO_UI_IMAGE_TAG:-latest}"
-export ACKO_UI_API_IMAGE="${ACKO_UI_API_IMAGE:-aerospike-cluster-manager-api}"
-export ACKO_UI_WEB_IMAGE="${ACKO_UI_WEB_IMAGE:-aerospike-cluster-manager-ui}"
+# Podman normalizes bare tags to `localhost/<name>`, and `kind load
+# image-archive` preserves whatever name the archive carries. Setting the
+# `localhost/` prefix here keeps the build tag, the in-archive name, and the
+# helm `image.repository` value (passed by acko-install.sh) in sync — without
+# it, the pod tries to pull `aerospike-cluster-manager-api:latest` from
+# Docker Hub and ends in ImagePullBackOff.
+export ACKO_UI_API_IMAGE="${ACKO_UI_API_IMAGE:-localhost/aerospike-cluster-manager-api}"
+export ACKO_UI_WEB_IMAGE="${ACKO_UI_WEB_IMAGE:-localhost/aerospike-cluster-manager-ui}"
 
 # Resolve repo root (scripts live at <repo>/scripts/local-dev/).
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/local-dev/build-ui-images.sh
+++ b/scripts/local-dev/build-ui-images.sh
@@ -5,6 +5,13 @@
 # Images produced (tag defaults to ${ACKO_UI_IMAGE_TAG}, default 'local'):
 #   - ${ACKO_UI_API_IMAGE}:${ACKO_UI_IMAGE_TAG}
 #   - ${ACKO_UI_WEB_IMAGE}:${ACKO_UI_IMAGE_TAG}
+#
+# Loads via `podman save | kind load image-archive` instead of
+# `kind load docker-image`. Podman normalizes un-prefixed tags to
+# `localhost/<name>` and `kind load docker-image` then can't find them
+# (kind's podman shim looks up the literal name, not the normalized one).
+# The image-archive path preserves the in-archive name so the helm
+# `--set ui.api.image.repository=localhost/...` value matches.
 set -euo pipefail
 source "$(cd "$(dirname "$0")" && pwd)/_common.sh"
 
@@ -19,13 +26,18 @@ build_and_load() {
   local image="$1"
   local dockerfile="$2"
   local tag="${ACKO_UI_IMAGE_TAG}"
+  local full="${image}:${tag}"
 
-  log "Building ${image}:${tag} (dockerfile: ${dockerfile})..."
-  (cd "${REPO_ROOT}" && podman build -t "${image}:${tag}" -f "${dockerfile}" .)
+  log "Building ${full} (dockerfile: ${dockerfile})..."
+  (cd "${REPO_ROOT}" && podman build -t "${full}" -f "${dockerfile}" .)
 
-  log "Loading ${image}:${tag} into kind cluster '${KIND_CLUSTER_NAME}'..."
-  kind load docker-image "${image}:${tag}" --name "${KIND_CLUSTER_NAME}"
-  ok "${image}:${tag} loaded"
+  log "Loading ${full} into kind cluster '${KIND_CLUSTER_NAME}' (via image-archive)..."
+  local tarball
+  tarball="$(mktemp -t kind-load.XXXXXX)"
+  trap 'rm -f "${tarball}"' RETURN
+  podman save "${full}" -o "${tarball}"
+  kind load image-archive "${tarball}" --name "${KIND_CLUSTER_NAME}"
+  ok "${full} loaded"
 }
 
 build_and_load "${ACKO_UI_API_IMAGE}" "Dockerfile.api"


### PR DESCRIPTION
## Summary

`make run-local-ui-local-build` aborts with \`ERROR: image: \"aerospike-cluster-manager-api:latest\" not present locally\` on macOS+podman. Root cause: podman normalizes un-prefixed tags to \`localhost/<name>\`, but \`kind load docker-image <name>\` looks up the literal name in podman's image store and the lookup fails.

Switch to the \`podman save | kind load image-archive\` pattern which is robust against tag normalization — the in-archive name is preserved exactly as podman stored it. Default \`ACKO_UI_API_IMAGE\` / \`ACKO_UI_WEB_IMAGE\` to the explicit \`localhost/\` prefix so the helm \`image.repository\` value passed by \`acko-install.sh\` matches the loaded tag (without the prefix the pod tries to pull from Docker Hub and ImagePullBackOff's).

Pre-existing bug, not caused by the rename in #243; ran into it during the post-merge end-to-end smoke test.

## Test plan

- [x] Tear down running release: \`helm uninstall aerospike-ce-kubernetes-operator -n aerospike-operator\`
- [x] Remove cached images from podman + kind: \`podman rmi -f localhost/aerospike-cluster-manager-{api,ui}:latest\` and \`crictl rmi …\` inside \`kind-control-plane\`
- [x] \`bash scripts/local-dev/build-ui-images.sh\` -- both images build, save, and load (\"All 2 UI images built and loaded into kind\")
- [x] \`bash scripts/local-dev/acko-install.sh\` -- helm install succeeds, ACKO operator Ready
- [x] \`kubectl get pods -n aerospike-operator\` -- 3/3 Running:
  - \`…-operator-…\` 1/1
  - \`…-ui-api-…\` 2/2 (api + postgres)
  - \`…-ui-web-…\` 1/1
- [x] No ImagePullBackOff
- [x] \`pre-commit run --all-files\` clean

## Notes

The user-overridable env vars still work — anyone exporting \`ACKO_UI_API_IMAGE=my.registry/foo\` (no \`localhost/\` prefix) will continue to function because the fix uses whatever the variable value is, both at build time and at helm install time.