### PR TITLE
fix(ui): stable React keys for Stepper editable lists (#273)

### DIFF
--- a/ui/src/components/k8s/create-cluster-wizard/StepAdvanced.tsx
+++ b/ui/src/components/k8s/create-cluster-wizard/StepAdvanced.tsx
@@ -5,6 +5,7 @@ import { Card } from "@/components/Card"
 import { Checkbox } from "@/components/Checkbox"
 import { Input } from "@/components/Input"
 import { Label } from "@/components/Label"
+import { useStableListKeys } from "@/hooks/use-stable-list-keys"
 import type {
   ACLConfig,
   ACLRoleSpec,
@@ -140,8 +141,20 @@ function AclSection({ form, updateForm }: StepAdvancedProps) {
   const set = (patch: Partial<ACLConfig>) =>
     updateForm({ acl: { ...acl, ...patch } })
 
+  const {
+    keys: roleKeys,
+    notifyAdd: addRoleKey,
+    notifyRemove: removeRoleKey,
+  } = useStableListKeys(acl.roles?.length ?? 0)
+  const {
+    keys: userKeys,
+    notifyAdd: addUserKey,
+    notifyRemove: removeUserKey,
+  } = useStableListKeys(acl.users?.length ?? 0)
+
   const addRole = () => {
     const role: ACLRoleSpec = { name: "", privileges: [], whitelist: null }
+    addRoleKey()
     set({ roles: [...(acl.roles ?? []), role] })
   }
   const updateRole = (i: number, patch: Partial<ACLRoleSpec>) => {
@@ -150,11 +163,14 @@ function AclSection({ form, updateForm }: StepAdvancedProps) {
     )
     set({ roles })
   }
-  const removeRole = (i: number) =>
+  const removeRole = (i: number) => {
+    removeRoleKey(i)
     set({ roles: (acl.roles ?? []).filter((_, idx) => idx !== i) })
+  }
 
   const addUser = () => {
     const user: ACLUserSpec = { name: "", secretName: "", roles: [] }
+    addUserKey()
     set({ users: [...(acl.users ?? []), user] })
   }
   const updateUser = (i: number, patch: Partial<ACLUserSpec>) => {
@@ -163,8 +179,10 @@ function AclSection({ form, updateForm }: StepAdvancedProps) {
     )
     set({ users })
   }
-  const removeUser = (i: number) =>
+  const removeUser = (i: number) => {
+    removeUserKey(i)
     set({ users: (acl.users ?? []).filter((_, idx) => idx !== i) })
+  }
 
   return (
     <Section title="Security (ACL)" summary={summary}>
@@ -212,7 +230,7 @@ function AclSection({ form, updateForm }: StepAdvancedProps) {
               </div>
               {(acl.roles ?? []).map((role, i) => (
                 <div
-                  key={i}
+                  key={roleKeys[i]}
                   className="flex flex-col gap-3 rounded-md border border-gray-200 p-3 dark:border-gray-800"
                 >
                   <div className="flex items-center justify-between">
@@ -268,7 +286,7 @@ function AclSection({ form, updateForm }: StepAdvancedProps) {
               </div>
               {(acl.users ?? []).map((user, i) => (
                 <div
-                  key={i}
+                  key={userKeys[i]}
                   className="flex flex-col gap-3 rounded-md border border-gray-200 p-3 dark:border-gray-800"
                 >
                   <div className="flex items-center justify-between">
@@ -401,10 +419,17 @@ function RackConfigSection({ form, updateForm }: StepAdvancedProps) {
   const set = (patch: Partial<typeof rc>) =>
     updateForm({ rackConfig: { ...rc, ...patch } })
 
+  const {
+    keys: rackKeys,
+    notifyAdd: addRackKey,
+    notifyRemove: removeRackKey,
+  } = useStableListKeys(racks.length)
+
   const addRack = () => {
     const nextId =
       (racks.reduce((max, r) => Math.max(max, r.id ?? 0), 0) || 0) + 1
     const rack: RackConfig = { id: nextId }
+    addRackKey()
     set({ racks: [...racks, rack] })
   }
 
@@ -414,8 +439,10 @@ function RackConfigSection({ form, updateForm }: StepAdvancedProps) {
     })
   }
 
-  const removeRack = (i: number) =>
+  const removeRack = (i: number) => {
+    removeRackKey(i)
     set({ racks: racks.filter((_, idx) => idx !== i) })
+  }
 
   return (
     <Section title="Rack Config" summary={summary}>
@@ -480,7 +507,7 @@ function RackConfigSection({ form, updateForm }: StepAdvancedProps) {
 
         {racks.map((rack, i) => (
           <div
-            key={i}
+            key={rackKeys[i]}
             className="flex flex-col gap-3 rounded-md border border-gray-200 p-3 dark:border-gray-800"
           >
             <div className="flex items-center justify-between">
@@ -575,6 +602,11 @@ function PodSettingsSection({ form, updateForm }: StepAdvancedProps) {
     Boolean(meta.annotations && Object.keys(meta.annotations).length)
 
   const tolerations = ps.tolerations ?? []
+  const {
+    keys: tolerationKeys,
+    notifyAdd: addTolerationKey,
+    notifyRemove: removeTolerationKey,
+  } = useStableListKeys(tolerations.length)
   const addToleration = () => {
     const t: TolerationConfig = {
       key: "",
@@ -582,6 +614,7 @@ function PodSettingsSection({ form, updateForm }: StepAdvancedProps) {
       value: "",
       effect: "NoSchedule",
     }
+    addTolerationKey()
     set({ tolerations: [...tolerations, t] })
   }
   const updateToleration = (i: number, patch: Partial<TolerationConfig>) =>
@@ -590,8 +623,10 @@ function PodSettingsSection({ form, updateForm }: StepAdvancedProps) {
         idx === i ? { ...t, ...patch } : t,
       ),
     })
-  const removeToleration = (i: number) =>
+  const removeToleration = (i: number) => {
+    removeTolerationKey(i)
     set({ tolerations: tolerations.filter((_, idx) => idx !== i) })
+  }
 
   return (
     <Section title="Pod Settings" summary={changed ? "Customized" : "Default"}>
@@ -696,7 +731,7 @@ function PodSettingsSection({ form, updateForm }: StepAdvancedProps) {
           )}
           {tolerations.map((t, i) => (
             <div
-              key={i}
+              key={tolerationKeys[i]}
               className="grid grid-cols-1 gap-2 rounded-md border border-gray-200 p-3 md:grid-cols-5 dark:border-gray-800"
             >
               <Input
@@ -796,10 +831,17 @@ function ContainerList({
   value: SidecarConfig[]
   onChange: (next: SidecarConfig[]) => void
 }) {
-  const add = () => onChange([...value, { name: "", image: "" }])
+  const { keys, notifyAdd, notifyRemove } = useStableListKeys(value.length)
+  const add = () => {
+    notifyAdd()
+    onChange([...value, { name: "", image: "" }])
+  }
   const update = (i: number, patch: Partial<SidecarConfig>) =>
     onChange(value.map((c, idx) => (idx === i ? { ...c, ...patch } : c)))
-  const remove = (i: number) => onChange(value.filter((_, idx) => idx !== i))
+  const remove = (i: number) => {
+    notifyRemove(i)
+    onChange(value.filter((_, idx) => idx !== i))
+  }
 
   return (
     <div className="flex flex-col gap-2">
@@ -814,7 +856,7 @@ function ContainerList({
       {value.length === 0 && <p className="text-xs text-gray-500">None.</p>}
       {value.map((c, i) => (
         <div
-          key={i}
+          key={keys[i]}
           className="grid grid-cols-1 gap-3 rounded-md border border-gray-200 p-3 md:grid-cols-2 dark:border-gray-800"
         >
           <div className="flex flex-col gap-1.5">

--- a/ui/src/components/k8s/create-cluster-wizard/StepNamespaceStorage.tsx
+++ b/ui/src/components/k8s/create-cluster-wizard/StepNamespaceStorage.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/Button"
 import { Card } from "@/components/Card"
 import { Input } from "@/components/Input"
 import { Label } from "@/components/Label"
+import { useStableListKeys } from "@/hooks/use-stable-list-keys"
 import { cx } from "@/lib/utils"
 import { CE_LIMITS } from "@/lib/validations/k8s"
 import type {
@@ -50,6 +51,12 @@ export function StepNamespaceStorage({
     updateForm({ namespaces })
   }
 
+  const {
+    keys: nsKeys,
+    notifyAdd: addNsKey,
+    notifyRemove: removeNsKey,
+  } = useStableListKeys(namespaces.length)
+
   const updateNamespace = (
     i: number,
     patch: Partial<AerospikeNamespaceConfig>,
@@ -62,6 +69,7 @@ export function StepNamespaceStorage({
 
   const addNamespace = () => {
     if (namespaces.length >= CE_LIMITS.MAX_CE_NAMESPACES) return
+    addNsKey()
     updateForm({
       namespaces: [
         ...namespaces,
@@ -72,6 +80,7 @@ export function StepNamespaceStorage({
 
   const removeNamespace = (i: number) => {
     if (namespaces.length <= 1) return
+    removeNsKey(i)
     updateForm({ namespaces: namespaces.filter((_, idx) => idx !== i) })
   }
 
@@ -100,7 +109,7 @@ export function StepNamespaceStorage({
         const storageType = ns.storageEngine?.type ?? "memory"
         return (
           <div
-            key={i}
+            key={nsKeys[i]}
             className="flex flex-col gap-4 rounded-md border border-gray-200 p-4 dark:border-gray-800"
           >
             <div className="flex items-center justify-between">

--- a/ui/src/hooks/use-stable-list-keys.ts
+++ b/ui/src/hooks/use-stable-list-keys.ts
@@ -1,0 +1,37 @@
+"use client"
+
+import { useRef } from "react"
+
+/**
+ * Maintains a parallel array of stable React keys for an externally
+ * controlled, append/remove-only list. Use to key Stepper editable
+ * lists whose entries serialize into a server-payload type and have
+ * no natural id of their own. The consumer must call
+ * `notifyAdd()` / `notifyRemove(i)` whenever the source list grows
+ * or shrinks so the parallel keys array stays index-aligned.
+ *
+ * Why: keying such lists by `index` causes focus, IME composition,
+ * and uncontrolled DOM state to leak from a removed entry into the
+ * surviving entry that takes its slot.
+ */
+export function useStableListKeys(currentLength: number) {
+  const keysRef = useRef<string[]>([])
+
+  // Defensive realignment if the source array changes outside the
+  // notify* helpers (e.g., form prefill on first render, async fill).
+  while (keysRef.current.length < currentLength) {
+    keysRef.current.push(crypto.randomUUID())
+  }
+  if (keysRef.current.length > currentLength) {
+    keysRef.current = keysRef.current.slice(0, currentLength)
+  }
+
+  const notifyAdd = () => {
+    keysRef.current = [...keysRef.current, crypto.randomUUID()]
+  }
+  const notifyRemove = (i: number) => {
+    keysRef.current = keysRef.current.filter((_, idx) => idx !== i)
+  }
+
+  return { keys: keysRef.current, notifyAdd, notifyRemove }
+}


### PR DESCRIPTION
## Summary
- Closes #273. Six editable lists in the K8s cluster wizard (Namespaces, ACL Roles, ACL Users, Racks, Tolerations, Sidecars/Init Containers) were keyed by array index. Removing item N caused item N+1 to inherit the React mount slot — and with it focus, IME composition, and uncontrolled DOM state. Typing under Korean/Japanese IME silently landed on the wrong row.
- Add a small helper hook `useStableListKeys` that maintains a parallel UUID keys array index-aligned with the source data. Each add/remove handler calls `notifyAdd()` / `notifyRemove(i)` so the keys array tracks the source list.
- Keys live in a `useRef`, not in the form payload — so the wizard's K8s CRD types stay untouched and `cleanupPayload` needs no change.

## Why this shape
- Two alternatives considered:
  1. **Per-entry `_clientId?: string` field** on six payload types + a `cleanupPayload` strip pass. Smaller per-list code but enlarges the surface in `lib/types/k8s.ts`.
  2. **WeakMap-keyed by entry reference**. Breaks under immutable updates: every `update(i, patch)` produces a new entry object → new key → input unmounts → focus loss every keystroke.
- The hook is the minimum-surface fix that holds under React's reconciliation contract.

## Files changed
- `ui/src/hooks/use-stable-list-keys.ts` (new)
- `ui/src/components/k8s/create-cluster-wizard/StepNamespaceStorage.tsx`
- `ui/src/components/k8s/create-cluster-wizard/StepAdvanced.tsx`

## Test plan
- [x] `cd ui && npm run type-check` — passes
- [x] `cd ui && npm run lint` — clean
- [x] `cd ui && npm run build` — clean
- [x] `cd ui && npx prettier --check` on the three touched files — clean
- [ ] Manual: open the wizard → Advanced → ACL → add 3 users → focus username on user 2 with IME composition → remove user 1 → verify focus and composition stay on the originally-second user (now user 1).
- [ ] Manual: same drill on Namespaces, Racks, Tolerations, Sidecars.

A Vitest regression test is part of the UI test-infra follow-up issue #277.