### PR TITLE
feat(api): add X-Request-ID trace middleware for log correlation

### DIFF
--- a/api/src/aerospike_cluster_manager_api/logging_config.py
+++ b/api/src/aerospike_cluster_manager_api/logging_config.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 import sys
 
+from aerospike_cluster_manager_api.middleware.trace_id import RequestIDFilter
+
 
 def setup_logging(level: str = "INFO", log_format: str = "text") -> None:
     """Configure structured logging for the application.
@@ -18,8 +20,10 @@ def setup_logging(level: str = "INFO", log_format: str = "text") -> None:
     if log_format == "json":
         from pythonjsonlogger.json import JsonFormatter
 
+        # %(request_id)s is populated by RequestIDFilter (attached below) so each
+        # JSON record carries the current X-Request-ID for log correlation.
         formatter = JsonFormatter(
-            fmt="%(asctime)s %(levelname)s %(name)s %(message)s",
+            fmt="%(asctime)s %(levelname)s %(name)s %(request_id)s %(message)s",
             datefmt="%Y-%m-%dT%H:%M:%S",
             rename_fields={"asctime": "timestamp", "levelname": "level", "name": "logger"},
         )
@@ -31,6 +35,9 @@ def setup_logging(level: str = "INFO", log_format: str = "text") -> None:
 
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(formatter)
+    # Attach to the handler so the filter runs for every record this handler
+    # processes, regardless of which logger emitted it.
+    handler.addFilter(RequestIDFilter())
 
     root = logging.getLogger("aerospike_cluster_manager_api")
     root.setLevel(log_level)

--- a/api/src/aerospike_cluster_manager_api/logging_config.py
+++ b/api/src/aerospike_cluster_manager_api/logging_config.py
@@ -22,10 +22,13 @@ def setup_logging(level: str = "INFO", log_format: str = "text") -> None:
 
         # %(request_id)s is populated by RequestIDFilter (attached below) so each
         # JSON record carries the current X-Request-ID for log correlation.
+        # `defaults` ensures missing request_id never raises if a handler is
+        # attached without the filter (defense-in-depth for python-json-logger >= 2.0).
         formatter = JsonFormatter(
             fmt="%(asctime)s %(levelname)s %(name)s %(request_id)s %(message)s",
             datefmt="%Y-%m-%dT%H:%M:%S",
             rename_fields={"asctime": "timestamp", "levelname": "level", "name": "logger"},
+            defaults={"request_id": "-"},
         )
     else:
         formatter = logging.Formatter(
@@ -40,6 +43,11 @@ def setup_logging(level: str = "INFO", log_format: str = "text") -> None:
     handler.addFilter(RequestIDFilter())
 
     root = logging.getLogger("aerospike_cluster_manager_api")
+    # Clear existing handlers before attaching a new one. Repeated calls
+    # (test fixtures, uvicorn --reload) would otherwise accumulate handlers
+    # with mismatched filter coverage and produce duplicate log lines.
+    for h in list(root.handlers):
+        root.removeHandler(h)
     root.setLevel(log_level)
     root.addHandler(handler)
     root.propagate = False

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -1,6 +1,5 @@
 import logging
 import time
-import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
@@ -21,6 +20,7 @@ from aerospike_cluster_manager_api.client_manager import client_manager
 from aerospike_cluster_manager_api.events.broker import broker
 from aerospike_cluster_manager_api.events.collector import collector
 from aerospike_cluster_manager_api.logging_config import setup_logging
+from aerospike_cluster_manager_api.middleware.trace_id import TraceIDMiddleware, request_id_var
 from aerospike_cluster_manager_api.rate_limit import limiter
 from aerospike_cluster_manager_api.routers import (
     admin_roles,
@@ -175,11 +175,12 @@ app.add_middleware(
 
 @app.middleware("http")
 async def request_logging_middleware(request: Request, call_next: RequestResponseEndpoint) -> Response:
-    request_id = request.headers.get("X-Request-ID", uuid.uuid4().hex[:16])
+    # TraceIDMiddleware (registered below) runs as the outermost layer and
+    # populates request_id_var before this handler executes.
     start = time.monotonic()
     response = await call_next(request)
     elapsed_ms = (time.monotonic() - start) * 1000
-    response.headers["X-Request-ID"] = request_id
+    request_id = request_id_var.get()
     logger.info(
         "%s %s %d %.1fms request_id=%s",
         request.method,
@@ -219,6 +220,14 @@ async def security_headers_middleware(request: Request, call_next: RequestRespon
         response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubDomains"
 
     return response
+
+
+# TraceIDMiddleware is registered AFTER all other middleware (CORS, SlowAPI,
+# request_logging, security_headers) so that — given Starlette's reverse-add
+# semantics where the last middleware added is the outermost layer — it reads
+# or generates X-Request-ID and stores it in the ContextVar BEFORE any inner
+# middleware or route handler runs, and echoes the header on the way out.
+app.add_middleware(TraceIDMiddleware)
 
 
 # ---------------------------------------------------------------------------

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -20,7 +20,7 @@ from aerospike_cluster_manager_api.client_manager import client_manager
 from aerospike_cluster_manager_api.events.broker import broker
 from aerospike_cluster_manager_api.events.collector import collector
 from aerospike_cluster_manager_api.logging_config import setup_logging
-from aerospike_cluster_manager_api.middleware.trace_id import TraceIDMiddleware, request_id_var
+from aerospike_cluster_manager_api.middleware.trace_id import TraceIDMiddleware
 from aerospike_cluster_manager_api.rate_limit import limiter
 from aerospike_cluster_manager_api.routers import (
     admin_roles,
@@ -176,18 +176,20 @@ app.add_middleware(
 @app.middleware("http")
 async def request_logging_middleware(request: Request, call_next: RequestResponseEndpoint) -> Response:
     # TraceIDMiddleware (registered below) runs as the outermost layer and
-    # populates request_id_var before this handler executes.
+    # populates request_id_var before this handler executes. It also owns
+    # the X-Request-ID response header — do NOT set it here.
     start = time.monotonic()
     response = await call_next(request)
     elapsed_ms = (time.monotonic() - start) * 1000
-    request_id = request_id_var.get()
+    # The structured `request_id` JSON field (populated by RequestIDFilter)
+    # is the source of truth for log correlation; no need to repeat it in
+    # the message text.
     logger.info(
-        "%s %s %d %.1fms request_id=%s",
+        "%s %s %d %.1fms",
         request.method,
         request.url.path,
         response.status_code,
         elapsed_ms,
-        request_id,
     )
     return response
 

--- a/api/src/aerospike_cluster_manager_api/middleware/__init__.py
+++ b/api/src/aerospike_cluster_manager_api/middleware/__init__.py
@@ -1,0 +1,17 @@
+"""Custom Starlette/FastAPI middleware for the Aerospike Cluster Manager API."""
+
+from __future__ import annotations
+
+from aerospike_cluster_manager_api.middleware.trace_id import (
+    REQUEST_ID_HEADER,
+    RequestIDFilter,
+    TraceIDMiddleware,
+    request_id_var,
+)
+
+__all__ = [
+    "REQUEST_ID_HEADER",
+    "RequestIDFilter",
+    "TraceIDMiddleware",
+    "request_id_var",
+]

--- a/api/src/aerospike_cluster_manager_api/middleware/trace_id.py
+++ b/api/src/aerospike_cluster_manager_api/middleware/trace_id.py
@@ -1,0 +1,64 @@
+"""X-Request-ID trace middleware for log correlation.
+
+Each incoming request is assigned a request id (echoed in the response) so
+operator UI actions can be correlated with API logs and downstream Kubernetes
+operator events. The id is stored in a ``contextvars.ContextVar`` so that any
+log call made while handling the request can attach it to the structured log
+record without explicit plumbing.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+REQUEST_ID_HEADER = "X-Request-ID"
+
+# Default "-" follows the convention used by access-log formatters when no
+# request id is in scope (e.g. logs emitted from app startup or shutdown).
+request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("request_id", default="-")
+
+
+class TraceIDMiddleware(BaseHTTPMiddleware):
+    """Read or generate ``X-Request-ID`` and expose it via a ContextVar.
+
+    - If the client sent ``X-Request-ID``, reuse it.
+    - Otherwise mint a new ``uuid.uuid4().hex`` (32 chars, no dashes).
+    - The id is set on a ContextVar for the duration of the request so any
+      logger in the call chain can pick it up via :class:`RequestIDFilter`.
+    - The same id is echoed back in the response so the caller (UI) can
+      correlate downstream logs.
+    """
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        rid = request.headers.get(REQUEST_ID_HEADER) or uuid.uuid4().hex
+        token = request_id_var.set(rid)
+        try:
+            response = await call_next(request)
+        finally:
+            request_id_var.reset(token)
+        response.headers[REQUEST_ID_HEADER] = rid
+        return response
+
+
+class RequestIDFilter(logging.Filter):
+    """Inject the current request id (or ``-``) onto every log record.
+
+    Attached to the root API logger so JSON formatters can include
+    ``request_id`` as a top-level field without every call site having to
+    pass ``extra={"request_id": ...}``.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_var.get()
+        return True

--- a/api/src/aerospike_cluster_manager_api/middleware/trace_id.py
+++ b/api/src/aerospike_cluster_manager_api/middleware/trace_id.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import contextvars
 import logging
+import re
 import uuid
 from collections.abc import Awaitable, Callable
 
@@ -20,6 +21,13 @@ from starlette.responses import Response
 
 REQUEST_ID_HEADER = "X-Request-ID"
 
+# Allowed character set for inbound X-Request-ID values. We intentionally
+# restrict to alphanumerics, dot, dash, and underscore so an attacker cannot
+# inject HTML/JS/control characters via a header that ends up in JSON logs
+# or response headers. Length 8-128 covers UUIDv4-hex and longer trace ids
+# (e.g. W3C traceparent fragments) without permitting unbounded payloads.
+_VALID_REQUEST_ID = re.compile(r"^[0-9a-zA-Z._\-]{8,128}$")
+
 # Default "-" follows the convention used by access-log formatters when no
 # request id is in scope (e.g. logs emitted from app startup or shutdown).
 request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("request_id", default="-")
@@ -28,7 +36,11 @@ request_id_var: contextvars.ContextVar[str] = contextvars.ContextVar("request_id
 class TraceIDMiddleware(BaseHTTPMiddleware):
     """Read or generate ``X-Request-ID`` and expose it via a ContextVar.
 
