### PR TITLE
fix(ui): Add filter popover overlap & tooltip bleed-through (#268)

### DIFF
--- a/ui/src/components/Popover.tsx
+++ b/ui/src/components/Popover.tsx
@@ -71,7 +71,7 @@ const PopoverContent = React.forwardRef<
           avoidCollisions
           className={cx(
             // base
-            "max-h-[var(--radix-popper-available-height)] min-w-60 overflow-hidden rounded-md border p-2.5 text-sm shadow-md",
+            "z-50 max-h-[var(--radix-popper-available-height)] min-w-60 overflow-hidden rounded-md border p-2.5 text-sm shadow-md",
             // border color
             "border-gray-200 dark:border-gray-800",
             // text color

--- a/ui/src/components/browser/RecordFilters.tsx
+++ b/ui/src/components/browser/RecordFilters.tsx
@@ -199,9 +199,11 @@ export function RecordFilters({
                 "dark:border-gray-700 dark:text-gray-400 dark:hover:border-gray-600 dark:hover:bg-gray-900 dark:hover:text-gray-50",
               )}
               title={
-                availableBins.length === 0
-                  ? "No secondary indexes found — create an index to enable filtering"
-                  : `${availableBins.length} indexed bin(s) available`
+                pickerOpen
+                  ? undefined
+                  : availableBins.length === 0
+                    ? "No secondary indexes found — create an index to enable filtering"
+                    : `${availableBins.length} indexed bin(s) available`
               }
             >
               {availableBins.length > 0 ? (
@@ -265,7 +267,7 @@ export function RecordFilters({
         )}
       </div>
 
-      {availableBins.length === 0 && (
+      {availableBins.length === 0 && !pickerOpen && (
         <p className="text-[11px] text-gray-500 dark:text-gray-500">
           Bin filters require a ready secondary index on this namespace/set. Use
           the Indexes tab to create one. Primary-key lookup above works without


### PR DESCRIPTION
## Summary
- Closes #268. The Records-view **Add filter** popover (`RecordFilters.tsx`) clipped the inline *"Bin filters require a ready secondary index…"* help text below it and let fragments of the trigger button's native `title` browser tooltip leak around the popover.
- Suppress the trigger's `title` while the popover is open so the OS-level tooltip can't render above the Radix Portal popover.
- Hide the redundant inline help paragraph while the picker is open — the popover's own empty state (`No indexed bins found / Create a secondary index on the Indexes tab to enable filtering.`) already conveys the same guidance, eliminating the visual clip.
- Add `z-50` to `PopoverContent` as defense-in-depth against ad-hoc stacking contexts in any page that hosts the popover.

## Why this is the right shape
The popover is portaled to `<body>` so DOM order alone should put it above the help text. Two real culprits remain:
1. The popover is `w-[240px]` while the help text below is full-width, so the help text leaks out at the sides — looking like z-index "bleed-through" even though it isn't.
2. The native `title=` tooltip is rendered by the browser, **outside** the React tree, and can paint above any portal — that's the source of the "…found" / "the Indexes tab" / "…g." fragments seen behind the popover.

Both are addressed without changing functionality (PK lookup + Add filter still work).

## Test plan
- [ ] `cd ui && npm run type-check`  — passes (verified locally)
- [ ] `cd ui && npm run lint`  — clean (verified locally)
- [ ] `cd ui && npm run format:check`  — clean (verified locally)
- [ ] Manual: open `/clusters/<id>` → Namespaces → a set with no secondary indexes → click **Add filter** → confirm popover renders cleanly with no inline help text overlap and no native tooltip leaking through.
- [ ] Manual: same flow on a set **with** indexes → confirm popover lists bins and inline help is not shown (correct prior behavior preserved).
- [ ] Manual: dark mode regression check.