### PR TITLE
feat(api,ui): PK regex/prefix search on record browser (#287)

### DIFF
--- a/api/src/aerospike_cluster_manager_api/expression_builder.py
+++ b/api/src/aerospike_cluster_manager_api/expression_builder.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import re
 from collections.abc import Callable
+from typing import Literal
 
 from aerospike_py import exp
 
@@ -14,6 +15,12 @@ from aerospike_cluster_manager_api.models.query import (
     FilterGroup,
     FilterOperator,
 )
+
+# POSIX regex compile flags accepted by exp.regex_compare. aerospike-py does
+# not yet expose named constants for these so we declare the values we use.
+# Existing bin-targeted regex paths already pass `2` (REG_ICASE).
+REGEX_FLAG_NONE = 0
+REGEX_FLAG_ICASE = 2  # POSIX REG_ICASE — case-insensitive matching
 
 
 def _bin_accessor(bin_name: str, bin_type: BinDataType) -> dict:
@@ -86,6 +93,12 @@ def _build_condition(cond: FilterCondition) -> dict:
     if op == FilterOperator.REGEX:
         return exp.regex_compare(str(cond.value), 2, exp.string_bin(bin_name))
 
+    if op == FilterOperator.PK_PREFIX:
+        return build_pk_filter_expression(str(cond.value), "prefix")
+
+    if op == FilterOperator.PK_REGEX:
+        return build_pk_filter_expression(str(cond.value), "regex")
+
     if op == FilterOperator.EXISTS:
         return exp.bin_exists(bin_name)
 
@@ -115,3 +128,29 @@ def build_expression(group: FilterGroup) -> dict:
     if group.logic == "and":
         return exp.and_(*exprs)
     return exp.or_(*exprs)
+
+
+def build_pk_filter_expression(pattern: str, mode: Literal["prefix", "regex"]) -> dict:
+    """Build a regex_compare expression that matches against the record's
+    primary key (user key) instead of a bin.
+
+    Notes:
+    - PK is digest-indexed in Aerospike — this expression runs as a server-side
+      filter over a full set scan. There is no PK B-tree prefix index.
+    - Records written without ``POLICY_KEY_SEND`` do not store the user key
+      and therefore never match.
+    - ``prefix`` mode escapes the pattern and anchors with ``^``. ``regex``
+      mode passes the pattern through verbatim.
+    """
+    if mode == "prefix":
+        regex_pattern = f"^{re.escape(pattern)}.*"
+    elif mode == "regex":
+        regex_pattern = pattern
+    else:
+        raise ValueError(f"Unsupported PK match mode: {mode!r}")
+
+    return exp.regex_compare(
+        regex_pattern,
+        REGEX_FLAG_ICASE,
+        exp.key(exp.EXP_TYPE_STRING),
+    )

--- a/api/src/aerospike_cluster_manager_api/expression_builder.py
+++ b/api/src/aerospike_cluster_manager_api/expression_builder.py
@@ -16,11 +16,25 @@ from aerospike_cluster_manager_api.models.query import (
     FilterOperator,
 )
 
-# POSIX regex compile flags accepted by exp.regex_compare. aerospike-py does
-# not yet expose named constants for these so we declare the values we use.
-# Existing bin-targeted regex paths already pass `2` (REG_ICASE).
-REGEX_FLAG_NONE = 0
-REGEX_FLAG_ICASE = 2  # POSIX REG_ICASE — case-insensitive matching
+# POSIX REG_ICASE — case-insensitive matching. aerospike-py forwards the int
+# straight to the server's POSIX regex engine.
+REGEX_FLAG_ICASE = 2
+
+
+class InvalidPkPatternError(ValueError):
+    """Raised when a user-supplied PK regex/prefix pattern is malformed."""
+
+
+def _validate_pattern(pattern: str) -> None:
+    """Catch the common syntactic regex errors (unbalanced brackets / parens,
+    dangling quantifiers) before the pattern reaches the server. Python's
+    regex grammar is more permissive than POSIX in places, but rejecting
+    the structural majority on the API side beats letting the user see an
+    empty result with no signal that their pattern was the problem."""
+    try:
+        re.compile(pattern)
+    except re.error as e:
+        raise InvalidPkPatternError(f"Invalid regex pattern: {e}") from e
 
 
 def _bin_accessor(bin_name: str, bin_type: BinDataType) -> dict:
@@ -84,14 +98,16 @@ def _build_condition(cond: FilterCondition) -> dict:
 
     if op == FilterOperator.CONTAINS:
         pattern = f".*{re.escape(str(cond.value))}.*"
-        return exp.regex_compare(pattern, 2, exp.string_bin(bin_name))
+        return exp.regex_compare(pattern, REGEX_FLAG_ICASE, exp.string_bin(bin_name))
 
     if op == FilterOperator.NOT_CONTAINS:
         pattern = f".*{re.escape(str(cond.value))}.*"
-        return exp.not_(exp.regex_compare(pattern, 2, exp.string_bin(bin_name)))
+        return exp.not_(exp.regex_compare(pattern, REGEX_FLAG_ICASE, exp.string_bin(bin_name)))
 
     if op == FilterOperator.REGEX:
-        return exp.regex_compare(str(cond.value), 2, exp.string_bin(bin_name))
+        regex = str(cond.value)
+        _validate_pattern(regex)
+        return exp.regex_compare(regex, REGEX_FLAG_ICASE, exp.string_bin(bin_name))
 
     if op == FilterOperator.PK_PREFIX:
         return build_pk_filter_expression(str(cond.value), "prefix")
@@ -143,8 +159,10 @@ def build_pk_filter_expression(pattern: str, mode: Literal["prefix", "regex"]) -
       mode passes the pattern through verbatim.
     """
     if mode == "prefix":
+        # re.escape produces a known-valid pattern; no validation needed.
         regex_pattern = f"^{re.escape(pattern)}.*"
     elif mode == "regex":
+        _validate_pattern(pattern)
         regex_pattern = pattern
     else:
         raise ValueError(f"Unsupported PK match mode: {mode!r}")

--- a/api/src/aerospike_cluster_manager_api/models/query.py
+++ b/api/src/aerospike_cluster_manager_api/models/query.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .record import AerospikeRecord, BinValue
+
+# Placeholder bin name used when a FilterCondition targets the primary key
+# (operators PK_PREFIX / PK_REGEX). The bin field on FilterCondition is
+# required (min_length=1) for serialization, but PK operators use exp.key()
+# instead of any bin accessor — this sentinel makes the intent explicit and
+# is rejected when paired with non-PK operators.
+PK_BIN_PLACEHOLDER = "__pk__"
 
 
 class QueryPredicate(BaseModel):
@@ -56,6 +63,13 @@ class FilterOperator(StrEnum):
     IS_FALSE = "is_false"
     GEO_WITHIN = "geo_within"
     GEO_CONTAINS = "geo_contains"
+    PK_PREFIX = "pk_prefix"
+    PK_REGEX = "pk_regex"
+
+
+# Operators that target the record's primary key via exp.key() rather than a
+# bin accessor. The condition's `bin` field is ignored (must be the placeholder).
+PK_OPERATORS: frozenset[FilterOperator] = frozenset({FilterOperator.PK_PREFIX, FilterOperator.PK_REGEX})
 
 
 class BinDataType(StrEnum):
@@ -71,11 +85,28 @@ class BinDataType(StrEnum):
 class FilterCondition(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
-    bin: str = Field(min_length=1, max_length=15)
+    bin: str = Field(min_length=1, max_length=255)
     operator: FilterOperator
     value: BinValue | None = None
     value2: BinValue | None = None
     bin_type: BinDataType = Field(default=BinDataType.STRING, alias="binType")
+
+    @model_validator(mode="after")
+    def _validate_pk_operator_pairing(self) -> FilterCondition:
+        """Enforce that PK operators only appear with the PK placeholder bin,
+        and conversely that the placeholder is reserved for PK operators.
+        Bin names are normally <=15 chars; the placeholder is checked here
+        so the regular field-length cap can be relaxed without losing safety."""
+        is_pk_op = self.operator in PK_OPERATORS
+        is_pk_bin = self.bin == PK_BIN_PLACEHOLDER
+        if is_pk_op != is_pk_bin:
+            raise ValueError(
+                f"Operator {self.operator!r} requires bin={PK_BIN_PLACEHOLDER!r} "
+                f"and that placeholder is only valid with PK operators."
+            )
+        if not is_pk_op and len(self.bin) > 15:
+            raise ValueError("bin must be at most 15 characters")
+        return self
 
 
 class FilterGroup(BaseModel):
@@ -97,6 +128,13 @@ class FilteredQueryRequest(BaseModel):
     primary_key: str | None = Field(default=None, max_length=1024, alias="primaryKey")
     # Particle type for primary_key resolution. "auto" retries alternate type on NOT_FOUND.
     pk_type: Literal["auto", "string", "int", "bytes"] = Field(default="auto", alias="pkType")
+    # PK pattern + match mode. When pk_match_mode is "exact", behaves like
+    # primary_key (single-record client.get). For "prefix"/"regex", the scan
+    # path is taken and a regex_compare(exp.key(STRING)) expression is composed
+    # with body.filters via AND. Resolution: pk_pattern preferred over the
+    # legacy primary_key field; both are accepted for backward compatibility.
+    pk_pattern: str | None = Field(default=None, max_length=4096, alias="pkPattern")
+    pk_match_mode: Literal["exact", "prefix", "regex"] = Field(default="exact", alias="pkMatchMode")
 
 
 class FilteredQueryResponse(BaseModel):

--- a/api/src/aerospike_cluster_manager_api/models/query.py
+++ b/api/src/aerospike_cluster_manager_api/models/query.py
@@ -7,11 +7,8 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from .record import AerospikeRecord, BinValue
 
-# Placeholder bin name used when a FilterCondition targets the primary key
-# (operators PK_PREFIX / PK_REGEX). The bin field on FilterCondition is
-# required (min_length=1) for serialization, but PK operators use exp.key()
-# instead of any bin accessor — this sentinel makes the intent explicit and
-# is rejected when paired with non-PK operators.
+# Sentinel bin name reserved for FilterConditions whose operator is PK_PREFIX
+# or PK_REGEX. PK operators target exp.key() rather than a bin accessor.
 PK_BIN_PLACEHOLDER = "__pk__"
 
 
@@ -85,7 +82,7 @@ class BinDataType(StrEnum):
 class FilterCondition(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
-    bin: str = Field(min_length=1, max_length=255)
+    bin: str = Field(min_length=1, max_length=15)
     operator: FilterOperator
     value: BinValue | None = None
     value2: BinValue | None = None
@@ -93,19 +90,23 @@ class FilterCondition(BaseModel):
 
     @model_validator(mode="after")
     def _validate_pk_operator_pairing(self) -> FilterCondition:
-        """Enforce that PK operators only appear with the PK placeholder bin,
-        and conversely that the placeholder is reserved for PK operators.
-        Bin names are normally <=15 chars; the placeholder is checked here
-        so the regular field-length cap can be relaxed without losing safety."""
         is_pk_op = self.operator in PK_OPERATORS
         is_pk_bin = self.bin == PK_BIN_PLACEHOLDER
-        if is_pk_op != is_pk_bin:
+
+        if is_pk_op and not is_pk_bin:
             raise ValueError(
-                f"Operator {self.operator!r} requires bin={PK_BIN_PLACEHOLDER!r} "
-                f"and that placeholder is only valid with PK operators."
+                f"PK operator {self.operator.value!r} requires bin={PK_BIN_PLACEHOLDER!r}; got bin={self.bin!r}"
             )
-        if not is_pk_op and len(self.bin) > 15:
-            raise ValueError("bin must be at most 15 characters")
+        if is_pk_bin and not is_pk_op:
+            allowed = sorted(o.value for o in PK_OPERATORS)
+            raise ValueError(
+                f"bin={PK_BIN_PLACEHOLDER!r} is reserved for PK operators ({allowed}); "
+                f"got operator={self.operator.value!r}"
+            )
+        if is_pk_op and not isinstance(self.value, str):
+            raise ValueError(
+                f"PK operator {self.operator.value!r} requires a string value; got {type(self.value).__name__}"
+            )
         return self
 
 
@@ -128,13 +129,25 @@ class FilteredQueryRequest(BaseModel):
     primary_key: str | None = Field(default=None, max_length=1024, alias="primaryKey")
     # Particle type for primary_key resolution. "auto" retries alternate type on NOT_FOUND.
     pk_type: Literal["auto", "string", "int", "bytes"] = Field(default="auto", alias="pkType")
-    # PK pattern + match mode. When pk_match_mode is "exact", behaves like
-    # primary_key (single-record client.get). For "prefix"/"regex", the scan
-    # path is taken and a regex_compare(exp.key(STRING)) expression is composed
-    # with body.filters via AND. Resolution: pk_pattern preferred over the
-    # legacy primary_key field; both are accepted for backward compatibility.
+    # Canonical PK search field; primary_key kept for backward compatibility.
     pk_pattern: str | None = Field(default=None, max_length=4096, alias="pkPattern")
     pk_match_mode: Literal["exact", "prefix", "regex"] = Field(default="exact", alias="pkMatchMode")
+
+    @model_validator(mode="after")
+    def _validate_pk_fields(self) -> FilteredQueryRequest:
+        # Disallow ambiguous request shapes where the legacy and canonical
+        # PK fields disagree, or where mode and pattern presence are out
+        # of sync. The router's `pk_pattern or primary_key` precedence
+        # would otherwise silently pick a winner.
+        if self.pk_pattern is not None and self.primary_key is not None:
+            raise ValueError("Provide either pk_pattern or primary_key, not both")
+        if self.primary_key is not None and self.pk_match_mode != "exact":
+            raise ValueError("Legacy primary_key only supports pk_match_mode='exact'; use pk_pattern for prefix/regex")
+        if self.pk_match_mode != "exact":
+            pattern = self.pk_pattern
+            if pattern is None or pattern.strip() == "":
+                raise ValueError(f"pk_match_mode={self.pk_match_mode!r} requires a non-empty pk_pattern")
+        return self
 
 
 class FilteredQueryResponse(BaseModel):

--- a/api/src/aerospike_cluster_manager_api/routers/records.py
+++ b/api/src/aerospike_cluster_manager_api/routers/records.py
@@ -4,6 +4,7 @@ import logging
 import time
 from typing import Any, Literal
 
+from aerospike_py import exp
 from aerospike_py.exception import AerospikeError, RecordNotFound
 from aerospike_py.types import WriteMeta
 from fastapi import APIRouter, HTTPException, Query
@@ -19,7 +20,10 @@ from aerospike_cluster_manager_api.constants import (
 )
 from aerospike_cluster_manager_api.converters import record_to_model
 from aerospike_cluster_manager_api.dependencies import AerospikeClient
-from aerospike_cluster_manager_api.expression_builder import build_expression
+from aerospike_cluster_manager_api.expression_builder import (
+    build_expression,
+    build_pk_filter_expression,
+)
 from aerospike_cluster_manager_api.info_parser import aggregate_node_kv, aggregate_set_records, safe_int
 from aerospike_cluster_manager_api.models.query import FilteredQueryRequest, FilteredQueryResponse
 from aerospike_cluster_manager_api.models.record import (
@@ -199,19 +203,24 @@ async def get_filtered_records(
     """Scan records with optional expression filters and pagination."""
     start_time = time.monotonic()
 
-    # PK lookup short-circuit. Falls back to the alternate particle type on
-    # NOT_FOUND when pk_type=auto so numeric-string keys (stored as STRING)
-    # are still found even though auto's heuristic resolves them as INTEGER.
-    if body.primary_key:
+    # Resolve PK lookup target. `pk_pattern` is the canonical field; the
+    # legacy `primary_key` field is still accepted for backward compatibility.
+    pk_target = body.pk_pattern or body.primary_key
+
+    # PK lookup short-circuit (exact mode). Falls back to the alternate
+    # particle type on NOT_FOUND when pk_type=auto so numeric-string keys
+    # (stored as STRING) are still found even though auto's heuristic resolves
+    # them as INTEGER. Prefix/regex modes skip this branch and run a scan.
+    if pk_target and body.pk_match_mode == "exact":
         if not body.set:
             raise HTTPException(status_code=400, detail="Set is required for primary key lookup")
 
-        resolved = resolve_pk(body.primary_key, body.pk_type)
+        resolved = resolve_pk(pk_target, body.pk_type)
         try:
             raw_result = await get_with_pk_fallback(
                 client,
                 (body.namespace, body.set, resolved),
-                body.primary_key,
+                pk_target,
                 body.pk_type,
                 POLICY_READ,
             )
@@ -250,7 +259,14 @@ async def get_filtered_records(
     # cannot be obtained without a separate count-only scan (which would
     # double cluster load) — `totalEstimated=True` plus a lower-bound
     # `total` are reported instead. See issue #284.
-    has_filters = body.filters is not None or body.predicate is not None
+    pk_expr: dict | None = None
+    if pk_target is not None:
+        if body.pk_match_mode == "prefix":
+            pk_expr = build_pk_filter_expression(pk_target, "prefix")
+        elif body.pk_match_mode == "regex":
+            pk_expr = build_pk_filter_expression(pk_target, "regex")
+
+    has_filters = body.filters is not None or body.predicate is not None or pk_expr is not None
     fetch_limit = min(
         body.max_records or MAX_QUERY_RECORDS,
         MAX_QUERY_RECORDS,
@@ -258,8 +274,13 @@ async def get_filtered_records(
     )
 
     policy: dict[str, Any] = {**POLICY_QUERY, "max_records": fetch_limit}
-    if body.filters:
-        policy["filter_expression"] = build_expression(body.filters)
+    bin_expr = build_expression(body.filters) if body.filters else None
+    if bin_expr is not None and pk_expr is not None:
+        policy["filter_expression"] = exp.and_(pk_expr, bin_expr)
+    elif pk_expr is not None:
+        policy["filter_expression"] = pk_expr
+    elif bin_expr is not None:
+        policy["filter_expression"] = bin_expr
 
     try:
         raw_results = await q.results(policy)

--- a/api/src/aerospike_cluster_manager_api/routers/records.py
+++ b/api/src/aerospike_cluster_manager_api/routers/records.py
@@ -21,6 +21,7 @@ from aerospike_cluster_manager_api.constants import (
 from aerospike_cluster_manager_api.converters import record_to_model
 from aerospike_cluster_manager_api.dependencies import AerospikeClient
 from aerospike_cluster_manager_api.expression_builder import (
+    InvalidPkPatternError,
     build_expression,
     build_pk_filter_expression,
 )
@@ -203,18 +204,21 @@ async def get_filtered_records(
     """Scan records with optional expression filters and pagination."""
     start_time = time.monotonic()
 
-    # Resolve PK lookup target. `pk_pattern` is the canonical field; the
-    # legacy `primary_key` field is still accepted for backward compatibility.
     pk_target = body.pk_pattern or body.primary_key
+
+    # Set is required for any PK-targeted query (exact, prefix, or regex):
+    # an unscoped namespace scan with a regex would dwarf the user's intent
+    # and is what the InfoBanner caveat warns against.
+    if pk_target and not body.set:
+        raise HTTPException(status_code=400, detail="Set is required for primary key lookup")
 
     # PK lookup short-circuit (exact mode). Falls back to the alternate
     # particle type on NOT_FOUND when pk_type=auto so numeric-string keys
     # (stored as STRING) are still found even though auto's heuristic resolves
     # them as INTEGER. Prefix/regex modes skip this branch and run a scan.
     if pk_target and body.pk_match_mode == "exact":
-        if not body.set:
-            raise HTTPException(status_code=400, detail="Set is required for primary key lookup")
-
+        # Set was already required above for PK-targeted queries.
+        assert body.set is not None
         resolved = resolve_pk(pk_target, body.pk_type)
         try:
             raw_result = await get_with_pk_fallback(
@@ -241,6 +245,21 @@ async def get_filtered_records(
             returnedRecords=len(records),
         )
 
+    # Build expressions BEFORE constructing the query — validating user input
+    # up front means a bad pattern surfaces as 400 without ever touching the
+    # client.query path.
+    pk_expr: dict | None = None
+    try:
+        if pk_target is not None:
+            if body.pk_match_mode == "prefix":
+                pk_expr = build_pk_filter_expression(pk_target, "prefix")
+            elif body.pk_match_mode == "regex":
+                pk_expr = build_pk_filter_expression(pk_target, "regex")
+    except InvalidPkPatternError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    bin_expr = build_expression(body.filters) if body.filters else None
+
     # Build query
     q = client.query(body.namespace, body.set or "")
 
@@ -259,13 +278,6 @@ async def get_filtered_records(
     # cannot be obtained without a separate count-only scan (which would
     # double cluster load) — `totalEstimated=True` plus a lower-bound
     # `total` are reported instead. See issue #284.
-    pk_expr: dict | None = None
-    if pk_target is not None:
-        if body.pk_match_mode == "prefix":
-            pk_expr = build_pk_filter_expression(pk_target, "prefix")
-        elif body.pk_match_mode == "regex":
-            pk_expr = build_pk_filter_expression(pk_target, "regex")
-
     has_filters = body.filters is not None or body.predicate is not None or pk_expr is not None
     fetch_limit = min(
         body.max_records or MAX_QUERY_RECORDS,
@@ -274,7 +286,6 @@ async def get_filtered_records(
     )
 
     policy: dict[str, Any] = {**POLICY_QUERY, "max_records": fetch_limit}
-    bin_expr = build_expression(body.filters) if body.filters else None
     if bin_expr is not None and pk_expr is not None:
         policy["filter_expression"] = exp.and_(pk_expr, bin_expr)
     elif pk_expr is not None:
@@ -285,10 +296,17 @@ async def get_filtered_records(
     try:
         raw_results = await q.results(policy)
     except AerospikeError:
+        # The empty/sparse-namespace failure mode (issue #259) is the reason
+        # this catch exists. Log at exception level so operators can still
+        # find the underlying cause in logs — pattern + filter context goes
+        # in the message so user-supplied PK patterns are reproducible.
         logger.exception(
-            "Filtered query failed for ns=%s set=%s; returning empty page",
+            "Filtered query failed for ns=%s set=%s pk_mode=%s pk_pattern=%r has_filters=%s; returning empty page",
             body.namespace,
             body.set,
+            body.pk_match_mode,
+            pk_target,
+            body.filters is not None,
         )
         raw_results = []
 

--- a/api/tests/test_expression_builder.py
+++ b/api/tests/test_expression_builder.py
@@ -1,0 +1,109 @@
+"""Unit tests for expression_builder, focused on PK regex/prefix support (#287)."""
+
+from __future__ import annotations
+
+import pytest
+from aerospike_py import exp
+
+from aerospike_cluster_manager_api.expression_builder import (
+    REGEX_FLAG_ICASE,
+    _build_condition,
+    build_expression,
+    build_pk_filter_expression,
+)
+from aerospike_cluster_manager_api.models.query import (
+    PK_BIN_PLACEHOLDER,
+    BinDataType,
+    FilterCondition,
+    FilterGroup,
+    FilterOperator,
+)
+
+
+class TestBuildPkFilterExpression:
+    def test_prefix_anchors_with_caret_and_escapes_metachars(self):
+        # Special regex chars in user input must not be re-interpreted in prefix mode.
+        result = build_pk_filter_expression("user.1+", "prefix")
+        expected = exp.regex_compare(
+            r"^user\.1\+.*",
+            REGEX_FLAG_ICASE,
+            exp.key(exp.EXP_TYPE_STRING),
+        )
+        assert result == expected
+
+    def test_regex_passes_pattern_verbatim(self):
+        result = build_pk_filter_expression(r".+@example\.com", "regex")
+        expected = exp.regex_compare(
+            r".+@example\.com",
+            REGEX_FLAG_ICASE,
+            exp.key(exp.EXP_TYPE_STRING),
+        )
+        assert result == expected
+
+    def test_unsupported_mode_raises(self):
+        with pytest.raises(ValueError, match="Unsupported PK match mode"):
+            build_pk_filter_expression("foo", "exact")  # type: ignore[arg-type]
+
+
+class TestBuildConditionPkOperators:
+    def test_pk_prefix_routes_through_pk_helper(self):
+        cond = FilterCondition(
+            bin=PK_BIN_PLACEHOLDER,
+            operator=FilterOperator.PK_PREFIX,
+            value="acct_",
+        )
+        result = _build_condition(cond)
+        assert result == build_pk_filter_expression("acct_", "prefix")
+
+    def test_pk_regex_routes_through_pk_helper(self):
+        cond = FilterCondition(
+            bin=PK_BIN_PLACEHOLDER,
+            operator=FilterOperator.PK_REGEX,
+            value=r"^id-[0-9]+$",
+        )
+        result = _build_condition(cond)
+        assert result == build_pk_filter_expression(r"^id-[0-9]+$", "regex")
+
+    def test_pk_operator_with_non_placeholder_bin_is_rejected_at_model_level(self):
+        # The validator on FilterCondition rejects this combination — the
+        # expression_builder never sees a malformed condition.
+        with pytest.raises(ValueError, match=PK_BIN_PLACEHOLDER):
+            FilterCondition(
+                bin="some_bin",
+                operator=FilterOperator.PK_PREFIX,
+                value="x",
+            )
+
+    def test_placeholder_bin_with_non_pk_operator_is_rejected(self):
+        with pytest.raises(ValueError, match=PK_BIN_PLACEHOLDER):
+            FilterCondition(
+                bin=PK_BIN_PLACEHOLDER,
+                operator=FilterOperator.EQ,
+                value="x",
+            )
+
+
+class TestBuildExpressionWithPkConditions:
+    def test_pk_condition_combines_with_bin_filter_via_and(self):
+        group = FilterGroup(
+            logic="and",
+            conditions=[
+                FilterCondition(
+                    bin=PK_BIN_PLACEHOLDER,
+                    operator=FilterOperator.PK_PREFIX,
+                    value="usr_",
+                ),
+                FilterCondition(
+                    bin="age",
+                    operator=FilterOperator.GT,
+                    value=21,
+                    bin_type=BinDataType.INTEGER,
+                ),
+            ],
+        )
+        expr = build_expression(group)
+        # Top-level operator should be AND with two children.
+        # exp.and_ returns a dict with a known structure — assert it composes.
+        pk_part = build_pk_filter_expression("usr_", "prefix")
+        bin_part = exp.gt(exp.int_bin("age"), exp.int_val(21))
+        assert expr == exp.and_(pk_part, bin_part)

--- a/api/tests/test_expression_builder.py
+++ b/api/tests/test_expression_builder.py
@@ -7,14 +7,17 @@ from aerospike_py import exp
 
 from aerospike_cluster_manager_api.expression_builder import (
     REGEX_FLAG_ICASE,
+    InvalidPkPatternError,
     _build_condition,
     build_expression,
     build_pk_filter_expression,
 )
 from aerospike_cluster_manager_api.models.query import (
     PK_BIN_PLACEHOLDER,
+    PK_OPERATORS,
     BinDataType,
     FilterCondition,
+    FilteredQueryRequest,
     FilterGroup,
     FilterOperator,
 )
@@ -43,6 +46,25 @@ class TestBuildPkFilterExpression:
     def test_unsupported_mode_raises(self):
         with pytest.raises(ValueError, match="Unsupported PK match mode"):
             build_pk_filter_expression("foo", "exact")  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "bad_pattern",
+        ["[unclosed", "(?P<bad>", "*at_start", "(unbalanced"],
+    )
+    def test_invalid_regex_raises_invalid_pk_pattern_error(self, bad_pattern: str):
+        with pytest.raises(InvalidPkPatternError, match="Invalid regex pattern"):
+            build_pk_filter_expression(bad_pattern, "regex")
+
+    def test_prefix_mode_does_not_validate_user_pattern(self):
+        # Prefix mode escapes the input first, so a "bad" regex is fine
+        # because re.escape produces a valid pattern.
+        result = build_pk_filter_expression("[unclosed", "prefix")
+        expected = exp.regex_compare(
+            r"^\[unclosed.*",
+            REGEX_FLAG_ICASE,
+            exp.key(exp.EXP_TYPE_STRING),
+        )
+        assert result == expected
 
 
 class TestBuildConditionPkOperators:
@@ -74,13 +96,87 @@ class TestBuildConditionPkOperators:
                 value="x",
             )
 