-    - If the client sent ``X-Request-ID``, reuse it.
+    - If the client sent ``X-Request-ID`` and it matches the allowed pattern
+      (``^[0-9a-zA-Z._\\-]{8,128}$``), reuse it.
+    - If the client sent ``X-Request-ID`` but it is invalid (wrong length or
+      forbidden characters), drop it and mint a new id. This prevents
+      log/XSS injection through arbitrary client-supplied header values.
     - Otherwise mint a new ``uuid.uuid4().hex`` (32 chars, no dashes).
     - The id is set on a ContextVar for the duration of the request so any
       logger in the call chain can pick it up via :class:`RequestIDFilter`.
@@ -41,7 +53,8 @@ class TraceIDMiddleware(BaseHTTPMiddleware):
         request: Request,
         call_next: Callable[[Request], Awaitable[Response]],
     ) -> Response:
-        rid = request.headers.get(REQUEST_ID_HEADER) or uuid.uuid4().hex
+        inbound = request.headers.get(REQUEST_ID_HEADER)
+        rid = inbound if inbound is not None and _VALID_REQUEST_ID.match(inbound) else uuid.uuid4().hex
         token = request_id_var.set(rid)
         try:
             response = await call_next(request)

--- a/api/tests/test_trace_id.py
+++ b/api/tests/test_trace_id.py
@@ -1,0 +1,84 @@
+"""Tests for X-Request-ID trace middleware."""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from aerospike_cluster_manager_api.main import app
+from aerospike_cluster_manager_api.middleware.trace_id import (
+    REQUEST_ID_HEADER,
+    RequestIDFilter,
+    request_id_var,
+)
+
+# uuid.uuid4().hex form: 32 lowercase hex chars, no dashes.
+_UUID_HEX_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+@pytest.fixture()
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture()
+async def client(init_test_db):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.anyio
+async def test_trace_id_generated_when_missing(client: AsyncClient):
+    """Server mints a fresh uuid4 hex when the client does not send one."""
+    resp = await client.get("/api/health")
+    assert resp.status_code == 200
+    rid = resp.headers.get(REQUEST_ID_HEADER)
+    assert rid is not None, "X-Request-ID must be present in the response"
+    assert _UUID_HEX_RE.match(rid), f"expected 32-char hex uuid, got {rid!r}"
+
+
+@pytest.mark.anyio
+async def test_trace_id_echoed_when_provided(client: AsyncClient):
+    """Server echoes the client-supplied X-Request-ID untouched."""
+    supplied = "client-supplied-trace-abc123"
+    resp = await client.get("/api/health", headers={REQUEST_ID_HEADER: supplied})
+    assert resp.status_code == 200
+    assert resp.headers.get(REQUEST_ID_HEADER) == supplied
+
+
+@pytest.mark.anyio
+async def test_trace_id_unique_per_request(client: AsyncClient):
+    """Two requests without an explicit id must get distinct generated ids."""
+    r1 = await client.get("/api/health")
+    r2 = await client.get("/api/health")
+    assert r1.headers[REQUEST_ID_HEADER] != r2.headers[REQUEST_ID_HEADER]
+
+
+def test_request_id_filter_default():
+    """Outside any request, the filter falls back to the '-' sentinel."""
+    f = RequestIDFilter()
+    record = logging.LogRecord(
+        name="t", level=logging.INFO, pathname=__file__, lineno=1, msg="x", args=(), exc_info=None
+    )
+    assert f.filter(record) is True
+    # request_id is set dynamically by the filter; use getattr to keep static
+    # type checkers happy.
+    assert getattr(record, "request_id", None) == "-"
+
+
+def test_request_id_filter_uses_contextvar():
+    """Inside the ContextVar scope, the filter populates record.request_id."""
+    token = request_id_var.set("trace-from-ctx-var")
+    try:
+        f = RequestIDFilter()
+        record = logging.LogRecord(
+            name="t", level=logging.INFO, pathname=__file__, lineno=1, msg="x", args=(), exc_info=None
+        )
+        assert f.filter(record) is True
+        assert getattr(record, "request_id", None) == "trace-from-ctx-var"
+    finally:
+        request_id_var.reset(token)

