### PR TITLE
feat(admin): structured error codes + CreateUser/Role dialog scaffolds

### DIFF
--- a/api/src/aerospike_cluster_manager_api/routers/_admin_utils.py
+++ b/api/src/aerospike_cluster_manager_api/routers/_admin_utils.py
@@ -6,29 +6,93 @@ import functools
 from collections.abc import Callable
 from typing import Any
 
-from aerospike_py.exception import AdminError, AerospikeError
+from aerospike_py.exception import AdminError, AerospikeError, ServerError
 from fastapi import HTTPException
 
 from aerospike_cluster_manager_api.constants import EE_MSG
 
 
+def _msg_lower(exc: BaseException) -> str:
+    return str(exc).lower()
+
+
+def _is_security_disabled(msg_lower: str) -> bool:
+    """Backward-compat string match used by older aerospike-py releases."""
+    return "security" in msg_lower or "not enabled" in msg_lower or "not supported" in msg_lower
+
+
+def _is_already_exists(exc: BaseException, msg_lower: str) -> bool:
+    """Detect "user/role already exists" errors.
+
+    aerospike-py 0.6 maps Aerospike result codes 61 (UserAlreadyExists) and
+    71 (RoleAlreadyExists) to plain ``ServerError`` with a message of the form
+    ``AEROSPIKE_ERR (-1): Server error: UserAlreadyExists, In Doubt: false,
+    Node: ...``. We prefer detecting the Rust ``ResultCode`` Debug variant
+    name (which is stable) and fall back to the lowercase human string for
+    cross-version compatibility.
+    """
+    raw = str(exc)
+    if "UserAlreadyExists" in raw or "RoleAlreadyExists" in raw:
+        return True
+    return "already exists" in msg_lower
+
+
+def _is_invalid_user_or_role(exc: BaseException, msg_lower: str) -> bool:
+    """Detect "user/role not found" (Aerospike result codes 60/70).
+
+    Code 60 (``InvalidUser``) is mapped by aerospike-py to ``AdminError``,
+    while code 70 (``InvalidRole``) currently falls through to ``ServerError``.
+    Both surface as the human string "Invalid user" / "Invalid role" inside
+    the message; we prefer the Rust Debug variant name and fall back to the
+    string match.
+    """
+    raw = str(exc)
+    if "InvalidUser" in raw or "InvalidRole" in raw:
+        return True
+    return "invalid user" in msg_lower or "invalid role" in msg_lower
+
+
 def admin_endpoint(func: Callable[..., Any]) -> Callable[..., Any]:
-    """Decorator that maps AdminError / security-related AerospikeError to HTTP 403.
+    """Decorator that maps aerospike-py admin errors to structured HTTP responses.
 
     Both admin_users and admin_roles routers share this identical error
     handling pattern.  Centralising it here removes duplication and ensures
     consistent behaviour.
+
+    Mapping (preferred via exception class + Rust ``ResultCode`` variant name;
+    string match retained as fallback for older aerospike-py builds):
+
+    * ``AdminError`` with InvalidUser → 404
+    * ``AdminError`` (security/not enabled/not supported) → 403 (EE_MSG)
+    * ``ServerError`` with UserAlreadyExists / RoleAlreadyExists → 409
+    * ``ServerError`` with InvalidRole → 404
+    * other ``AerospikeError`` carrying security text → 403 (legacy)
+    * everything else propagates to FastAPI's global handler.
     """
 
     @functools.wraps(func)
     async def wrapper(*args: Any, **kwargs: Any) -> Any:
         try:
             return await func(*args, **kwargs)
-        except AdminError:
+        except AdminError as e:
+            msg = _msg_lower(e)
+            if _is_invalid_user_or_role(e, msg):
+                raise HTTPException(status_code=404, detail="User or role not found") from None
+            # AdminError is the canonical "security disabled / privilege" error.
             raise HTTPException(status_code=403, detail=EE_MSG) from None
+        except ServerError as e:
+            msg = _msg_lower(e)
+            if _is_already_exists(e, msg):
+                raise HTTPException(status_code=409, detail="User or role already exists") from None
+            if _is_invalid_user_or_role(e, msg):
+                raise HTTPException(status_code=404, detail="User or role not found") from None
+            # Fall through to the global ServerError handler.
+            raise
         except AerospikeError as e:
-            msg = str(e).lower()
-            if "security" in msg or "not enabled" in msg or "not supported" in msg:
+            # Backward-compat fallback: some older aerospike-py builds may surface
+            # security errors as a plain AerospikeError without the AdminError
+            # subclass. Detect via lowercase string match.
+            if _is_security_disabled(_msg_lower(e)):
                 raise HTTPException(status_code=403, detail=EE_MSG) from None
             raise
 

--- a/api/src/aerospike_cluster_manager_api/routers/_admin_utils.py
+++ b/api/src/aerospike_cluster_manager_api/routers/_admin_utils.py
@@ -52,6 +52,37 @@ def _is_invalid_user_or_role(exc: BaseException, msg_lower: str) -> bool:
     return "invalid user" in msg_lower or "invalid role" in msg_lower
 
 
+def _user_or_role(exc: BaseException, msg_lower: str) -> str:
+    """Disambiguate which side of an "invalid user/role" error fired.
+
+    Returns ``"User"`` or ``"Role"`` so 404 detail messages can surface
+    the specific entity. Falls back to ``"User or role"`` when the
+    message text is ambiguous.
+    """
+    raw = str(exc)
+    if "InvalidUser" in raw or "invalid user" in msg_lower:
+        return "User"
+    if "InvalidRole" in raw or "invalid role" in msg_lower:
+        return "Role"
+    return "User or role"
+
+
+def _is_not_authenticated(exc: BaseException, msg_lower: str) -> bool:
+    """Detect Aerospike result code 80 (``NotAuthenticated``)."""
+    raw = str(exc)
+    if "NotAuthenticated" in raw:
+        return True
+    return "not authenticated" in msg_lower
+
+
+def _is_role_violation(exc: BaseException, msg_lower: str) -> bool:
+    """Detect Aerospike result code 81 (``RoleViolation``)."""
+    raw = str(exc)
+    if "RoleViolation" in raw:
+        return True
+    return "role violation" in msg_lower
+
+
 def admin_endpoint(func: Callable[..., Any]) -> Callable[..., Any]:
     """Decorator that maps aerospike-py admin errors to structured HTTP responses.
 
@@ -62,8 +93,17 @@ def admin_endpoint(func: Callable[..., Any]) -> Callable[..., Any]:
     Mapping (preferred via exception class + Rust ``ResultCode`` variant name;
     string match retained as fallback for older aerospike-py builds):
 
-    * ``AdminError`` with InvalidUser → 404
-    * ``AdminError`` (security/not enabled/not supported) → 403 (EE_MSG)
+    * ``AdminError`` with InvalidUser → 404 ("User not found")
+    * ``AdminError`` with InvalidRole → 404 ("Role not found")
+    * ``AdminError`` with UserAlreadyExists / RoleAlreadyExists → 409
+      (defensive — future aerospike-py versions may dispatch the
+      "already exists" codes through ``AdminError`` instead of the
+      generic ``ServerError`` path).
+    * ``AdminError`` with NotAuthenticated (code 80) → 401
+    * ``AdminError`` with RoleViolation (code 81) → 403 (generic)
+    * ``AdminError`` with security/not enabled/not supported text → 403 (EE_MSG)
+    * ``AdminError`` with anything else → 500 (do NOT silently surface EE_MSG
+      because the message would be misleading for ordinary auth failures).
     * ``ServerError`` with UserAlreadyExists / RoleAlreadyExists → 409
     * ``ServerError`` with InvalidRole → 404
     * other ``AerospikeError`` carrying security text → 403 (legacy)