-    def test_placeholder_bin_with_non_pk_operator_is_rejected(self):
-        with pytest.raises(ValueError, match=PK_BIN_PLACEHOLDER):
+    @pytest.mark.parametrize(
+        "operator",
+        [
+            FilterOperator.EQ,
+            FilterOperator.GT,
+            FilterOperator.REGEX,
+            FilterOperator.BETWEEN,
+            FilterOperator.EXISTS,
+        ],
+    )
+    def test_placeholder_bin_with_non_pk_operator_is_rejected(self, operator: FilterOperator):
+        with pytest.raises(ValueError, match="reserved for PK operators"):
             FilterCondition(
                 bin=PK_BIN_PLACEHOLDER,
-                operator=FilterOperator.EQ,
+                operator=operator,
                 value="x",
             )
+
+    def test_pk_operator_requires_string_value(self):
+        with pytest.raises(ValueError, match="requires a string value"):
+            FilterCondition(
+                bin=PK_BIN_PLACEHOLDER,
+                operator=FilterOperator.PK_PREFIX,
+                value=123,  # int, not str
+            )
+
+    def test_non_pk_bin_longer_than_15_chars_is_rejected(self):
+        with pytest.raises(ValueError, match="at most 15"):
+            FilterCondition(
+                bin="x" * 16,
+                operator=FilterOperator.EQ,
+                value="v",
+            )
+
+
+class TestPkOperatorsConstant:
+    """Drift guard — every FilterOperator name starting with PK_ must be in
+    PK_OPERATORS, and vice versa. Catches the common mistake of adding a new
+    PK operator to the enum without updating the classifier."""
+
+    def test_pk_operators_matches_enum_names(self):
+        derived = {op for op in FilterOperator if op.name.startswith("PK_")}
+        assert derived == set(PK_OPERATORS)
+
+
+class TestFilteredQueryRequestPkValidation:
+    """C2 + I4 — request-level PK field invariants."""
+
+    def test_prefix_mode_with_no_pattern_is_rejected(self):
+        with pytest.raises(ValueError, match="non-empty pk_pattern"):
+            FilteredQueryRequest(namespace="test", set="demo", pk_match_mode="prefix")
+
+    def test_regex_mode_with_blank_pattern_is_rejected(self):
+        with pytest.raises(ValueError, match="non-empty pk_pattern"):
+            FilteredQueryRequest(namespace="test", set="demo", pk_pattern="   ", pk_match_mode="regex")
+
+    def test_pk_pattern_and_primary_key_simultaneously_is_rejected(self):
+        with pytest.raises(ValueError, match="not both"):
+            FilteredQueryRequest(
+                namespace="test",
+                set="demo",
+                pk_pattern="a",
+                primary_key="b",
+            )
+
+    def test_legacy_primary_key_with_non_exact_mode_is_rejected(self):
+        with pytest.raises(ValueError, match="primary_key only supports"):
+            FilteredQueryRequest(
+                namespace="test",
+                set="demo",
+                primary_key="a",
+                pk_match_mode="prefix",
+            )
+
+    def test_default_request_with_no_pk_fields_is_valid(self):
+        # Pure bin-filter request: pk_match_mode defaults to "exact" but
+        # neither pk_pattern nor primary_key is set — must not be rejected.
+        req = FilteredQueryRequest(namespace="test", set="demo")
+        assert req.pk_pattern is None
+        assert req.primary_key is None
+        assert req.pk_match_mode == "exact"
 
 
 class TestBuildExpressionWithPkConditions:

--- a/api/tests/test_records_router.py
+++ b/api/tests/test_records_router.py
@@ -5,13 +5,15 @@ from __future__ import annotations
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from aerospike_py import exp
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from aerospike_cluster_manager_api.constants import POLICY_READ
+from aerospike_cluster_manager_api.expression_builder import build_pk_filter_expression
 from aerospike_cluster_manager_api.main import app
 
 
@@ -133,3 +135,167 @@ class TestGetRecordDetail:
         body = response.json()
         assert body["error_kind"] == "rust_panic"
         assert "particle type" in body["detail"]
+
+
+def _build_query_mock(records: list[SimpleNamespace] | None = None) -> AsyncMock:
+    """Build an AsyncMock client whose .query(...) returns a query object whose
+    .results(policy) records the policy and resolves to the given records."""
+    query_obj = MagicMock()
+    query_obj.results = AsyncMock(return_value=records or [])
+    query_obj.where = MagicMock()
+    query_obj.select = MagicMock()
+    mock_client = AsyncMock()
+    mock_client.query = MagicMock(return_value=query_obj)
+    mock_client.info_all = AsyncMock(return_value={})
+    return mock_client
+
+
+class TestFilteredRecordsPkMatchMode:
+    """Coverage for issue #287: PK exact / prefix / regex match modes on the
+    POST /api/records/{conn_id}/filter endpoint."""
+
+    async def test_exact_mode_uses_pk_short_circuit(self, client: AsyncClient):
+        mock_client = _build_query_mock()
+        mock_client.get = AsyncMock(
+            return_value=SimpleNamespace(
+                key=("test", "demo", "k1", b"\x00"),
+                meta={"gen": 1, "ttl": 0},
+                bins={"a": 1},
+            )
+        )
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test/filter",
+                json={
+                    "namespace": "test",
+                    "set": "demo",
+                    "pkPattern": "k1",
+                    "pkMatchMode": "exact",
+                },
+            )
+
+        assert resp.status_code == 200
+        # Short-circuit: client.get is called, scan path is NOT taken.
+        mock_client.get.assert_awaited_once()
+        mock_client.query.assert_not_called()
+
+    async def test_prefix_mode_runs_scan_with_pk_filter_expression(self, client: AsyncClient):
+        mock_client = _build_query_mock()
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test/filter",
+                json={
+                    "namespace": "test",
+                    "set": "demo",
+                    "pkPattern": "user_",
+                    "pkMatchMode": "prefix",
+                },
+            )
+
+        assert resp.status_code == 200
+        # Scan path was taken.
+        mock_client.query.assert_called_once_with("test", "demo")
+        # The policy passed to .results contains a filter_expression matching
+        # the PK regex helper output.
+        call_args = mock_client.query.return_value.results.await_args
+        assert call_args is not None
+        policy = call_args.args[0]
+        assert "filter_expression" in policy
+        assert policy["filter_expression"] == build_pk_filter_expression("user_", "prefix")
+
+    async def test_regex_mode_combines_with_bin_filters_via_and(self, client: AsyncClient):
+        mock_client = _build_query_mock()
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test/filter",
+                json={
+                    "namespace": "test",
+                    "set": "demo",
+                    "pkPattern": "^acct[0-9]+$",
+                    "pkMatchMode": "regex",
+                    "filters": {
+                        "logic": "and",
+                        "conditions": [
+                            {
+                                "bin": "score",
+                                "operator": "gt",
+                                "value": 100,
+                                "binType": "integer",
+                            }
+                        ],
+                    },
+                },
+            )
+
+        assert resp.status_code == 200
+        call_args = mock_client.query.return_value.results.await_args
+        assert call_args is not None
+        policy = call_args.args[0]
+        pk_part = build_pk_filter_expression("^acct[0-9]+$", "regex")
+        bin_part = exp.gt(exp.int_bin("score"), exp.int_val(100))
+        assert policy["filter_expression"] == exp.and_(pk_part, bin_part)
+
+    async def test_legacy_primary_key_field_still_works(self, client: AsyncClient):
+        """Backward compatibility: callers that send the legacy `primaryKey`
+        field without `pkMatchMode` must still get exact-match short-circuit."""
+        mock_client = _build_query_mock()
+        mock_client.get = AsyncMock(
+            return_value=SimpleNamespace(
+                key=("test", "demo", "legacy", b"\x00"),
+                meta={"gen": 1, "ttl": 0},
+                bins={},
+            )
+        )
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test/filter",
+                json={
+                    "namespace": "test",
+                    "set": "demo",
+                    "primaryKey": "legacy",
+                },
+            )
+
+        assert resp.status_code == 200
+        mock_client.get.assert_awaited_once()
+        mock_client.query.assert_not_called()

