### PR TITLE
fix(ui): branch on ApiError.status per ui/CLAUDE.md mapping contract (#275)

### DIFF
--- a/ui/src/app/(main)/acko/templates/page.tsx
+++ b/ui/src/app/(main)/acko/templates/page.tsx
@@ -13,6 +13,7 @@ import {
   TableRoot,
   TableRow,
 } from "@/components/Table"
+import { mapApiError } from "@/lib/api/error-mapping"
 import { listK8sTemplates } from "@/lib/api/k8s"
 import { logFetchError } from "@/lib/api/log"
 import type { K8sTemplateSummary } from "@/lib/types/k8s"
@@ -31,7 +32,7 @@ export default function AckoTemplatesPage() {
       setTemplates(data)
     } catch (err) {
       logFetchError("templates", err)
-      setError(err instanceof Error ? err.message : String(err))
+      setError(mapApiError(err).message)
     } finally {
       setLoading(false)
     }

--- a/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
@@ -16,7 +16,7 @@ import {
   TableRow,
 } from "@/components/Table"
 import { listRoles, listUsers } from "@/lib/api/admin"
-import { ApiError } from "@/lib/api/client"
+import { mapApiError } from "@/lib/api/error-mapping"
 import { logFetchError } from "@/lib/api/log"
 import type { AerospikeRole, AerospikeUser } from "@/lib/types/admin"
 import { RiShieldKeyholeLine } from "@remixicon/react"
@@ -54,16 +54,21 @@ export default function AdminPage({ params }: PageProps) {
       setRolesState({ data: roles, loading: false, error: null })
     } catch (err) {
       logFetchError("admin", err)
-      if (err instanceof ApiError && err.status === 403) {
-        // Backend EE_MSG: "Security is not enabled. Add a 'security { }' block ..."
+      const mapped = mapApiError(err)
+      // Admin endpoints refuse access either because security is off (CE
+      // default) or the connecting user lacks ACL — both surface as the
+      // same explanatory card here.
+      if (
+        mapped.kind === "security-disabled" ||
+        mapped.kind === "permission-denied"
+      ) {
         setSecurityDisabled(true)
         setUsersState({ data: null, loading: false, error: null })
         setRolesState({ data: null, loading: false, error: null })
         return
       }
-      const message = err instanceof Error ? err.message : String(err)
-      setUsersState({ data: null, loading: false, error: message })
-      setRolesState({ data: null, loading: false, error: message })
+      setUsersState({ data: null, loading: false, error: mapped.message })
+      setRolesState({ data: null, loading: false, error: mapped.message })
     }
   }, [params.clusterId])
 

--- a/ui/src/app/(main)/clusters/[clusterId]/secondary-indexes/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/secondary-indexes/page.tsx
@@ -14,6 +14,7 @@ import {
   TableRoot,
   TableRow,
 } from "@/components/Table"
+import { mapApiError } from "@/lib/api/error-mapping"
 import { listIndexes } from "@/lib/api/indexes"
 import { logFetchError } from "@/lib/api/log"
 import type { SecondaryIndex, SecondaryIndexState } from "@/lib/types/index"
@@ -45,7 +46,7 @@ export default function SecondaryIndexesPage({ params }: PageProps) {
       setIndexes(data)
     } catch (err) {
       logFetchError("sindex", err)
-      setError(err instanceof Error ? err.message : String(err))
+      setError(mapApiError(err).message)
     } finally {
       setLoading(false)
     }

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
@@ -28,6 +28,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/Select"
+import { mapApiError } from "@/lib/api/error-mapping"
 import { listIndexes } from "@/lib/api/indexes"
 import { logFetchError } from "@/lib/api/log"
 import { filterRecords } from "@/lib/api/records"
@@ -190,7 +191,7 @@ export default function RecordBrowserPage({ params }: PageProps) {
         })
       } catch (err) {
         logFetchError("records", err)
-        setError(err instanceof Error ? err.message : String(err))
+        setError(mapApiError(err).message)
       } finally {
         setLoading(false)
       }

--- a/ui/src/app/(main)/clusters/[clusterId]/udfs/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/udfs/page.tsx
@@ -14,6 +14,7 @@ import {
   TableRoot,
   TableRow,
 } from "@/components/Table"
+import { mapApiError } from "@/lib/api/error-mapping"
 import { listUdfs } from "@/lib/api/udfs"
 import { logFetchError } from "@/lib/api/log"
 import type { UDFModule } from "@/lib/types/udf"
@@ -35,7 +36,7 @@ export default function UdfsPage({ params }: PageProps) {
       setUdfs(data)
     } catch (err) {
       logFetchError("udfs", err)
-      setError(err instanceof Error ? err.message : String(err))
+      setError(mapApiError(err).message)
     } finally {
       setLoading(false)
     }