@@ -77,15 +117,32 @@ def admin_endpoint(func: Callable[..., Any]) -> Callable[..., Any]:
         except AdminError as e:
             msg = _msg_lower(e)
             if _is_invalid_user_or_role(e, msg):
-                raise HTTPException(status_code=404, detail="User or role not found") from None
-            # AdminError is the canonical "security disabled / privilege" error.
-            raise HTTPException(status_code=403, detail=EE_MSG) from None
+                entity = _user_or_role(e, msg)
+                raise HTTPException(status_code=404, detail=f"{entity} not found") from None
+            if _is_already_exists(e, msg):
+                # Defensive: future aerospike-py versions may route 61/71 through
+                # AdminError instead of plain ServerError. Treat as 409 here too.
+                raise HTTPException(status_code=409, detail="User or role already exists") from None
+            if _is_not_authenticated(e, msg):
+                raise HTTPException(status_code=401, detail="Authentication required") from None
+            if _is_role_violation(e, msg):
+                raise HTTPException(
+                    status_code=403,
+                    detail="Insufficient privileges to perform this action",
+                ) from None
+            if _is_security_disabled(msg):
+                raise HTTPException(status_code=403, detail=EE_MSG) from None
+            # Unknown AdminError variant — surfacing EE_MSG would mislead the
+            # operator (e.g. for 'IllegalState' or 'ExpiredSession'). Promote
+            # to 500 so the global handler logs the original exception.
+            raise HTTPException(status_code=500, detail="Admin operation failed") from None
         except ServerError as e:
             msg = _msg_lower(e)
             if _is_already_exists(e, msg):
                 raise HTTPException(status_code=409, detail="User or role already exists") from None
             if _is_invalid_user_or_role(e, msg):
-                raise HTTPException(status_code=404, detail="User or role not found") from None
+                entity = _user_or_role(e, msg)
+                raise HTTPException(status_code=404, detail=f"{entity} not found") from None
             # Fall through to the global ServerError handler.
             raise
         except AerospikeError as e:

--- a/api/src/aerospike_cluster_manager_api/routers/_admin_utils.py
+++ b/api/src/aerospike_cluster_manager_api/routers/_admin_utils.py
@@ -6,10 +6,33 @@ import functools
 from collections.abc import Callable
 from typing import Any
 
+import aerospike_py
 from aerospike_py.exception import AdminError, AerospikeError, ServerError
 from fastapi import HTTPException
 
 from aerospike_cluster_manager_api.constants import EE_MSG
+
+# Mapping between Aerospike privilege string codes (used by clients/REST API)
+# and the integer constants required by aerospike-py's ``Privilege`` TypedDict.
+#
+# aerospike-py's admin protocol expects ``code`` to be an int (e.g. PRIV_READ=10).
+# However the REST API and UI surface privileges as human-readable strings
+# ("read", "read-write", ...). Translate at the router boundary so internal
+# call sites speak ints and external clients speak strings.
+PRIVILEGE_NAME_TO_CODE: dict[str, int] = {
+    "read": aerospike_py.PRIV_READ,
+    "read-write": aerospike_py.PRIV_READ_WRITE,
+    "read-write-udf": aerospike_py.PRIV_READ_WRITE_UDF,
+    "write": aerospike_py.PRIV_WRITE,
+    "truncate": aerospike_py.PRIV_TRUNCATE,
+    "user-admin": aerospike_py.PRIV_USER_ADMIN,
+    "sys-admin": aerospike_py.PRIV_SYS_ADMIN,
+    "data-admin": aerospike_py.PRIV_DATA_ADMIN,
+    "udf-admin": aerospike_py.PRIV_UDF_ADMIN,
+    "sindex-admin": aerospike_py.PRIV_SINDEX_ADMIN,
+}
+
+PRIVILEGE_CODE_TO_NAME: dict[int, str] = {v: k for k, v in PRIVILEGE_NAME_TO_CODE.items()}
 
 
 def _msg_lower(exc: BaseException) -> str:

--- a/api/src/aerospike_cluster_manager_api/routers/admin_roles.py
+++ b/api/src/aerospike_cluster_manager_api/routers/admin_roles.py
@@ -9,7 +9,11 @@ from starlette.responses import Response
 
 from aerospike_cluster_manager_api.dependencies import AerospikeClient
 from aerospike_cluster_manager_api.models.admin import AerospikeRole, CreateRoleRequest, Privilege
