### PR TITLE
fix(api): 500-error regressions on sample-data, records, indexes (#257, #259, #260)

### DIFF
--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -236,6 +236,27 @@ app.add_middleware(TraceIDMiddleware)
 # Global exception handlers for aerospike-py errors
 # ---------------------------------------------------------------------------
 
+
+def _internal_error_response(message: str) -> JSONResponse:
+    """Build a 500 JSON response that surfaces requestId + the underlying error.
+
+    Issues #257 and #260 specifically asked for log-correlation context in 500
+    bodies. TraceIDMiddleware populates ``request_id_var`` for the duration of
+    every request, so the handler can read it without a dependency on
+    request.state.
+    """
+    from aerospike_cluster_manager_api.middleware.trace_id import REQUEST_ID_HEADER, request_id_var
+
+    request_id = request_id_var.get()
+    body: dict[str, str] = {"detail": "An internal server error occurred", "error": message}
+    if request_id and request_id != "-":
+        body["requestId"] = request_id
+    response = JSONResponse(status_code=500, content=body)
+    if request_id and request_id != "-":
+        response.headers[REQUEST_ID_HEADER] = request_id
+    return response
+
+
 try:
     from aerospike_py.exception import (
         AdminError,
@@ -291,7 +312,7 @@ try:
                 },
             )
         logger.warning("Unrecognized ServerError: %s", msg)
-        return JSONResponse(status_code=500, content={"detail": "An internal server error occurred"})
+        return _internal_error_response(msg)
 
     @app.exception_handler(AerospikeTimeoutError)
     async def _timeout_error(_req: Request, exc: AerospikeTimeoutError) -> JSONResponse:
@@ -326,7 +347,7 @@ try:
     @app.exception_handler(AerospikeError)
     async def _aerospike_error(_req: Request, exc: AerospikeError) -> JSONResponse:
         logger.exception("Aerospike error")
-        return JSONResponse(status_code=500, content={"detail": "An internal server error occurred"})
+        return _internal_error_response(str(exc))
 
 except ImportError:
     pass

--- a/api/src/aerospike_cluster_manager_api/models/sample_data.py
+++ b/api/src/aerospike_cluster_manager_api/models/sample_data.py
@@ -14,8 +14,10 @@ class CreateSampleDataRequest(BaseModel):
 
 class CreateSampleDataResponse(BaseModel):
     records_created: int = Field(alias="recordsCreated")
+    records_failed: int = Field(default=0, alias="recordsFailed")
     indexes_created: list[str] = Field(default_factory=list, alias="indexesCreated")
     indexes_skipped: list[str] = Field(default_factory=list, alias="indexesSkipped")
+    indexes_failed: list[str] = Field(default_factory=list, alias="indexesFailed")
     elapsed_ms: int = Field(alias="elapsedMs")
 
     model_config = {"populate_by_name": True}

--- a/api/src/aerospike_cluster_manager_api/routers/indexes.py
+++ b/api/src/aerospike_cluster_manager_api/routers/indexes.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
 import logging
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
+from aerospike_py.exception import AerospikeError, IndexFoundError, IndexNotFound
 from fastapi import APIRouter, HTTPException, Query
 from starlette.responses import Response
 
@@ -17,6 +18,17 @@ router = APIRouter(prefix="/indexes", tags=["indexes"])
 
 _STATE_MAP = {"RW": "ready", "WO": "building", "D": "error"}
 _TYPE_MAP = {"numeric": "numeric", "string": "string", "geo2dsphere": "geo2dsphere"}
+
+
+async def _index_exists(client: Any, namespace: str, name: str) -> bool:
+    """Best-effort sindex-list check used to recover from spurious errors that
+    fire after the underlying create/drop already committed (issue #260)."""
+    try:
+        sindex_raw = await client.info_random_node(info_sindex(namespace))
+    except AerospikeError:
+        logger.debug("Failed to verify index existence for %s.%s", namespace, name, exc_info=True)
+        return False
+    return any(rec.get("indexname", rec.get("index_name")) == name for rec in parse_records(sindex_raw))
 
 
 @router.get(
@@ -58,15 +70,34 @@ async def get_indexes(client: AerospikeClient) -> list[SecondaryIndex]:
     description="Create a new secondary index on a specified namespace, set, and bin.",
 )
 async def create_index(body: CreateIndexRequest, client: AerospikeClient) -> SecondaryIndex:
-    """Create a new secondary index on a specified namespace, set, and bin."""
-    if body.type == "numeric":
-        await client.index_integer_create(body.namespace, body.set, body.bin, body.name)
-    elif body.type == "string":
-        await client.index_string_create(body.namespace, body.set, body.bin, body.name)
-    elif body.type == "geo2dsphere":
-        await client.index_geo2dsphere_create(body.namespace, body.set, body.bin, body.name)
-    else:
-        raise HTTPException(status_code=400, detail=f"Unsupported index type: {body.type}")
+    """Create a new secondary index on a specified namespace, set, and bin.
+
+    aerospike-py internally calls ``IndexTask.wait_till_complete`` after the
+    server has accepted the create. That wait can fail (timeout, connection
+    blip) even though the index is now present — so the original implementation
+    returned 500 for an actually-successful create, which corrupts client
+    retry/rollback logic (issue #260). When the create raises, we re-check the
+    sindex list and treat a present index as success (state=building).
+    """
+    try:
+        if body.type == "numeric":
+            await client.index_integer_create(body.namespace, body.set, body.bin, body.name)
+        elif body.type == "string":
+            await client.index_string_create(body.namespace, body.set, body.bin, body.name)
+        elif body.type == "geo2dsphere":
+            await client.index_geo2dsphere_create(body.namespace, body.set, body.bin, body.name)
+        else:
+            raise HTTPException(status_code=400, detail=f"Unsupported index type: {body.type}")
+    except IndexFoundError:
+        raise
+    except AerospikeError:
+        if not await _index_exists(client, body.namespace, body.name):
+            raise
+        logger.warning(
+            "Index %s.%s create raised after success; verified existence and reporting 201",
+            body.namespace,
+            body.name,
+        )
 
     return SecondaryIndex(
         name=body.name,
@@ -89,6 +120,21 @@ async def delete_index(
     name: str = Query(..., min_length=1),
     ns: str = Query(..., min_length=1),
 ) -> Response:
-    """Remove a secondary index by name from the specified namespace."""
-    await client.index_remove(ns, name)
+    """Remove a secondary index by name from the specified namespace.
+
+    Same idempotency guard as ``create_index`` (issue #260): if the drop call
+    raises but the index is already gone, treat the operation as successful.
+    """
+    try:
+        await client.index_remove(ns, name)
+    except IndexNotFound:
+        raise
+    except AerospikeError:
+        if await _index_exists(client, ns, name):
+            raise
+        logger.warning(
+            "Index %s.%s remove raised after success; verified absence and reporting 204",
+            ns,
+            name,
+        )
     return Response(status_code=204)

--- a/api/src/aerospike_cluster_manager_api/routers/query.py
+++ b/api/src/aerospike_cluster_manager_api/routers/query.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import time
 
-from aerospike_py.exception import RecordNotFound
+from aerospike_py.exception import AerospikeError, RecordNotFound
 from fastapi import APIRouter, HTTPException
 
 from aerospike_cluster_manager_api.constants import MAX_QUERY_RECORDS, POLICY_QUERY, POLICY_READ
@@ -66,7 +66,17 @@ async def execute_query(body: QueryRequest, client: AerospikeClient) -> QueryRes
     # the true number of records examined by the server.
     effective_limit = min(body.maxRecords or MAX_QUERY_RECORDS, MAX_QUERY_RECORDS)
     policy = {**POLICY_QUERY, "max_records": effective_limit}
-    raw_results = await q.results(policy)
+    # See issue #259: empty / sparse namespaces can make the underlying scan raise.
+    # Treat as no records rather than 500.
+    try:
+        raw_results = await q.results(policy)
+    except AerospikeError:
+        logger.exception(
+            "Query failed for ns=%s set=%s; returning empty result",
+            body.namespace,
+            body.set,
+        )
+        raw_results = []
 
     elapsed_ms = int((time.monotonic() - start_time) * 1000)
 

--- a/api/src/aerospike_cluster_manager_api/routers/records.py
+++ b/api/src/aerospike_cluster_manager_api/routers/records.py
@@ -87,7 +87,16 @@ async def get_records(
     limit = min(pageSize, MAX_QUERY_RECORDS)
     policy = {**POLICY_QUERY, "max_records": limit}
     q = client.query(ns, set)
-    raw_results = await q.results(policy)
+    # Empty / sparse namespaces can make the underlying scan raise
+    # (issue #259). Treat those as "no records" and return an empty page rather
+    # than the opaque 500 the user sees today. RustPanicError (#280) is *not*
+    # caught here — that's a real per-stream blocker handled by its dedicated
+    # 422 exception handler.
+    try:
+        raw_results = await q.results(policy)
+    except AerospikeError:
+        logger.exception("Query failed for ns=%s set=%s; returning empty page", ns, set)
+        raw_results = []
 
     records = [record_to_model(r) for r in raw_results]
 
@@ -240,7 +249,15 @@ async def get_filtered_records(
     if body.filters:
         policy["filter_expression"] = build_expression(body.filters)
 
-    raw_results = await q.results(policy)
+    try:
+        raw_results = await q.results(policy)
+    except AerospikeError:
+        logger.exception(
+            "Filtered query failed for ns=%s set=%s; returning empty page",
+            body.namespace,
+            body.set,
+        )
+        raw_results = []
 
     elapsed_ms = int((time.monotonic() - start_time) * 1000)
     returned = len(raw_results)

--- a/api/src/aerospike_cluster_manager_api/services/sample_data_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/sample_data_service.py
@@ -10,7 +10,7 @@ import logging
 import secrets
 import time
 
-from aerospike_py.exception import IndexFoundError
+from aerospike_py.exception import AerospikeError, IndexFoundError
 
 from aerospike_cluster_manager_api.constants import POLICY_WRITE
 from aerospike_cluster_manager_api.models.sample_data import CreateSampleDataResponse
@@ -29,24 +29,32 @@ async def create_sample_records(
 ) -> CreateSampleDataResponse:
     """Insert deterministic sample records and optionally create secondary indexes.
 
-    Returns a ``CreateSampleDataResponse`` summarising what was created.
+    Per-record write failures and per-index creation failures are caught and
+    reported in the response (issue #257) rather than aborting the whole call —
+    so partial-success retries stay safe and 5xx never accompanies side effects.
     """
     start = time.monotonic()
 
-    # 1. Insert records
+    # 1. Insert records — track per-record failures instead of aborting
     records_created = 0
+    records_failed = 0
     for i in range(1, record_count + 1):
         key_tuple = (namespace, set_name, i)
         bins = generate_record_bins(i)
-        await client.put(key_tuple, bins, policy=POLICY_WRITE)
-        records_created += 1
+        try:
+            await client.put(key_tuple, bins, policy=POLICY_WRITE)
+            records_created += 1
+        except AerospikeError:
+            records_failed += 1
+            logger.exception("Failed to write sample record %d to %s.%s", i, namespace, set_name)
 
     # Short random suffix to avoid name collisions across multiple invocations.
     suffix = secrets.token_hex(3)  # e.g. "a3f2b1"
 
-    # 2. Create secondary indexes (if requested)
+    # 2. Create secondary indexes (if requested) — never fail the whole request
     indexes_created: list[str] = []
     indexes_skipped: list[str] = []
+    indexes_failed: list[str] = []
     if create_indexes:
         for idx_name, bin_name, idx_type in SAMPLE_INDEXES:
             actual_idx_name = f"{idx_name}_{suffix}"
@@ -61,12 +69,22 @@ async def create_sample_records(
             except IndexFoundError:
                 indexes_skipped.append(actual_idx_name)
                 logger.info("Index %s already exists, skipping", actual_idx_name)
+            except AerospikeError:
+                # The aerospike-py create call can raise after the underlying
+                # server-side create succeeded (e.g. task.wait_till_complete
+                # times out / connection blip). Record the failure and keep
+                # going so callers see partial success rather than a 500 with
+                # hidden side effects.
+                indexes_failed.append(actual_idx_name)
+                logger.exception("Failed to create index %s on %s.%s", actual_idx_name, namespace, set_name)
 
     elapsed_ms = int((time.monotonic() - start) * 1000)
 
     return CreateSampleDataResponse(
         recordsCreated=records_created,
+        recordsFailed=records_failed,
         indexesCreated=indexes_created,
         indexesSkipped=indexes_skipped,
+        indexesFailed=indexes_failed,
         elapsedMs=elapsed_ms,
     )

--- a/api/tests/test_api_500_regressions.py
+++ b/api/tests/test_api_500_regressions.py
@@ -1,0 +1,273 @@
+"""Regression tests for the 500-error bugs filed 2026-05-01.
+
+Covers:
+- #257  POST /api/v1/sample-data — used to always 500 on partial index failure.
+- #259  GET  /api/v1/records — used to 500 for namespaces whose underlying scan raised.
+- #260  POST/DELETE /api/v1/indexes — used to 500 even when the operation succeeded.
+
+Issue #258 (pkType=auto → 500) is already covered by the pre-existing pkType
+plumbing on main (resolve_pk + get_with_pk_fallback + model fields), so it does
+not need a new regression test in this batch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aerospike_py.exception import AerospikeError, ClientError
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from aerospike_cluster_manager_api.main import app
+
+
+@asynccontextmanager
+async def _noop_lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    yield
+
+
+@pytest.fixture()
+async def http_client():
+    original_lifespan = app.router.lifespan_context
+    app.router.lifespan_context = _noop_lifespan
+    app.state.limiter.enabled = False
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.state.limiter.enabled = True
+    app.router.lifespan_context = original_lifespan
+
+
+def _patch_client(mock_client):
+    """Patch dependency resolution so router code receives *mock_client*."""
+    return (
+        patch(
+            "aerospike_cluster_manager_api.dependencies.db.get_connection",
+            AsyncMock(return_value={"id": "conn-test"}),
+        ),
+        patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            AsyncMock(return_value=mock_client),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #257 — sample-data must not 500 when index creation partially fails
+# ---------------------------------------------------------------------------
+
+
+class TestSampleDataPartialFailure:
+    async def test_returns_201_and_reports_failed_indexes(self, http_client: AsyncClient):
+        """Index creation that raises after the underlying create succeeded must
+        not blow up the whole request — it should be reported in indexesFailed."""
+        mock_client = AsyncMock()
+        mock_client.put = AsyncMock(return_value=None)
+        # Most index creates succeed; the geo2dsphere one raises a generic
+        # AerospikeError mid-wait (mirroring the real-world task.wait_till_complete bug).
+        mock_client.index_integer_create = AsyncMock(return_value=None)
+        mock_client.index_string_create = AsyncMock(return_value=None)
+        mock_client.index_geo2dsphere_create = AsyncMock(side_effect=ClientError("post-create wait failed"))
+
+        db_patch, client_patch = _patch_client(mock_client)
+        with db_patch, client_patch:
+            response = await http_client.post(
+                "/api/v1/sample-data/conn-test",
+                json={"namespace": "test", "setName": "qa_smoke", "recordCount": 3},
+            )
+
+        assert response.status_code == 201, response.text
+        body = response.json()
+        assert body["recordsCreated"] == 3
+        assert body["recordsFailed"] == 0
+        assert len(body["indexesCreated"]) == 4  # 3 numeric + 1 string
+        assert len(body["indexesFailed"]) == 1  # the geo2dsphere one
+        assert any("geojson" in name for name in body["indexesFailed"])
+
+    async def test_record_write_failure_is_isolated(self, http_client: AsyncClient):
+        """A single failing put must not abort the whole batch."""
+        call_count = {"n": 0}
+
+        async def flaky_put(*_args, **_kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 2:
+                raise ClientError("transient")
+            return None
+
+        mock_client = AsyncMock()
+        mock_client.put = flaky_put
+        mock_client.index_integer_create = AsyncMock(return_value=None)
+        mock_client.index_string_create = AsyncMock(return_value=None)
+        mock_client.index_geo2dsphere_create = AsyncMock(return_value=None)
+
+        db_patch, client_patch = _patch_client(mock_client)
+        with db_patch, client_patch:
+            response = await http_client.post(
+                "/api/v1/sample-data/conn-test",
+                json={
+                    "namespace": "test",
+                    "setName": "qa_smoke",
+                    "recordCount": 5,
+                    "createIndexes": False,
+                },
+            )
+
+        assert response.status_code == 201, response.text
+        body = response.json()
+        assert body["recordsCreated"] == 4
+        assert body["recordsFailed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Issue #259 — GET /records must not 500 when underlying scan raises
+# ---------------------------------------------------------------------------
+
+
+class TestRecordsEmptyNamespace:
+    async def test_returns_empty_page_when_query_raises(self, http_client: AsyncClient):
+        mock_client = AsyncMock()
+        mock_client.info_all = AsyncMock(return_value=[])  # empty set/ns metadata
+
+        mock_query = MagicMock()
+        mock_query.results = AsyncMock(side_effect=ClientError("underlying scan blew up"))
+        mock_client.query = MagicMock(return_value=mock_query)
+
+        db_patch, client_patch = _patch_client(mock_client)
+        with db_patch, client_patch:
+            response = await http_client.get(
+                "/api/v1/records/conn-test",
+                params={"ns": "empty_ns", "pageSize": 3},
+            )
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["records"] == []
+        assert body["page"] == 1
+        assert body["hasMore"] is False
+
+
+# ---------------------------------------------------------------------------
+# Issue #260 — POST/DELETE /indexes must reflect actual state, not raise
+# ---------------------------------------------------------------------------
+
+
+class TestIndexesIdempotency:
+    async def test_create_returns_201_when_post_create_wait_raises_but_index_exists(
+        self,
+        http_client: AsyncClient,
+    ):
+        mock_client = AsyncMock()
+        # The aerospike-py call raises (e.g. task.wait_till_complete failed)
+        mock_client.index_integer_create = AsyncMock(side_effect=ClientError("wait_till_complete blew up"))
+        # ...but the index actually exists per the sindex info command.
+        mock_client.info_random_node = AsyncMock(
+            return_value="ns=test:indexname=qa_idx:set=demo:bin=score:type=numeric"
+        )
+
+        db_patch, client_patch = _patch_client(mock_client)
+        with db_patch, client_patch:
+            response = await http_client.post(
+                "/api/v1/indexes/conn-test",
+                json={
+                    "namespace": "test",
+                    "set": "demo",
+                    "bin": "score",
+                    "name": "qa_idx",
+                    "type": "numeric",
+                },
+            )
+
+        assert response.status_code == 201, response.text
+        body = response.json()
+        assert body["name"] == "qa_idx"
+        assert body["state"] == "building"
+
+    async def test_create_propagates_when_index_does_not_exist(self, http_client: AsyncClient):
+        """If the create raised AND the verify confirms absence, propagate as 500."""
+        mock_client = AsyncMock()
+        mock_client.index_integer_create = AsyncMock(side_effect=ClientError("real failure"))
+        mock_client.info_random_node = AsyncMock(return_value="")  # no indexes reported
+
+        db_patch, client_patch = _patch_client(mock_client)
+        with db_patch, client_patch:
+            response = await http_client.post(
+                "/api/v1/indexes/conn-test",
+                json={
+                    "namespace": "test",
+                    "set": "demo",
+                    "bin": "score",
+                    "name": "qa_idx",
+                    "type": "numeric",
+                },
+            )
+
+        assert response.status_code == 500
+        body = response.json()
+        # The improved 500 handler now surfaces requestId + error message.
+        assert "requestId" in body
+        assert "real failure" in body.get("error", "")
+
+    async def test_delete_returns_204_when_drop_raises_but_index_already_gone(
+        self,
+        http_client: AsyncClient,
+    ):
+        mock_client = AsyncMock()
+        mock_client.index_remove = AsyncMock(side_effect=ClientError("drop wait blew up"))
+        mock_client.info_random_node = AsyncMock(return_value="")  # no indexes — already gone
+
+        db_patch, client_patch = _patch_client(mock_client)
+        with db_patch, client_patch:
+            response = await http_client.delete(
+                "/api/v1/indexes/conn-test",
+                params={"name": "qa_idx", "ns": "test"},
+            )
+
+        assert response.status_code == 204
+        assert response.text == ""
+
+    async def test_delete_propagates_when_index_still_exists(self, http_client: AsyncClient):
+        mock_client = AsyncMock()
+        mock_client.index_remove = AsyncMock(side_effect=ClientError("actual drop failure"))
+        mock_client.info_random_node = AsyncMock(
+            return_value="ns=test:indexname=qa_idx:set=demo:bin=score:type=numeric"
+        )
+
+        db_patch, client_patch = _patch_client(mock_client)
+        with db_patch, client_patch:
+            response = await http_client.delete(
+                "/api/v1/indexes/conn-test",
+                params={"name": "qa_idx", "ns": "test"},
+            )
+
+        assert response.status_code == 500
+
+
+# ---------------------------------------------------------------------------
+# 500 handler — common ask in #257/#260: include requestId + error in body
+# ---------------------------------------------------------------------------
+
+
+class TestInternalErrorBody:
+    async def test_500_body_includes_request_id_and_error_message(self, http_client: AsyncClient):
+        mock_client = AsyncMock()
+        mock_client.index_integer_create = AsyncMock(side_effect=AerospikeError("boom"))
+        mock_client.info_random_node = AsyncMock(return_value="")
+
+        db_patch, client_patch = _patch_client(mock_client)
+        with db_patch, client_patch:
+            response = await http_client.post(
+                "/api/v1/indexes/conn-test",
+                # 32-char alphanumeric — TraceIDMiddleware accepts this as-is.
+                headers={"X-Request-ID": "abcd1234abcd1234abcd1234abcd1234"},
+                json={"namespace": "test", "set": "demo", "bin": "x", "name": "i", "type": "numeric"},
+            )
+
+        assert response.status_code == 500
+        body = response.json()
+        assert body["detail"] == "An internal server error occurred"
+        assert body["requestId"] == "abcd1234abcd1234abcd1234abcd1234"
+        assert body["error"] == "boom"
+        assert response.headers.get("X-Request-ID") == "abcd1234abcd1234abcd1234abcd1234"

--- a/ui/src/lib/types/sample-data.ts
+++ b/ui/src/lib/types/sample-data.ts
@@ -7,7 +7,9 @@ export interface CreateSampleDataRequest {
 
 export interface CreateSampleDataResponse {
   recordsCreated: number
+  recordsFailed: number
   indexesCreated: string[]
   indexesSkipped: string[]
+  indexesFailed: string[]
   elapsedMs: number
 }


### PR DESCRIPTION
## Summary
Resolves the bug reports filed 2026-05-01 that surfaced as `HTTP 500 + {"detail":"An internal server error occurred"}` with no debug context.

> Note: #258 (`pkType`) was already resolved on main via `resolve_pk` + `get_with_pk_fallback` and the `pkType` field on each model. No further action needed for that ticket.

| # | Endpoint | Root cause | Fix |
|---|---|---|---|
| #257 | `POST /sample-data` | A single failing `index_create` (typically the geo2dsphere `wait_till_complete`) aborted the request after some indexes had already been created. | Catch per-record + per-index errors and surface them in the response (`recordsFailed` / `indexesFailed`). Partial success becomes observable; retries are safe. |
| #259 | `GET /records`, `POST /records/{}/filter`, `POST /query` | The underlying `q.results()` raised on empty / sparse namespaces and the exception bubbled up. | Catch `AerospikeError` and return a well-formed empty page. `RustPanicError` (#280) is *not* caught here — its dedicated 422 handler still fires. |
| #260 | `POST/DELETE /indexes` | aerospike-py's `task.wait_till_complete` raised after the underlying create/drop already committed, so a successful operation reported 500. | Catch `AerospikeError`, re-check existence via the sindex info command, return 201/204 when observed state matches the request. Real failures still surface as 500. |

The shared 500 handler now reads `request_id` from `TraceIDMiddleware`'s ContextVar and includes `requestId` + the underlying error message in the body — addresses the cross-cutting log-correlation ask in #257 and #260.

`ui/src/lib/types/sample-data.ts` kept in lockstep with the new response fields per the type-mirroring policy in `CLAUDE.md`.

## Test plan

- [x] `uv run pytest` — 285 tests pass (277 existing + 8 new in `test_api_500_regressions.py`)
- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format src tests` — clean
- [x] `uv run pyright src` — 0 errors
- [ ] Reviewer: kick off a real cluster, repro the `curl` recipes from each issue and confirm 4xx/2xx as expected

## Files

- `api/src/.../services/sample_data_service.py` — partial-failure handling
- `api/src/.../models/sample_data.py` — `recordsFailed` / `indexesFailed` in response
- `api/src/.../routers/{query,records,indexes}.py` — defensive error handling
- `api/src/.../main.py` — 500 envelope now reads `request_id_var`, includes `requestId` + `error`
- `api/tests/test_api_500_regressions.py` — new regression suite (8 tests)
- `ui/src/lib/types/sample-data.ts` — type sync