### PR TITLE
fix(ui): cancel record-detail reload after a save when route changes

### DIFF
--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
@@ -13,7 +13,7 @@ import { deleteRecord, getRecordDetail, putRecord } from "@/lib/api/records"
 import type { AerospikeRecord, BinValue, PkType } from "@/lib/types/record"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 
 type PageProps = {
   params: { clusterId: string; namespace: string; set: string; key: string }
@@ -275,8 +275,15 @@ export default function RecordDetailPage({ params }: PageProps) {
       })
   }
 
+  // Keep the latest cancellation signal in a ref so handleSave's
+  // post-PUT reload can be canceled when the user navigates away mid-save.
+  // Without this, an old PUT's getRecordDetail can resolve onto a different
+  // record's page and overwrite its state.
+  const loadSignalRef = useRef<{ cancelled: boolean }>({ cancelled: false })
+
   useEffect(() => {
     const signal = { cancelled: false }
+    loadSignalRef.current = signal
     loadRecord(signal)
     return () => {
       signal.cancelled = true
@@ -410,7 +417,7 @@ export default function RecordDetailPage({ params }: PageProps) {
       })
       setIsEditing(false)
       setDrafts([])
-      await loadRecord()
+      await loadRecord(loadSignalRef.current)
     } catch (err) {
       logFetchError("record-save", err)
       if (err instanceof ApiError) setError(err.detail || err.message)


### PR DESCRIPTION
## Summary
The record-detail page's `handleSave` calls `await loadRecord()` after the PUT to refresh the displayed record. The reload had no cancellation signal, so if the user navigated from `/sets/A/recordX` to `/sets/B/recordY` between the PUT resolving and the GET landing, the GET response could overwrite recordY's state with recordX's bins. Audit M5 from the PR #274 review.

## Fix
Stash the useEffect's cancellation signal in a ref (`loadSignalRef`) so any in-flight `loadRecord` triggered from `handleSave` is canceled by the same cleanup that cancels the useEffect-driven load. The signal is rotated on every route-param change — useEffect re-runs and writes a fresh signal into the ref before calling `loadRecord`.

No behavior change on the happy path (component stays mounted → `signal.cancelled` stays false → reload completes normally). The race only manifests when the user navigates away mid-save.

## Files changed
- `ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx` — +9 / -2

## Test plan
- [x] `cd ui && npm run type-check` — passes
- [x] `cd ui && npm run lint` — clean
- [x] `cd ui && npm run test` — 11 existing tests still pass
- [ ] Manual: edit a record on `/sets/A/recordX`, click Save, immediately navigate to `/sets/B/recordY` before the post-save GET resolves; verify recordY's bins remain intact.