### PR TITLE
docs: correct Tech Stack — split app metadata (SQLite/PG) vs managed target (Aerospike CE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ Browse, create, edit, duplicate and delete records with server-side limiting and
 |---|---|
 | **UI**  | Next.js 14, React 18, TypeScript, Tailwind CSS 3.4, Tremor Raw, Zustand, recharts, Monaco Editor |
 | **API** | Python 3.13, FastAPI, Uvicorn, Pydantic |
-| **Database** | Aerospike Server Community Edition 8.1.x |
+| **App metadata** | SQLite (default, file-based) / PostgreSQL (optional, set `ENABLE_POSTGRES=true`) — stores connection profiles & UI state |
+| **Managed target** | Aerospike Server Community Edition 8.x |
 | **Infra** | Podman Compose, uv (Python), npm (Node.js) |
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Browse, create, edit, duplicate and delete records with server-side limiting and
 |---|---|
 | **UI**  | Next.js 14, React 18, TypeScript, Tailwind CSS 3.4, Tremor Raw, Zustand, recharts, Monaco Editor |
 | **API** | Python 3.13, FastAPI, Uvicorn, Pydantic |
-| **Database** | Aerospike Server Enterprise 8.0 |
+| **Database** | Aerospike Server Community Edition 8.1.x |
 | **Infra** | Podman Compose, uv (Python), npm (Node.js) |
 
 ## Quick Start


### PR DESCRIPTION
## Summary
The README's Tech Stack table had two problems:
1. **Wrong product**: listed `Aerospike Server Enterprise 8.0`, but this is a CE-only tool (CLAUDE.md L7: "GUI management tool for Aerospike **Community Edition**", goal #1: "managing Aerospike **CE** clusters"; compose files pull `aerospike:ce-8.1.1.1_1`).
2. **Wrong concept**: the row conflated the app's own metadata store with the database it *manages*. The cluster-manager itself runs on **SQLite (default) or PostgreSQL** (`api/src/aerospike_cluster_manager_api/db/{_sqlite.py,_postgres.py}`, env vars `ENABLE_POSTGRES` / `SQLITE_PATH`). Aerospike CE is the **target**, not the backing store. Listing only "Aerospike Server" on the Database row implied the tool needs Aerospike to run, which is wrong.

## Changes
Split the single `Database` row into two:

| Layer | Was | Now |
|---|---|---|
| `Database` | `Aerospike Server Enterprise 8.0` | (removed) |
| `App metadata` | — | `SQLite (default, file-based) / PostgreSQL (optional, set ENABLE_POSTGRES=true) — stores connection profiles & UI state` |
| `Managed target` | — | `Aerospike Server Community Edition 8.x` |

2 commits, +2/-1 lines in `README.md`.

## Test plan
- [x] `grep -nE "Aerospike Server (Enterprise\|Community)" README.md` → only the new "Managed target" line
- [x] `grep -nE "SQLite\|PostgreSQL" README.md` → at least the new App metadata line + existing Quick Start mention
- [x] No other content changed