### PR TITLE
fix(ui): records table z-index + long string bin truncation (#271)

### DIFF
--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
@@ -139,7 +139,10 @@ function renderBin(v: unknown, name: string): React.ReactNode {
   }
   const s = String(v)
   return (
-    <span className="font-mono text-xs text-gray-900 dark:text-gray-50">
+    <span
+      title={s}
+      className="block max-w-[20rem] truncate font-mono text-xs text-gray-900 dark:text-gray-50"
+    >
       {s}
     </span>
   )
@@ -367,7 +370,7 @@ export default function RecordBrowserPage({ params }: PageProps) {
           <Table>
             <TableHead>
               <TableRow>
-                <TableHeaderCell className="sticky left-0 z-10 bg-white dark:bg-[#090E1A]">
+                <TableHeaderCell className="sticky left-0 z-20 bg-white dark:bg-[#090E1A]">
                   Primary key
                 </TableHeaderCell>
                 <TableHeaderCell className="text-right">Gen</TableHeaderCell>


### PR DESCRIPTION
## Summary
- Closes #271. Two related layout defects in the records browser at \`/clusters/[id]/sets/[ns]/[set]\`.

### 1. Sticky header z-index
Header sticky cell and body sticky cell both used \`z-10\`. On horizontal scroll the body row content could render over the header at the top-left intersection. Header is now \`z-20\`; body cells remain \`z-10\`.

### 2. Long string bin → table width blowup
\`renderBin\` rendered plain \`<span>{String(v)}</span>\` for string bins with no max-width and no \`title\`. A single multi-KB string bin pushed the table several screens wide. String values now render in \`block max-w-[20rem] truncate\` with \`title={s}\` so the full value is recoverable on hover. Other bin kinds (integer, double, bool, list, map, geojson) already had their own \`max-w-[Nrem] truncate\` treatment in their badges and are unchanged.

## Files changed
- \`ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx\`

## Test plan
- [x] \`cd ui && npm run type-check\` — passes
- [x] \`cd ui && npm run lint\` — clean
- [x] \`cd ui && npx prettier --check\` on the touched file — clean
- [ ] Manual: insert a record with a 5KB random string bin, open the records view, confirm the cell truncates and the table fits the viewport. Hover the cell to confirm the native title shows the full value.
- [ ] Manual: horizontally scroll the records table; the Primary-key header stays above body sticky cells (no row content peeks through at the top-left).