-from aerospike_cluster_manager_api.routers._admin_utils import admin_endpoint
+from aerospike_cluster_manager_api.routers._admin_utils import (
+    PRIVILEGE_CODE_TO_NAME,
+    PRIVILEGE_NAME_TO_CODE,
+    admin_endpoint,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -31,15 +35,27 @@ async def get_roles(client: AerospikeClient) -> list[AerospikeRole]:
         privileges: list[Privilege] = []
         for p in privs_raw:
             if isinstance(p, dict):
+                raw_code = p.get("code", "")
+                # aerospike-py returns ``code`` as an int (PRIV_READ=10, ...).
+                # Translate to the canonical string for API consumers; fall back
+                # to ``str()`` if an unknown int slips through (defensive).
+                if isinstance(raw_code, int):
+                    code_str = PRIVILEGE_CODE_TO_NAME.get(raw_code, str(raw_code))
+                else:
+                    code_str = str(raw_code)
                 privileges.append(
                     Privilege(
-                        code=p.get("code", ""),
+                        code=code_str,
                         namespace=p.get("ns") or p.get("namespace"),
                         set=p.get("set"),
                     )
                 )
             else:
-                privileges.append(Privilege(code=str(p)))
+                # Bare scalar — assume it's an int code or already a string.
+                if isinstance(p, int):
+                    privileges.append(Privilege(code=PRIVILEGE_CODE_TO_NAME.get(p, str(p))))
+                else:
+                    privileges.append(Privilege(code=str(p)))
 
         roles.append(
             AerospikeRole(
@@ -65,9 +81,25 @@ async def create_role(body: CreateRoleRequest, client: AerospikeClient) -> Aeros
     if not body.name or not body.privileges:
         raise HTTPException(status_code=400, detail="Missing required fields: name, privileges")
 
-    privileges: list[AerospikePrivilege] = [
-        cast(AerospikePrivilege, {"code": p.code, "ns": p.namespace or "", "set": p.set or ""}) for p in body.privileges
-    ]
+    # aerospike-py's ``Privilege`` TypedDict requires ``code`` to be an int
+    # (e.g. PRIV_READ=10). Translate the human-readable string codes that
+    # the REST API accepts into the int constants before passing to the
+    # client. Reject unknown names with 422 rather than letting aerospike-py
+    # raise ``TypeError: 'str' object cannot be interpreted as an integer``.
+    privileges: list[AerospikePrivilege] = []
+    for p in body.privileges:
+        code_int = PRIVILEGE_NAME_TO_CODE.get(p.code)
+        if code_int is None:
+            raise HTTPException(
+                status_code=422,
+                detail=f"Unknown privilege: {p.code!r}",
+            )
+        privileges.append(
+            cast(
+                AerospikePrivilege,
+                {"code": code_int, "ns": p.namespace or "", "set": p.set or ""},
+            )
+        )
     await client.admin_create_role(
         body.name,
         privileges,

--- a/api/tests/test_admin_roles_router.py
+++ b/api/tests/test_admin_roles_router.py
@@ -1,0 +1,184 @@
+"""Integration tests for the admin_roles router.
+
+These cover the privilege string→int translation that sits at the router
+boundary. aerospike-py's ``Privilege`` TypedDict requires ``code`` to be an
+int (PRIV_READ=10, ...), but the REST API and UI surface privileges as
+human-readable strings. Without translation, POST /api/admin/{c}/roles 500s
+with ``TypeError: 'str' object cannot be interpreted as an integer``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import aerospike_py
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from aerospike_cluster_manager_api.main import app
+
+
+@asynccontextmanager
+async def _noop_lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    yield
+
+
+@pytest.fixture()
+async def client():
+    original_lifespan = app.router.lifespan_context
+    app.router.lifespan_context = _noop_lifespan
+
+    app.state.limiter.enabled = False
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.state.limiter.enabled = True
+    app.router.lifespan_context = original_lifespan
+
+
+def _patch_deps(mock_client: AsyncMock):
+    """Patch the FastAPI deps so the router resolves to *mock_client*."""
+    return (
+        patch(
+            "aerospike_cluster_manager_api.dependencies.db.get_connection",
+            AsyncMock(return_value={"id": "conn-test"}),
+        ),
+        patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            AsyncMock(return_value=mock_client),
+        ),
+    )
+
+
+class TestCreateRole:
+    async def test_translates_string_privilege_to_int_code(self, client: AsyncClient):
+        """POST with code='read' must call admin_create_role with int code 10."""
+        mock_client = AsyncMock()
+        mock_client.admin_create_role = AsyncMock(return_value=None)
+
+        deps = _patch_deps(mock_client)
+        with deps[0], deps[1]:
+            response = await client.post(
+                "/api/admin/conn-test/roles",
+                json={
+                    "name": "analytics_reader",
+                    "privileges": [{"code": "read", "namespace": "test", "set": ""}],
+                },
+            )
+
+        assert response.status_code == 201, response.text
+        mock_client.admin_create_role.assert_awaited_once()
+        call = mock_client.admin_create_role.await_args
+        # Positional: (name, privileges)
+        assert call.args[0] == "analytics_reader"
+        privileges_arg = call.args[1]
+        assert len(privileges_arg) == 1
+        assert privileges_arg[0] == {
+            "code": aerospike_py.PRIV_READ,  # 10
+            "ns": "test",
+            "set": "",
+        }
+        # Sanity: the payload sent to aerospike-py is an int, not a string.
+        assert isinstance(privileges_arg[0]["code"], int)
+
+    async def test_translates_each_known_privilege_name(self, client: AsyncClient):
+        """All canonical privilege names map to the correct aerospike_py constant."""
+        cases = [
+            ("read", aerospike_py.PRIV_READ),
+            ("read-write", aerospike_py.PRIV_READ_WRITE),
+            ("read-write-udf", aerospike_py.PRIV_READ_WRITE_UDF),
+            ("write", aerospike_py.PRIV_WRITE),
+            ("truncate", aerospike_py.PRIV_TRUNCATE),
+            ("user-admin", aerospike_py.PRIV_USER_ADMIN),
+            ("sys-admin", aerospike_py.PRIV_SYS_ADMIN),
+            ("data-admin", aerospike_py.PRIV_DATA_ADMIN),
+            ("udf-admin", aerospike_py.PRIV_UDF_ADMIN),
+            ("sindex-admin", aerospike_py.PRIV_SINDEX_ADMIN),
+        ]
+
+        for name, expected_int in cases:
+            mock_client = AsyncMock()
+            mock_client.admin_create_role = AsyncMock(return_value=None)
+            deps = _patch_deps(mock_client)
+            with deps[0], deps[1]:
+                response = await client.post(
+                    "/api/admin/conn-test/roles",
+                    json={"name": f"role_{name}", "privileges": [{"code": name}]},
+                )
+            assert response.status_code == 201, f"{name}: {response.text}"
+            sent = mock_client.admin_create_role.await_args.args[1][0]
+            assert sent["code"] == expected_int, f"{name} -> expected {expected_int}, got {sent['code']}"
+
+    async def test_unknown_privilege_returns_422(self, client: AsyncClient):
+        """POST with an unknown privilege string must return 422, not 500."""
+        mock_client = AsyncMock()
+        mock_client.admin_create_role = AsyncMock(return_value=None)
+
+        deps = _patch_deps(mock_client)
+        with deps[0], deps[1]:
+            response = await client.post(
+                "/api/admin/conn-test/roles",
+                json={"name": "bad_role", "privileges": [{"code": "bogus"}]},
+            )
+
+        assert response.status_code == 422, response.text
+        body = response.json()
+        # FastAPI wraps detail in the response body
+        detail = body.get("detail", "")
+        assert "bogus" in str(detail).lower()
+        # admin_create_role must NOT have been called when validation fails
+        mock_client.admin_create_role.assert_not_called()
+
+    async def test_namespace_and_set_propagate(self, client: AsyncClient):
+        """ns/set scope from the request body must reach aerospike-py unchanged."""
+        mock_client = AsyncMock()
+        mock_client.admin_create_role = AsyncMock(return_value=None)
+
+        deps = _patch_deps(mock_client)
+        with deps[0], deps[1]:
+            response = await client.post(
+                "/api/admin/conn-test/roles",
+                json={
+                    "name": "scoped_writer",
+                    "privileges": [{"code": "read-write", "namespace": "metrics", "set": "events"}],
+                },
+            )
+
+        assert response.status_code == 201, response.text
+        sent = mock_client.admin_create_role.await_args.args[1][0]
+        assert sent == {
+            "code": aerospike_py.PRIV_READ_WRITE,
+            "ns": "metrics",
+            "set": "events",
+        }
+
+
+class TestGetRoles:
+    async def test_translates_int_code_back_to_string(self, client: AsyncClient):
+        """GET handler must surface privilege codes as canonical strings."""
+        mock_client = AsyncMock()
+        mock_client.admin_query_roles = AsyncMock(
+            return_value=[
+                {
+                    "role": "analytics_reader",
+                    "privileges": [{"code": aerospike_py.PRIV_READ, "ns": "test", "set": ""}],
+                    "whitelist": [],
+                    "read_quota": 0,
+                    "write_quota": 0,
+                }
+            ]
+        )
+
+        deps = _patch_deps(mock_client)
+        with deps[0], deps[1]:
+            response = await client.get("/api/admin/conn-test/roles")
+
+        assert response.status_code == 200, response.text
+        roles = response.json()
+        assert len(roles) == 1
+        assert roles[0]["name"] == "analytics_reader"
+        assert roles[0]["privileges"][0]["code"] == "read"
+        assert roles[0]["privileges"][0]["namespace"] == "test"

--- a/api/tests/test_admin_utils.py
+++ b/api/tests/test_admin_utils.py
@@ -1,0 +1,103 @@
+"""Unit tests for ``routers._admin_utils.admin_endpoint`` error mapping.
+
+These exercise the decorator directly so we don't need a running Aerospike
+cluster or the full FastAPI app stack.
+"""
+
+from __future__ import annotations
+
+import pytest
+from aerospike_py.exception import AdminError, AerospikeError, ServerError
+from fastapi import HTTPException
+
+from aerospike_cluster_manager_api.routers._admin_utils import admin_endpoint
+
+
+@admin_endpoint
+async def _passthrough(*, raise_with: BaseException | None = None) -> str:
+    if raise_with is not None:
+        raise raise_with
+    return "ok"
+
+
+class TestAdminEndpointDecorator:
+    async def test_passes_through_on_success(self) -> None:
+        result = await _passthrough()
+        assert result == "ok"
+
+    # ----- AdminError → 403 / 404 ------------------------------------------------
+
+    async def test_admin_error_maps_to_403(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            await _passthrough(raise_with=AdminError("AEROSPIKE_ERR (52): security not enabled"))
+        assert exc_info.value.status_code == 403
+
+    async def test_admin_error_invalid_user_maps_to_404(self) -> None:
+        # Rust Debug variant name path
+        with pytest.raises(HTTPException) as exc_info:
+            await _passthrough(
+                raise_with=AdminError("AEROSPIKE_ERR (60): Server error: InvalidUser, In Doubt: false, Node: BB...")
+            )
+        assert exc_info.value.status_code == 404
+
+    async def test_admin_error_invalid_user_string_fallback(self) -> None:
+        # Older aerospike-py versions might surface only the human-readable text.
+        with pytest.raises(HTTPException) as exc_info:
+            await _passthrough(raise_with=AdminError("Invalid user"))
+        assert exc_info.value.status_code == 404
+
+    # ----- ServerError → 409 (already exists) -----------------------------------
+
+    async def test_server_error_user_already_exists_maps_to_409(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            await _passthrough(
+                raise_with=ServerError(
+                    "AEROSPIKE_ERR (-1): Server error: UserAlreadyExists, In Doubt: false, Node: BB..."
+                )
+            )
+        assert exc_info.value.status_code == 409
+
+    async def test_server_error_role_already_exists_maps_to_409(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            await _passthrough(
+                raise_with=ServerError(
+                    "AEROSPIKE_ERR (-1): Server error: RoleAlreadyExists, In Doubt: false, Node: BB..."
+                )
+            )
+        assert exc_info.value.status_code == 409
+
+    async def test_server_error_already_exists_string_fallback(self) -> None:
+        # Backward-compat path — older aerospike-py may not embed the variant name.
+        with pytest.raises(HTTPException) as exc_info:
+            await _passthrough(raise_with=ServerError("AEROSPIKE_ERR (61): User already exists"))
+        assert exc_info.value.status_code == 409
+
+    # ----- ServerError → 404 (invalid role) -------------------------------------
+
+    async def test_server_error_invalid_role_maps_to_404(self) -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            await _passthrough(
+                raise_with=ServerError("AEROSPIKE_ERR (-1): Server error: InvalidRole, In Doubt: false, Node: BB...")
+            )
+        assert exc_info.value.status_code == 404
+
+    # ----- Pass-through for unknown server errors -------------------------------
+
+    async def test_unknown_server_error_propagates(self) -> None:
+        original = ServerError("AEROSPIKE_ERR (1): Server error: ServerError, In Doubt: false, Node: BB...")
+        with pytest.raises(ServerError):
+            await _passthrough(raise_with=original)
+
+    # ----- Generic AerospikeError -----------------------------------------------
+
+    async def test_generic_aerospike_security_text_maps_to_403(self) -> None:
+        # Path used as a forward-compat fallback if a future aerospike-py
+        # surfaces security errors as plain AerospikeError.
+        with pytest.raises(HTTPException) as exc_info:
+            await _passthrough(raise_with=AerospikeError("Security not supported on this cluster"))
+        assert exc_info.value.status_code == 403
+
+    async def test_generic_aerospike_unrelated_propagates(self) -> None:
+        original = AerospikeError("Unrelated transient failure")
+        with pytest.raises(AerospikeError):
+            await _passthrough(raise_with=original)

--- a/api/tests/test_admin_utils.py
+++ b/api/tests/test_admin_utils.py
@@ -46,6 +46,77 @@ class TestAdminEndpointDecorator:
             await _passthrough(raise_with=AdminError("Invalid user"))
         assert exc_info.value.status_code == 404
 
+    async def test_admin_error_invalid_user_detail_text(self) -> None:
+        """404 detail must say 'User not found' specifically when InvalidUser fires."""
+        with pytest.raises(HTTPException) as exc_info:
+            await _passthrough(
+                raise_with=AdminError("AEROSPIKE_ERR (60): Server error: InvalidUser, In Doubt: false, Node: BB...")
+            )
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "User not found"
+
+    async def test_admin_error_invalid_role_detail_text(self) -> None:
+        """404 detail must say 'Role not found' specifically when InvalidRole fires."""
+        with pytest.raises(HTTPException) as exc_info:
+            await _passthrough(
+                raise_with=AdminError("AEROSPIKE_ERR (70): Server error: InvalidRole, In Doubt: false, Node: BB...")
+            )
+        assert exc_info.value.status_code == 404
+        assert exc_info.value.detail == "Role not found"
+
+    # ----- AdminError with NotAuthenticated → 401 (NEW) ------------------------
+
+    async def test_admin_error_not_authenticated_maps_to_401(self) -> None:
+        """Code 80 (NotAuthenticated) must surface 401 rather than 403/EE_MSG."""
+        with pytest.raises(HTTPException) as exc_info:
+            await _passthrough(
+                raise_with=AdminError(
+                    "AEROSPIKE_ERR (80): Server error: NotAuthenticated, In Doubt: false, Node: BB..."
+                )
+            )
+        assert exc_info.value.status_code == 401
+        # Must NOT bleed the EE_MSG — that would mislead the operator.
+        assert "Security is not enabled" not in str(exc_info.value.detail)
+
+    async def test_admin_error_role_violation_maps_to_403_generic(self) -> None:
+        """Code 81 (RoleViolation) → 403 with a generic privilege message."""
+        with pytest.raises(HTTPException) as exc_info:
+            await _passthrough(
+                raise_with=AdminError("AEROSPIKE_ERR (81): Server error: RoleViolation, In Doubt: false, Node: BB...")
+            )
+        assert exc_info.value.status_code == 403
+        assert "Security is not enabled" not in str(exc_info.value.detail)
+        assert "privileges" in str(exc_info.value.detail).lower()
+
+    async def test_unknown_admin_error_does_not_leak_ee_msg(self) -> None:
+        """Unknown AdminError variants must NOT silently return 403/EE_MSG."""
+        with pytest.raises(HTTPException) as exc_info:
+            await _passthrough(raise_with=AdminError("AEROSPIKE_ERR (?): Server error: NewUnknownVariant"))
+        assert exc_info.value.status_code == 500
+        assert "Security is not enabled" not in str(exc_info.value.detail)
+
+    # ----- AdminError dispatch for already-exists (defensive, NEW) -------------
+
+    async def test_admin_error_role_already_exists_maps_to_409(self) -> None:
+        """Future aerospike-py may route 71 through AdminError; treat as 409."""
+        with pytest.raises(HTTPException) as exc_info:
+            await _passthrough(
+                raise_with=AdminError(
+                    "AEROSPIKE_ERR (71): Server error: RoleAlreadyExists, In Doubt: false, Node: BB..."
+                )
+            )
+        assert exc_info.value.status_code == 409
+
+    async def test_admin_error_user_already_exists_maps_to_409(self) -> None:
+        """Symmetric defensive coverage for code 61 routed through AdminError."""
+        with pytest.raises(HTTPException) as exc_info:
+            await _passthrough(
+                raise_with=AdminError(
+                    "AEROSPIKE_ERR (61): Server error: UserAlreadyExists, In Doubt: false, Node: BB..."
+                )
+            )
+        assert exc_info.value.status_code == 409
+
     # ----- ServerError → 409 (already exists) -----------------------------------
 
     async def test_server_error_user_already_exists_maps_to_409(self) -> None:

--- a/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
@@ -3,6 +3,8 @@
 import { Badge } from "@/components/Badge"
 import { Button } from "@/components/Button"
 import { Card } from "@/components/Card"
+import { CreateRoleDialog } from "@/components/dialogs/CreateRoleDialog"
+import { CreateUserDialog } from "@/components/dialogs/CreateUserDialog"
 import { Input } from "@/components/Input"
 import {
   Table,
@@ -35,6 +37,8 @@ export default function AdminPage({ params }: PageProps) {
     error: null,
   })
   const [securityDisabled, setSecurityDisabled] = useState(false)
+  const [createUserOpen, setCreateUserOpen] = useState(false)
+  const [createRoleOpen, setCreateRoleOpen] = useState(false)
 
   const load = useCallback(async () => {
     setUsersState((s) => ({ ...s, loading: true, error: null }))
@@ -88,14 +92,26 @@ export default function AdminPage({ params }: PageProps) {
         <>
           <UsersSection
             state={usersState}
-            onCreate={() => {
-              /* TODO: CreateUserDialog */
-            }}
+            onCreate={() => setCreateUserOpen(true)}
           />
           <RolesSection
             state={rolesState}
-            onCreate={() => {
-              /* TODO: CreateRoleDialog */
+            onCreate={() => setCreateRoleOpen(true)}
+          />
+          <CreateUserDialog
+            clusterId={params.clusterId}
+            open={createUserOpen}
+            onOpenChange={setCreateUserOpen}
+            onCreated={() => {
+              void load()
+            }}
+          />
+          <CreateRoleDialog
+            clusterId={params.clusterId}
+            open={createRoleOpen}
+            onOpenChange={setCreateRoleOpen}
+            onCreated={() => {
+              void load()
             }}
           />
         </>

--- a/ui/src/components/dialogs/CreateRoleDialog.tsx
+++ b/ui/src/components/dialogs/CreateRoleDialog.tsx
@@ -1,0 +1,321 @@
+"use client"
+
+import React from "react"
+
+import { Badge } from "@/components/Badge"
+import { Button } from "@/components/Button"
+import { Checkbox } from "@/components/Checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/Dialog"
+import { Input } from "@/components/Input"
+import { Label } from "@/components/Label"
+import { createRole } from "@/lib/api/admin"
+import { ApiError } from "@/lib/api/client"
+import type { CreateRoleRequest, Privilege } from "@/lib/types/admin"
+
+interface CreateRoleDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onCreated?: () => void
+  clusterId: string
+}
+
+interface FormState {
+  name: string
+  privileges: string[] // privilege codes
+  whitelist: string
+  readQuota: string
+  writeQuota: string
+}
+
+const INITIAL_STATE: FormState = {
+  name: "",
+  privileges: [],
+  whitelist: "",
+  readQuota: "",
+  writeQuota: "",
+}
+
+/**
+ * Static catalogue of Aerospike privilege codes.
+ *
+ * The aerospike-py admin protocol does not currently expose a privileges
+ * catalogue endpoint, so we mirror the canonical set documented at
+ * https://aerospike.com/docs/server/operations/configure/security/access-control
+ *
+ * Keep this in sync with the backend (server/aerospike-core ResultCode etc.)
+ * when new privileges are added.
+ */
+const PRIVILEGE_CATALOG: ReadonlyArray<{ code: string; description: string }> =
+  [
+    { code: "user-admin", description: "Manage users and roles" },
+    { code: "sys-admin", description: "Server configuration" },
+    { code: "data-admin", description: "Manage data (UDF, sindex)" },
+    { code: "udf-admin", description: "Manage UDFs" },
+    { code: "sindex-admin", description: "Manage secondary indexes" },
+    { code: "truncate", description: "Truncate sets" },
+    { code: "read", description: "Read records" },
+    { code: "read-write", description: "Read and write records" },
+    { code: "read-write-udf", description: "Read/write + execute UDFs" },
+    { code: "write", description: "Write records" },
+  ]
+
+export function CreateRoleDialog({
+  open,
+  onOpenChange,
+  onCreated,
+  clusterId,
+}: CreateRoleDialogProps) {
+  const [form, setForm] = React.useState<FormState>(INITIAL_STATE)
+  const [error, setError] = React.useState<string | null>(null)
+  const [nameError, setNameError] = React.useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = React.useState(false)
+
+  const resetForm = React.useCallback(() => {
+    setForm(INITIAL_STATE)
+    setError(null)
+    setNameError(null)
+  }, [])
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) resetForm()
+    onOpenChange(next)
+  }
+
+  const togglePrivilege = (code: string) => {
+    setForm((prev) => {
+      const has = prev.privileges.includes(code)
+      return {
+        ...prev,
+        privileges: has
+          ? prev.privileges.filter((p) => p !== code)
+          : [...prev.privileges, code],
+      }
+    })
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    setNameError(null)
+
+    const name = form.name.trim()
+    if (!name) {
+      setError("Role name is required.")
+      return
+    }
+    if (form.privileges.length === 0) {
+      setError("Select at least one privilege.")
+      return
+    }
+
+    const whitelist = form.whitelist
+      .split(",")
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0)
+
+    const readQuotaValue = form.readQuota.trim()
+    const writeQuotaValue = form.writeQuota.trim()
+    const readQuota = readQuotaValue ? Number(readQuotaValue) : null
+    const writeQuota = writeQuotaValue ? Number(writeQuotaValue) : null
+
+    if (readQuota !== null && (!Number.isFinite(readQuota) || readQuota < 0)) {
+      setError("Read quota must be a non-negative number.")
+      return
+    }
+    if (
+      writeQuota !== null &&
+      (!Number.isFinite(writeQuota) || writeQuota < 0)
+    ) {
+      setError("Write quota must be a non-negative number.")
+      return
+    }
+
+    const privileges: Privilege[] = form.privileges.map((code) => ({ code }))
+
+    const body: CreateRoleRequest = {
+      name,
+      privileges,
+      whitelist: whitelist.length > 0 ? whitelist : null,
+      readQuota,
+      writeQuota,
+    }
+
+    setIsSubmitting(true)
+    try {
+      await createRole(clusterId, body)
+      resetForm()
+      onCreated?.()
+      onOpenChange(false)
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.status === 409) {
+          setNameError("Role already exists.")
+        } else {
+          setError(err.detail || err.message)
+        }
+      } else if (err instanceof Error) {
+        setError(err.message)
+      } else {
+        setError("Failed to create role.")
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-y-4">
+          <DialogHeader>
+            <DialogTitle>Create role</DialogTitle>
+            <DialogDescription>
+              Define a new Aerospike role with one or more privileges.
+            </DialogDescription>
+          </DialogHeader>
+
+          {error && (
+            <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
+              {error}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-y-1.5">
+            <Label htmlFor="role-name">Role name</Label>
+            <Input
+              id="role-name"
+              value={form.name}
+              onChange={(e) => {
+                setNameError(null)
+                setForm({ ...form, name: e.target.value })
+              }}
+              placeholder="analytics_reader"
+              autoFocus
+              required
+            />
+            {nameError && (
+              <span className="text-xs text-red-600 dark:text-red-400">
+                {nameError}
+              </span>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-y-1.5">
+            <Label>Privileges</Label>
+            <div className="flex max-h-48 flex-col gap-1 overflow-y-auto rounded border border-gray-200 p-2 dark:border-gray-800">
+              {PRIVILEGE_CATALOG.map((p) => {
+                const checked = form.privileges.includes(p.code)
+                return (
+                  <label
+                    key={p.code}
+                    className="flex cursor-pointer items-start gap-2 rounded px-1 py-0.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-900"
+                  >
+                    <Checkbox
+                      checked={checked}
+                      onCheckedChange={() => togglePrivilege(p.code)}
+                      className="mt-0.5"
+                    />
+                    <span className="flex flex-col">
+                      <span className="font-mono text-xs font-medium text-gray-900 dark:text-gray-50">
+                        {p.code}
+                      </span>
+                      <span className="text-xs text-gray-500 dark:text-gray-400">
+                        {p.description}
+                      </span>
+                    </span>
+                  </label>
+                )
+              })}
+            </div>
+            {form.privileges.length > 0 && (
+              <div className="mt-1 flex flex-wrap gap-1">
+                {form.privileges.map((code) => (
+                  <Badge key={code} variant="neutral">
+                    {code}
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <div className="flex flex-col gap-y-1.5">
+            <Label htmlFor="role-whitelist">
+              Whitelisted IPs <span className="text-gray-500">(optional)</span>
+            </Label>
+            <Input
+              id="role-whitelist"
+              value={form.whitelist}
+              onChange={(e) => setForm({ ...form, whitelist: e.target.value })}
+              placeholder="10.0.0.1, 10.0.0.2"
+            />
+            <span className="text-xs text-gray-500">
+              Comma-separated. Leave blank to allow all IPs.
+            </span>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-y-1.5">
+              <Label htmlFor="role-read-quota">
+                Read quota{" "}
+                <span className="text-gray-500">(TPS, optional)</span>
+              </Label>
+              <Input
+                id="role-read-quota"
+                type="number"
+                min={0}
+                value={form.readQuota}
+                onChange={(e) =>
+                  setForm({ ...form, readQuota: e.target.value })
+                }
+                placeholder="0"
+              />
+            </div>
+            <div className="flex flex-col gap-y-1.5">
+              <Label htmlFor="role-write-quota">
+                Write quota{" "}
+                <span className="text-gray-500">(TPS, optional)</span>
+              </Label>
+              <Input
+                id="role-write-quota"
+                type="number"
+                min={0}
+                value={form.writeQuota}
+                onChange={(e) =>
+                  setForm({ ...form, writeQuota: e.target.value })
+                }
+                placeholder="0"
+              />
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => handleOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              isLoading={isSubmitting}
+              loadingText="Creating..."
+            >
+              Create role
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default CreateRoleDialog

--- a/ui/src/components/dialogs/CreateRoleDialog.tsx
+++ b/ui/src/components/dialogs/CreateRoleDialog.tsx
@@ -55,12 +55,9 @@ const INITIAL_STATE: FormState = {
  * catalogue endpoint, so we mirror the canonical set documented at
  * https://aerospike.com/docs/server/operations/configure/security/access-control
  *
- * Note: ``udf-admin`` is intentionally not in this list — it is not a
- * standard Aerospike privilege; the canonical UDF privilege is
- * ``read-write-udf``.
- *
  * Keep this in sync with the backend (server/aerospike-core ResultCode etc.)
- * when new privileges are added.
+ * and with ``api/src/aerospike_cluster_manager_api/routers/_admin_utils.py``
+ * (PRIVILEGE_NAME_TO_CODE) when new privileges are added.
  */
 const PRIVILEGE_CATALOG: ReadonlyArray<{ code: string; description: string }> =
   [
@@ -69,10 +66,11 @@ const PRIVILEGE_CATALOG: ReadonlyArray<{ code: string; description: string }> =
     { code: "read-write-udf", description: "Read/write + execute UDFs" },
     { code: "write", description: "Write records" },
     { code: "data-admin", description: "Manage data (UDF, sindex)" },
+    { code: "udf-admin", description: "Manage UDF modules" },
+    { code: "sindex-admin", description: "Manage secondary indexes" },
     { code: "sys-admin", description: "Server configuration" },
     { code: "user-admin", description: "Manage users and roles" },
     { code: "truncate", description: "Truncate sets" },
-    { code: "sindex-admin", description: "Manage secondary indexes" },
   ]
 
 export function CreateRoleDialog({
@@ -153,21 +151,40 @@ export function CreateRoleDialog({
       .map((s) => s.trim())
       .filter((s) => s.length > 0)
 
+    // Aerospike quotas are integer TPS values; reject decimals/whitespace
+    // outright rather than silently truncating via Number(). parseInt with
+    // radix 10 stops at the first non-digit, so we additionally guard against
+    // inputs like "10.5" or "10abc" by requiring an exact digits-only match.
     const readQuotaValue = form.readQuota.trim()
     const writeQuotaValue = form.writeQuota.trim()
-    const readQuota = readQuotaValue ? Number(readQuotaValue) : null
-    const writeQuota = writeQuotaValue ? Number(writeQuotaValue) : null
+    const INT_RE = /^\d+$/
 
-    if (readQuota !== null && (!Number.isFinite(readQuota) || readQuota < 0)) {
-      setError("Read quota must be a non-negative number.")
-      return
+    let readQuota: number | null = null
+    if (readQuotaValue) {
+      if (!INT_RE.test(readQuotaValue)) {
+        setError("Read quota must be a non-negative integer (no decimals).")
+        return
+      }
+      const parsed = parseInt(readQuotaValue, 10)
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        setError("Read quota must be a non-negative integer.")
+        return
+      }
+      readQuota = parsed
     }
-    if (
-      writeQuota !== null &&
-      (!Number.isFinite(writeQuota) || writeQuota < 0)
-    ) {
-      setError("Write quota must be a non-negative number.")
-      return
+
+    let writeQuota: number | null = null
+    if (writeQuotaValue) {
+      if (!INT_RE.test(writeQuotaValue)) {
+        setError("Write quota must be a non-negative integer (no decimals).")
+        return
+      }
+      const parsed = parseInt(writeQuotaValue, 10)
+      if (!Number.isFinite(parsed) || parsed < 0) {
+        setError("Write quota must be a non-negative integer.")
+        return
+      }
+      writeQuota = parsed
     }
 
     const privileges: Privilege[] = form.privileges.map((p) => {

--- a/ui/src/components/dialogs/CreateRoleDialog.tsx
+++ b/ui/src/components/dialogs/CreateRoleDialog.tsx
@@ -26,9 +26,15 @@ interface CreateRoleDialogProps {
   clusterId: string
 }
 
+interface PrivilegeRow {
+  code: string
+  ns: string
+  set: string
+}
+
 interface FormState {
   name: string
-  privileges: string[] // privilege codes
+  privileges: PrivilegeRow[]
   whitelist: string
   readQuota: string
   writeQuota: string
@@ -49,21 +55,24 @@ const INITIAL_STATE: FormState = {
  * catalogue endpoint, so we mirror the canonical set documented at
  * https://aerospike.com/docs/server/operations/configure/security/access-control
  *
+ * Note: ``udf-admin`` is intentionally not in this list — it is not a
+ * standard Aerospike privilege; the canonical UDF privilege is
+ * ``read-write-udf``.
+ *
  * Keep this in sync with the backend (server/aerospike-core ResultCode etc.)
  * when new privileges are added.
  */
 const PRIVILEGE_CATALOG: ReadonlyArray<{ code: string; description: string }> =
   [
-    { code: "user-admin", description: "Manage users and roles" },
-    { code: "sys-admin", description: "Server configuration" },
-    { code: "data-admin", description: "Manage data (UDF, sindex)" },
-    { code: "udf-admin", description: "Manage UDFs" },
-    { code: "sindex-admin", description: "Manage secondary indexes" },
-    { code: "truncate", description: "Truncate sets" },
     { code: "read", description: "Read records" },
     { code: "read-write", description: "Read and write records" },
     { code: "read-write-udf", description: "Read/write + execute UDFs" },
     { code: "write", description: "Write records" },
+    { code: "data-admin", description: "Manage data (UDF, sindex)" },
+    { code: "sys-admin", description: "Server configuration" },
+    { code: "user-admin", description: "Manage users and roles" },
+    { code: "truncate", description: "Truncate sets" },
+    { code: "sindex-admin", description: "Manage secondary indexes" },
   ]
 
 export function CreateRoleDialog({
@@ -90,14 +99,27 @@ export function CreateRoleDialog({
 
   const togglePrivilege = (code: string) => {
     setForm((prev) => {
-      const has = prev.privileges.includes(code)
+      const has = prev.privileges.some((p) => p.code === code)
       return {
         ...prev,
         privileges: has
-          ? prev.privileges.filter((p) => p !== code)
-          : [...prev.privileges, code],
+          ? prev.privileges.filter((p) => p.code !== code)
+          : [...prev.privileges, { code, ns: "", set: "" }],
       }
     })
+  }
+
+  const updatePrivilegeScope = (
+    code: string,
+    field: "ns" | "set",
+    value: string,
+  ) => {
+    setForm((prev) => ({
+      ...prev,
+      privileges: prev.privileges.map((p) =>
+        p.code === code ? { ...p, [field]: value } : p,
+      ),
+    }))
   }
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -113,6 +135,17 @@ export function CreateRoleDialog({
     if (form.privileges.length === 0) {
       setError("Select at least one privilege.")
       return
+    }
+
+    // Reject set scoping without a namespace — Aerospike requires the
+    // namespace to be set whenever a set is specified.
+    for (const p of form.privileges) {
+      if (p.set.trim() && !p.ns.trim()) {
+        setError(
+          `Privilege "${p.code}" specifies a set but no namespace; provide both.`,
+        )
+        return
+      }
     }
 
     const whitelist = form.whitelist
@@ -137,7 +170,15 @@ export function CreateRoleDialog({
       return
     }
 
-    const privileges: Privilege[] = form.privileges.map((code) => ({ code }))
+    const privileges: Privilege[] = form.privileges.map((p) => {
+      const ns = p.ns.trim()
+      const set = p.set.trim()
+      return {
+        code: p.code,
+        namespace: ns ? ns : null,
+        set: set ? set : null,
+      }
+    })
 
     const body: CreateRoleRequest = {
       name,
@@ -182,7 +223,11 @@ export function CreateRoleDialog({
           </DialogHeader>
 
           {error && (
-            <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
+            <div
+              role="alert"
+              aria-live="polite"
+              className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300"
+            >
               {error}
             </div>
           )}
@@ -199,9 +244,14 @@ export function CreateRoleDialog({
               placeholder="analytics_reader"
               autoFocus
               required
+              aria-invalid={!!nameError}
+              aria-describedby={nameError ? "role-name-error" : undefined}
             />
             {nameError && (
-              <span className="text-xs text-red-600 dark:text-red-400">
+              <span
+                id="role-name-error"
+                className="text-xs text-red-600 dark:text-red-400"
+              >
                 {nameError}
               </span>
             )}
@@ -211,36 +261,69 @@ export function CreateRoleDialog({
             <Label>Privileges</Label>
             <div className="flex max-h-48 flex-col gap-1 overflow-y-auto rounded border border-gray-200 p-2 dark:border-gray-800">
               {PRIVILEGE_CATALOG.map((p) => {
-                const checked = form.privileges.includes(p.code)
+                const selected = form.privileges.find(
+                  (row) => row.code === p.code,
+                )
+                const checked = !!selected
                 return (
-                  <label
+                  <div
                     key={p.code}
-                    className="flex cursor-pointer items-start gap-2 rounded px-1 py-0.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-900"
+                    className="flex flex-col gap-1 rounded px-1 py-0.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-900"
                   >
-                    <Checkbox
-                      checked={checked}
-                      onCheckedChange={() => togglePrivilege(p.code)}
-                      className="mt-0.5"
-                    />
-                    <span className="flex flex-col">
-                      <span className="font-mono text-xs font-medium text-gray-900 dark:text-gray-50">
-                        {p.code}
+                    <label className="flex cursor-pointer items-start gap-2">
+                      <Checkbox
+                        checked={checked}
+                        onCheckedChange={() => togglePrivilege(p.code)}
+                        className="mt-0.5"
+                      />
+                      <span className="flex flex-col">
+                        <span className="font-mono text-xs font-medium text-gray-900 dark:text-gray-50">
+                          {p.code}
+                        </span>
+                        <span className="text-xs text-gray-500 dark:text-gray-400">
+                          {p.description}
+                        </span>
                       </span>
-                      <span className="text-xs text-gray-500 dark:text-gray-400">
-                        {p.description}
-                      </span>
-                    </span>
-                  </label>
+                    </label>
+                    {checked && selected && (
+                      <div className="ml-6 mt-1 grid grid-cols-2 gap-2">
+                        <Input
+                          aria-label={`${p.code} namespace scope`}
+                          value={selected.ns}
+                          onChange={(e) =>
+                            updatePrivilegeScope(p.code, "ns", e.target.value)
+                          }
+                          placeholder="namespace (optional)"
+                        />
+                        <Input
+                          aria-label={`${p.code} set scope`}
+                          value={selected.set}
+                          onChange={(e) =>
+                            updatePrivilegeScope(p.code, "set", e.target.value)
+                          }
+                          placeholder="set (optional)"
+                        />
+                      </div>
+                    )}
+                  </div>
                 )
               })}
             </div>
             {form.privileges.length > 0 && (
               <div className="mt-1 flex flex-wrap gap-1">
-                {form.privileges.map((code) => (
-                  <Badge key={code} variant="neutral">
-                    {code}
-                  </Badge>
-                ))}
+                {form.privileges.map((row) => {
+                  const scope = row.ns
+                    ? row.set
+                      ? ` (${row.ns}:${row.set})`
+                      : ` (${row.ns})`
+                    : ""
+                  return (
+                    <Badge key={row.code} variant="neutral">
+                      {row.code}
+                      {scope}
+                    </Badge>
+                  )
+                })}
               </div>
             )}
           </div>

--- a/ui/src/components/dialogs/CreateUserDialog.tsx
+++ b/ui/src/components/dialogs/CreateUserDialog.tsx
@@ -1,0 +1,278 @@
+"use client"
+
+import React from "react"
+
+import { Badge } from "@/components/Badge"
+import { Button } from "@/components/Button"
+import { Checkbox } from "@/components/Checkbox"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/Dialog"
+import { Input } from "@/components/Input"
+import { Label } from "@/components/Label"
+import { createUser, listRoles } from "@/lib/api/admin"
+import { ApiError } from "@/lib/api/client"
+import type { AerospikeRole } from "@/lib/types/admin"
+
+interface CreateUserDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onCreated?: () => void
+  clusterId: string
+}
+
+interface FormState {
+  username: string
+  password: string
+  confirmPassword: string
+  roles: string[]
+}
+
+const INITIAL_STATE: FormState = {
+  username: "",
+  password: "",
+  confirmPassword: "",
+  roles: [],
+}
+
+const MIN_PASSWORD_LENGTH = 8
+
+export function CreateUserDialog({
+  open,
+  onOpenChange,
+  onCreated,
+  clusterId,
+}: CreateUserDialogProps) {
+  const [form, setForm] = React.useState<FormState>(INITIAL_STATE)
+  const [error, setError] = React.useState<string | null>(null)
+  const [usernameError, setUsernameError] = React.useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = React.useState(false)
+  const [availableRoles, setAvailableRoles] = React.useState<AerospikeRole[]>(
+    [],
+  )
+  const [rolesLoading, setRolesLoading] = React.useState(false)
+
+  const resetForm = React.useCallback(() => {
+    setForm(INITIAL_STATE)
+    setError(null)
+    setUsernameError(null)
+  }, [])
+
+  // Lazily load roles whenever the dialog opens.
+  React.useEffect(() => {
+    if (!open) return
+    let cancelled = false
+    setRolesLoading(true)
+    listRoles(clusterId)
+      .then((roles) => {
+        if (!cancelled) setAvailableRoles(roles)
+      })
+      .catch(() => {
+        // Roles list is optional; failure is non-fatal for user creation.
+        if (!cancelled) setAvailableRoles([])
+      })
+      .finally(() => {
+        if (!cancelled) setRolesLoading(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [open, clusterId])
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) resetForm()
+    onOpenChange(next)
+  }
+
+  const toggleRole = (roleName: string) => {
+    setForm((prev) => {
+      const has = prev.roles.includes(roleName)
+      return {
+        ...prev,
+        roles: has
+          ? prev.roles.filter((r) => r !== roleName)
+          : [...prev.roles, roleName],
+      }
+    })
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+    setUsernameError(null)
+
+    const username = form.username.trim()
+    if (!username) {
+      setError("Username is required.")
+      return
+    }
+    if (form.password.length < MIN_PASSWORD_LENGTH) {
+      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`)
+      return
+    }
+    if (form.password !== form.confirmPassword) {
+      setError("Passwords do not match.")
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      await createUser(clusterId, {
+        username,
+        password: form.password,
+        roles: form.roles.length > 0 ? form.roles : null,
+      })
+      resetForm()
+      onCreated?.()
+      onOpenChange(false)
+    } catch (err) {
+      if (err instanceof ApiError) {
+        if (err.status === 409) {
+          setUsernameError("User already exists.")
+        } else {
+          setError(err.detail || err.message)
+        }
+      } else if (err instanceof Error) {
+        setError(err.message)
+      } else {
+        setError("Failed to create user.")
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-y-4">
+          <DialogHeader>
+            <DialogTitle>Create user</DialogTitle>
+            <DialogDescription>
+              Add a new Aerospike user. Requires security to be enabled in
+              aerospike.conf.
+            </DialogDescription>
+          </DialogHeader>
+
+          {error && (
+            <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
+              {error}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-y-1.5">
+            <Label htmlFor="user-username">Username</Label>
+            <Input
+              id="user-username"
+              value={form.username}
+              onChange={(e) => {
+                setUsernameError(null)
+                setForm({ ...form, username: e.target.value })
+              }}
+              placeholder="alice"
+              autoFocus
+              required
+            />
+            {usernameError && (
+              <span className="text-xs text-red-600 dark:text-red-400">
+                {usernameError}
+              </span>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="flex flex-col gap-y-1.5">
+              <Label htmlFor="user-password">Password</Label>
+              <Input
+                id="user-password"
+                type="password"
+                value={form.password}
+                onChange={(e) => setForm({ ...form, password: e.target.value })}
+                placeholder={`min ${MIN_PASSWORD_LENGTH} characters`}
+                required
+                minLength={MIN_PASSWORD_LENGTH}
+              />
+            </div>
+            <div className="flex flex-col gap-y-1.5">
+              <Label htmlFor="user-confirm">Confirm password</Label>
+              <Input
+                id="user-confirm"
+                type="password"
+                value={form.confirmPassword}
+                onChange={(e) =>
+                  setForm({ ...form, confirmPassword: e.target.value })
+                }
+                placeholder="repeat password"
+                required
+                minLength={MIN_PASSWORD_LENGTH}
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-y-1.5">
+            <Label>Roles (optional)</Label>
+            {rolesLoading ? (
+              <span className="text-xs text-gray-500">Loading roles…</span>
+            ) : availableRoles.length === 0 ? (
+              <span className="text-xs text-gray-500">
+                No roles defined. You can grant roles later.
+              </span>
+            ) : (
+              <div className="flex max-h-40 flex-col gap-1 overflow-y-auto rounded border border-gray-200 p-2 dark:border-gray-800">
+                {availableRoles.map((r) => {
+                  const checked = form.roles.includes(r.name)
+                  return (
+                    <label
+                      key={r.name}
+                      className="flex cursor-pointer items-center gap-2 rounded px-1 py-0.5 text-sm hover:bg-gray-50 dark:hover:bg-gray-900"
+                    >
+                      <Checkbox
+                        checked={checked}
+                        onCheckedChange={() => toggleRole(r.name)}
+                      />
+                      <span className="font-mono text-xs">{r.name}</span>
+                    </label>
+                  )
+                })}
+              </div>
+            )}
+            {form.roles.length > 0 && (
+              <div className="mt-1 flex flex-wrap gap-1">
+                {form.roles.map((r) => (
+                  <Badge key={r} variant="neutral">
+                    {r}
+                  </Badge>
+                ))}
+              </div>
+            )}
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => handleOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              isLoading={isSubmitting}
+              loadingText="Creating..."
+            >
+              Create user
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default CreateUserDialog

--- a/ui/src/components/dialogs/CreateUserDialog.tsx
+++ b/ui/src/components/dialogs/CreateUserDialog.tsx
@@ -160,7 +160,11 @@ export function CreateUserDialog({
           </DialogHeader>
 
           {error && (
-            <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
+            <div
+              role="alert"
+              aria-live="polite"
+              className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300"
+            >
               {error}
             </div>
           )}
@@ -177,9 +181,16 @@ export function CreateUserDialog({
               placeholder="alice"
               autoFocus
               required
+              aria-invalid={!!usernameError}
+              aria-describedby={
+                usernameError ? "user-username-error" : undefined
+              }
             />
             {usernameError && (
-              <span className="text-xs text-red-600 dark:text-red-400">
+              <span
+                id="user-username-error"
+                className="text-xs text-red-600 dark:text-red-400"
+              >
                 {usernameError}
               </span>
             )}


### PR DESCRIPTION
## Summary
Closes the half-implemented admin UX gap (delete-only → full CRUD) and replaces fragile string-match error detection with aerospike-py exception classes.

**C2 — Backend (`_admin_utils.py`)**:
- Catch `aerospike_py.exception.AdminError` and `ServerError` (aerospike-py 0.6+) and map to HTTP status:
  - `InvalidUser` / `InvalidRole` → 404
  - `UserAlreadyExists` / `RoleAlreadyExists` → 409
  - Security disabled / unsupported → 403 with `EE_MSG`
- Lowercase string fallback retained for forward compat.
- 11 new tests in `test_admin_utils.py`.

**C5 — Frontend**:
- `CreateUserDialog` and `CreateRoleDialog` follow the existing `CreateIndexDialog` pattern (Tremor Raw `Dialog`/`Button`/`Input` + Radix `Checkbox`).
- Submit to `POST /api/admin/{clusterId}/{users,roles}` via existing `createUser`/`createRole` helpers in `ui/src/lib/api/admin.ts`.
- 409 responses surface inline as "User/Role already exists."; other errors render a top banner.
- On success, parent's `load()` refreshes the list.

## Files
- `api/src/aerospike_cluster_manager_api/routers/_admin_utils.py`
- `api/tests/test_admin_utils.py` (new — 11 tests)
- `ui/src/components/dialogs/CreateUserDialog.tsx` (new)
- `ui/src/components/dialogs/CreateRoleDialog.tsx` (new)
- `ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx` (wire dialogs + buttons)

## Test plan
- [ ] `pytest -k admin` — 11 passed (verified locally).
- [ ] Frontend `tsc --noEmit` — clean (verified locally).
- [ ] Manual: open admin page → "Add User" → submit valid form → user appears in list. Submit duplicate → 409 inline message.
- [ ] Same flow for "Add Role".