### PR TITLE
fix(ui): replace native title= with Tooltip on remaining #268 sites (#272)

### DIFF
--- a/ui/src/components/browser/RecordFilters.tsx
+++ b/ui/src/components/browser/RecordFilters.tsx
@@ -11,6 +11,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { Button } from "@/components/Button"
 import { Input } from "@/components/Input"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/Popover"
+import { Tooltip } from "@/components/Tooltip"
 import {
   Select,
   SelectContent,
@@ -405,14 +406,19 @@ function ConditionChip({
   return (
     <div className="flex items-center gap-1.5">
       {leadingLogic && (
-        <button
-          type="button"
-          onClick={onToggleLogic}
-          title={`Switch to ${leadingLogic === "and" ? "OR" : "AND"} logic`}
-          className="inline-flex h-6 items-center rounded bg-gray-100 px-1.5 font-mono text-[10px] font-semibold uppercase tracking-wider text-gray-600 hover:bg-gray-200 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-gray-800"
+        <Tooltip
+          content={`Switch to ${leadingLogic === "and" ? "OR" : "AND"} logic`}
+          side="top"
+          triggerAsChild
         >
-          {leadingLogic}
-        </button>
+          <button
+            type="button"
+            onClick={onToggleLogic}
+            className="inline-flex h-6 items-center rounded bg-gray-100 px-1.5 font-mono text-[10px] font-semibold uppercase tracking-wider text-gray-600 hover:bg-gray-200 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-gray-800"
+          >
+            {leadingLogic}
+          </button>
+        </Tooltip>
       )}
       <Popover open={editing} onOpenChange={onOpenChange}>
         <PopoverTrigger asChild>

--- a/ui/src/components/ui/navigation/Sidebar.tsx
+++ b/ui/src/components/ui/navigation/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from "@/components/Accordion"
+import { Tooltip } from "@/components/Tooltip"
 import { useConnections } from "@/hooks/use-connections"
 import { useK8sClusters } from "@/hooks/use-k8s-clusters"
 import { getCluster } from "@/lib/api/clusters"
@@ -210,7 +211,6 @@ function BrandCard({ active }: { active?: boolean }) {
     <Link
       href="/clusters"
       aria-label="All clusters"
-      title="All clusters"
       className={cx(
         "flex items-center gap-3 rounded-md px-2 py-1.5 transition",
         active
@@ -311,24 +311,25 @@ function ClusterNode({
             : "text-gray-700 dark:text-gray-400",
         )}
       >
-        <Link
-          href={`/clusters/${cluster.id}`}
-          title={cluster.name}
-          className={cx(
-            "flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium",
-            focusRing,
-          )}
-        >
-          <RiStackLine className="size-4 shrink-0" aria-hidden="true" />
-          <span className="min-w-0 flex-1 truncate font-mono">
-            {displayName}
-          </span>
-          {cluster.managedBy === "ACKO" && (
-            <span className="shrink-0 rounded bg-indigo-50 px-1.5 text-[10px] font-semibold uppercase tracking-wider text-indigo-600 dark:bg-indigo-950/40 dark:text-indigo-400">
-              ACKO
+        <Tooltip content={cluster.name} side="right" triggerAsChild>
+          <Link
+            href={`/clusters/${cluster.id}`}
+            className={cx(
+              "flex min-w-0 flex-1 items-center gap-2 rounded-md px-2 py-1.5 text-sm font-medium",
+              focusRing,
+            )}
+          >
+            <RiStackLine className="size-4 shrink-0" aria-hidden="true" />
+            <span className="min-w-0 flex-1 truncate font-mono">
+              {displayName}
             </span>
-          )}
-        </Link>
+            {cluster.managedBy === "ACKO" && (
+              <span className="shrink-0 rounded bg-indigo-50 px-1.5 text-[10px] font-semibold uppercase tracking-wider text-indigo-600 dark:bg-indigo-950/40 dark:text-indigo-400">
+                ACKO
+              </span>
+            )}
+          </Link>
+        </Tooltip>
         <AccordionPrimitives.Trigger
           aria-label={`Toggle ${displayName} namespaces`}
           className={cx(
@@ -431,16 +432,21 @@ function NamespaceNode({
                   if (s.objects === 0) {
                     return (
                       <li key={s.name}>
-                        <span
-                          aria-disabled="true"
-                          title="Empty set"
-                          className={cx(
-                            "relative flex cursor-not-allowed items-center rounded-md py-1 pl-10 pr-2 font-mono text-sm",
-                            "text-gray-400 opacity-70 dark:text-gray-600",
-                          )}
+                        <Tooltip
+                          content="Empty set"
+                          side="right"
+                          triggerAsChild
                         >
-                          {s.name}
-                        </span>
+                          <span
+                            aria-disabled="true"
+                            className={cx(
+                              "relative flex cursor-not-allowed items-center rounded-md py-1 pl-10 pr-2 font-mono text-sm",
+                              "text-gray-400 opacity-70 dark:text-gray-600",
+                            )}
+                          >
+                            {s.name}
+                          </span>
+                        </Tooltip>
                       </li>
                     )
                   }


### PR DESCRIPTION
## Summary
- Closes #272. The fix in #268 (PR #269) removed the native `title=` from the Add filter button only. Three more sites in the codebase still mixed a `title=` attribute with a portaled floating layer next to it — the OS tooltip can paint above the portal.
- Replace the offending `title=` attributes with the in-app Tremor Raw `<Tooltip>` (portaled, `z-50`, same stacking contract as `PopoverContent`).

## Files changed
- `ui/src/components/browser/RecordFilters.tsx` — AND/OR toggle button (sibling of the ConditionChip editor Popover).
- `ui/src/components/ui/navigation/Sidebar.tsx`:
  - Cluster link `<Link title={cluster.name}>` → `<Tooltip>`.
  - Empty-set `<span title="Empty set">` → `<Tooltip>`.
  - BrandCard `title="All clusters"` → dropped (already covered by `aria-label`, no information loss).

## Why Tooltip rather than removing every title
- Cluster names truncate in the sidebar; users still need a way to see the full name on hover. The in-app `<Tooltip>` provides that without the OS-rendered tooltip racing the popover layer.
- The AND/OR toggle relies on the tooltip text to teach the click affordance ("Switch to OR logic"); removing it would lose that hint.

## Test plan
- [x] `cd ui && npm run type-check` — passes
- [x] `cd ui && npm run lint` — clean
- [x] `cd ui && npm run build` — clean
- [x] `cd ui && npx prettier --check` on the two touched files — clean
- [ ] Manual: open a ConditionChip editor on the records page → hover the AND/OR toggle next to it → confirm the in-app tooltip renders above (or beside) the editor popover with no stray OS tooltip.
- [ ] Manual: open the workspaces dropdown / any sidebar popover → hover a cluster row with a long name → confirm the cluster-name tooltip renders cleanly with no OS tooltip leakage.