--- a/api/tests/test_records_router.py
+++ b/api/tests/test_records_router.py
@@ -186,7 +186,11 @@ class TestFilteredRecordsPkMatchMode:
 
         assert resp.status_code == 200
         # Short-circuit: client.get is called, scan path is NOT taken.
-        mock_client.get.assert_awaited_once()
+        # Assert the resolved key is plumbed through correctly.
+        mock_client.get.assert_awaited_once_with(
+            ("test", "demo", "k1"),
+            policy=POLICY_READ,
+        )
         mock_client.query.assert_not_called()
 
     async def test_prefix_mode_runs_scan_with_pk_filter_expression(self, client: AsyncClient):
@@ -299,3 +303,163 @@ class TestFilteredRecordsPkMatchMode:
         assert resp.status_code == 200
         mock_client.get.assert_awaited_once()
         mock_client.query.assert_not_called()
+
+    async def test_invalid_regex_returns_400(self, client: AsyncClient):
+        """C1: a malformed user pattern surfaces as 400, not silent empty page."""
+        mock_client = _build_query_mock()
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test/filter",
+                json={
+                    "namespace": "test",
+                    "set": "demo",
+                    "pkPattern": "[unclosed",
+                    "pkMatchMode": "regex",
+                },
+            )
+
+        assert resp.status_code == 400
+        assert "Invalid regex pattern" in resp.json()["detail"]
+        # Critical: the scan never executes when validation fails.
+        mock_client.query.assert_not_called()
+
+    async def test_prefix_or_regex_mode_with_no_pattern_returns_422(self, client: AsyncClient):
+        """C2: empty pk_pattern with non-exact mode rejected at request level."""
+        mock_client = _build_query_mock()
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test/filter",
+                json={
+                    "namespace": "test",
+                    "set": "demo",
+                    "pkMatchMode": "prefix",
+                    # no pkPattern
+                },
+            )
+
+        assert resp.status_code == 422
+        mock_client.query.assert_not_called()
+
+    async def test_pk_prefix_without_set_returns_400(self, client: AsyncClient):
+        """C3: set is required for any PK-targeted query, not only exact mode."""
+        mock_client = _build_query_mock()
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test/filter",
+                json={
+                    "namespace": "test",
+                    "pkPattern": "user_",
+                    "pkMatchMode": "prefix",
+                },
+            )
+
+        assert resp.status_code == 400
+        assert "Set is required" in resp.json()["detail"]
+        mock_client.query.assert_not_called()
+
+    async def test_exact_mode_without_pk_falls_through_to_scan_path(self, client: AsyncClient):
+        """Pure bin-filter request (default pkMatchMode=exact, no pkPattern)
+        must skip both PK branches and run the regular scan."""
+        mock_client = _build_query_mock()
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test/filter",
+                json={
+                    "namespace": "test",
+                    "set": "demo",
+                    "filters": {
+                        "logic": "and",
+                        "conditions": [
+                            {"bin": "score", "operator": "gt", "value": 1, "binType": "integer"},
+                        ],
+                    },
+                },
+            )
+
+        assert resp.status_code == 200
+        mock_client.get.assert_not_called()
+        mock_client.query.assert_called_once_with("test", "demo")
+        policy = mock_client.query.return_value.results.await_args.args[0]
+        # Only the bin filter, no PK component.
+        assert policy["filter_expression"] == exp.gt(exp.int_bin("score"), exp.int_val(1))
+
+    async def test_prefix_mode_hasMore_true_when_results_equal_pageSize_plus_one(self, client: AsyncClient):
+        """The scan path fetches pageSize+1 records and trims to pageSize so
+        hasMore is reliable. Pin this for the new PK prefix path."""
+        # 6 records returned for pageSize=5 → hasMore=True, returned=5.
+        records = [
+            SimpleNamespace(
+                key=("test", "demo", f"k{i}", b"\x00"),
+                meta={"gen": 1, "ttl": 0},
+                bins={"score": i},
+            )
+            for i in range(6)
+        ]
+        mock_client = _build_query_mock(records)
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test/filter",
+                json={
+                    "namespace": "test",
+                    "set": "demo",
+                    "pkPattern": "k",
+                    "pkMatchMode": "prefix",
+                    "pageSize": 5,
+                },
+            )
+
+        body = resp.json()
+        assert resp.status_code == 200
+        assert body["hasMore"] is True
+        assert body["returnedRecords"] == 5
+        assert len(body["records"]) == 5

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.test.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.test.tsx
@@ -108,3 +108,65 @@ describe("RecordBrowserPage — error / empty / loading separation (#270 regress
     expect(mockedFilter).toHaveBeenCalledTimes(2)
   })
 })
