### PR TITLE
fix(ui): add titles to truncated names + disable not-yet-wired buttons

### DIFF
--- a/ui/src/app/(main)/acko/templates/page.tsx
+++ b/ui/src/app/(main)/acko/templates/page.tsx
@@ -130,7 +130,10 @@ export default function AckoTemplatesPage() {
                         {t.name}
                       </span>
                       {t.description && (
-                        <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+                        <p
+                          title={t.description}
+                          className="truncate text-xs text-gray-500 dark:text-gray-400"
+                        >
                           {t.description}
                         </p>
                       )}
@@ -158,7 +161,12 @@ export default function AckoTemplatesPage() {
                       {t.age ?? "—"}
                     </TableCell>
                     <TableCell className="text-right">
-                      <Button variant="ghost" className="h-7 px-2 text-xs">
+                      <Button
+                        variant="ghost"
+                        disabled
+                        title="Edit is not yet implemented"
+                        className="h-7 px-2 text-xs"
+                      >
                         Edit
                       </Button>
                     </TableCell>

--- a/ui/src/app/(main)/clusters/[clusterId]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/page.tsx
@@ -144,10 +144,16 @@ export default function ClusterOverview({ params }: PageProps) {
                       aria-hidden="true"
                     />
                     <div className="min-w-0 flex-1">
-                      <p className="truncate font-mono text-sm font-semibold text-gray-900 dark:text-gray-50">
+                      <p
+                        title={n.name}
+                        className="truncate font-mono text-sm font-semibold text-gray-900 dark:text-gray-50"
+                      >
                         {n.name}
                       </p>
-                      <p className="truncate font-mono text-xs text-gray-500 dark:text-gray-500">
+                      <p
+                        title={`${n.address}:${n.port}`}
+                        className="truncate font-mono text-xs text-gray-500 dark:text-gray-500"
+                      >
                         {n.address}:{n.port}
                       </p>
                     </div>

--- a/ui/src/app/(main)/clusters/[clusterId]/secondary-indexes/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/secondary-indexes/page.tsx
@@ -186,6 +186,8 @@ export default function SecondaryIndexesPage({ params }: PageProps) {
                           <TableCell className="text-right">
                             <Button
                               variant="ghost"
+                              disabled
+                              title="Drop is not yet implemented"
                               className="h-7 px-2 text-xs"
                             >
                               Drop

--- a/ui/src/app/(main)/clusters/[clusterId]/udfs/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/udfs/page.tsx
@@ -154,7 +154,12 @@ export default function UdfsPage({ params }: PageProps) {
                       {u.hash}
                     </TableCell>
                     <TableCell className="text-right">
-                      <Button variant="ghost" className="h-7 px-2 text-xs">
+                      <Button
+                        variant="ghost"
+                        disabled
+                        title="Remove is not yet implemented"
+                        className="h-7 px-2 text-xs"
+                      >
                         Remove
                       </Button>
                     </TableCell>

--- a/ui/src/components/clusters/ClusterCard.tsx
+++ b/ui/src/components/clusters/ClusterCard.tsx
@@ -54,7 +54,10 @@ export function ClusterCard({
               </span>
             )}
           </div>
-          <h3 className="mt-2 truncate font-mono text-base font-semibold text-gray-900 dark:text-gray-50">
+          <h3
+            title={row.displayName}
+            className="mt-2 truncate font-mono text-base font-semibold text-gray-900 dark:text-gray-50"
+          >
             {row.displayName}
           </h3>
           {row.description && (

--- a/ui/src/components/clusters/NameLink.tsx
+++ b/ui/src/components/clusters/NameLink.tsx
@@ -15,6 +15,7 @@ export function NameLink({ row }: { row: ClusterRow }) {
     return (
       <Link
         href={clusterSections.overview(row.connId)}
+        title={row.displayName}
         className={cx(
           "block truncate font-mono font-medium text-gray-900 transition hover:text-indigo-700 dark:text-gray-50 dark:hover:text-indigo-300",
           focusRing,
@@ -25,7 +26,10 @@ export function NameLink({ row }: { row: ClusterRow }) {
     )
   }
   return (
-    <span className="block truncate font-mono font-medium text-gray-500 dark:text-gray-500">
+    <span
+      title={row.displayName}
+      className="block truncate font-mono font-medium text-gray-500 dark:text-gray-500"
+    >
       {row.displayName}
     </span>
   )


### PR DESCRIPTION
## Summary
Two clusters of audit findings from the PR #274 review, neither big enough to deserve its own issue:

### 1. Truncated text without `title`
User-facing cluster / node / address / template-description text used the `truncate` Tailwind utility but had no `title` attribute, so the full value was unrecoverable on hover. Added `title=` matching the rendered string in:
- `NameLink.tsx` (cluster row link, both linked and unlinked)
- `ClusterCard.tsx` (card heading)
- `clusters/[clusterId]/page.tsx` (overview node name + address)
- `acko/templates/page.tsx` (template description)

These sites are not adjacent to any portaled popover, so the #268/#272 native-tooltip-leak hazard does not apply here; native `title` is the lighter primitive than wrapping each cell in an in-app `<Tooltip>`.

### 2. Ghost buttons that were enabled but had no `onClick`
Clicking them did nothing — users would assume the app was broken. Marked all three as `disabled` with a "not yet implemented" `title`:
- `acko/templates/page.tsx` — **Edit**
- `clusters/[clusterId]/udfs/page.tsx` — **Remove**
- `clusters/[clusterId]/secondary-indexes/page.tsx` — **Drop**

Wiring real handlers is out of scope; those will land with the corresponding mutation API plumbing.

## Test plan
- [x] `cd ui && npm run type-check` — passes
- [x] `cd ui && npm run lint` — clean
- [x] `cd ui && npm run test` — 11 existing tests still pass
- [x] `cd ui && npx prettier --check` on the touched files — clean
- [ ] Manual: hover a truncated cluster name on `/clusters` → native tooltip surfaces the full value.
- [ ] Manual: visit `/acko/templates` / `/clusters/<id>/udfs` / `/clusters/<id>/secondary-indexes` and confirm the ghost actions are now visibly disabled with a "not yet implemented" tooltip.