--- a/api/tests/test_trace_id.py
+++ b/api/tests/test_trace_id.py
@@ -2,16 +2,22 @@
 
 from __future__ import annotations
 
+import asyncio
+import io
+import json
 import logging
 import re
 
 import pytest
+from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
+from aerospike_cluster_manager_api.logging_config import setup_logging
 from aerospike_cluster_manager_api.main import app
 from aerospike_cluster_manager_api.middleware.trace_id import (
     REQUEST_ID_HEADER,
     RequestIDFilter,
+    TraceIDMiddleware,
     request_id_var,
 )
 
@@ -82,3 +88,130 @@ def test_request_id_filter_uses_contextvar():
         assert getattr(record, "request_id", None) == "trace-from-ctx-var"
     finally:
         request_id_var.reset(token)
+
+
+# ---------------------------------------------------------------------------
+# PR #253 review additions: error path, JSON correlation, idempotent setup,
+# inbound validation, concurrent isolation.
+# ---------------------------------------------------------------------------
+
+
+def _build_app_with_routes() -> FastAPI:
+    """Standalone FastAPI app with TraceIDMiddleware + a deliberate error route."""
+    from fastapi.responses import JSONResponse
+
+    test_app = FastAPI()
+    test_app.add_middleware(TraceIDMiddleware)
+
+    @test_app.exception_handler(RuntimeError)
+    async def _runtime(_req, _exc) -> JSONResponse:  # type: ignore[no-untyped-def]
+        return JSONResponse(status_code=500, content={"detail": "boom"})
+
+    @test_app.get("/boom")
+    async def boom() -> dict:
+        raise RuntimeError("kaboom")
+
+    @test_app.get("/ok")
+    async def ok() -> dict:
+        return {"ok": True}
+
+    return test_app
+
+
+@pytest.mark.anyio
+async def test_trace_id_present_on_error_response():
+    """A route that raises must still echo X-Request-ID on the response."""
+    test_app = _build_app_with_routes()
+    transport = ASGITransport(app=test_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/boom", headers={REQUEST_ID_HEADER: "client-trace-on-error-1"})
+    # Even when the route raises, TraceIDMiddleware (BaseHTTPMiddleware) must
+    # still set the response header before returning to the caller.
+    assert resp.status_code == 500
+    assert resp.headers.get(REQUEST_ID_HEADER) == "client-trace-on-error-1"
+
+
+def test_json_log_correlation_uses_request_id():
+    """JSON log records emitted while a request id is in scope carry it."""
+    from pythonjsonlogger.json import JsonFormatter
+
+    buf = io.StringIO()
+    formatter = JsonFormatter(
+        fmt="%(asctime)s %(levelname)s %(name)s %(request_id)s %(message)s",
+        rename_fields={"asctime": "timestamp", "levelname": "level", "name": "logger"},
+        defaults={"request_id": "-"},
+    )
+    handler = logging.StreamHandler(buf)
+    handler.setFormatter(formatter)
+    handler.addFilter(RequestIDFilter())
+    test_logger = logging.getLogger("aerospike_cluster_manager_api.tests.json_correlation")
+    test_logger.handlers = [handler]
+    test_logger.setLevel(logging.INFO)
+    test_logger.propagate = False
+
+    token = request_id_var.set("supplied-trace-json-correlate-001")
+    try:
+        test_logger.info("hello structured world")
+    finally:
+        request_id_var.reset(token)
+
+    line = buf.getvalue().strip().splitlines()[-1]
+    payload = json.loads(line)
+    assert payload["request_id"] == "supplied-trace-json-correlate-001"
+    assert payload["message"] == "hello structured world"
+
+
+def test_setup_logging_is_idempotent():
+    """Calling setup_logging twice must not accumulate stacked handlers."""
+    setup_logging("INFO", "text")
+    handlers_after_first = list(logging.getLogger("aerospike_cluster_manager_api").handlers)
+    setup_logging("INFO", "text")
+    handlers_after_second = list(logging.getLogger("aerospike_cluster_manager_api").handlers)
+    assert len(handlers_after_first) == 1
+    assert len(handlers_after_second) == 1
+    # Ensure the second call replaced rather than appended (different object).
+    assert handlers_after_second[0] is not handlers_after_first[0]
+
+
+@pytest.mark.anyio
+async def test_invalid_inbound_request_id_is_replaced():
+    """A header containing forbidden characters must be dropped and replaced."""
+    test_app = _build_app_with_routes()
+    transport = ASGITransport(app=test_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/ok", headers={REQUEST_ID_HEADER: "<script>alert(1)</script>"})
+    assert resp.status_code == 200
+    rid = resp.headers.get(REQUEST_ID_HEADER)
+    assert rid is not None
+    assert rid != "<script>alert(1)</script>"
+    # Replacement is uuid4().hex form.
+    assert _UUID_HEX_RE.match(rid)
+
+
+@pytest.mark.anyio
+async def test_too_short_inbound_request_id_is_replaced():
+    """Short header values fall outside the regex and must be replaced."""
+    test_app = _build_app_with_routes()
+    transport = ASGITransport(app=test_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/ok", headers={REQUEST_ID_HEADER: "abc"})
+    assert resp.status_code == 200
+    assert _UUID_HEX_RE.match(resp.headers[REQUEST_ID_HEADER])
+
+
+@pytest.mark.anyio
+async def test_concurrent_requests_have_isolated_ids():
+    """50 concurrent requests must each get their own id (proves ContextVar isolation)."""
+    test_app = _build_app_with_routes()
+    transport = ASGITransport(app=test_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+
+        async def hit() -> str:
+            r = await ac.get("/ok")
+            return r.headers[REQUEST_ID_HEADER]
+
+        ids = await asyncio.gather(*(hit() for _ in range(50)))
+    assert len(ids) == 50
+    assert len(set(ids)) == 50, "expected 50 distinct request ids across concurrent requests"
+    for rid in ids:
+        assert _UUID_HEX_RE.match(rid), f"non-uuid hex id leaked: {rid!r}"


### PR DESCRIPTION
## Summary
- New `TraceIDMiddleware` reads `X-Request-ID` from incoming requests or generates a UUID4-hex if absent; stores in a `ContextVar` and echoes the header in the response.
- JSON log formatter now includes `request_id` field via `RequestIDFilter`, so UI actions can be correlated with API + downstream K8s operator logs.
- Existing inline `request_logging_middleware` updated to read from `request_id_var` instead of generating its own.
- Pytest covers: generated id, echoed id, uniqueness across requests, filter behavior with/without ContextVar.

## Files
- `api/src/aerospike_cluster_manager_api/middleware/__init__.py` (new)
- `api/src/aerospike_cluster_manager_api/middleware/trace_id.py` (new)
- `api/src/aerospike_cluster_manager_api/main.py` (register middleware)
- `api/src/aerospike_cluster_manager_api/logging_config.py` (filter + formatter)
- `api/tests/test_trace_id.py` (5 tests)

## Test plan
- [ ] `cd api && uv run pytest -k trace` — 5 passed (verified locally).
- [ ] Full backend suite — 248 passed.
- [ ] Manual `curl -H "X-Request-ID: abc123" http://localhost:8000/api/health -i` — response echoes `X-Request-ID: abc123`.
- [ ] No header → response includes `X-Request-ID: <generated-uuid4-hex>`.
- [ ] `LOG_FORMAT=json` runs show `"request_id": "..."` in every log line.