--- a/ui/src/lib/api/error-mapping.ts
+++ b/ui/src/lib/api/error-mapping.ts
@@ -1,0 +1,53 @@
+"use client"
+
+import { ApiError } from "./client"
+
+/**
+ * Mapped API error kinds. Pages branch on this discriminator to render
+ * the right UI surface per the ui/CLAUDE.md "API error → UI state mapping"
+ * contract:
+ *
+ *   - 403 with EE_MSG ("Security is not enabled…") → security-disabled card
+ *   - 403 otherwise                                 → permission-denied
+ *   - 404                                           → empty state for the resource
+ *   - 503                                           → banner + retry, do not hide page
+ *   - everything else                               → generic banner
+ */
+export type ApiErrorKind =
+  | { kind: "security-disabled"; message: string }
+  | { kind: "permission-denied"; message: string }
+  | { kind: "not-found"; message: string }
+  | { kind: "unreachable"; message: string }
+  | { kind: "generic"; message: string }
+
+const SECURITY_DISABLED_MARKERS = [
+  "security is not enabled",
+  "ee_msg",
+] as const
+
+function looksLikeSecurityDisabled(detail: string): boolean {
+  const lower = detail.toLowerCase()
+  return SECURITY_DISABLED_MARKERS.some((m) => lower.includes(m))
+}
+
+export function mapApiError(err: unknown): ApiErrorKind {
+  if (err instanceof ApiError) {
+    if (err.status === 403 && looksLikeSecurityDisabled(err.detail)) {
+      return { kind: "security-disabled", message: err.detail }
+    }
+    switch (err.status) {
+      case 403:
+        return { kind: "permission-denied", message: err.detail }
+      case 404:
+        return { kind: "not-found", message: err.detail }
+      case 503:
+        return { kind: "unreachable", message: err.detail }
+      default:
+        return { kind: "generic", message: err.detail }
+    }
+  }
+  return {
+    kind: "generic",
+    message: err instanceof Error ? err.message : String(err),
+  }
+}

--- a/ui/src/lib/api/error-mapping.ts
+++ b/ui/src/lib/api/error-mapping.ts
@@ -20,10 +20,7 @@ export type ApiErrorKind =
   | { kind: "unreachable"; message: string }
   | { kind: "generic"; message: string }
 
-const SECURITY_DISABLED_MARKERS = [
-  "security is not enabled",
-  "ee_msg",
-] as const
+const SECURITY_DISABLED_MARKERS = ["security is not enabled", "ee_msg"] as const
 
 function looksLikeSecurityDisabled(detail: string): boolean {
   const lower = detail.toLowerCase()


### PR DESCRIPTION
## Summary
- Closes #275. Catch handlers reduced every error to `err.message`, dropping the typed `ApiError.status`. `ui/CLAUDE.md` mandates per-status branching (403 with EE_MSG → security-disabled card; 404 → empty; 503 → banner+retry).
- Add `mapApiError(err)` returning a **discriminated union**: `security-disabled` / `permission-denied` / `not-found` / `unreachable` / `generic`. The 403 EE_MSG marker check (\"security is not enabled\" / \"ee_msg\") distinguishes CE security-off from a real ACL refusal.

## Files changed
- `ui/src/lib/api/error-mapping.ts` (new)
- `ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx` — drop the inline `instanceof ApiError && status === 403` check; use `mapApiError`. Both `security-disabled` and `permission-denied` surface as the existing `SecurityDisabledState` card (admin endpoints only refuse access when security is off OR the user lacks ACL — same explanatory card fits both).
- `templates / udfs / secondary-indexes / records browser` — route catches through `mapApiError(err).message` so banners prefer the server-provided `ApiError.detail` over the raw `Error.message`.

## Why this shape
- The discriminated union keeps the type system honest about what a UI page can do with each kind. Today only the admin page differentiates; the four list pages all collapse to the generic banner. The helper makes future per-status surfaces a one-line change in the call site rather than a fresh `instanceof` chain.
- The EE_MSG marker is the official Aerospike error string for CE security-off (per ui/CLAUDE.md). Treating bare 403 as `permission-denied` rather than `security-disabled` is more accurate; admin still routes it to the same card by intent.

## Test plan
- [x] `cd ui && npm run type-check` — passes
- [x] `cd ui && npm run lint` — clean
- [x] `cd ui && npm run build` — clean
- [x] `cd ui && npx prettier --check` on the touched files — clean
- [ ] Manual: open admin page on a CE cluster (security off) → expect SecurityDisabledState card. Open admin page on a cluster where the connecting user lacks ACL → expect the same card (parity with prior behavior).
- [ ] Manual: trigger a 503 / network failure on a list page → expect generic banner with the API's `detail` text rather than the bare \"Failed to fetch\".

## Related
- Companion PR #281 (#276) adds structured `console.error` for every catch — together they make triage of an error a one-line console grep + a clear UI surface.
- Both PRs touch overlapping catch blocks; whichever lands second will need a trivial rebase to keep both `logFetchError` and `mapApiError` calls.