### PR TITLE
feat(ui): skeleton loading states for record browser and detail pages

### DIFF
--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
@@ -29,6 +29,7 @@ import {
 } from "@/components/Select"
 import { listIndexes } from "@/lib/api/indexes"
 import { filterRecords } from "@/lib/api/records"
+import { TableSkeleton } from "@/components/skeletons/TableSkeleton"
 import type { BinDataType } from "@/lib/types/query"
 import type { SecondaryIndex } from "@/lib/types/index"
 import type { AerospikeRecord } from "@/lib/types/record"
@@ -379,7 +380,10 @@ export default function RecordBrowserPage({ params }: PageProps) {
             </TableHead>
             <TableBody>
               {loading && !records ? (
-                <RecordSkeleton cols={Math.max(binColumns.length, 4) + 4} />
+                <TableSkeleton
+                  rows={6}
+                  cols={Math.max(binColumns.length, 4) + 4}
+                />
               ) : !records || records.length === 0 ? (
                 <TableRow>
                   <TableCell
@@ -516,22 +520,6 @@ function StatusBar({
         </Select>
       </div>
     </div>
-  )
-}
-
-function RecordSkeleton({ cols }: { cols: number }) {
-  return (
-    <>
-      {[0, 1, 2, 3, 4].map((r) => (
-        <TableRow key={r}>
-          {Array.from({ length: cols }).map((_, c) => (
-            <TableCell key={c}>
-              <div className="h-3 w-20 animate-pulse rounded bg-gray-100 dark:bg-gray-900" />
-            </TableCell>
-          ))}
-        </TableRow>
-      ))}
-    </>
   )
 }
 

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/Button"
 import { Card } from "@/components/Card"
 import { Input } from "@/components/Input"
 import { Label } from "@/components/Label"
+import { RecordDetailSkeleton } from "@/components/skeletons/RecordDetailSkeleton"
 import { clusterSections } from "@/app/siteConfig"
 import { ApiError } from "@/lib/api/client"
 import { deleteRecord, getRecordDetail, putRecord } from "@/lib/api/records"
@@ -513,9 +514,7 @@ export default function RecordDetailPage({ params }: PageProps) {
       )}
 
       {isLoading && !record ? (
-        <Card className="py-10 text-center text-sm text-gray-500 dark:text-gray-500">
-          Loading record…
-        </Card>
+        <RecordDetailSkeleton />
       ) : !record ? (
         <Card className="py-10 text-center text-sm text-gray-500 dark:text-gray-500">
           Record not found.

--- a/ui/src/components/skeletons/RecordDetailSkeleton.tsx
+++ b/ui/src/components/skeletons/RecordDetailSkeleton.tsx
@@ -1,0 +1,39 @@
+import { Card } from "@/components/Card"
+
+// RecordDetailSkeleton mirrors the record detail layout: a 4-column metadata
+// strip (gen / TTL / last update / bins) on top, and a list of bin rows below.
+// Used while getRecordDetail() is in flight so the user sees structure
+// instead of a centered "Loading record…" string.
+export function RecordDetailSkeleton({ binRows = 4 }: { binRows?: number }) {
+  return (
+    <>
+      <Card className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="flex flex-col gap-2">
+            <div className="h-3 w-16 animate-pulse rounded bg-gray-200 dark:bg-gray-800" />
+            <div className="h-4 w-24 animate-pulse rounded bg-gray-200 dark:bg-gray-800" />
+          </div>
+        ))}
+      </Card>
+
+      <Card className="p-0">
+        <ul className="flex flex-col divide-y divide-gray-200 dark:divide-gray-800">
+          {Array.from({ length: binRows }).map((_, i) => (
+            <li
+              key={i}
+              className="flex flex-col gap-2 px-5 py-3 sm:flex-row sm:items-start"
+            >
+              <div className="flex min-w-40 flex-col gap-2 sm:w-56">
+                <div className="h-4 w-28 animate-pulse rounded bg-gray-200 dark:bg-gray-800" />
+                <div className="h-4 w-16 animate-pulse rounded bg-gray-100 dark:bg-gray-900" />
+              </div>
+              <div className="flex-1">
+                <div className="h-16 w-full animate-pulse rounded bg-gray-100 dark:bg-gray-900" />
+              </div>
+            </li>
+          ))}
+        </ul>
+      </Card>
+    </>
+  )
+}

--- a/ui/src/components/skeletons/RecordDetailSkeleton.tsx
+++ b/ui/src/components/skeletons/RecordDetailSkeleton.tsx
@@ -4,9 +4,16 @@ import { Card } from "@/components/Card"
 // strip (gen / TTL / last update / bins) on top, and a list of bin rows below.
 // Used while getRecordDetail() is in flight so the user sees structure
 // instead of a centered "Loading record…" string.
+//
+// Accessibility: a top-level visually-hidden status node carries
+// role="status" + aria-live="polite" so screen readers announce the
+// loading state instead of staying silent.
 export function RecordDetailSkeleton({ binRows = 4 }: { binRows?: number }) {
   return (
     <>
+      <span role="status" aria-live="polite" className="sr-only">
+        Loading…
+      </span>
       <Card className="grid grid-cols-2 gap-4 sm:grid-cols-4">
         {[0, 1, 2, 3].map((i) => (
           <div key={i} className="flex flex-col gap-2">

--- a/ui/src/components/skeletons/TableSkeleton.tsx
+++ b/ui/src/components/skeletons/TableSkeleton.tsx
@@ -1,0 +1,32 @@
+import { TableCell, TableRow } from "@/components/Table"
+
+// TableSkeleton renders pulse-shimmer placeholder rows that mirror the shape
+// of the table while the initial fetch is in flight. Use this inside a
+// <TableBody> when `loading && !data` so users see structure instead of an
+// empty card.
+export function TableSkeleton({
+  rows = 5,
+  cols,
+  cellWidth = "w-20",
+}: {
+  rows?: number
+  cols: number
+  // Tailwind width class for the inner skeleton bar. Tweak per page if needed.
+  cellWidth?: string
+}) {
+  return (
+    <>
+      {Array.from({ length: rows }).map((_, r) => (
+        <TableRow key={r}>
+          {Array.from({ length: cols }).map((_, c) => (
+            <TableCell key={c}>
+              <div
+                className={`h-3 ${cellWidth} animate-pulse rounded bg-gray-200 dark:bg-gray-800`}
+              />
+            </TableCell>
+          ))}
+        </TableRow>
+      ))}
+    </>
+  )
+}

--- a/ui/src/components/skeletons/TableSkeleton.tsx
+++ b/ui/src/components/skeletons/TableSkeleton.tsx
@@ -1,9 +1,30 @@
 import { TableCell, TableRow } from "@/components/Table"
 
+// Restrict cellWidth to a literal union so callers cannot pass an arbitrary
+// Tailwind-class string (e.g. "w-[173px]" or a dynamically built name).
+// Tailwind's JIT compiler purges any class it cannot statically see in
+// source. A dynamic string would compile fine but get stripped at build
+// time, collapsing the skeleton bar to width:auto. Each value below is
+// referenced statically in this file so the JIT keeps it.
+export type SkeletonCellWidth =
+  | "w-12"
+  | "w-16"
+  | "w-20"
+  | "w-24"
+  | "w-28"
+  | "w-32"
+  | "w-40"
+  | "w-full"
+
 // TableSkeleton renders pulse-shimmer placeholder rows that mirror the shape
 // of the table while the initial fetch is in flight. Use this inside a
 // <TableBody> when `loading && !data` so users see structure instead of an
 // empty card.
+//
+// Accessibility: the first cell of the first row contains a visually-hidden
+// "Loading…" status node with role="status" + aria-live="polite" so screen
+// readers announce the loading state instead of nothing while a request is
+// in flight.
 export function TableSkeleton({
   rows = 5,
   cols,
@@ -12,7 +33,7 @@ export function TableSkeleton({
   rows?: number
   cols: number
   // Tailwind width class for the inner skeleton bar. Tweak per page if needed.
-  cellWidth?: string
+  cellWidth?: SkeletonCellWidth
 }) {
   return (
     <>
@@ -20,6 +41,16 @@ export function TableSkeleton({
         <TableRow key={r}>
           {Array.from({ length: cols }).map((_, c) => (
             <TableCell key={c}>
+              {r === 0 && c === 0 && (
+                <span
+                  role="status"
+                  aria-live="polite"
+                  aria-hidden="false"
+                  className="sr-only"
+                >
+                  Loading…
+                </span>
+              )}
               <div
                 className={`h-3 ${cellWidth} animate-pulse rounded bg-gray-200 dark:bg-gray-800`}
               />


### PR DESCRIPTION
## Summary
- Record browser (`sets/[namespace]/[set]`) used inline `RecordSkeleton` — refactored to shared reusable `<TableSkeleton rows={N} cols={M} />`.
- Record detail page replaced "Loading record…" text with `<RecordDetailSkeleton />` mirroring the metadata strip + bin list layout.
- Tailwind-based pulse-shimmer (`animate-pulse bg-gray-200 dark:bg-gray-800`), matching the existing convention used in `ClustersSkeleton` and admin pages.

## Files
- `ui/src/components/skeletons/TableSkeleton.tsx` (new — reusable)
- `ui/src/components/skeletons/RecordDetailSkeleton.tsx` (new — page-specific)
- `ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx` (use TableSkeleton)
- `ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx` (use RecordDetailSkeleton)

## Test plan
- [ ] `pnpm type-check` — passes (verified locally).
- [ ] Pre-commit hooks (eslint, prettier, tsc) — pass.
- [ ] Throttle network in DevTools, navigate to `/clusters/<id>/sets/<ns>/<set>` → observe shimmer instead of blank state.
- [ ] Same for record detail page.