+
+describe("RecordBrowserPage — PK match mode (#287)", () => {
+  it("defaults to exact mode and sends pkMatchMode=exact in the request", async () => {
+    mockedFilter.mockResolvedValueOnce(fixtureResponse(1))
+    render(<RecordBrowserPage params={PARAMS} />)
+    await screen.findByText("pk-0")
+
+    expect(mockedFilter).toHaveBeenLastCalledWith(
+      "conn-test",
+      expect.objectContaining({
+        pkMatchMode: "exact",
+        pkPattern: null,
+      }),
+    )
+  })
+
+  it("switching to prefix mode updates placeholder and reveals the caveat banner", async () => {
+    mockedFilter.mockResolvedValue(fixtureResponse(0))
+    render(<RecordBrowserPage params={PARAMS} />)
+
+    // Wait for initial load to settle.
+    await screen.findByText(/no records in this set/i)
+
+    // Default placeholder is exact-mode.
+    expect(screen.getByPlaceholderText("Primary key...")).toBeInTheDocument()
+
+    await userEvent.click(screen.getByLabelText(/pk match mode/i))
+    await userEvent.click(screen.getByRole("option", { name: /prefix/i }))
+
+    expect(
+      screen.getByPlaceholderText(/Prefix \(e.g\., user_\)/i),
+    ).toBeInTheDocument()
+    // InfoBanner caveat is rendered.
+    expect(screen.getByRole("status")).toHaveTextContent(/full set scan/i)
+    expect(screen.getByRole("status")).toHaveTextContent(/POLICY_KEY_SEND/)
+  })
+
+  it("submitting in prefix mode sends pkPattern + pkMatchMode=prefix", async () => {
+    mockedFilter
+      .mockResolvedValueOnce(fixtureResponse(0)) // initial load
+      .mockResolvedValueOnce(fixtureResponse(2)) // after Search
+
+    render(<RecordBrowserPage params={PARAMS} />)
+    await screen.findByText(/no records in this set/i)
+
+    await userEvent.click(screen.getByLabelText(/pk match mode/i))
+    await userEvent.click(screen.getByRole("option", { name: /prefix/i }))
+
+    const input = screen.getByPlaceholderText(/Prefix \(e.g\., user_\)/i)
+    await userEvent.type(input, "acct_")
+
+    await userEvent.click(screen.getByRole("button", { name: /^search$/i }))
+
+    expect(mockedFilter).toHaveBeenLastCalledWith(
+      "conn-test",
+      expect.objectContaining({
+        pkPattern: "acct_",
+        pkMatchMode: "prefix",
+      }),
+    )
+  })
+})

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.test.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.test.tsx
@@ -145,7 +145,7 @@ describe("RecordBrowserPage — PK match mode (#287)", () => {
     expect(screen.getByRole("status")).toHaveTextContent(/POLICY_KEY_SEND/)
   })
 
