### PR TITLE
fix(api): instrument FastAPI in setup_observability (closes #264)

### DIFF
--- a/api/src/aerospike_cluster_manager_api/observability.py
+++ b/api/src/aerospike_cluster_manager_api/observability.py
@@ -27,6 +27,7 @@ from typing import Any
 from opentelemetry import metrics, trace
 from opentelemetry._logs import set_logger_provider
 from opentelemetry.instrumentation.asyncpg import AsyncPGInstrumentor
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
 from opentelemetry.instrumentation.logging import LoggingInstrumentor
 from opentelemetry.sdk._logs import LoggerProvider
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
@@ -118,6 +119,12 @@ def setup_observability() -> bool:
     # attribute injection (otelTraceID/otelSpanID).
     LoggingInstrumentor().instrument(set_logging_format=False)
     AsyncPGInstrumentor().instrument()
+    # FastAPIInstrumentor must be invoked before the FastAPI app is constructed
+    # in main.py — setup_observability() runs at module import time, before
+    # `app = FastAPI(...)`, so the global instrument() form patches every app
+    # created afterwards. Without this, no HTTP request spans are produced and
+    # asyncpg child spans float without an HTTP parent (see #264).
+    FastAPIInstrumentor().instrument()
 
     _initialized = True
     logger.info("OpenTelemetry providers initialized")


### PR DESCRIPTION
## Summary

- `setup_observability()`가 `FastAPIInstrumentor`를 호출하지 않아, OTel을 켜도 collector에 HTTP request span이 한 개도 도달하지 않던 버그 수정. asyncpg child span만 부모 없이 떠다니던 문제.
- `setup_observability()`가 `app = FastAPI(...)` 생성 전(main.py:47 vs main.py:73)에 import-time으로 실행되므로, app 인자 없는 글로벌 `FastAPIInstrumentor().instrument()` 형태로 충분. 이후 생성되는 모든 FastAPI 앱이 패치됨.
- 의존성은 이미 `pyproject.toml`에 `opentelemetry-instrumentation-fastapi>=0.51b0`로 선언되어 있어 추가 작업 없음.

Closes #264

## Discovered During

ACKO e2e full mode (`aerospike-ce-kubernetes-operator/main@a46d1bc`, 2026-05-02) — Section 3 "OTel opt-in — runtime export" 검증 중. 환경변수(`OTEL_SDK_DISABLED=false`, `OTEL_EXPORTER_OTLP_*`)는 모두 정상 주입되었으나 collector 로그에 application span이 0건. 진단 결과 SDK는 init되지만 instrumentor가 빠져 있었음.

## Test plan

- [x] **In-proc verification (already run)** — `OTEL_SDK_DISABLED=false OTEL_TRACES_SAMPLER=always_on uv run python ...` + Starlette TestClient로 GET / 호출 시 라우트 핸들러가 `is_recording=True` + `trace_id != 0`인 span 안에서 실행됨을 확인.
- [x] `uv run ruff check src/aerospike_cluster_manager_api/observability.py` — pass.
- [x] `uv run ruff format --check ...` — already formatted.
- [ ] **Runtime verification (post-merge)** — ACKO Helm chart에 새 이미지가 배포된 뒤 e2e Section 3 OTel runtime 체크가 다음을 만족해야 함:
  - collector logs에 `service.name=aerospike-cluster-manager-api` resource span 등장
  - 동일 Trace ID 안에 parent HTTP span (`Name: GET /api/v1/connections`, `http.method=GET`, `http.route=...`) + child asyncpg `SELECT` span
- [ ] **Default-disabled regression check** — `OTEL_SDK_DISABLED=true`(기본값)일 때 변경된 코드는 그 어떤 instrumentor도 호출하지 않아야 함 — `setup_observability()`의 early-return은 그대로이므로 회귀 위험 없음.

## Risk

- 매우 낮음. 글로벌 `FastAPIInstrumentor().instrument()`는 이미 패치된 앱은 무시하고, 패치 자체는 OTel SDK가 활성화될 때만 실행됨.
- 기본 설정(`OTEL_SDK_DISABLED=true`)인 사용자에게는 코드 경로가 바뀌지 않음.