### PR TITLE
fix(ui): hook race conditions in use-event-stream and CommandBar

### DIFF
--- a/ui/src/components/CommandBar.tsx
+++ b/ui/src/components/CommandBar.tsx
@@ -127,23 +127,27 @@ const CommandBarCommand = React.forwardRef<HTMLButtonElement, CommandProps>(
     }: CommandProps,
     ref,
   ) => {
+    // Keep the latest `action` in a ref so changing closures don't re-bind
+    // the document-level keydown listener every render.
+    const actionRef = React.useRef(action)
+    actionRef.current = action
+
+    const shortcutKey = shortcut.shortcut
+
     React.useEffect(() => {
+      if (disabled) return
       const handleKeyDown = (event: KeyboardEvent) => {
-        if (event.key === shortcut.shortcut) {
+        if (event.key === shortcutKey) {
           event.preventDefault()
           event.stopPropagation()
-          action()
+          void actionRef.current()
         }
       }
-
-      if (!disabled) {
-        document.addEventListener("keydown", handleKeyDown)
-      }
-
+      document.addEventListener("keydown", handleKeyDown)
       return () => {
         document.removeEventListener("keydown", handleKeyDown)
       }
-    }, [action, shortcut, disabled])
+    }, [shortcutKey, disabled])
 
     return (
       <span

--- a/ui/src/hooks/use-event-stream.ts
+++ b/ui/src/hooks/use-event-stream.ts
@@ -42,17 +42,22 @@ export function useEventStream<T = unknown>(
     if (!enabled) return
     if (typeof window === "undefined") return
 
+    let cancelled = false
     let sub: EventSubscription | null = null
     try {
       sub = subscribeEvents<T>({
         types,
-        onOpen: () => setConnected(true),
+        onOpen: () => {
+          if (!cancelled) setConnected(true)
+        },
         onError: (err) => {
+          if (cancelled) return
           logFetchError("event-stream", err)
           setError(err)
           setConnected(false)
         },
         onMessage: (event) => {
+          if (cancelled) return
           setLastEvent(event)
           handlerRef.current?.(event)
         },
@@ -60,10 +65,11 @@ export function useEventStream<T = unknown>(
     } catch (err) {
       // subscribeEvents throws on SSR — already guarded above, but be safe.
       logFetchError("event-stream", err)
-      setError(err as Event)
+      if (!cancelled) setError(err as Event)
     }
 
     return () => {
+      cancelled = true
       sub?.close()
       setConnected(false)
     }


### PR DESCRIPTION
## Summary
Two HIGH-severity hook race conditions surfaced by the silent-failure audit on PR #274. Neither has its own GitHub issue; this PR closes them with a small targeted change to each.

## use-event-stream.ts
- Add a `cancelled` flag to the SSE subscribe effect. The previous code could fire `setLastEvent`, `setError`, or `setConnected` after the component had already unmounted (or after StrictMode's double-invoke had moved on to the second mount), since EventSource callbacks run asynchronously and the cleanup did not invalidate them. Each callback now early-returns when `cancelled`.

## CommandBar.tsx
- The keydown effect depended on `action` and `shortcut` (object identity), so callers passing inline literals (the typical `shortcut={{ shortcut: "k" }}`) re-bound the document-level listener on every render. Between the cleanup and the re-add a keystroke could be missed, and StrictMode could double-fire.
- Stash `action` in a ref; depend only on `shortcut.shortcut` (primitive) and `disabled`. The listener now binds once per mount + truly orthogonal dependency change.

## Why this shape
Both fixes follow the same React idiom — capture mutable closures in a ref, depend only on primitives. No new abstractions, no behavior change on the happy path.

## Test plan
- [x] `npm run type-check` — passes
- [x] `npm run lint` — clean
- [x] `npm run test` — 11 existing tests still pass
- [x] `npx prettier --check` on the two files — clean
- [ ] Manual: open the cluster overview while the events stream is connected, navigate away rapidly, confirm DevTools shows no React warnings about state updates on unmounted components.
- [ ] Manual: open a CommandBar with an inline `action` closure (e.g., from a parent that re-renders frequently); press the shortcut key in rapid succession — every press should fire the action.