-  it("submitting in prefix mode sends pkPattern + pkMatchMode=prefix", async () => {
+  it("submitting in prefix mode sends pkPattern + pkMatchMode=prefix and no legacy primaryKey", async () => {
     mockedFilter
       .mockResolvedValueOnce(fixtureResponse(0)) // initial load
       .mockResolvedValueOnce(fixtureResponse(2)) // after Search
@@ -168,5 +168,43 @@ describe("RecordBrowserPage — PK match mode (#287)", () => {
         pkMatchMode: "prefix",
       }),
     )
+    // Belt-and-braces: no dual-field send. Backend rejects pkPattern +
+    // primaryKey simultaneously, so this assertion would catch a regression
+    // where the page accidentally re-introduces the legacy field.
+    const lastCallBody = mockedFilter.mock.lastCall?.[1] ?? {}
+    expect(lastCallBody).not.toHaveProperty("primaryKey")
+  })
+
+  it("disables the Search button and surfaces an inline error for an invalid regex", async () => {
+    mockedFilter.mockResolvedValueOnce(fixtureResponse(0))
+    render(<RecordBrowserPage params={PARAMS} />)
+    await screen.findByText(/no records in this set/i)
+
+    await userEvent.click(screen.getByLabelText(/pk match mode/i))
+    await userEvent.click(screen.getByRole("option", { name: /regex/i }))
+
+    const input = screen.getByPlaceholderText(/Regex/i)
+    // userEvent.type treats `[` as a special key sequence — paste a literal value instead.
+    input.focus()
+    await userEvent.paste("[unclosed")
+
+    // Inline error visible (alert role).
+    expect(await screen.findByRole("alert")).toBeInTheDocument()
+    // Search button is disabled because the draft is invalid.
+    expect(screen.getByRole("button", { name: /^search$/i })).toBeDisabled()
+    // No call past the initial mount.
+    expect(mockedFilter).toHaveBeenCalledTimes(1)
+  })
+
+  it("disables Search when prefix/regex mode is selected with an empty input", async () => {
+    mockedFilter.mockResolvedValueOnce(fixtureResponse(0))
+    render(<RecordBrowserPage params={PARAMS} />)
+    await screen.findByText(/no records in this set/i)
+
+    await userEvent.click(screen.getByLabelText(/pk match mode/i))
+    await userEvent.click(screen.getByRole("option", { name: /prefix/i }))
+
+    // Input is still empty in prefix mode.
+    expect(screen.getByRole("button", { name: /^search$/i })).toBeDisabled()
   })
 })

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
@@ -180,7 +180,8 @@ export default function RecordBrowserPage({ params }: PageProps) {
           namespace: params.namespace,
           set: params.set,
           pageSize: size,
-          primaryKey: pk || null,
+          pkPattern: pk || null,
+          pkMatchMode: target.pkMatchMode,
           filters: filters ?? null,
         })
         setRecords(resp.records)
