### PR TITLE
fix(ui): structured client-side error logging on every fetch failure (#276)

### DIFF
--- a/ui/src/app/(main)/acko/templates/page.tsx
+++ b/ui/src/app/(main)/acko/templates/page.tsx
@@ -14,6 +14,7 @@ import {
   TableRow,
 } from "@/components/Table"
 import { listK8sTemplates } from "@/lib/api/k8s"
+import { logFetchError } from "@/lib/api/log"
 import type { K8sTemplateSummary } from "@/lib/types/k8s"
 import { useCallback, useEffect, useState } from "react"
 
@@ -29,6 +30,7 @@ export default function AckoTemplatesPage() {
       const data = await listK8sTemplates()
       setTemplates(data)
     } catch (err) {
+      logFetchError("templates", err)
       setError(err instanceof Error ? err.message : String(err))
     } finally {
       setLoading(false)

--- a/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
@@ -17,6 +17,7 @@ import {
 } from "@/components/Table"
 import { listRoles, listUsers } from "@/lib/api/admin"
 import { ApiError } from "@/lib/api/client"
+import { logFetchError } from "@/lib/api/log"
 import type { AerospikeRole, AerospikeUser } from "@/lib/types/admin"
 import { RiShieldKeyholeLine } from "@remixicon/react"
 import { useCallback, useEffect, useState } from "react"
@@ -52,6 +53,7 @@ export default function AdminPage({ params }: PageProps) {
       setUsersState({ data: users, loading: false, error: null })
       setRolesState({ data: roles, loading: false, error: null })
     } catch (err) {
+      logFetchError("admin", err)
       if (err instanceof ApiError && err.status === 403) {
         // Backend EE_MSG: "Security is not enabled. Add a 'security { }' block ..."
         setSecurityDisabled(true)

--- a/ui/src/app/(main)/clusters/[clusterId]/secondary-indexes/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/secondary-indexes/page.tsx
@@ -15,6 +15,7 @@ import {
   TableRow,
 } from "@/components/Table"
 import { listIndexes } from "@/lib/api/indexes"
+import { logFetchError } from "@/lib/api/log"
 import type { SecondaryIndex, SecondaryIndexState } from "@/lib/types/index"
 import { useCallback, useEffect, useMemo, useState } from "react"
 import { Fragment } from "react"
@@ -43,6 +44,7 @@ export default function SecondaryIndexesPage({ params }: PageProps) {
       const data = await listIndexes(params.clusterId)
       setIndexes(data)
     } catch (err) {
+      logFetchError("sindex", err)
       setError(err instanceof Error ? err.message : String(err))
     } finally {
       setLoading(false)

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
@@ -29,6 +29,7 @@ import {
   SelectValue,
 } from "@/components/Select"
 import { listIndexes } from "@/lib/api/indexes"
+import { logFetchError } from "@/lib/api/log"
 import { filterRecords } from "@/lib/api/records"
 import { TableSkeleton } from "@/components/skeletons/TableSkeleton"
 import type { BinDataType } from "@/lib/types/query"
@@ -188,6 +189,7 @@ export default function RecordBrowserPage({ params }: PageProps) {
           executionTimeMs: resp.executionTimeMs,
         })
       } catch (err) {
+        logFetchError("records", err)
         setError(err instanceof Error ? err.message : String(err))
       } finally {
         setLoading(false)
@@ -218,7 +220,8 @@ export default function RecordBrowserPage({ params }: PageProps) {
       .then((data) => {
         if (!cancelled) setIndexes(data)
       })
-      .catch(() => {
+      .catch((err) => {
+        logFetchError("records-indexes", err)
         if (!cancelled) setIndexes([])
       })
     return () => {

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
@@ -8,6 +8,7 @@ import { Label } from "@/components/Label"
 import { RecordDetailSkeleton } from "@/components/skeletons/RecordDetailSkeleton"
 import { clusterSections } from "@/app/siteConfig"
 import { ApiError } from "@/lib/api/client"
+import { logFetchError } from "@/lib/api/log"
 import { deleteRecord, getRecordDetail, putRecord } from "@/lib/api/records"
 import type { AerospikeRecord, BinValue, PkType } from "@/lib/types/record"
 import Link from "next/link"
@@ -298,6 +299,7 @@ export default function RecordDetailPage({ params }: PageProps) {
         clusterSections.set(params.clusterId, params.namespace, params.set),
       )
     } catch (err) {
+      logFetchError("record-delete", err)
       if (err instanceof ApiError) setError(err.detail || err.message)
       else if (err instanceof Error) setError(err.message)
       else setError("Failed to delete record")
@@ -410,6 +412,7 @@ export default function RecordDetailPage({ params }: PageProps) {
       setDrafts([])
       await loadRecord()
     } catch (err) {
+      logFetchError("record-save", err)
       if (err instanceof ApiError) setError(err.detail || err.message)
       else if (err instanceof Error) setError(err.message)
       else setError("Failed to save record")

--- a/ui/src/app/(main)/clusters/[clusterId]/udfs/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/udfs/page.tsx
@@ -15,6 +15,7 @@ import {
   TableRow,
 } from "@/components/Table"
 import { listUdfs } from "@/lib/api/udfs"
+import { logFetchError } from "@/lib/api/log"
 import type { UDFModule } from "@/lib/types/udf"
 import { useCallback, useEffect, useMemo, useState } from "react"
 
@@ -33,6 +34,7 @@ export default function UdfsPage({ params }: PageProps) {
       const data = await listUdfs(params.clusterId)
       setUdfs(data)
     } catch (err) {
+      logFetchError("udfs", err)
       setError(err instanceof Error ? err.message : String(err))
     } finally {
       setLoading(false)

--- a/ui/src/hooks/use-cluster.ts
+++ b/ui/src/hooks/use-cluster.ts
@@ -8,6 +8,7 @@
 import { useCallback, useEffect, useState } from "react"
 
 import { getCluster } from "@/lib/api/clusters"
+import { logFetchError } from "@/lib/api/log"
 import type { ClusterInfo } from "@/lib/types/cluster"
 
 export interface UseClusterResult {
@@ -32,6 +33,7 @@ export function useCluster(
       const result = await getCluster(connId)
       setData(result)
     } catch (err) {
+      logFetchError("cluster", err)
       setError(err instanceof Error ? err : new Error(String(err)))
     } finally {
       setIsLoading(false)
@@ -55,6 +57,7 @@ export function useCluster(
           setError(null)
         }
       } catch (err) {
+        logFetchError("cluster", err)
         if (!cancelled) {
           setError(err instanceof Error ? err : new Error(String(err)))
         }

--- a/ui/src/hooks/use-connections.ts
+++ b/ui/src/hooks/use-connections.ts
@@ -8,6 +8,7 @@
 import { useCallback, useEffect, useState } from "react"
 
 import { listConnections } from "@/lib/api/connections"
+import { logFetchError } from "@/lib/api/log"
 import type { ConnectionProfileResponse } from "@/lib/types/connection"
 
 export interface UseConnectionsResult {
@@ -29,6 +30,7 @@ export function useConnections(): UseConnectionsResult {
       const result = await listConnections()
       setData(result)
     } catch (err) {
+      logFetchError("connections", err)
       setError(err instanceof Error ? err : new Error(String(err)))
     } finally {
       setIsLoading(false)
@@ -45,6 +47,7 @@ export function useConnections(): UseConnectionsResult {
           setError(null)
         }
       } catch (err) {
+        logFetchError("connections", err)
         if (!cancelled) {
           setError(err instanceof Error ? err : new Error(String(err)))
         }

--- a/ui/src/hooks/use-event-stream.ts
+++ b/ui/src/hooks/use-event-stream.ts
@@ -8,6 +8,7 @@
 import { useEffect, useRef, useState } from "react"
 
 import { subscribeEvents, type EventSubscription } from "@/lib/api/events"
+import { logFetchError } from "@/lib/api/log"
 import type { SSEEvent } from "@/lib/types/events"
 
 export interface UseEventStreamOptions<T> {
@@ -47,6 +48,7 @@ export function useEventStream<T = unknown>(
         types,
         onOpen: () => setConnected(true),
         onError: (err) => {
+          logFetchError("event-stream", err)
           setError(err)
           setConnected(false)
         },
@@ -57,6 +59,7 @@ export function useEventStream<T = unknown>(
       })
     } catch (err) {
       // subscribeEvents throws on SSR — already guarded above, but be safe.
+      logFetchError("event-stream", err)
       setError(err as Event)
     }
 

--- a/ui/src/hooks/use-k8s-clusters.ts
+++ b/ui/src/hooks/use-k8s-clusters.ts
@@ -8,6 +8,7 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 
 import { listK8sClusters, type ListK8sClustersParams } from "@/lib/api/k8s"
+import { logFetchError } from "@/lib/api/log"
 import type { K8sClusterListResponse } from "@/lib/types/k8s"
 
 export interface UseK8sClustersResult {
@@ -37,6 +38,7 @@ export function useK8sClusters(
       const result = await listK8sClusters(paramsRef.current)
       setData(result)
     } catch (err) {
+      logFetchError("k8s-clusters", err)
       setError(err instanceof Error ? err : new Error(String(err)))
     } finally {
       setIsLoading(false)
@@ -54,6 +56,7 @@ export function useK8sClusters(
           setError(null)
         }
       } catch (err) {
+        logFetchError("k8s-clusters", err)
         if (!cancelled) {
           setError(err instanceof Error ? err : new Error(String(err)))
         }

--- a/ui/src/lib/api/log.ts
+++ b/ui/src/lib/api/log.ts
@@ -1,0 +1,25 @@
+"use client"
+
+import { ApiError } from "./client"
+
+/**
+ * Log a fetch failure with structured context.
+ *
+ * Goes through `console.error` so it shows up in DevTools and any
+ * downstream telemetry that hooks into console output. Extracts
+ * status/detail/body from `ApiError` to keep the payload terse;
+ * passes the raw error through otherwise.
+ */
+export function logFetchError(scope: string, err: unknown): void {
+  if (err instanceof ApiError) {
+    // eslint-disable-next-line no-console
+    console.error(`[${scope}] fetch failed`, {
+      status: err.status,
+      detail: err.detail,
+      body: err.body,
+    })
+    return
+  }
+  // eslint-disable-next-line no-console
+  console.error(`[${scope}] fetch failed`, err)
+}


### PR DESCRIPTION
## Summary
- Closes #276. Every `catch` site that handled a fetch failure surfaced a banner but never logged the error. Repeated Retry failures left no debug trail. Add a tiny `logFetchError(scope, err)` helper and call it from each catch.
- ApiError → log \`{ status, detail, body }\` so 4xx/5xx vs network/parse vs timeout are distinguishable in DevTools.
- Otherwise → raw error.
- Pure observability change. No user-visible behavior change.

## Files changed
- `ui/src/lib/api/log.ts` (new)
- 4 list pages, record/[key] page, admin page, 4 hooks — 14 catch sites total
- Records page's `listIndexes` swallow-all (`.catch(() => …)`) now logs before falling through (silent-failure audit F7)

## Why now
- Surfaced during the review of PR #274. Repeating the empty `setError(...)`-only pattern across the codebase makes triage of "the user clicked Retry three times" harder than it needs to be.
- `console.error` is allowed by the project's ESLint config (`no-console: warn` warns on `console.log` only).

## Test plan
- [x] `cd ui && npm run type-check` — passes
- [x] `cd ui && npm run lint` — clean
- [x] `cd ui && npm run build` — clean
- [x] `cd ui && npx prettier --check` on the touched files — clean
- [ ] Manual: open DevTools console, navigate to any list page on an unreachable cluster, click Retry — observe `[<scope>] fetch failed { status, detail, body }` in the console.

## Related
Follow-up #275 will branch UI surface on `ApiError.status` per the ui/CLAUDE.md "API error → UI state mapping" contract; this PR is pure logging and complementary.