### PR TITLE
feat(docker): add backend target stage for API-only deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,41 @@ COPY backend/src/ src/
 RUN uv sync --frozen --no-dev
 
 # =============================================================================
-# Stage 3: Production runtime (Python + Node.js)
+# Stage 3a: Backend-only runtime (FastAPI on :8000)
+# Used by ACKO helm chart `ui.api` deployment. Equivalent to
+# `cd backend && uv run uvicorn aerospike_cluster_manager_api.main:app`.
+# =============================================================================
+FROM python:3.13-slim AS backend
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+COPY --from=backend-builder /app/backend /app/backend
+
+WORKDIR /app/backend
+
+RUN groupadd --gid 1001 appuser \
+    && useradd --uid 1001 --gid appuser --shell /bin/false --create-home appuser \
+    && mkdir -p /app/data \
+    && chown -R appuser:appuser /app /app/backend \
+    && chmod 755 /app/data
+
+USER appuser
+
+ENV SQLITE_PATH=/app/data/connections.db
+ENV PATH="/app/backend/.venv/bin:${PATH}"
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=10s --timeout=5s --retries=3 --start-period=15s \
+    CMD curl -f http://localhost:8000/api/health || exit 1
+
+ENTRYPOINT ["uv", "run", "--no-sync", "uvicorn", "aerospike_cluster_manager_api.main:app", "--host", "0.0.0.0", "--port", "8000"]
+
+# =============================================================================
+# Stage 3: Production runtime (Python + Node.js — combined for podman compose)
 # =============================================================================
 FROM python:3.13-slim AS runtime
 


### PR DESCRIPTION
## Summary

- Add a slim `backend` Docker stage that runs only the FastAPI app on `:8000` (uvicorn ENTRYPOINT, non-root, `/api/health` healthcheck), reusing the existing `backend-builder` artifacts.
- The combined `runtime` stage (Python + Node.js + entrypoint.sh) is unchanged — podman compose and the single-image build path keep working.
- Motivation: ACKO helm chart deploys the API and the Web UI as independent Deployments (`ui.api` / `ui.web`). The combined `runtime` was mismatched with `ui.api`, and ACKO's `Makefile` was looking for a non-existent `Dockerfile.backend`. With `--target backend`, ACKO can build the right image from this single Dockerfile.

## Test plan

- [ ] `podman build --target backend -f Dockerfile -t aerospike-cluster-manager-api:latest .` produces a working image.
- [ ] Container responds on `:8000/api/health` returning `{"status":"ok"}`.
- [ ] Default build (`podman build .`) still produces the combined `runtime` image (unchanged behaviour).
- [ ] Used by ACKO `make run-local` and verified end-to-end against an `aerospike-cluster-manager-api` Service via `kubectl port-forward`.