@@ -547,6 +548,7 @@ function StatusBar({
 
 function draftEquals(a: FilterDraft, b: FilterDraft): boolean {
   if (a.pk !== b.pk) return false
+  if (a.pkMatchMode !== b.pkMatchMode) return false
   if (a.logic !== b.logic) return false
   if (a.conditions.length !== b.conditions.length) return false
   for (let i = 0; i < a.conditions.length; i++) {

--- a/ui/src/components/InfoBanner.tsx
+++ b/ui/src/components/InfoBanner.tsx
@@ -1,0 +1,26 @@
+"use client"
+
+import { RiInformationLine } from "@remixicon/react"
+
+export interface InfoBannerProps {
+  title?: string
+  children: React.ReactNode
+}
+
+export function InfoBanner({ title, children }: InfoBannerProps) {
+  return (
+    <div
+      role="status"
+      className="flex gap-2 rounded border border-indigo-200 bg-indigo-50 px-3 py-2 text-xs text-indigo-700 dark:border-indigo-900/50 dark:bg-indigo-950/40 dark:text-indigo-300"
+    >
+      <RiInformationLine
+        className="mt-0.5 size-3.5 shrink-0"
+        aria-hidden="true"
+      />
+      <div className="flex flex-col gap-0.5">
+        {title && <span className="font-semibold">{title}</span>}
+        <span>{children}</span>
+      </div>
+    </div>
+  )
+}

--- a/ui/src/components/browser/RecordFilters.tsx
+++ b/ui/src/components/browser/RecordFilters.tsx
@@ -9,6 +9,7 @@ import {
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { Button } from "@/components/Button"
+import { InfoBanner } from "@/components/InfoBanner"
 import { Input } from "@/components/Input"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/Popover"
 import { Tooltip } from "@/components/Tooltip"
@@ -29,9 +30,16 @@ import type {
   BinDataType,
   FilterCondition,
   FilterOperator,
+  PkMatchMode,
 } from "@/lib/types/query"
 import type { BinValue } from "@/lib/types/record"
 import { cx } from "@/lib/utils"
+
+const PK_PLACEHOLDER_BY_MODE: Record<PkMatchMode, string> = {
+  exact: "Primary key...",
+  prefix: "Prefix (e.g., user_)",
+  regex: "Regex (e.g., ^acct[0-9]+$)",
+}
 
 export interface FilterDraftCondition extends FilterCondition {
   id: string
@@ -40,12 +48,13 @@ export interface FilterDraftCondition extends FilterCondition {
 
 export interface FilterDraft {
   pk: string
+  pkMatchMode: PkMatchMode
   logic: "and" | "or"
   conditions: FilterDraftCondition[]
 }
 
 export function emptyFilterDraft(): FilterDraft {
-  return { pk: "", logic: "and", conditions: [] }
+  return { pk: "", pkMatchMode: "exact", logic: "and", conditions: [] }
 }
 
 export function draftHasFilters(draft: FilterDraft): boolean {
@@ -109,6 +118,11 @@ export function RecordFilters({
 
   const updatePk = useCallback(
     (pk: string) => onChange({ ...draft, pk }),
+    [draft, onChange],
+  )
+
+  const updatePkMatchMode = useCallback(
+    (pkMatchMode: PkMatchMode) => onChange({ ...draft, pkMatchMode }),
     [draft, onChange],
   )
 
@@ -177,13 +191,32 @@ export function RecordFilters({
           <span className="font-mono text-[10px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-500">
             PK
           </span>
+          <Select
+            value={draft.pkMatchMode}
+            onValueChange={(v) => updatePkMatchMode(v as PkMatchMode)}
+          >
+            <SelectTrigger
+              className="h-8 w-[88px] text-xs"
+              aria-label="PK match mode"
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="exact">Exact</SelectItem>
+              <SelectItem value="prefix">Prefix</SelectItem>
+              <SelectItem value="regex">Regex</SelectItem>
+            </SelectContent>
+          </Select>
           <Input
             type="search"
             value={draft.pk}
             onChange={(e) => updatePk(e.target.value)}
             onKeyDown={handleApplyKey}
-            placeholder="Primary key..."
-            className="sm:w-60"
+            placeholder={PK_PLACEHOLDER_BY_MODE[draft.pkMatchMode]}
+            className={cx(
+              "sm:w-60",
+              draft.pkMatchMode !== "exact" && "font-mono",
+            )}
           />
         </div>
 
@@ -267,6 +300,14 @@ export function RecordFilters({
           </div>
         )}
       </div>
+
+      {draft.pkMatchMode !== "exact" && (
+        <InfoBanner title="PK pattern search uses a full set scan">
+          PK is digest-indexed, so prefix/regex matching falls back to a
+          server-side regex over every record. Only records written with
+          POLICY_KEY_SEND (user key persisted) are eligible to match.
+        </InfoBanner>
+      )}
 
       {availableBins.length === 0 && !pickerOpen && (
         <p className="text-[11px] text-gray-500 dark:text-gray-500">

--- a/ui/src/components/browser/RecordFilters.tsx
+++ b/ui/src/components/browser/RecordFilters.tsx
@@ -41,6 +41,34 @@ const PK_PLACEHOLDER_BY_MODE: Record<PkMatchMode, string> = {
   regex: "Regex (e.g., ^acct[0-9]+$)",
 }
 
+/**
+ * Validate the PK input against the selected match mode. Returns null when
+ * the draft is OK to submit, otherwise a short user-facing error string.
+ *
+ * Caveat: JS RegExp follows ECMAScript syntax, while the Aerospike server
+ * uses POSIX. The two grammars overlap on the structural errors users hit
+ * most (unbalanced brackets / parens, dangling quantifiers), so a JS-side
+ * compile catches the common typos and surfaces them as inline UI feedback
+ * before the user wastes a round-trip on a 400.
+ */
+export function validatePkDraft(pk: string, mode: PkMatchMode): string | null {
+  if (mode === "exact") return null
+  if (pk.trim() === "") {
+    return mode === "prefix"
+      ? "Enter a prefix to search."
+      : "Enter a regex pattern."
+  }
+  if (mode === "regex") {
+    try {
+      // eslint-disable-next-line no-new
+      new RegExp(pk)
+    } catch (e) {
+      return e instanceof Error ? e.message : "Invalid regex pattern"
+    }
+  }
+  return null
+}
+
 export interface FilterDraftCondition extends FilterCondition {
   id: string
   binType: BinDataType
@@ -170,18 +198,23 @@ export function RecordFilters({
     onChange({ ...draft, logic: draft.logic === "and" ? "or" : "and" })
   }, [draft, onChange])
 
+  const pkError = useMemo(
+    () => validatePkDraft(draft.pk, draft.pkMatchMode),
+    [draft.pk, draft.pkMatchMode],
+  )
+
   const handleApplyKey = useCallback(
     (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key === "Enter") {
+      if (e.key === "Enter" && pkError == null) {
         e.preventDefault()
         onApply()
       }
     },
-    [onApply],
+    [onApply, pkError],
   )
 
   const hasDraft = draftHasFilters(draft)
-  const canApply = !loading && dirty !== false
+  const canApply = !loading && dirty !== false && pkError == null
 
   return (
     <div className="flex flex-col gap-2">
@@ -213,9 +246,14 @@ export function RecordFilters({
             onChange={(e) => updatePk(e.target.value)}
             onKeyDown={handleApplyKey}
             placeholder={PK_PLACEHOLDER_BY_MODE[draft.pkMatchMode]}
+            aria-invalid={pkError != null && draft.pk.length > 0}
+            aria-describedby={pkError ? "pk-error" : undefined}
             className={cx(
               "sm:w-60",
               draft.pkMatchMode !== "exact" && "font-mono",
+              pkError != null &&
+                draft.pk.length > 0 &&
+                "border-red-400 focus:border-red-500 focus:ring-red-200 dark:border-red-700",
             )}
           />
         </div>
@@ -300,6 +338,16 @@ export function RecordFilters({
           </div>
         )}
       </div>
+
+      {pkError && draft.pk.length > 0 && (
+        <p
+          id="pk-error"
+          role="alert"
+          className="text-[11px] text-red-600 dark:text-red-400"
+        >
+          {pkError}
+        </p>
+      )}
 
       {draft.pkMatchMode !== "exact" && (
         <InfoBanner title="PK pattern search uses a full set scan">

--- a/ui/src/lib/types/query.ts
+++ b/ui/src/lib/types/query.ts
@@ -54,6 +54,22 @@ export type FilterOperator =
   | "is_false"
   | "geo_within"
   | "geo_contains"
+  | "pk_prefix"
+  | "pk_regex"
+
+/**
+ * PK match modes for the top-level pkPattern field on FilteredQueryRequest.
+ * - "exact": single-record client.get short-circuit (no scan).
+ * - "prefix" / "regex": full set scan + server-side regex_compare on the
+ *   record's user key. Only matches records written with POLICY_KEY_SEND.
+ */
+export type PkMatchMode = "exact" | "prefix" | "regex"
+
+/**
+ * Sentinel bin name for FilterCondition entries that target the primary key
+ * via pk_prefix / pk_regex operators. Mirrors PK_BIN_PLACEHOLDER on the API.
+ */
+export const PK_BIN_PLACEHOLDER = "__pk__"
 
 export type BinDataType =
   | "integer"
@@ -88,6 +104,10 @@ export interface FilteredQueryRequest {
   pageSize?: number
   primaryKey?: string | null
   pkType?: PkType
+  /** PK pattern; canonical replacement for primaryKey. */
+  pkPattern?: string | null
+  /** Match mode for pkPattern. Defaults to "exact" when omitted. */
+  pkMatchMode?: PkMatchMode
 }
 
 export interface FilteredQueryResponse {

--- a/ui/src/lib/types/query.ts
+++ b/ui/src/lib/types/query.ts
@@ -65,12 +65,6 @@ export type FilterOperator =
  */
 export type PkMatchMode = "exact" | "prefix" | "regex"
 
-/**
- * Sentinel bin name for FilterCondition entries that target the primary key
- * via pk_prefix / pk_regex operators. Mirrors PK_BIN_PLACEHOLDER on the API.
- */
-export const PK_BIN_PLACEHOLDER = "__pk__"
-
 export type BinDataType =
   | "integer"
   | "float"

--- a/ui/vitest.setup.ts
+++ b/ui/vitest.setup.ts
@@ -3,6 +3,22 @@ import "@testing-library/jest-dom/vitest"
 import { afterEach, vi } from "vitest"
 import { cleanup } from "@testing-library/react"
 
+// Radix UI primitives (Select, Popover, …) call DOM methods that jsdom doesn't
+// implement: hasPointerCapture / releasePointerCapture / scrollIntoView.
+// Polyfill them globally so userEvent interactions on Radix components don't
+// throw inside their internal pointer-capture logic.
+if (typeof Element !== "undefined") {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => {}
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = () => {}
+  }
+}
+
 afterEach(() => {
   cleanup()
   vi.restoreAllMocks()


### PR DESCRIPTION
## Summary

Closes #287. Adds PK (Primary Key) regex/prefix search to the record browser. Until now cluster-manager only exposed exact-match lookup, even though aerospike-py already supports `exp.regex_compare(exp.key(STRING))`.

- **API**: `FilteredQueryRequest` gains `pkPattern` + `pkMatchMode` (`exact`/`prefix`/`regex`). Exact preserves the existing `client.get` short-circuit; prefix/regex run a scan and AND the PK expression with bin filters via `exp.and_`. New `PK_PREFIX`/`PK_REGEX` `FilterOperator` values are also exposed (gated to a `__pk__` placeholder via a model validator) so a future query builder can compose PK conditions with bin filters.
- **UI**: PK input on the record browser gets an Exact/Prefix/Regex `Select`. Non-exact modes render a new `InfoBanner` caveat — "full set scan, only matches records written with POLICY_KEY_SEND". Backwards compatible: the legacy `primaryKey` field is still accepted by the API.
- **No-Lua policy preserved** (`CLAUDE.md:119`) — all server-side filtering uses `aerospike_py.exp.*`.
- **Out of scope**: a separate `/clusters/[id]/query` route doesn't exist in the codebase; that's left for a follow-up. Legacy `routers/query.py` (predicate-based) is untouched.

## Test plan

- [x] API: new `tests/test_expression_builder.py` (PK helper, model validator, AND-composition) + extended `test_records_router.py` (exact short-circuit, prefix scan policy, regex+bin AND, legacy `primaryKey` back-compat). 320 passed.
- [x] UI: extended `page.test.tsx` with PK mode default, placeholder switch + InfoBanner render, and prefix-mode payload assertion. 25 passed. `vitest.setup.ts` polyfills `hasPointerCapture`/`scrollIntoView` so Radix Select can be exercised under jsdom.
- [x] `ruff check`, `pyright`, `tsc --noEmit`, `next lint` clean.
- [ ] Manual e2e on `compose.yaml` stack: seed `test.sample_set` (1234 records, POLICY_KEY_SEND), exercise `exact`/`prefix`/`regex` modes + AND-with-bin-filter; verify InfoBanner copy + scanned vs returned counts.