### PR TITLE
fix(api): accurate hasMore + lower-bound total for filtered record scans (#284)

### DIFF
--- a/api/src/aerospike_cluster_manager_api/routers/records.py
+++ b/api/src/aerospike_cluster_manager_api/routers/records.py
@@ -241,11 +241,23 @@ async def get_filtered_records(
     if body.select_bins:
         q.select(*body.select_bins)
 
-    # Build policy with server-side max_records limit to prevent OOM
+    # Build policy with server-side max_records limit to prevent OOM.
+    #
+    # For paginated filter queries we fetch ONE extra record beyond the page
+    # size so we can detect "is there at least one more record" without an
+    # extra round trip. The fetched +1 record is dropped before responding.
+    # This makes `hasMore` accurate. The true `total` for filter-mode queries
+    # cannot be obtained without a separate count-only scan (which would
+    # double cluster load) — `totalEstimated=True` plus a lower-bound
+    # `total` are reported instead. See issue #284.
     has_filters = body.filters is not None or body.predicate is not None
-    effective_limit = min(body.max_records or MAX_QUERY_RECORDS, MAX_QUERY_RECORDS, body.page_size)
+    fetch_limit = min(
+        body.max_records or MAX_QUERY_RECORDS,
+        MAX_QUERY_RECORDS,
+        body.page_size + 1,
+    )
 
-    policy: dict[str, Any] = {**POLICY_QUERY, "max_records": effective_limit}
+    policy: dict[str, Any] = {**POLICY_QUERY, "max_records": fetch_limit}
     if body.filters:
         policy["filter_expression"] = build_expression(body.filters)
 
@@ -260,6 +272,10 @@ async def get_filtered_records(
         raw_results = []
 
     elapsed_ms = int((time.monotonic() - start_time) * 1000)
+    fetched = len(raw_results)
+    has_more = fetched > body.page_size
+    if has_more:
+        raw_results = raw_results[: body.page_size]
     returned = len(raw_results)
 
     records = [record_to_model(r) for r in raw_results]
@@ -269,9 +285,9 @@ async def get_filtered_records(
     # reflect the true number of records scanned by the Aerospike server.
     # For unfiltered scans we use the info command to get the real set size.
     if has_filters:
-        set_total = returned
+        set_total = returned + (1 if has_more else 0)  # lower bound
         scanned = returned  # lower bound; actual server-side scan may be higher
-        total_estimated = False
+        total_estimated = True
     else:
         set_total = await _get_set_object_count(client, body.namespace, body.set or "")
         scanned = set_total  # info-based: represents all objects in the set
@@ -282,7 +298,7 @@ async def get_filtered_records(
         total=set_total,
         page=1,
         pageSize=body.page_size,
-        hasMore=set_total > returned,
+        hasMore=has_more,
         executionTimeMs=elapsed_ms,
         scannedRecords=scanned,
         returnedRecords=returned,


### PR DESCRIPTION
## Summary
- Closes #284. The \`POST /api/v1/records/{conn_id}/filter\` endpoint reported \`total = pageSize\` and \`hasMore = false\` for every page of a filtered scan, regardless of the true matching count. The user's reproduction: a filter that actually matched ~500K records was reported as \`total=500, hasMore=false\` for every 500-record page.

## Root cause
The policy's \`max_records\` was capped at \`body.page_size\`, so \`len(raw_results)\` always equaled \`page_size\`. \`set_total\` was that count and \`hasMore = set_total > returned\` was therefore always false by construction.

## Fix
1. **Fetch `page_size + 1`** records server-side. If `len(raw_results) > page_size`, set `hasMore=True` and trim the slice to `page_size` before responding. The boolean is now correct without an extra round trip.
2. **Total is now an honest lower bound** (`returned + (1 if has_more else 0)`) with `totalEstimated=True`. Frontends can render \"X+ records\" instead of an inaccurate concrete number.
3. **Non-filter mode** (full-set scan) behaviour unchanged — uses the info-based set object count which is already accurate.
4. **PK-lookup short-circuit** (single-record fetch) unchanged — already correctly reports \`hasMore=False\`.

## Why not return the true total?
A precise filtered count requires a dedicated count-only scan (\`foreach\` callback or a `select(_meta_only)` scan) over the entire matching set. For a 500K-record filter that would double the cluster load on every page request. A separate count endpoint that runs the expensive scan once on demand is the right follow-up — filed as a comment on this PR for a follow-up issue.

## Files changed
- `api/src/aerospike_cluster_manager_api/routers/records.py` — single \`get_filtered_records\` function, +22/-6 lines.

## Test plan
- [x] `cd api && uv run ruff check` — clean
- [x] `cd api && uv run ruff format --check` — clean
- [x] `cd api && uv run pytest tests/test_records_router.py` — 3 existing tests still pass
- [ ] Manual reproduction from #284: filter \`orch_ver = "v0.3.7"\` against a 1.34M-record set with \~500K matches; verify \`hasMore\` is \`true\` until the last page (where it flips to \`false\`), and \`totalEstimated=true\` is set on every page.

## Related
Companion follow-up to file: a precise count-only filter endpoint that runs the expensive scan once and caches the result. The frontend can render \"counting…\" while it runs and \"498,234 records\" once it returns.