### PR TITLE
fix(docker): backend stage references renamed api-builder + /app/api paths

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,31 +28,31 @@ COPY api/src/ src/
 RUN uv sync --frozen --no-dev
 
 # =============================================================================
-# Stage 3a: Backend-only runtime (FastAPI on :8000)
+# Stage 3a: API-only runtime (FastAPI on :8000)
 # Used by ACKO helm chart `ui.api` deployment. Equivalent to
-# `cd backend && uv run uvicorn aerospike_cluster_manager_api.main:app`.
+# `cd api && uv run uvicorn aerospike_cluster_manager_api.main:app`.
 # =============================================================================
-FROM python:3.13-slim AS backend
+FROM python:3.14-slim AS backend
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
-COPY --from=backend-builder /app/backend /app/backend
+COPY --from=api-builder /app/api /app/api
 
-WORKDIR /app/backend
+WORKDIR /app/api
 
 RUN groupadd --gid 1001 appuser \
     && useradd --uid 1001 --gid appuser --shell /bin/false --create-home appuser \
     && mkdir -p /app/data \
-    && chown -R appuser:appuser /app /app/backend \
+    && chown -R appuser:appuser /app /app/api \
     && chmod 755 /app/data
 
 USER appuser
 
 ENV SQLITE_PATH=/app/data/connections.db
-ENV PATH="/app/backend/.venv/bin:${PATH}"
+ENV PATH="/app/api/.venv/bin:${PATH}"
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary

PR #266 added a `backend` target stage that referenced `backend-builder` and `/app/backend/`. It merged at the same time as the rename of the combined runtime stages (`backend-builder` → `api-builder`, `frontend-*` → `ui-*`, Python 3.13 → 3.14), so the new stage now points at names that no longer exist — `podman build --target backend .` fails with `unknown stage: backend-builder`.

## Changes

- `--from=backend-builder` → `--from=api-builder`
- `WORKDIR /app/backend` → `WORKDIR /app/api`
- `chown` / `ENV PATH` / venv paths follow the same rename
- Base image bumped to `python:3.14-slim` to match `api-builder`

ENTRYPOINT and `EXPOSE 8000` unchanged (the FastAPI module path `aerospike_cluster_manager_api.main:app` was not renamed).

## Test plan

- [ ] `podman build --target backend -f Dockerfile -t aerospike-cluster-manager-api:latest .` succeeds.
- [ ] Container responds on `:8000/api/health` returning `{"status":"ok"}`.
- [ ] Default `runtime` build is unaffected.
- [ ] Used by ACKO `make run-local` (PR aerospike-ce-kubernetes-operator#237).