### PR TITLE
feat(api,ui): add workspace concept for cluster grouping

### DIFF
--- a/api/src/aerospike_cluster_manager_api/db/__init__.py
+++ b/api/src/aerospike_cluster_manager_api/db/__init__.py
@@ -15,6 +15,7 @@ from aerospike_cluster_manager_api.db._base import DatabaseBackend
 
 if TYPE_CHECKING:
     from aerospike_cluster_manager_api.models.connection import ConnectionProfile
+    from aerospike_cluster_manager_api.models.workspace import Workspace
 
 _backend: types.ModuleType | None = None
 
@@ -47,8 +48,13 @@ async def check_health() -> bool:
     return await _get_backend().check_health()
 
 
-async def get_all_connections() -> list[ConnectionProfile]:
-    return await _get_backend().get_all_connections()
+# ---------------------------------------------------------------------------
+# Connections
+# ---------------------------------------------------------------------------
+
+
+async def get_all_connections(workspace_id: str | None = None) -> list[ConnectionProfile]:
+    return await _get_backend().get_all_connections(workspace_id)
 
 
 async def get_connection(conn_id: str) -> ConnectionProfile | None:
@@ -65,3 +71,32 @@ async def update_connection(conn_id: str, data: dict) -> ConnectionProfile | Non
 
 async def delete_connection(conn_id: str) -> bool:
     return await _get_backend().delete_connection(conn_id)
+
+
+# ---------------------------------------------------------------------------
+# Workspaces
+# ---------------------------------------------------------------------------
+
+
+async def get_all_workspaces() -> list[Workspace]:
+    return await _get_backend().get_all_workspaces()
+
+
+async def get_workspace(workspace_id: str) -> Workspace | None:
+    return await _get_backend().get_workspace(workspace_id)
+
+
+async def create_workspace(ws: Workspace) -> None:
+    await _get_backend().create_workspace(ws)
+
+
+async def update_workspace(workspace_id: str, data: dict) -> Workspace | None:
+    return await _get_backend().update_workspace(workspace_id, data)
+
+
+async def delete_workspace(workspace_id: str) -> bool:
+    return await _get_backend().delete_workspace(workspace_id)
+
+
+async def count_connections_in_workspace(workspace_id: str) -> int:
+    return await _get_backend().count_connections_in_workspace(workspace_id)

--- a/api/src/aerospike_cluster_manager_api/db/_base.py
+++ b/api/src/aerospike_cluster_manager_api/db/_base.py
@@ -10,6 +10,7 @@ from datetime import UTC, datetime
 from typing import Any, Protocol, runtime_checkable
 
 from aerospike_cluster_manager_api.models.connection import ConnectionProfile
+from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID, Workspace
 
 
 @runtime_checkable
@@ -22,7 +23,7 @@ class DatabaseBackend(Protocol):
 
     async def check_health(self) -> bool: ...
 
-    async def get_all_connections(self) -> list[ConnectionProfile]: ...
+    async def get_all_connections(self, workspace_id: str | None = None) -> list[ConnectionProfile]: ...
 
     async def get_connection(self, conn_id: str) -> ConnectionProfile | None: ...
 
@@ -31,6 +32,18 @@ class DatabaseBackend(Protocol):
     async def update_connection(self, conn_id: str, data: dict) -> ConnectionProfile | None: ...
 
     async def delete_connection(self, conn_id: str) -> bool: ...
+
+    async def get_all_workspaces(self) -> list[Workspace]: ...
+
+    async def get_workspace(self, workspace_id: str) -> Workspace | None: ...
+
+    async def create_workspace(self, ws: Workspace) -> None: ...
+
+    async def update_workspace(self, workspace_id: str, data: dict) -> Workspace | None: ...
+
+    async def delete_workspace(self, workspace_id: str) -> bool: ...
+
+    async def count_connections_in_workspace(self, workspace_id: str) -> int: ...
 
 
 def _decode_json_dict(value: object) -> dict[str, Any]:
@@ -73,6 +86,7 @@ def row_to_profile(row: Any) -> ConnectionProfile:
     labels_raw = row["labels"] if "labels" in row.keys() else None  # noqa: SIM118
     # ConnectionProfile.labels validator normalizes {} -> {"env": "default"}.
     labels = _decode_json_dict(labels_raw)
+    workspace_id = row["workspace_id"] if "workspace_id" in row.keys() else None  # noqa: SIM118
     return ConnectionProfile(
         id=row["id"],
         name=row["name"],
@@ -84,8 +98,43 @@ def row_to_profile(row: Any) -> ConnectionProfile:
         color=row["color"],
         description=row["description"],
         labels=labels,
+        workspaceId=workspace_id or DEFAULT_WORKSPACE_ID,
         createdAt=row["created_at"],
         updatedAt=row["updated_at"],
+    )
+
+
+def row_to_workspace(row: Any) -> Workspace:
+    """Convert a database row (dict-like) to a Workspace model."""
+    return Workspace(
+        id=row["id"],
+        name=row["name"],
+        color=row["color"],
+        description=row["description"] if "description" in row.keys() else None,  # noqa: SIM118
+        isDefault=bool(row["is_default"]),
+        createdAt=row["created_at"],
+        updatedAt=row["updated_at"],
+    )
+
+
+def build_merged_workspace(
+    existing: Workspace,
+    data: dict[str, Any],
+) -> Workspace:
+    """Merge update data into an existing workspace, refreshing ``updatedAt``."""
+    merged = existing.model_dump()
+    merged.update(data)
+    merged["updatedAt"] = datetime.now(UTC).isoformat()
+    return Workspace(
+        id=existing.id,
+        name=merged["name"],
+        color=merged["color"],
+        description=merged.get("description"),
+        # is_default is intentionally never overwritten through update — only
+        # the migration sets it. Preserves the built-in default flag.
+        isDefault=existing.isDefault,
+        createdAt=existing.createdAt,
+        updatedAt=merged["updatedAt"],
     )
 
 
@@ -112,6 +161,7 @@ def build_merged_profile(
         color=merged["color"],
         description=merged.get("description"),
         labels=merged.get("labels") or {},
+        workspaceId=merged.get("workspaceId") or DEFAULT_WORKSPACE_ID,
         createdAt=existing.createdAt,
         updatedAt=merged["updatedAt"],
     )

--- a/api/src/aerospike_cluster_manager_api/db/_postgres.py
+++ b/api/src/aerospike_cluster_manager_api/db/_postgres.py
@@ -279,8 +279,18 @@ async def update_workspace(workspace_id: str, data: dict) -> Workspace | None:
 
 
 async def delete_workspace(workspace_id: str) -> bool:
+    """Delete a workspace by id, refusing to delete the built-in default.
+
+    The ``is_default = FALSE`` clause is defense-in-depth: the router already
+    rejects deletes of the default workspace with HTTP 400, but enforcing
+    it at the DB layer guarantees the invariant holds even if a future
+    caller bypasses the router (refactor, internal task, direct tests).
+    """
     pool = _get_pool()
-    result = await pool.execute("DELETE FROM workspaces WHERE id = $1", workspace_id)
+    result = await pool.execute(
+        "DELETE FROM workspaces WHERE id = $1 AND is_default = FALSE",
+        workspace_id,
+    )
     return result == "DELETE 1"
 
 

--- a/api/src/aerospike_cluster_manager_api/db/_postgres.py
+++ b/api/src/aerospike_cluster_manager_api/db/_postgres.py
@@ -7,12 +7,19 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import UTC, datetime
 
 import asyncpg
 
 from aerospike_cluster_manager_api import config
-from aerospike_cluster_manager_api.db._base import build_merged_profile, row_to_profile
+from aerospike_cluster_manager_api.db._base import (
+    build_merged_profile,
+    build_merged_workspace,
+    row_to_profile,
+    row_to_workspace,
+)
 from aerospike_cluster_manager_api.models.connection import ConnectionProfile
+from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID, Workspace
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +41,18 @@ CREATE TABLE IF NOT EXISTS connections (
 );
 """
 
+CREATE_WORKSPACES_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS workspaces (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    color       TEXT NOT NULL DEFAULT '#6366F1',
+    description TEXT,
+    is_default  BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
+);
+"""
+
 
 def _get_pool() -> asyncpg.Pool:
     if _pool is None:
@@ -49,6 +68,27 @@ async def _apply_migrations(conn: asyncpg.Connection | asyncpg.pool.PoolConnecti
     """
     await conn.execute("ALTER TABLE connections ADD COLUMN IF NOT EXISTS description TEXT")
     await conn.execute("ALTER TABLE connections ADD COLUMN IF NOT EXISTS labels JSONB")
+    await conn.execute("ALTER TABLE connections ADD COLUMN IF NOT EXISTS workspace_id TEXT")
+
+    # Seed the built-in default workspace and back-fill any pre-existing
+    # connections. Idempotent: ON CONFLICT DO NOTHING / WHERE workspace_id IS NULL.
+    now = datetime.now(UTC).isoformat()
+    await conn.execute(
+        """INSERT INTO workspaces
+               (id, name, color, description, is_default, created_at, updated_at)
+           VALUES ($1, $2, $3, $4, TRUE, $5, $6)
+           ON CONFLICT (id) DO NOTHING""",
+        DEFAULT_WORKSPACE_ID,
+        "Default",
+        "#6366F1",
+        "Default workspace",
+        now,
+        now,
+    )
+    await conn.execute(
+        "UPDATE connections SET workspace_id = $1 WHERE workspace_id IS NULL",
+        DEFAULT_WORKSPACE_ID,
+    )
 
 
 async def init_db() -> None:
@@ -64,6 +104,7 @@ async def init_db() -> None:
     try:
         async with pool.acquire() as conn:
             await conn.execute(CREATE_TABLE_SQL)
+            await conn.execute(CREATE_WORKSPACES_TABLE_SQL)
             await _apply_migrations(conn)
         _pool = pool
     except Exception:
@@ -95,16 +136,23 @@ async def close_db() -> None:
 # ---------------------------------------------------------------------------
 
 _row_to_profile = row_to_profile
+_row_to_workspace = row_to_workspace
 
 
 # ---------------------------------------------------------------------------
-# Async public API
+# Async public API — connections
 # ---------------------------------------------------------------------------
 
 
-async def get_all_connections() -> list[ConnectionProfile]:
+async def get_all_connections(workspace_id: str | None = None) -> list[ConnectionProfile]:
     pool = _get_pool()
-    rows = await pool.fetch("SELECT * FROM connections ORDER BY created_at")
+    if workspace_id is not None:
+        rows = await pool.fetch(
+            "SELECT * FROM connections WHERE workspace_id = $1 ORDER BY created_at",
+            workspace_id,
+        )
+    else:
+        rows = await pool.fetch("SELECT * FROM connections ORDER BY created_at")
     return [_row_to_profile(row) for row in rows]
 
 
@@ -117,8 +165,9 @@ async def get_connection(conn_id: str) -> ConnectionProfile | None:
 async def create_connection(conn: ConnectionProfile) -> None:
     pool = _get_pool()
     await pool.execute(
-        """INSERT INTO connections (id, name, hosts, port, cluster_name, username, password, color, description, labels, created_at, updated_at)
-           VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7, $8, $9, $10::jsonb, $11, $12)""",
+        """INSERT INTO connections (id, name, hosts, port, cluster_name, username, password,
+                                    color, description, labels, workspace_id, created_at, updated_at)
+           VALUES ($1, $2, $3::jsonb, $4, $5, $6, $7, $8, $9, $10::jsonb, $11, $12, $13)""",
         conn.id,
         conn.name,
         json.dumps(conn.hosts),
@@ -129,6 +178,7 @@ async def create_connection(conn: ConnectionProfile) -> None:
         conn.color,
         conn.description,
         json.dumps(conn.labels),
+        conn.workspaceId,
         conn.createdAt,
         conn.updatedAt,
     )
@@ -148,9 +198,9 @@ async def update_connection(conn_id: str, data: dict) -> ConnectionProfile | Non
             """UPDATE connections
                    SET name = $1, hosts = $2::jsonb, port = $3, cluster_name = $4,
                        username = $5, password = $6, color = $7,
-                       description = $8, labels = $9::jsonb,
-                       updated_at = $10
-                   WHERE id = $11""",
+                       description = $8, labels = $9::jsonb, workspace_id = $10,
+                       updated_at = $11
+                   WHERE id = $12""",
             updated.name,
             json.dumps(updated.hosts),
             updated.port,
@@ -160,6 +210,7 @@ async def update_connection(conn_id: str, data: dict) -> ConnectionProfile | Non
             updated.color,
             updated.description,
             json.dumps(updated.labels),
+            updated.workspaceId,
             updated.updatedAt,
             conn_id,
         )
@@ -170,3 +221,70 @@ async def delete_connection(conn_id: str) -> bool:
     pool = _get_pool()
     result = await pool.execute("DELETE FROM connections WHERE id = $1", conn_id)
     return result == "DELETE 1"
+
+
+# ---------------------------------------------------------------------------
+# Async public API — workspaces
+# ---------------------------------------------------------------------------
+
+
+async def get_all_workspaces() -> list[Workspace]:
+    pool = _get_pool()
+    rows = await pool.fetch("SELECT * FROM workspaces ORDER BY is_default DESC, created_at")
+    return [_row_to_workspace(row) for row in rows]
+
+
+async def get_workspace(workspace_id: str) -> Workspace | None:
+    pool = _get_pool()
+    row = await pool.fetchrow("SELECT * FROM workspaces WHERE id = $1", workspace_id)
+    return _row_to_workspace(row) if row else None
+
+
+async def create_workspace(ws: Workspace) -> None:
+    pool = _get_pool()
+    await pool.execute(
+        """INSERT INTO workspaces (id, name, color, description, is_default, created_at, updated_at)
+           VALUES ($1, $2, $3, $4, $5, $6, $7)""",
+        ws.id,
+        ws.name,
+        ws.color,
+        ws.description,
+        ws.isDefault,
+        ws.createdAt,
+        ws.updatedAt,
+    )
+
+
+async def update_workspace(workspace_id: str, data: dict) -> Workspace | None:
+    pool = _get_pool()
+    async with pool.acquire() as conn, conn.transaction():
+        row = await conn.fetchrow("SELECT * FROM workspaces WHERE id = $1 FOR UPDATE", workspace_id)
+        if not row:
+            return None
+
+        existing = _row_to_workspace(row)
+        updated = build_merged_workspace(existing, data)
+
+        await conn.execute(
+            """UPDATE workspaces
+                   SET name = $1, color = $2, description = $3, updated_at = $4
+                   WHERE id = $5""",
+            updated.name,
+            updated.color,
+            updated.description,
+            updated.updatedAt,
+            workspace_id,
+        )
+        return updated
+
+
+async def delete_workspace(workspace_id: str) -> bool:
+    pool = _get_pool()
+    result = await pool.execute("DELETE FROM workspaces WHERE id = $1", workspace_id)
+    return result == "DELETE 1"
+
+
+async def count_connections_in_workspace(workspace_id: str) -> int:
+    pool = _get_pool()
+    val = await pool.fetchval("SELECT COUNT(*) FROM connections WHERE workspace_id = $1", workspace_id)
+    return int(val) if val is not None else 0

--- a/api/src/aerospike_cluster_manager_api/db/_sqlite.py
+++ b/api/src/aerospike_cluster_manager_api/db/_sqlite.py
@@ -166,14 +166,14 @@ _row_to_workspace = row_to_workspace
 async def get_all_connections(workspace_id: str | None = None) -> list[ConnectionProfile]:
     conn = _get_conn()
     if workspace_id is not None:
-        cursor = conn.execute(
+        async with conn.execute(
             "SELECT * FROM connections WHERE workspace_id = ? ORDER BY created_at",
             (workspace_id,),
-        )
+        ) as cursor:
+            rows = await cursor.fetchall()
     else:
-        cursor = conn.execute("SELECT * FROM connections ORDER BY created_at")
-    async with cursor as cur:
-        rows = await cur.fetchall()
+        async with conn.execute("SELECT * FROM connections ORDER BY created_at") as cursor:
+            rows = await cursor.fetchall()
     return [_row_to_profile(row) for row in rows]
 
 
@@ -309,16 +309,24 @@ async def create_workspace(ws: Workspace) -> None:
 
 
 async def update_workspace(workspace_id: str, data: dict) -> Workspace | None:
+    """Atomic read-modify-write under a BEGIN IMMEDIATE write lock.
+
+    Mirrors the Postgres ``SELECT ... FOR UPDATE`` invariant: the SELECT
+    and UPDATE must run inside the same transaction so a concurrent
+    writer cannot overwrite our merged result with stale data.
+    """
     db_conn = _get_conn()
-    async with db_conn.execute("SELECT * FROM workspaces WHERE id = ?", (workspace_id,)) as cursor:
-        row = await cursor.fetchone()
-    if not row:
-        return None
-
-    existing = _row_to_workspace(row)
-    updated = build_merged_workspace(existing, data)
-
+    await db_conn.execute("BEGIN IMMEDIATE")
     try:
+        async with db_conn.execute("SELECT * FROM workspaces WHERE id = ?", (workspace_id,)) as cursor:
+            row = await cursor.fetchone()
+        if not row:
+            await db_conn.rollback()
+            return None
+
+        existing = _row_to_workspace(row)
+        updated = build_merged_workspace(existing, data)
+
         await db_conn.execute(
             """UPDATE workspaces
                    SET name = ?, color = ?, description = ?, updated_at = ?
@@ -340,9 +348,19 @@ async def update_workspace(workspace_id: str, data: dict) -> Workspace | None:
 
 
 async def delete_workspace(workspace_id: str) -> bool:
+    """Delete a workspace by id, refusing to delete the built-in default.
+
+    The ``is_default = 0`` clause is defense-in-depth: the router already
+    rejects deletes of the default workspace with HTTP 400, but enforcing
+    it at the DB layer guarantees the invariant holds even if a future
+    caller bypasses the router (refactor, internal task, direct tests).
+    """
     db_conn = _get_conn()
     try:
-        cursor = await db_conn.execute("DELETE FROM workspaces WHERE id = ?", (workspace_id,))
+        cursor = await db_conn.execute(
+            "DELETE FROM workspaces WHERE id = ? AND is_default = 0",
+            (workspace_id,),
+        )
         await db_conn.commit()
     except Exception:
         await db_conn.rollback()

--- a/api/src/aerospike_cluster_manager_api/db/_sqlite.py
+++ b/api/src/aerospike_cluster_manager_api/db/_sqlite.py
@@ -9,12 +9,19 @@ import json
 import logging
 import os
 import sqlite3
+from datetime import UTC, datetime
 
 import aiosqlite
 
 from aerospike_cluster_manager_api import config
-from aerospike_cluster_manager_api.db._base import build_merged_profile, row_to_profile
+from aerospike_cluster_manager_api.db._base import (
+    build_merged_profile,
+    build_merged_workspace,
+    row_to_profile,
+    row_to_workspace,
+)
 from aerospike_cluster_manager_api.models.connection import ConnectionProfile
+from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID, Workspace
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +41,18 @@ CREATE TABLE IF NOT EXISTS connections (
     labels       TEXT,
     created_at   TEXT NOT NULL,
     updated_at   TEXT NOT NULL
+);
+"""
+
+CREATE_WORKSPACES_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS workspaces (
+    id          TEXT PRIMARY KEY,
+    name        TEXT NOT NULL,
+    color       TEXT NOT NULL DEFAULT '#6366F1',
+    description TEXT,
+    is_default  INTEGER NOT NULL DEFAULT 0,
+    created_at  TEXT NOT NULL,
+    updated_at  TEXT NOT NULL
 );
 """
 
@@ -59,6 +78,33 @@ async def _apply_migrations(conn: aiosqlite.Connection) -> None:
         await conn.execute("ALTER TABLE connections ADD COLUMN labels TEXT")
         await conn.commit()
 
+    if "workspace_id" not in columns:
+        logger.info("Migrating SQLite: adding workspace_id column")
+        await conn.execute("ALTER TABLE connections ADD COLUMN workspace_id TEXT")
+        await conn.commit()
+
+    # Seed the built-in default workspace and back-fill any pre-existing
+    # connections. Idempotent: INSERT OR IGNORE / UPDATE WHERE NULL.
+    now = datetime.now(UTC).isoformat()
+    await conn.execute(
+        """INSERT OR IGNORE INTO workspaces
+               (id, name, color, description, is_default, created_at, updated_at)
+           VALUES (?, ?, ?, ?, 1, ?, ?)""",
+        (
+            DEFAULT_WORKSPACE_ID,
+            "Default",
+            "#6366F1",
+            "Default workspace",
+            now,
+            now,
+        ),
+    )
+    await conn.execute(
+        "UPDATE connections SET workspace_id = ? WHERE workspace_id IS NULL",
+        (DEFAULT_WORKSPACE_ID,),
+    )
+    await conn.commit()
+
 
 async def init_db() -> None:
     global _conn
@@ -73,6 +119,7 @@ async def init_db() -> None:
         await conn.execute("PRAGMA journal_mode=WAL")
         await conn.execute("PRAGMA foreign_keys=ON")
         await conn.execute(CREATE_TABLE_SQL)
+        await conn.execute(CREATE_WORKSPACES_TABLE_SQL)
         await conn.commit()
         await _apply_migrations(conn)
         _conn = conn
@@ -108,17 +155,25 @@ async def close_db() -> None:
 # ---------------------------------------------------------------------------
 
 _row_to_profile = row_to_profile
+_row_to_workspace = row_to_workspace
 
 
 # ---------------------------------------------------------------------------
-# Async public API
+# Async public API — connections
 # ---------------------------------------------------------------------------
 
 
-async def get_all_connections() -> list[ConnectionProfile]:
+async def get_all_connections(workspace_id: str | None = None) -> list[ConnectionProfile]:
     conn = _get_conn()
-    async with conn.execute("SELECT * FROM connections ORDER BY created_at") as cursor:
-        rows = await cursor.fetchall()
+    if workspace_id is not None:
+        cursor = conn.execute(
+            "SELECT * FROM connections WHERE workspace_id = ? ORDER BY created_at",
+            (workspace_id,),
+        )
+    else:
+        cursor = conn.execute("SELECT * FROM connections ORDER BY created_at")
+    async with cursor as cur:
+        rows = await cur.fetchall()
     return [_row_to_profile(row) for row in rows]
 
 
@@ -133,8 +188,9 @@ async def create_connection(conn: ConnectionProfile) -> None:
     db_conn = _get_conn()
     try:
         await db_conn.execute(
-            """INSERT INTO connections (id, name, hosts, port, cluster_name, username, password, color, description, labels, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            """INSERT INTO connections (id, name, hosts, port, cluster_name, username, password,
+                                        color, description, labels, workspace_id, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 conn.id,
                 conn.name,
@@ -146,6 +202,7 @@ async def create_connection(conn: ConnectionProfile) -> None:
                 conn.color,
                 conn.description,
                 json.dumps(conn.labels),
+                conn.workspaceId,
                 conn.createdAt,
                 conn.updatedAt,
             ),
@@ -171,7 +228,7 @@ async def update_connection(conn_id: str, data: dict) -> ConnectionProfile | Non
             """UPDATE connections
                    SET name = ?, hosts = ?, port = ?, cluster_name = ?,
                        username = ?, password = ?, color = ?,
-                       description = ?, labels = ?,
+                       description = ?, labels = ?, workspace_id = ?,
                        updated_at = ?
                    WHERE id = ?""",
             (
@@ -184,6 +241,7 @@ async def update_connection(conn_id: str, data: dict) -> ConnectionProfile | Non
                 updated.color,
                 updated.description,
                 json.dumps(updated.labels),
+                updated.workspaceId,
                 updated.updatedAt,
                 conn_id,
             ),
@@ -205,3 +263,95 @@ async def delete_connection(conn_id: str) -> bool:
         await db_conn.rollback()
         raise
     return cursor.rowcount == 1
+
+
+# ---------------------------------------------------------------------------
+# Async public API — workspaces
+# ---------------------------------------------------------------------------
+
+
+async def get_all_workspaces() -> list[Workspace]:
+    conn = _get_conn()
+    # Built-in default workspace must always sort first so the UI can pick a
+    # stable initial selection without an extra query.
+    async with conn.execute("SELECT * FROM workspaces ORDER BY is_default DESC, created_at") as cursor:
+        rows = await cursor.fetchall()
+    return [_row_to_workspace(row) for row in rows]
+
+
+async def get_workspace(workspace_id: str) -> Workspace | None:
+    conn = _get_conn()
+    async with conn.execute("SELECT * FROM workspaces WHERE id = ?", (workspace_id,)) as cursor:
+        row = await cursor.fetchone()
+    return _row_to_workspace(row) if row else None
+
+
+async def create_workspace(ws: Workspace) -> None:
+    db_conn = _get_conn()
+    try:
+        await db_conn.execute(
+            """INSERT INTO workspaces (id, name, color, description, is_default, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (
+                ws.id,
+                ws.name,
+                ws.color,
+                ws.description,
+                1 if ws.isDefault else 0,
+                ws.createdAt,
+                ws.updatedAt,
+            ),
+        )
+        await db_conn.commit()
+    except Exception:
+        await db_conn.rollback()
+        raise
+
+
+async def update_workspace(workspace_id: str, data: dict) -> Workspace | None:
+    db_conn = _get_conn()
+    async with db_conn.execute("SELECT * FROM workspaces WHERE id = ?", (workspace_id,)) as cursor:
+        row = await cursor.fetchone()
+    if not row:
+        return None
+
+    existing = _row_to_workspace(row)
+    updated = build_merged_workspace(existing, data)
+
+    try:
+        await db_conn.execute(
+            """UPDATE workspaces
+                   SET name = ?, color = ?, description = ?, updated_at = ?
+                   WHERE id = ?""",
+            (
+                updated.name,
+                updated.color,
+                updated.description,
+                updated.updatedAt,
+                workspace_id,
+            ),
+        )
+        await db_conn.commit()
+    except Exception:
+        await db_conn.rollback()
+        raise
+
+    return updated
+
+
+async def delete_workspace(workspace_id: str) -> bool:
+    db_conn = _get_conn()
+    try:
+        cursor = await db_conn.execute("DELETE FROM workspaces WHERE id = ?", (workspace_id,))
+        await db_conn.commit()
+    except Exception:
+        await db_conn.rollback()
+        raise
+    return cursor.rowcount == 1
+
+
+async def count_connections_in_workspace(workspace_id: str) -> int:
+    conn = _get_conn()
+    async with conn.execute("SELECT COUNT(*) FROM connections WHERE workspace_id = ?", (workspace_id,)) as cursor:
+        row = await cursor.fetchone()
+    return int(row[0]) if row else 0

--- a/api/src/aerospike_cluster_manager_api/dependencies.py
+++ b/api/src/aerospike_cluster_manager_api/dependencies.py
@@ -12,6 +12,7 @@ from fastapi import Depends, HTTPException, Path
 from aerospike_cluster_manager_api import db
 from aerospike_cluster_manager_api.client_manager import client_manager
 from aerospike_cluster_manager_api.models.connection import ConnectionProfile
+from aerospike_cluster_manager_api.models.workspace import Workspace
 
 logger = logging.getLogger(__name__)
 
@@ -22,6 +23,22 @@ async def _get_verified_connection(conn_id: str = Path()) -> str:
     if not conn:
         raise HTTPException(status_code=404, detail=f"Connection '{conn_id}' not found")
     return conn_id
+
+
+async def _get_verified_workspace(workspace_id: str = Path()) -> str:
+    """Verify that a workspace exists (path parameter) and return its id."""
+    ws = await db.get_workspace(workspace_id)
+    if not ws:
+        raise HTTPException(status_code=404, detail=f"Workspace '{workspace_id}' not found")
+    return workspace_id
+
+
+async def _get_workspace(workspace_id: str = Path()) -> Workspace:
+    """Fetch and return the full ``Workspace`` for path parameter ``workspace_id``."""
+    ws = await db.get_workspace(workspace_id)
+    if not ws:
+        raise HTTPException(status_code=404, detail=f"Workspace '{workspace_id}' not found")
+    return ws
 
 
 async def _get_connection_profile(conn_id: str = Path()) -> ConnectionProfile:
@@ -58,3 +75,9 @@ AerospikeClient = Annotated[aerospike_py.AsyncClient, Depends(_get_client)]
 
 VerifiedConnectionProfile = Annotated[ConnectionProfile, Depends(_get_connection_profile)]
 """Inject a full ``ConnectionProfile`` looked up from the path ``conn_id``."""
+
+VerifiedWorkspaceId = Annotated[str, Depends(_get_verified_workspace)]
+"""Inject a verified workspace id from the path."""
+
+VerifiedWorkspace = Annotated[Workspace, Depends(_get_workspace)]
+"""Inject a full ``Workspace`` looked up from the path ``workspace_id``."""

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -35,6 +35,7 @@ from aerospike_cluster_manager_api.routers import (
     records,
     sample_data,
     udfs,
+    workspaces,
 )
 
 if config.K8S_MANAGEMENT_ENABLED:
@@ -368,6 +369,7 @@ except ImportError:
 #   - New clients can target /api/v1/... for explicit versioning
 
 _routers = [
+    workspaces.router,
     connections.router,
     clusters.router,
     records.router,

--- a/api/src/aerospike_cluster_manager_api/models/connection.py
+++ b/api/src/aerospike_cluster_manager_api/models/connection.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID
+
 
 def _normalize_labels(v: object) -> dict[str, str]:
     """Coerce label input to a clean dict and ensure ``env`` is always present.
@@ -51,6 +53,7 @@ class ConnectionProfile(BaseModel):
     color: str = Field(pattern=r"^#[0-9a-fA-F]{6}$")
     description: str | None = None
     labels: dict[str, str] = Field(default_factory=lambda: {"env": "default"})
+    workspaceId: str = DEFAULT_WORKSPACE_ID
     createdAt: str
     updatedAt: str
 
@@ -79,6 +82,10 @@ class CreateConnectionRequest(BaseModel):
     color: str = Field(pattern=r"^#[0-9a-fA-F]{6}$", default="#0097D3")
     description: str | None = None
     labels: dict[str, str] | None = None
+    # When None, the router falls back to the built-in default workspace
+    # (DEFAULT_WORKSPACE_ID). Pre-existing clients that omit the field stay
+    # backward-compatible.
+    workspaceId: str | None = None
 
 
 class UpdateConnectionRequest(BaseModel):
@@ -93,6 +100,7 @@ class UpdateConnectionRequest(BaseModel):
     color: str | None = Field(None, pattern=r"^#[0-9a-fA-F]{6}$")
     description: str | None = None
     labels: dict[str, str] | None = None
+    workspaceId: str | None = None
 
 
 class TestConnectionRequest(BaseModel):
@@ -121,6 +129,7 @@ class ConnectionProfileResponse(BaseModel):
     color: str = Field(pattern=r"^#[0-9a-fA-F]{6}$")
     description: str | None = None
     labels: dict[str, str] = Field(default_factory=lambda: {"env": "default"})
+    workspaceId: str = DEFAULT_WORKSPACE_ID
     createdAt: str
     updatedAt: str
 

--- a/api/src/aerospike_cluster_manager_api/models/k8s/cluster.py
+++ b/api/src/aerospike_cluster_manager_api/models/k8s/cluster.py
@@ -120,6 +120,15 @@ class CreateK8sClusterRequest(BaseModel):
     rack_config: RackAwareConfig | None = Field(default=None, alias="rackConfig")
     enable_dynamic_config: bool = Field(default=False, alias="enableDynamicConfig")
     auto_connect: bool = Field(default=True, alias="autoConnect")
+    workspace_id: str | None = Field(
+        default=None,
+        alias="workspaceId",
+        description=(
+            "Workspace to attach the auto-created connection to. When None or "
+            "the workspace doesn't exist, the connection lands in the built-in "
+            "default workspace."
+        ),
+    )
     network_policy: NetworkAccessConfig | None = Field(default=None, alias="networkPolicy")
     k8s_node_block_list: list[str] | None = Field(default=None, alias="k8sNodeBlockList")
     pod_scheduling: PodSchedulingConfig | None = Field(

--- a/api/src/aerospike_cluster_manager_api/models/workspace.py
+++ b/api/src/aerospike_cluster_manager_api/models/workspace.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# Identifier of the built-in workspace that always exists. Created by the
+# database migration on first init_db() and used as the fallback when a
+# CreateConnectionRequest does not specify a workspace.
+DEFAULT_WORKSPACE_ID = "ws-default"
+
+
+class Workspace(BaseModel):
+    id: str
+    name: str = Field(min_length=1, max_length=255)
+    color: str = Field(pattern=r"^#[0-9a-fA-F]{6}$", default="#6366F1")
+    description: str | None = None
+    isDefault: bool = False
+    createdAt: str
+    updatedAt: str
+
+
+class CreateWorkspaceRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str = Field(min_length=1, max_length=255)
+    color: str = Field(pattern=r"^#[0-9a-fA-F]{6}$", default="#6366F1")
+    description: str | None = None
+
+
+class UpdateWorkspaceRequest(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    color: str | None = Field(default=None, pattern=r"^#[0-9a-fA-F]{6}$")
+    description: str | None = None
+
+
+class WorkspaceResponse(BaseModel):
+    """Workspace shape returned by the API.
+
+    Mirrors :class:`Workspace`. Kept as a separate type so future fields that
+    should not leak to the client (e.g. internal flags) can be excluded
+    without breaking the persistence model.
+    """
+
+    id: str
+    name: str
+    color: str
+    description: str | None = None
+    isDefault: bool = False
+    createdAt: str
+    updatedAt: str
+
+    @classmethod
+    def from_workspace(cls, ws: Workspace) -> WorkspaceResponse:
+        return cls(**ws.model_dump())

--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -42,7 +42,7 @@ async def list_connections(
     if workspace_id is not None:
         ws = await db.get_workspace(workspace_id)
         if not ws:
-            raise HTTPException(status_code=400, detail=f"Workspace '{workspace_id}' not found")
+            raise HTTPException(status_code=404, detail=f"Workspace '{workspace_id}' not found")
     profiles = await db.get_all_connections(workspace_id)
     return [ConnectionProfileResponse.from_profile(p) for p in profiles]
 
@@ -53,7 +53,7 @@ async def create_connection(request: Request, body: CreateConnectionRequest) -> 
     """Create a new Aerospike connection profile."""
     workspace_id = body.workspaceId or DEFAULT_WORKSPACE_ID
     if not await db.get_workspace(workspace_id):
-        raise HTTPException(status_code=400, detail=f"Workspace '{workspace_id}' not found")
+        raise HTTPException(status_code=404, detail=f"Workspace '{workspace_id}' not found")
     now = datetime.now(UTC).isoformat()
     conn = ConnectionProfile(
         id=f"conn-{uuid.uuid4().hex[:12]}",
@@ -92,7 +92,7 @@ async def update_connection(
     if "workspaceId" in update_data and update_data["workspaceId"] is not None:
         target_ws = update_data["workspaceId"]
         if not await db.get_workspace(target_ws):
-            raise HTTPException(status_code=400, detail=f"Workspace '{target_ws}' not found")
+            raise HTTPException(status_code=404, detail=f"Workspace '{target_ws}' not found")
     conn = await db.update_connection(conn_id, update_data)
     if not conn:
         raise HTTPException(status_code=404, detail=f"Connection '{conn_id}' not found")

--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import aerospike_py
 from aerospike_py.exception import AerospikeError, AerospikeTimeoutError, ClusterError
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from starlette.responses import Response
 
 from aerospike_cluster_manager_api import db
@@ -25,6 +25,7 @@ from aerospike_cluster_manager_api.models.connection import (
     TestConnectionRequest,
     UpdateConnectionRequest,
 )
+from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID
 from aerospike_cluster_manager_api.rate_limit import limiter
 from aerospike_cluster_manager_api.utils import parse_host_port
 
@@ -34,9 +35,15 @@ router = APIRouter(prefix="/connections", tags=["connections"])
 
 
 @router.get("", summary="List connections", description="Retrieve all saved Aerospike connection profiles.")
-async def list_connections() -> list[ConnectionProfileResponse]:
-    """Retrieve all saved Aerospike connection profiles."""
-    profiles = await db.get_all_connections()
+async def list_connections(
+    workspace_id: str | None = Query(default=None, description="Filter by workspace id."),
+) -> list[ConnectionProfileResponse]:
+    """Retrieve all saved Aerospike connection profiles, optionally filtered by workspace."""
+    if workspace_id is not None:
+        ws = await db.get_workspace(workspace_id)
+        if not ws:
+            raise HTTPException(status_code=400, detail=f"Workspace '{workspace_id}' not found")
+    profiles = await db.get_all_connections(workspace_id)
     return [ConnectionProfileResponse.from_profile(p) for p in profiles]
 
 
@@ -44,6 +51,9 @@ async def list_connections() -> list[ConnectionProfileResponse]:
 @limiter.limit("10/minute")
 async def create_connection(request: Request, body: CreateConnectionRequest) -> ConnectionProfileResponse:
     """Create a new Aerospike connection profile."""
+    workspace_id = body.workspaceId or DEFAULT_WORKSPACE_ID
+    if not await db.get_workspace(workspace_id):
+        raise HTTPException(status_code=400, detail=f"Workspace '{workspace_id}' not found")
     now = datetime.now(UTC).isoformat()
     conn = ConnectionProfile(
         id=f"conn-{uuid.uuid4().hex[:12]}",
@@ -56,6 +66,7 @@ async def create_connection(request: Request, body: CreateConnectionRequest) -> 
         color=body.color,
         description=body.description,
         labels=body.labels or {},
+        workspaceId=workspace_id,
         createdAt=now,
         updatedAt=now,
     )
@@ -78,6 +89,10 @@ async def update_connection(
 ) -> ConnectionProfileResponse:
     """Update an existing connection profile with new settings."""
     update_data = body.model_dump(exclude_unset=True, by_alias=False)
+    if "workspaceId" in update_data and update_data["workspaceId"] is not None:
+        target_ws = update_data["workspaceId"]
+        if not await db.get_workspace(target_ws):
+            raise HTTPException(status_code=400, detail=f"Workspace '{target_ws}' not found")
     conn = await db.update_connection(conn_id, update_data)
     if not conn:
         raise HTTPException(status_code=404, detail=f"Connection '{conn_id}' not found")

--- a/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
@@ -46,6 +46,7 @@ from aerospike_cluster_manager_api.models.k8s_cluster import (
     UpdateK8sClusterRequest,
     UpdateK8sTemplateRequest,
 )
+from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID
 from aerospike_cluster_manager_api.services.k8s_service import (
     build_cr,
     build_template_cr,
@@ -443,6 +444,14 @@ async def create_k8s_cluster(body: CreateK8sClusterRequest) -> K8sClusterSummary
             service_host = f"{body.name}.{body.namespace}.svc.cluster.local"
             service_port = 3000
 
+            # Honour the workspace the user was operating in when they hit
+            # "Create Cluster". Fall back to the built-in default if the
+            # field is missing (legacy clients) or points at a workspace that
+            # was deleted between request and reconcile.
+            target_workspace_id = body.workspace_id or DEFAULT_WORKSPACE_ID
+            if not await db.get_workspace(target_workspace_id):
+                target_workspace_id = DEFAULT_WORKSPACE_ID
+
             now = datetime.now(UTC).isoformat()
             conn = ConnectionProfile(
                 id=f"conn-{uuid.uuid4().hex[:12]}",
@@ -455,12 +464,18 @@ async def create_k8s_cluster(body: CreateK8sClusterRequest) -> K8sClusterSummary
                 # user assigns a more specific value via Edit. Passed explicitly
                 # so the contract does not depend on the model validator's default.
                 labels={"env": "default"},
+                workspaceId=target_workspace_id,
                 createdAt=now,
                 updatedAt=now,
             )
             await db.create_connection(conn)
             connection_id = conn.id
-            logger.info("Auto-created connection profile for K8s cluster %s/%s", body.namespace, body.name)
+            logger.info(
+                "Auto-created connection profile for K8s cluster %s/%s in workspace %s",
+                body.namespace,
+                body.name,
+                target_workspace_id,
+            )
         except Exception:
             auto_connect_warning = f"Cluster created but auto-connect failed for {body.namespace}/{body.name}"
             logger.warning("Failed to auto-create connection for %s/%s", body.namespace, body.name, exc_info=True)

--- a/api/src/aerospike_cluster_manager_api/routers/workspaces.py
+++ b/api/src/aerospike_cluster_manager_api/routers/workspaces.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, HTTPException, Request
+from starlette.responses import Response
+
+from aerospike_cluster_manager_api import db
+from aerospike_cluster_manager_api.dependencies import VerifiedWorkspace
+from aerospike_cluster_manager_api.models.workspace import (
+    DEFAULT_WORKSPACE_ID,
+    CreateWorkspaceRequest,
+    UpdateWorkspaceRequest,
+    Workspace,
+    WorkspaceResponse,
+)
+from aerospike_cluster_manager_api.rate_limit import limiter
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/workspaces", tags=["workspaces"])
+
+
+@router.get("", summary="List workspaces", description="Retrieve all workspaces. The built-in default sorts first.")
+async def list_workspaces() -> list[WorkspaceResponse]:
+    workspaces = await db.get_all_workspaces()
+    return [WorkspaceResponse.from_workspace(w) for w in workspaces]
+
+
+@router.post(
+    "",
+    status_code=201,
+    summary="Create workspace",
+    description="Create a new workspace. The id is generated server-side.",
+)
+@limiter.limit("10/minute")
+async def create_workspace(request: Request, body: CreateWorkspaceRequest) -> WorkspaceResponse:
+    now = datetime.now(UTC).isoformat()
+    ws = Workspace(
+        id=f"ws-{uuid.uuid4().hex[:12]}",
+        name=body.name,
+        color=body.color,
+        description=body.description,
+        isDefault=False,
+        createdAt=now,
+        updatedAt=now,
+    )
+    await db.create_workspace(ws)
+    return WorkspaceResponse.from_workspace(ws)
+
+
+@router.get("/{workspace_id}", summary="Get workspace", description="Retrieve a single workspace by id.")
+async def get_workspace(ws: VerifiedWorkspace) -> WorkspaceResponse:
+    return WorkspaceResponse.from_workspace(ws)
+
+
+@router.put(
+    "/{workspace_id}",
+    summary="Update workspace",
+    description="Update a workspace's name, color, or description. The default workspace can be renamed.",
+)
+async def update_workspace(body: UpdateWorkspaceRequest, ws: VerifiedWorkspace) -> WorkspaceResponse:
+    update_data = body.model_dump(exclude_unset=True, by_alias=False)
+    updated = await db.update_workspace(ws.id, update_data)
+    if not updated:
+        # Race: workspace deleted between dependency resolution and update.
+        raise HTTPException(status_code=404, detail=f"Workspace '{ws.id}' not found")
+    return WorkspaceResponse.from_workspace(updated)
+
+
+@router.delete(
+    "/{workspace_id}",
+    status_code=204,
+    summary="Delete workspace",
+    description=(
+        "Delete a workspace. The built-in default cannot be deleted. "
+        "Workspaces with connections still attached are rejected with 409 — "
+        "move or delete those connections first."
+    ),
+)
+@limiter.limit("10/minute")
+async def delete_workspace(request: Request, ws: VerifiedWorkspace) -> Response:
+    if ws.isDefault or ws.id == DEFAULT_WORKSPACE_ID:
+        raise HTTPException(status_code=400, detail="The default workspace cannot be deleted")
+    remaining = await db.count_connections_in_workspace(ws.id)
+    if remaining > 0:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Workspace '{ws.id}' still has {remaining} connection(s). "
+                "Move or delete them before deleting the workspace."
+            ),
+        )
+    await db.delete_workspace(ws.id)
+    return Response(status_code=204)

--- a/api/tests/test_connections_router.py
+++ b/api/tests/test_connections_router.py
@@ -215,7 +215,7 @@ class TestConnectionWorkspaces:
     async def test_create_with_unknown_workspace_id_rejected(self, client: AsyncClient):
         payload = {**CREATE_PAYLOAD, "workspaceId": "ws-missing"}
         response = await client.post("/api/connections", json=payload)
-        assert response.status_code == 400
+        assert response.status_code == 404
 
     async def test_list_filters_by_workspace_id(self, client: AsyncClient):
         # Set up: two workspaces, one connection in each
@@ -235,7 +235,7 @@ class TestConnectionWorkspaces:
 
     async def test_list_unknown_workspace_id_rejected(self, client: AsyncClient):
         response = await client.get("/api/connections?workspace_id=ws-missing")
-        assert response.status_code == 400
+        assert response.status_code == 404
 
     async def test_update_moves_connection_between_workspaces(self, client: AsyncClient):
         ws_resp = await client.post("/api/workspaces", json={"name": "team-b"})
@@ -258,7 +258,7 @@ class TestConnectionWorkspaces:
             f"/api/connections/{conn_id}",
             json={"workspaceId": "ws-missing"},
         )
-        assert update.status_code == 400
+        assert update.status_code == 404
 
 
 class TestDeleteConnection:

--- a/api/tests/test_connections_router.py
+++ b/api/tests/test_connections_router.py
@@ -206,6 +206,61 @@ class TestUpdateConnection:
         assert response.status_code == 404
 
 
+class TestConnectionWorkspaces:
+    async def test_create_without_workspace_id_uses_default(self, client: AsyncClient):
+        response = await client.post("/api/connections", json=CREATE_PAYLOAD)
+        assert response.status_code == 201
+        assert response.json()["workspaceId"] == "ws-default"
+
+    async def test_create_with_unknown_workspace_id_rejected(self, client: AsyncClient):
+        payload = {**CREATE_PAYLOAD, "workspaceId": "ws-missing"}
+        response = await client.post("/api/connections", json=payload)
+        assert response.status_code == 400
+
+    async def test_list_filters_by_workspace_id(self, client: AsyncClient):
+        # Set up: two workspaces, one connection in each
+        ws_resp = await client.post("/api/workspaces", json={"name": "team-a"})
+        team_a = ws_resp.json()["id"]
+
+        await client.post("/api/connections", json={**CREATE_PAYLOAD, "workspaceId": "ws-default"})
+        await client.post("/api/connections", json={**CREATE_PAYLOAD, "workspaceId": team_a})
+
+        default_list = (await client.get("/api/connections?workspace_id=ws-default")).json()
+        team_a_list = (await client.get(f"/api/connections?workspace_id={team_a}")).json()
+
+        assert all(c["workspaceId"] == "ws-default" for c in default_list)
+        assert all(c["workspaceId"] == team_a for c in team_a_list)
+        assert len(default_list) >= 1
+        assert len(team_a_list) >= 1
+
+    async def test_list_unknown_workspace_id_rejected(self, client: AsyncClient):
+        response = await client.get("/api/connections?workspace_id=ws-missing")
+        assert response.status_code == 400
+
+    async def test_update_moves_connection_between_workspaces(self, client: AsyncClient):
+        ws_resp = await client.post("/api/workspaces", json={"name": "team-b"})
+        team_b = ws_resp.json()["id"]
+        create = await client.post("/api/connections", json=CREATE_PAYLOAD)
+        conn_id = create.json()["id"]
+
+        update = await client.put(
+            f"/api/connections/{conn_id}",
+            json={"workspaceId": team_b},
+        )
+        assert update.status_code == 200
+        assert update.json()["workspaceId"] == team_b
+
+    async def test_update_with_unknown_workspace_id_rejected(self, client: AsyncClient):
+        create = await client.post("/api/connections", json=CREATE_PAYLOAD)
+        conn_id = create.json()["id"]
+
+        update = await client.put(
+            f"/api/connections/{conn_id}",
+            json={"workspaceId": "ws-missing"},
+        )
+        assert update.status_code == 400
+
+
 class TestDeleteConnection:
     async def test_delete_returns_204(self, client: AsyncClient):
         create_resp = await client.post("/api/connections", json=CREATE_PAYLOAD)

--- a/api/tests/test_workspace_migrations.py
+++ b/api/tests/test_workspace_migrations.py
@@ -1,0 +1,83 @@
+"""Migration tests for the workspaces table and connections.workspace_id."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import aiosqlite
+
+from aerospike_cluster_manager_api import db
+from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID
+
+
+class TestDefaultWorkspaceSeed:
+    async def test_default_created_on_init(self, init_test_db):
+        ws = await db.get_workspace(DEFAULT_WORKSPACE_ID)
+        assert ws is not None
+        assert ws.isDefault is True
+        assert ws.name == "Default"
+
+    async def test_idempotent_init(self, init_test_db):
+        # Re-init pointing at the same SQLite file used by the fixture.
+        await db.close_db()
+        with (
+            patch("aerospike_cluster_manager_api.config.ENABLE_POSTGRES", False),
+            patch("aerospike_cluster_manager_api.config.SQLITE_PATH", init_test_db),
+        ):
+            await db.init_db()
+            workspaces = await db.get_all_workspaces()
+        # Only one default workspace, no duplicates.
+        assert sum(1 for w in workspaces if w.id == DEFAULT_WORKSPACE_ID) == 1
+
+
+class TestConnectionBackfill:
+    async def test_pre_existing_connection_backfilled(self, tmp_path):
+        """A connection inserted before the workspace_id column existed
+        should be migrated into the default workspace."""
+        db_path = str(tmp_path / "legacy.db")
+
+        # Build a "legacy" schema: the original connections table without
+        # workspace_id, no workspaces table, with one row already present.
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute("PRAGMA foreign_keys=ON")
+            await conn.execute(
+                """CREATE TABLE connections (
+                    id           TEXT PRIMARY KEY,
+                    name         TEXT NOT NULL,
+                    hosts        TEXT NOT NULL,
+                    port         INTEGER NOT NULL DEFAULT 3000,
+                    cluster_name TEXT,
+                    username     TEXT,
+                    password     TEXT,
+                    color        TEXT NOT NULL DEFAULT '#0097D3',
+                    description  TEXT,
+                    labels       TEXT,
+                    created_at   TEXT NOT NULL,
+                    updated_at   TEXT NOT NULL
+                )"""
+            )
+            now = datetime.now(UTC).isoformat()
+            await conn.execute(
+                """INSERT INTO connections
+                       (id, name, hosts, port, color, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?)""",
+                ("conn-legacy-1", "legacy", json.dumps(["localhost"]), 3000, "#0097D3", now, now),
+            )
+            await conn.commit()
+
+        with (
+            patch("aerospike_cluster_manager_api.config.ENABLE_POSTGRES", False),
+            patch("aerospike_cluster_manager_api.config.SQLITE_PATH", db_path),
+        ):
+            await db.init_db()
+            try:
+                conn_profile = await db.get_connection("conn-legacy-1")
+                workspaces = await db.get_all_workspaces()
+            finally:
+                await db.close_db()
+
+        assert conn_profile is not None
+        assert conn_profile.workspaceId == DEFAULT_WORKSPACE_ID
+        assert any(w.id == DEFAULT_WORKSPACE_ID and w.isDefault for w in workspaces)

--- a/api/tests/test_workspaces_router.py
+++ b/api/tests/test_workspaces_router.py
@@ -153,3 +153,17 @@ class TestDeleteWorkspace:
     async def test_delete_not_found(self, client: AsyncClient):
         response = await client.delete("/api/workspaces/ws-missing")
         assert response.status_code == 404
+
+
+class TestDeleteWorkspaceDbGuard:
+    """Defense-in-depth: even direct db.delete_workspace() must not delete the default."""
+
+    async def test_db_layer_refuses_to_delete_default(self, init_test_db):
+        from aerospike_cluster_manager_api import db
+
+        deleted = await db.delete_workspace("ws-default")
+        assert deleted is False
+        # The default workspace must still exist after the failed delete.
+        ws = await db.get_workspace("ws-default")
+        assert ws is not None
+        assert ws.isDefault is True

--- a/api/tests/test_workspaces_router.py
+++ b/api/tests/test_workspaces_router.py
@@ -1,0 +1,155 @@
+"""Integration tests for the /api/workspaces router."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from aerospike_cluster_manager_api.main import app
+
+
+@asynccontextmanager
+async def _noop_lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    yield
+
+
+@pytest.fixture()
+async def client(init_test_db):
+    original_lifespan = app.router.lifespan_context
+    app.router.lifespan_context = _noop_lifespan
+    app.state.limiter.enabled = False
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.state.limiter.enabled = True
+    app.router.lifespan_context = original_lifespan
+
+
+CREATE_PAYLOAD = {
+    "name": "team-a",
+    "color": "#FF8800",
+    "description": "Team A workspace",
+}
+
+
+class TestListWorkspaces:
+    async def test_default_workspace_seeded(self, client: AsyncClient):
+        response = await client.get("/api/workspaces")
+        assert response.status_code == 200
+        body = response.json()
+        assert isinstance(body, list)
+        # init_test_db's init_db() should have created the built-in default.
+        assert any(w["id"] == "ws-default" and w["isDefault"] for w in body)
+
+    async def test_default_sorts_first(self, client: AsyncClient):
+        await client.post("/api/workspaces", json=CREATE_PAYLOAD)
+        response = await client.get("/api/workspaces")
+        body = response.json()
+        assert body[0]["id"] == "ws-default"
+
+
+class TestCreateWorkspace:
+    async def test_returns_201(self, client: AsyncClient):
+        response = await client.post("/api/workspaces", json=CREATE_PAYLOAD)
+        assert response.status_code == 201
+        body = response.json()
+        assert body["id"].startswith("ws-")
+        assert body["id"] != "ws-default"
+        assert body["name"] == "team-a"
+        assert body["color"] == "#FF8800"
+        assert body["isDefault"] is False
+        assert body["description"] == "Team A workspace"
+
+    async def test_minimal_payload(self, client: AsyncClient):
+        response = await client.post("/api/workspaces", json={"name": "minimal"})
+        assert response.status_code == 201
+        body = response.json()
+        assert body["color"] == "#6366F1"
+        assert body["description"] is None
+
+    async def test_invalid_color(self, client: AsyncClient):
+        response = await client.post("/api/workspaces", json={"name": "x", "color": "not-a-color"})
+        assert response.status_code == 422
+
+    async def test_empty_name(self, client: AsyncClient):
+        response = await client.post("/api/workspaces", json={"name": ""})
+        assert response.status_code == 422
+
+
+class TestGetWorkspace:
+    async def test_get_default(self, client: AsyncClient):
+        response = await client.get("/api/workspaces/ws-default")
+        assert response.status_code == 200
+        body = response.json()
+        assert body["id"] == "ws-default"
+        assert body["isDefault"] is True
+
+    async def test_not_found(self, client: AsyncClient):
+        response = await client.get("/api/workspaces/ws-missing")
+        assert response.status_code == 404
+
+
+class TestUpdateWorkspace:
+    async def test_rename_default_allowed(self, client: AsyncClient):
+        response = await client.put("/api/workspaces/ws-default", json={"name": "Production"})
+        assert response.status_code == 200
+        body = response.json()
+        assert body["name"] == "Production"
+        # Default flag must remain on after rename — we never let it flip.
+        assert body["isDefault"] is True
+
+    async def test_update_color(self, client: AsyncClient):
+        create = await client.post("/api/workspaces", json=CREATE_PAYLOAD)
+        ws_id = create.json()["id"]
+        response = await client.put(f"/api/workspaces/{ws_id}", json={"color": "#00FF00"})
+        assert response.status_code == 200
+        assert response.json()["color"] == "#00FF00"
+
+    async def test_partial_update_preserves_other_fields(self, client: AsyncClient):
+        create = await client.post("/api/workspaces", json=CREATE_PAYLOAD)
+        ws_id = create.json()["id"]
+        response = await client.put(f"/api/workspaces/{ws_id}", json={"name": "renamed"})
+        assert response.status_code == 200
+        body = response.json()
+        assert body["name"] == "renamed"
+        assert body["color"] == CREATE_PAYLOAD["color"]
+        assert body["description"] == CREATE_PAYLOAD["description"]
+
+
+class TestDeleteWorkspace:
+    async def test_delete_empty_workspace(self, client: AsyncClient):
+        create = await client.post("/api/workspaces", json=CREATE_PAYLOAD)
+        ws_id = create.json()["id"]
+        response = await client.delete(f"/api/workspaces/{ws_id}")
+        assert response.status_code == 204
+        # Confirm gone.
+        assert (await client.get(f"/api/workspaces/{ws_id}")).status_code == 404
+
+    async def test_delete_default_rejected(self, client: AsyncClient):
+        response = await client.delete("/api/workspaces/ws-default")
+        assert response.status_code == 400
+        assert "default" in response.json()["detail"].lower()
+
+    async def test_delete_with_connections_rejected(self, client: AsyncClient):
+        ws_id = (await client.post("/api/workspaces", json=CREATE_PAYLOAD)).json()["id"]
+        # Attach a connection
+        conn_payload = {
+            "name": "c1",
+            "hosts": ["10.0.0.1"],
+            "port": 3000,
+            "color": "#FF5500",
+            "workspaceId": ws_id,
+        }
+        await client.post("/api/connections", json=conn_payload)
+
+        response = await client.delete(f"/api/workspaces/{ws_id}")
+        assert response.status_code == 409
+        assert "connection" in response.json()["detail"].lower()
+
+    async def test_delete_not_found(self, client: AsyncClient):
+        response = await client.delete("/api/workspaces/ws-missing")
+        assert response.status_code == 404

--- a/ui/src/app/(main)/clusters/page.tsx
+++ b/ui/src/app/(main)/clusters/page.tsx
@@ -24,10 +24,17 @@ export default function ClustersPage() {
     useState<ConnectionProfileResponse | null>(null)
   const view = useUiStore((s) => s.clustersView)
   const setView = useUiStore((s) => s.setClustersView)
+  const currentWorkspaceId = useUiStore((s) => s.currentWorkspaceId)
+
+  const filteredConnections = useMemo(
+    () =>
+      conn.data?.filter((c) => c.workspaceId === currentWorkspaceId) ?? null,
+    [conn.data, currentWorkspaceId],
+  )
 
   const rows = useMemo(
-    () => mergeRows(conn.data, k8s.data?.items ?? null),
-    [conn.data, k8s.data],
+    () => mergeRows(filteredConnections, k8s.data?.items ?? null),
+    [filteredConnections, k8s.data],
   )
   const groups = useMemo(() => groupByEnv(rows), [rows])
 

--- a/ui/src/components/dialogs/AddConnectionDialog.tsx
+++ b/ui/src/components/dialogs/AddConnectionDialog.tsx
@@ -15,6 +15,7 @@ import { ConnectionFormFields } from "@/components/dialogs/ConnectionFormFields"
 import { useConnectionForm } from "@/components/dialogs/useConnectionForm"
 import { ApiError } from "@/lib/api/client"
 import { createConnection } from "@/lib/api/connections"
+import { useUiStore } from "@/stores/ui-store"
 
 interface AddConnectionDialogProps {
   open: boolean
@@ -30,6 +31,7 @@ export function AddConnectionDialog({
   const { form, setForm, validate, reset } = useConnectionForm()
   const [error, setError] = React.useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = React.useState(false)
+  const currentWorkspaceId = useUiStore((s) => s.currentWorkspaceId)
 
   const handleOpenChange = (next: boolean) => {
     if (!next) {
@@ -51,7 +53,10 @@ export function AddConnectionDialog({
 
     setIsSubmitting(true)
     try {
-      await createConnection(result.payload)
+      await createConnection({
+        ...result.payload,
+        workspaceId: currentWorkspaceId,
+      })
       reset()
       onSuccess?.()
       onOpenChange(false)

--- a/ui/src/components/dialogs/AddWorkspaceDialog.tsx
+++ b/ui/src/components/dialogs/AddWorkspaceDialog.tsx
@@ -11,8 +11,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/Dialog"
-import { Input } from "@/components/Input"
-import { Label } from "@/components/Label"
+import { WorkspaceFormFields } from "@/components/dialogs/WorkspaceFormFields"
+import { useWorkspaceForm } from "@/components/dialogs/useWorkspaceForm"
 import { ApiError } from "@/lib/api/client"
 import { createWorkspace } from "@/lib/api/workspaces"
 import type { WorkspaceResponse } from "@/lib/types/workspace"
@@ -23,30 +23,20 @@ interface AddWorkspaceDialogProps {
   onSuccess?: (ws: WorkspaceResponse) => void
 }
 
-const DEFAULT_COLOR = "#6366F1"
-const TEXTAREA_CLASSES =
-  "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-indigo-400/20"
-
 export function AddWorkspaceDialog({
   open,
   onOpenChange,
   onSuccess,
 }: AddWorkspaceDialogProps) {
-  const [name, setName] = React.useState("")
-  const [color, setColor] = React.useState(DEFAULT_COLOR)
-  const [description, setDescription] = React.useState("")
+  const { form, setForm, validate, reset } = useWorkspaceForm()
   const [error, setError] = React.useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = React.useState(false)
 
-  const reset = () => {
-    setName("")
-    setColor(DEFAULT_COLOR)
-    setDescription("")
-    setError(null)
-  }
-
   const handleOpenChange = (next: boolean) => {
-    if (!next) reset()
+    if (!next) {
+      reset()
+      setError(null)
+    }
     onOpenChange(next)
   }
 
@@ -54,19 +44,15 @@ export function AddWorkspaceDialog({
     event.preventDefault()
     setError(null)
 
-    const trimmedName = name.trim()
-    if (!trimmedName) {
-      setError("Name is required.")
+    const result = validate()
+    if (!result.ok) {
+      setError(result.error)
       return
     }
 
     setIsSubmitting(true)
     try {
-      const created = await createWorkspace({
-        name: trimmedName,
-        color,
-        description: description.trim() || null,
-      })
+      const created = await createWorkspace(result.payload)
       reset()
       onSuccess?.(created)
       onOpenChange(false)
@@ -100,45 +86,7 @@ export function AddWorkspaceDialog({
             </div>
           )}
 
-          <div className="flex flex-col gap-y-1.5">
-            <Label htmlFor="ws-name">Name</Label>
-            <Input
-              id="ws-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="team-a"
-              autoFocus
-              required
-            />
-          </div>
-
-          <div className="flex flex-col gap-y-1.5">
-            <Label htmlFor="ws-color">Color</Label>
-            <div className="flex items-center gap-x-3">
-              <Input
-                id="ws-color"
-                type="color"
-                value={color}
-                onChange={(e) => setColor(e.target.value)}
-                className="h-9 w-16 cursor-pointer p-1"
-              />
-              <span className="font-mono text-xs text-gray-500 dark:text-gray-400">
-                {color}
-              </span>
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-y-1.5">
-            <Label htmlFor="ws-description">Description</Label>
-            <textarea
-              id="ws-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              rows={2}
-              placeholder="What's this workspace for?"
-              className={TEXTAREA_CLASSES}
-            />
-          </div>
+          <WorkspaceFormFields form={form} setForm={setForm} idPrefix="ws-add" />
 
           <DialogFooter>
             <Button

--- a/ui/src/components/dialogs/AddWorkspaceDialog.tsx
+++ b/ui/src/components/dialogs/AddWorkspaceDialog.tsx
@@ -86,7 +86,11 @@ export function AddWorkspaceDialog({
             </div>
           )}
 
-          <WorkspaceFormFields form={form} setForm={setForm} idPrefix="ws-add" />
+          <WorkspaceFormFields
+            form={form}
+            setForm={setForm}
+            idPrefix="ws-add"
+          />
 
           <DialogFooter>
             <Button

--- a/ui/src/components/dialogs/AddWorkspaceDialog.tsx
+++ b/ui/src/components/dialogs/AddWorkspaceDialog.tsx
@@ -1,0 +1,166 @@
+"use client"
+
+import React from "react"
+
+import { Button } from "@/components/Button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/Dialog"
+import { Input } from "@/components/Input"
+import { Label } from "@/components/Label"
+import { ApiError } from "@/lib/api/client"
+import { createWorkspace } from "@/lib/api/workspaces"
+import type { WorkspaceResponse } from "@/lib/types/workspace"
+
+interface AddWorkspaceDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSuccess?: (ws: WorkspaceResponse) => void
+}
+
+const DEFAULT_COLOR = "#6366F1"
+const TEXTAREA_CLASSES =
+  "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-indigo-400/20"
+
+export function AddWorkspaceDialog({
+  open,
+  onOpenChange,
+  onSuccess,
+}: AddWorkspaceDialogProps) {
+  const [name, setName] = React.useState("")
+  const [color, setColor] = React.useState(DEFAULT_COLOR)
+  const [description, setDescription] = React.useState("")
+  const [error, setError] = React.useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = React.useState(false)
+
+  const reset = () => {
+    setName("")
+    setColor(DEFAULT_COLOR)
+    setDescription("")
+    setError(null)
+  }
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) reset()
+    onOpenChange(next)
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setError(null)
+
+    const trimmedName = name.trim()
+    if (!trimmedName) {
+      setError("Name is required.")
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      const created = await createWorkspace({
+        name: trimmedName,
+        color,
+        description: description.trim() || null,
+      })
+      reset()
+      onSuccess?.(created)
+      onOpenChange(false)
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.detail || err.message)
+      } else if (err instanceof Error) {
+        setError(err.message)
+      } else {
+        setError("Failed to create workspace.")
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-y-4">
+          <DialogHeader>
+            <DialogTitle>Add workspace</DialogTitle>
+            <DialogDescription>
+              Group Aerospike clusters managed by your team into a workspace.
+            </DialogDescription>
+          </DialogHeader>
+
+          {error && (
+            <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
+              {error}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-y-1.5">
+            <Label htmlFor="ws-name">Name</Label>
+            <Input
+              id="ws-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="team-a"
+              autoFocus
+              required
+            />
+          </div>
+
+          <div className="flex flex-col gap-y-1.5">
+            <Label htmlFor="ws-color">Color</Label>
+            <div className="flex items-center gap-x-3">
+              <Input
+                id="ws-color"
+                type="color"
+                value={color}
+                onChange={(e) => setColor(e.target.value)}
+                className="h-9 w-16 cursor-pointer p-1"
+              />
+              <span className="font-mono text-xs text-gray-500 dark:text-gray-400">
+                {color}
+              </span>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-y-1.5">
+            <Label htmlFor="ws-description">Description</Label>
+            <textarea
+              id="ws-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={2}
+              placeholder="What's this workspace for?"
+              className={TEXTAREA_CLASSES}
+            />
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={() => handleOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Go back
+            </Button>
+            <Button
+              type="submit"
+              isLoading={isSubmitting}
+              loadingText="Creating..."
+            >
+              Add workspace
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default AddWorkspaceDialog

--- a/ui/src/components/dialogs/EditWorkspaceDialog.tsx
+++ b/ui/src/components/dialogs/EditWorkspaceDialog.tsx
@@ -11,8 +11,11 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/Dialog"
-import { Input } from "@/components/Input"
-import { Label } from "@/components/Label"
+import { WorkspaceFormFields } from "@/components/dialogs/WorkspaceFormFields"
+import {
+  fromWorkspace,
+  useWorkspaceForm,
+} from "@/components/dialogs/useWorkspaceForm"
 import { ApiError } from "@/lib/api/client"
 import { deleteWorkspace, updateWorkspace } from "@/lib/api/workspaces"
 import type { WorkspaceResponse } from "@/lib/types/workspace"
@@ -25,9 +28,6 @@ interface EditWorkspaceDialogProps {
   onDeleted?: (id: string) => void
 }
 
-const TEXTAREA_CLASSES =
-  "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-indigo-400/20"
-
 export function EditWorkspaceDialog({
   workspace,
   open,
@@ -35,9 +35,7 @@ export function EditWorkspaceDialog({
   onSaved,
   onDeleted,
 }: EditWorkspaceDialogProps) {
-  const [name, setName] = React.useState("")
-  const [color, setColor] = React.useState("#6366F1")
-  const [description, setDescription] = React.useState("")
+  const { form, setForm, validate, hydrate } = useWorkspaceForm()
   const [error, setError] = React.useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = React.useState(false)
   const [isDeleting, setIsDeleting] = React.useState(false)
@@ -45,12 +43,10 @@ export function EditWorkspaceDialog({
   // Re-hydrate the form whenever a different workspace is opened.
   React.useEffect(() => {
     if (workspace) {
-      setName(workspace.name)
-      setColor(workspace.color)
-      setDescription(workspace.description ?? "")
+      hydrate(fromWorkspace(workspace))
       setError(null)
     }
-  }, [workspace])
+  }, [workspace, hydrate])
 
   const handleOpenChange = (next: boolean) => {
     if (!next) {
@@ -64,19 +60,15 @@ export function EditWorkspaceDialog({
     if (!workspace) return
     setError(null)
 
-    const trimmedName = name.trim()
-    if (!trimmedName) {
-      setError("Name is required.")
+    const result = validate()
+    if (!result.ok) {
+      setError(result.error)
       return
     }
 
     setIsSubmitting(true)
     try {
-      const saved = await updateWorkspace(workspace.id, {
-        name: trimmedName,
-        color,
-        description: description.trim() || null,
-      })
+      const saved = await updateWorkspace(workspace.id, result.payload)
       onSaved?.(saved)
       onOpenChange(false)
     } catch (err) {
@@ -135,42 +127,11 @@ export function EditWorkspaceDialog({
             </div>
           )}
 
-          <div className="flex flex-col gap-y-1.5">
-            <Label htmlFor="ws-edit-name">Name</Label>
-            <Input
-              id="ws-edit-name"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              required
-            />
-          </div>
-
-          <div className="flex flex-col gap-y-1.5">
-            <Label htmlFor="ws-edit-color">Color</Label>
-            <div className="flex items-center gap-x-3">
-              <Input
-                id="ws-edit-color"
-                type="color"
-                value={color}
-                onChange={(e) => setColor(e.target.value)}
-                className="h-9 w-16 cursor-pointer p-1"
-              />
-              <span className="font-mono text-xs text-gray-500 dark:text-gray-400">
-                {color}
-              </span>
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-y-1.5">
-            <Label htmlFor="ws-edit-description">Description</Label>
-            <textarea
-              id="ws-edit-description"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-              rows={2}
-              className={TEXTAREA_CLASSES}
-            />
-          </div>
+          <WorkspaceFormFields
+            form={form}
+            setForm={setForm}
+            idPrefix="ws-edit"
+          />
 
           <DialogFooter className="sm:justify-between">
             {!workspace.isDefault ? (

--- a/ui/src/components/dialogs/EditWorkspaceDialog.tsx
+++ b/ui/src/components/dialogs/EditWorkspaceDialog.tsx
@@ -1,0 +1,215 @@
+"use client"
+
+import React from "react"
+
+import { Button } from "@/components/Button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/Dialog"
+import { Input } from "@/components/Input"
+import { Label } from "@/components/Label"
+import { ApiError } from "@/lib/api/client"
+import { deleteWorkspace, updateWorkspace } from "@/lib/api/workspaces"
+import type { WorkspaceResponse } from "@/lib/types/workspace"
+
+interface EditWorkspaceDialogProps {
+  workspace: WorkspaceResponse | null
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSaved?: (ws: WorkspaceResponse) => void
+  onDeleted?: (id: string) => void
+}
+
+const TEXTAREA_CLASSES =
+  "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-indigo-400/20"
+
+export function EditWorkspaceDialog({
+  workspace,
+  open,
+  onOpenChange,
+  onSaved,
+  onDeleted,
+}: EditWorkspaceDialogProps) {
+  const [name, setName] = React.useState("")
+  const [color, setColor] = React.useState("#6366F1")
+  const [description, setDescription] = React.useState("")
+  const [error, setError] = React.useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = React.useState(false)
+  const [isDeleting, setIsDeleting] = React.useState(false)
+
+  // Re-hydrate the form whenever a different workspace is opened.
+  React.useEffect(() => {
+    if (workspace) {
+      setName(workspace.name)
+      setColor(workspace.color)
+      setDescription(workspace.description ?? "")
+      setError(null)
+    }
+  }, [workspace])
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) {
+      setError(null)
+    }
+    onOpenChange(next)
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!workspace) return
+    setError(null)
+
+    const trimmedName = name.trim()
+    if (!trimmedName) {
+      setError("Name is required.")
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      const saved = await updateWorkspace(workspace.id, {
+        name: trimmedName,
+        color,
+        description: description.trim() || null,
+      })
+      onSaved?.(saved)
+      onOpenChange(false)
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.detail || err.message)
+      } else if (err instanceof Error) {
+        setError(err.message)
+      } else {
+        setError("Failed to update workspace.")
+      }
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!workspace) return
+    if (workspace.isDefault) return
+    setError(null)
+    setIsDeleting(true)
+    try {
+      await deleteWorkspace(workspace.id)
+      onDeleted?.(workspace.id)
+      onOpenChange(false)
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.detail || err.message)
+      } else if (err instanceof Error) {
+        setError(err.message)
+      } else {
+        setError("Failed to delete workspace.")
+      }
+    } finally {
+      setIsDeleting(false)
+    }
+  }
+
+  if (!workspace) return null
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-y-4">
+          <DialogHeader>
+            <DialogTitle>Edit workspace</DialogTitle>
+            <DialogDescription>
+              {workspace.isDefault
+                ? "The built-in default workspace can be renamed but not deleted."
+                : "Update name, color, or description."}
+            </DialogDescription>
+          </DialogHeader>
+
+          {error && (
+            <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
+              {error}
+            </div>
+          )}
+
+          <div className="flex flex-col gap-y-1.5">
+            <Label htmlFor="ws-edit-name">Name</Label>
+            <Input
+              id="ws-edit-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
+            />
+          </div>
+
+          <div className="flex flex-col gap-y-1.5">
+            <Label htmlFor="ws-edit-color">Color</Label>
+            <div className="flex items-center gap-x-3">
+              <Input
+                id="ws-edit-color"
+                type="color"
+                value={color}
+                onChange={(e) => setColor(e.target.value)}
+                className="h-9 w-16 cursor-pointer p-1"
+              />
+              <span className="font-mono text-xs text-gray-500 dark:text-gray-400">
+                {color}
+              </span>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-y-1.5">
+            <Label htmlFor="ws-edit-description">Description</Label>
+            <textarea
+              id="ws-edit-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              rows={2}
+              className={TEXTAREA_CLASSES}
+            />
+          </div>
+
+          <DialogFooter className="sm:justify-between">
+            {!workspace.isDefault ? (
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={handleDelete}
+                disabled={isSubmitting || isDeleting}
+                isLoading={isDeleting}
+                loadingText="Deleting..."
+              >
+                Delete
+              </Button>
+            ) : (
+              <span />
+            )}
+            <div className="flex gap-x-2">
+              <Button
+                type="button"
+                variant="secondary"
+                onClick={() => handleOpenChange(false)}
+                disabled={isSubmitting || isDeleting}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                isLoading={isSubmitting}
+                loadingText="Saving..."
+                disabled={isDeleting}
+              >
+                Save
+              </Button>
+            </div>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default EditWorkspaceDialog

--- a/ui/src/components/dialogs/WorkspaceFormFields.tsx
+++ b/ui/src/components/dialogs/WorkspaceFormFields.tsx
@@ -1,0 +1,67 @@
+"use client"
+
+import { Input } from "@/components/Input"
+import { Label } from "@/components/Label"
+import type { WorkspaceFormState } from "@/components/dialogs/useWorkspaceForm"
+
+interface WorkspaceFormFieldsProps {
+  form: WorkspaceFormState
+  setForm: React.Dispatch<React.SetStateAction<WorkspaceFormState>>
+  /** Distinguishes input ids when both Add and Edit dialogs render in the same DOM. */
+  idPrefix: string
+}
+
+const TEXTAREA_CLASSES =
+  "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-indigo-400/20"
+
+export function WorkspaceFormFields({
+  form,
+  setForm,
+  idPrefix,
+}: WorkspaceFormFieldsProps) {
+  const id = (suffix: string) => `${idPrefix}-${suffix}`
+
+  return (
+    <>
+      <div className="flex flex-col gap-y-1.5">
+        <Label htmlFor={id("name")}>Name</Label>
+        <Input
+          id={id("name")}
+          value={form.name}
+          onChange={(e) => setForm({ ...form, name: e.target.value })}
+          placeholder="team-a"
+          autoFocus
+          required
+        />
+      </div>
+
+      <div className="flex flex-col gap-y-1.5">
+        <Label htmlFor={id("color")}>Color</Label>
+        <div className="flex items-center gap-x-3">
+          <Input
+            id={id("color")}
+            type="color"
+            value={form.color}
+            onChange={(e) => setForm({ ...form, color: e.target.value })}
+            className="h-9 w-16 cursor-pointer p-1"
+          />
+          <span className="font-mono text-xs text-gray-500 dark:text-gray-400">
+            {form.color}
+          </span>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-y-1.5">
+        <Label htmlFor={id("description")}>Description</Label>
+        <textarea
+          id={id("description")}
+          value={form.description}
+          onChange={(e) => setForm({ ...form, description: e.target.value })}
+          rows={2}
+          placeholder="What's this workspace for?"
+          className={TEXTAREA_CLASSES}
+        />
+      </div>
+    </>
+  )
+}

--- a/ui/src/components/dialogs/useWorkspaceForm.ts
+++ b/ui/src/components/dialogs/useWorkspaceForm.ts
@@ -1,0 +1,72 @@
+"use client"
+
+import React from "react"
+
+import type { WorkspaceResponse } from "@/lib/types/workspace"
+
+export interface WorkspaceFormState {
+  name: string
+  color: string
+  description: string
+}
+
+export interface ParsedWorkspacePayload {
+  name: string
+  color: string
+  description: string | null
+}
+
+export const DEFAULT_WORKSPACE_COLOR = "#6366F1"
+
+const EMPTY_FORM: WorkspaceFormState = {
+  name: "",
+  color: DEFAULT_WORKSPACE_COLOR,
+  description: "",
+}
+
+export function fromWorkspace(ws: WorkspaceResponse): WorkspaceFormState {
+  return {
+    name: ws.name,
+    color: ws.color,
+    description: ws.description ?? "",
+  }
+}
+
+/**
+ * Shared state + validation for Add / Edit Workspace dialogs.
+ *
+ * - ``form`` / ``setForm``: form state.
+ * - ``validate``: returns either ``{ ok: true, payload }`` or ``{ ok: false, error }``.
+ * - ``reset``: restore defaults (used by Add dialog after submit).
+ * - ``hydrate``: replace the entire form (used by Edit dialog when a different
+ *   workspace is opened).
+ */
+export function useWorkspaceForm(initial?: WorkspaceFormState) {
+  const [form, setForm] = React.useState<WorkspaceFormState>(
+    initial ?? EMPTY_FORM,
+  )
+
+  const reset = React.useCallback(() => setForm(EMPTY_FORM), [])
+  const hydrate = React.useCallback(
+    (next: WorkspaceFormState) => setForm(next),
+    [],
+  )
+
+  const validate = React.useCallback(():
+    | { ok: true; payload: ParsedWorkspacePayload }
+    | { ok: false; error: string } => {
+    const name = form.name.trim()
+    if (!name) return { ok: false, error: "Name is required." }
+
+    return {
+      ok: true,
+      payload: {
+        name,
+        color: form.color || DEFAULT_WORKSPACE_COLOR,
+        description: form.description.trim() || null,
+      },
+    }
+  }, [form])
+
+  return { form, setForm, validate, reset, hydrate }
+}

--- a/ui/src/components/k8s/create-cluster-wizard/CreateClusterWizard.tsx
+++ b/ui/src/components/k8s/create-cluster-wizard/CreateClusterWizard.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react"
 
 import { Button } from "@/components/Button"
 import { ApiError } from "@/lib/api/client"
+import { useUiStore } from "@/stores/ui-store"
 import {
   createK8sCluster,
   getK8sTemplate,
@@ -353,6 +354,10 @@ export function CreateClusterWizard() {
     setSubmitting(true)
     try {
       const payload = cleanupPayload(form)
+      // Attach the auto-created connection to the workspace the user is
+      // currently viewing — otherwise the new cluster only appears after
+      // they switch back to Default.
+      payload.workspaceId = useUiStore.getState().currentWorkspaceId
       await createK8sCluster(payload)
       router.push("/clusters")
     } catch (err) {

--- a/ui/src/components/ui/navigation/MobileSidebar.tsx
+++ b/ui/src/components/ui/navigation/MobileSidebar.tsx
@@ -14,6 +14,7 @@ import { RiCodeSSlashLine, RiMenuLine, RiStackLine } from "@remixicon/react"
 import Image from "next/image"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
+import { WorkspacesDropdown } from "./WorkspacesDropdown"
 
 const navigation = [
   { name: "Clusters", href: siteConfig.baseLinks.clusters, icon: RiStackLine },
@@ -60,6 +61,9 @@ export default function MobileSidebar() {
           </DrawerTitle>
         </DrawerHeader>
         <DrawerBody>
+          <div className="mb-4">
+            <WorkspacesDropdown />
+          </div>
           <nav
             aria-label="core mobile navigation"
             className="flex flex-1 flex-col"

--- a/ui/src/components/ui/navigation/Sidebar.tsx
+++ b/ui/src/components/ui/navigation/Sidebar.tsx
@@ -14,6 +14,7 @@ import { getCluster } from "@/lib/api/clusters"
 import type { ConnectionProfileResponse } from "@/lib/types/connection"
 import type { K8sClusterSummary } from "@/lib/types/k8s"
 import { cx, focusRing } from "@/lib/utils"
+import { useUiStore } from "@/stores/ui-store"
 import * as AccordionPrimitives from "@radix-ui/react-accordion"
 import {
   RiArrowDownSLine,
@@ -29,6 +30,7 @@ import { useParams, usePathname } from "next/navigation"
 import { useEffect, useMemo, useState } from "react"
 import MobileSidebar from "./MobileSidebar"
 import { UserProfileDesktop, UserProfileMobile } from "./UserProfile"
+import { WorkspacesDropdown } from "./WorkspacesDropdown"
 
 type SidebarSet = {
   name: string
@@ -85,9 +87,11 @@ function buildClusterList(
   connections: ConnectionProfileResponse[] | null,
   k8s: K8sClusterSummary[] | null,
   nsByConn: Record<string, NamespaceSummary[]>,
+  workspaceId: string,
 ): ClusterSummary[] {
   const list: ClusterSummary[] = []
   for (const c of connections ?? []) {
+    if (c.workspaceId !== workspaceId) continue
     const linked = k8s?.find((k) => k.connectionId === c.id)
     list.push({
       id: c.id,
@@ -105,10 +109,30 @@ export function Sidebar() {
   const conn = useConnections()
   const k8s = useK8sClusters()
   const nsByConn = useClusterNamespaces(params?.clusterId ?? null)
+  const currentWorkspaceId = useUiStore((s) => s.currentWorkspaceId)
+  const setCurrentWorkspaceId = useUiStore((s) => s.setCurrentWorkspaceId)
+
+  // When the user navigates directly to a cluster URL whose connection lives
+  // in a different workspace than the one currently selected (e.g. opening a
+  // shared link), follow the URL: switch the persisted workspace so the
+  // cluster is visible in the sidebar drill-down.
+  useEffect(() => {
+    if (!params?.clusterId || !conn.data) return
+    const target = conn.data.find((c) => c.id === params.clusterId)
+    if (target && target.workspaceId !== currentWorkspaceId) {
+      setCurrentWorkspaceId(target.workspaceId)
+    }
+  }, [params?.clusterId, conn.data, currentWorkspaceId, setCurrentWorkspaceId])
 
   const clusterList = useMemo(
-    () => buildClusterList(conn.data, k8s.data?.items ?? null, nsByConn),
-    [conn.data, k8s.data, nsByConn],
+    () =>
+      buildClusterList(
+        conn.data,
+        k8s.data?.items ?? null,
+        nsByConn,
+        currentWorkspaceId,
+      ),
+    [conn.data, k8s.data, nsByConn, currentWorkspaceId],
   )
 
   const isActive = (href: string, exact = false) =>
@@ -128,6 +152,7 @@ export function Sidebar() {
       <nav className="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
         <aside className="flex grow flex-col gap-y-4 overflow-y-auto border-r border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-950">
           <BrandCard active={pathname === "/clusters"} />
+          <WorkspacesDropdown />
 
           <nav aria-label="core navigation" className="flex flex-1 flex-col">
             <Accordion

--- a/ui/src/components/ui/navigation/WorkspacesDropdown.tsx
+++ b/ui/src/components/ui/navigation/WorkspacesDropdown.tsx
@@ -70,10 +70,13 @@ export function WorkspacesDropdown() {
   // Reconcile the persisted currentWorkspaceId against the live list once
   // workspaces load — if the saved id no longer exists (e.g. it was deleted
   // in another session), fall back to the default so the rest of the UI
-  // doesn't filter on an orphan id.
+  // doesn't filter on an orphan id. Skip when we're already on the default;
+  // otherwise a backend race that yields a list missing ws-default would
+  // re-fire the setter on every refetch.
   React.useEffect(() => {
     if (!data) return
     if (data.length === 0) return
+    if (currentWorkspaceId === DEFAULT_WORKSPACE_ID) return
     if (!data.some((w) => w.id === currentWorkspaceId)) {
       setCurrentWorkspaceId(DEFAULT_WORKSPACE_ID)
     }

--- a/ui/src/components/ui/navigation/WorkspacesDropdown.tsx
+++ b/ui/src/components/ui/navigation/WorkspacesDropdown.tsx
@@ -1,0 +1,214 @@
+"use client"
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/Dropdown"
+import { AddWorkspaceDialog } from "@/components/dialogs/AddWorkspaceDialog"
+import { EditWorkspaceDialog } from "@/components/dialogs/EditWorkspaceDialog"
+import { useWorkspaces } from "@/hooks/use-workspaces"
+import { cx, focusRing } from "@/lib/utils"
+import {
+  DEFAULT_WORKSPACE_ID,
+  type WorkspaceResponse,
+} from "@/lib/types/workspace"
+import { useUiStore } from "@/stores/ui-store"
+import {
+  RiAddLine,
+  RiCheckLine,
+  RiExpandUpDownLine,
+  RiPencilLine,
+} from "@remixicon/react"
+import * as React from "react"
+
+function workspaceInitials(name: string): string {
+  const trimmed = name.trim()
+  if (!trimmed) return "WS"
+  const parts = trimmed.split(/\s+/)
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase()
+  return (parts[0][0] + parts[1][0]).toUpperCase()
+}
+
+function WorkspaceAvatar({
+  name,
+  color,
+  size = "md",
+}: {
+  name: string
+  color: string
+  size?: "sm" | "md"
+}) {
+  const dimension = size === "sm" ? "size-7" : "size-9"
+  return (
+    <span
+      aria-hidden="true"
+      style={{ backgroundColor: color }}
+      className={cx(
+        "flex shrink-0 items-center justify-center rounded-md text-xs font-semibold text-white",
+        dimension,
+      )}
+    >
+      {workspaceInitials(name)}
+    </span>
+  )
+}
+
+export function WorkspacesDropdown() {
+  const { data, isLoading, refetch } = useWorkspaces()
+  const currentWorkspaceId = useUiStore((s) => s.currentWorkspaceId)
+  const setCurrentWorkspaceId = useUiStore((s) => s.setCurrentWorkspaceId)
+
+  const [addOpen, setAddOpen] = React.useState(false)
+  const [editTarget, setEditTarget] = React.useState<WorkspaceResponse | null>(
+    null,
+  )
+
+  // Reconcile the persisted currentWorkspaceId against the live list once
+  // workspaces load — if the saved id no longer exists (e.g. it was deleted
+  // in another session), fall back to the default so the rest of the UI
+  // doesn't filter on an orphan id.
+  React.useEffect(() => {
+    if (!data) return
+    if (data.length === 0) return
+    if (!data.some((w) => w.id === currentWorkspaceId)) {
+      setCurrentWorkspaceId(DEFAULT_WORKSPACE_ID)
+    }
+  }, [data, currentWorkspaceId, setCurrentWorkspaceId])
+
+  const current =
+    data?.find((w) => w.id === currentWorkspaceId) ??
+    data?.find((w) => w.id === DEFAULT_WORKSPACE_ID) ??
+    null
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label="Switch workspace"
+            className={cx(
+              "flex w-full items-center gap-3 rounded-md border border-gray-200 bg-white px-2 py-1.5 text-left transition hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-950 dark:hover:bg-gray-900",
+              focusRing,
+            )}
+          >
+            {current ? (
+              <WorkspaceAvatar name={current.name} color={current.color} />
+            ) : (
+              <span className="size-9 shrink-0 animate-pulse rounded-md bg-gray-200 dark:bg-gray-800" />
+            )}
+            <div className="min-w-0 flex-1 leading-tight">
+              <p className="truncate text-sm font-semibold text-gray-900 dark:text-gray-50">
+                {current?.name ?? (isLoading ? "Loading…" : "No workspace")}
+              </p>
+              <p className="truncate text-xs text-gray-500 dark:text-gray-400">
+                {current?.isDefault ? "Default" : "Workspace"}
+              </p>
+            </div>
+            <RiExpandUpDownLine
+              className="size-4 shrink-0 text-gray-400"
+              aria-hidden="true"
+            />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-64">
+          <DropdownMenuLabel>
+            Workspaces ({data?.length ?? 0})
+          </DropdownMenuLabel>
+          {data?.map((ws) => {
+            const selected = ws.id === currentWorkspaceId
+            return (
+              <DropdownMenuItem
+                key={ws.id}
+                onSelect={(event) => {
+                  // Avoid closing the menu when the inline edit button was clicked.
+                  const target = event.target as HTMLElement | null
+                  if (target?.closest("[data-ws-edit]")) {
+                    event.preventDefault()
+                    return
+                  }
+                  setCurrentWorkspaceId(ws.id)
+                }}
+                className="flex items-center gap-2"
+              >
+                <WorkspaceAvatar name={ws.name} color={ws.color} size="sm" />
+                <span className="min-w-0 flex-1 truncate text-sm">
+                  {ws.name}
+                </span>
+                {selected && (
+                  <RiCheckLine
+                    className="size-4 shrink-0 text-indigo-600 dark:text-indigo-400"
+                    aria-hidden="true"
+                  />
+                )}
+                <button
+                  type="button"
+                  data-ws-edit
+                  aria-label={`Edit ${ws.name}`}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setEditTarget(ws)
+                  }}
+                  className={cx(
+                    "ml-1 flex size-6 shrink-0 items-center justify-center rounded text-gray-400 hover:bg-gray-200 hover:text-gray-900 dark:text-gray-500 hover:dark:bg-gray-800 hover:dark:text-gray-50",
+                    focusRing,
+                  )}
+                >
+                  <RiPencilLine className="size-3.5" aria-hidden="true" />
+                </button>
+              </DropdownMenuItem>
+            )
+          })}
+          {data && data.length === 0 && !isLoading && (
+            <div className="px-2 py-1.5 text-sm italic text-gray-400 dark:text-gray-600">
+              No workspaces
+            </div>
+          )}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onSelect={() => {
+              setAddOpen(true)
+            }}
+            className="flex items-center gap-2"
+          >
+            <RiAddLine
+              className="size-4 shrink-0 text-gray-500"
+              aria-hidden="true"
+            />
+            Add workspace
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <AddWorkspaceDialog
+        open={addOpen}
+        onOpenChange={setAddOpen}
+        onSuccess={async (created) => {
+          await refetch()
+          setCurrentWorkspaceId(created.id)
+        }}
+      />
+
+      <EditWorkspaceDialog
+        workspace={editTarget}
+        open={editTarget !== null}
+        onOpenChange={(next) => {
+          if (!next) setEditTarget(null)
+        }}
+        onSaved={() => refetch()}
+        onDeleted={(deletedId) => {
+          if (deletedId === currentWorkspaceId) {
+            setCurrentWorkspaceId(DEFAULT_WORKSPACE_ID)
+          }
+          refetch()
+        }}
+      />
+    </>
+  )
+}
+
+export default WorkspacesDropdown

--- a/ui/src/hooks/use-connections.test.ts
+++ b/ui/src/hooks/use-connections.test.ts
@@ -20,6 +20,7 @@ const FIXTURE: ConnectionProfileResponse[] = [
     port: 3000,
     color: "#4f46e5",
     labels: { env: "default" },
+    workspaceId: "ws-default",
     createdAt: "2026-05-04T00:00:00Z",
     updatedAt: "2026-05-04T00:00:00Z",
   },

--- a/ui/src/hooks/use-workspaces.ts
+++ b/ui/src/hooks/use-workspaces.ts
@@ -1,0 +1,64 @@
+/**
+ * useWorkspaces — fetch-on-mount hook for the workspace list.
+ * Returns data/error/isLoading plus a `refetch` for manual reloads.
+ */
+
+"use client"
+
+import { useCallback, useEffect, useState } from "react"
+
+import { listWorkspaces } from "@/lib/api/workspaces"
+import { logFetchError } from "@/lib/api/log"
+import type { WorkspaceResponse } from "@/lib/types/workspace"
+
+export interface UseWorkspacesResult {
+  data: WorkspaceResponse[] | null
+  error: Error | null
+  isLoading: boolean
+  refetch: () => Promise<void>
+}
+
+export function useWorkspaces(): UseWorkspacesResult {
+  const [data, setData] = useState<WorkspaceResponse[] | null>(null)
+  const [error, setError] = useState<Error | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+
+  const refetch = useCallback(async () => {
+    setIsLoading(true)
+    setError(null)
+    try {
+      const result = await listWorkspaces()
+      setData(result)
+    } catch (err) {
+      logFetchError("workspaces", err)
+      setError(err instanceof Error ? err : new Error(String(err)))
+    } finally {
+      setIsLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    ;(async () => {
+      try {
+        const result = await listWorkspaces()
+        if (!cancelled) {
+          setData(result)
+          setError(null)
+        }
+      } catch (err) {
+        logFetchError("workspaces", err)
+        if (!cancelled) {
+          setError(err instanceof Error ? err : new Error(String(err)))
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return { data, error, isLoading, refetch }
+}

--- a/ui/src/lib/api/workspaces.ts
+++ b/ui/src/lib/api/workspaces.ts
@@ -1,0 +1,41 @@
+/**
+ * Workspace CRUD client.
+ * Endpoint base: /api/workspaces
+ */
+
+import type {
+  CreateWorkspaceRequest,
+  UpdateWorkspaceRequest,
+  WorkspaceResponse,
+} from "../types/workspace"
+import { apiDelete, apiGet, apiPost, apiPut } from "./client"
+
+/** GET /api/workspaces — list all workspaces. */
+export function listWorkspaces(): Promise<WorkspaceResponse[]> {
+  return apiGet("/workspaces")
+}
+
+/** GET /api/workspaces/{id} — fetch a single workspace. */
+export function getWorkspace(id: string): Promise<WorkspaceResponse> {
+  return apiGet(`/workspaces/${encodeURIComponent(id)}`)
+}
+
+/** POST /api/workspaces — create a new workspace. */
+export function createWorkspace(
+  body: CreateWorkspaceRequest,
+): Promise<WorkspaceResponse> {
+  return apiPost("/workspaces", body)
+}
+
+/** PUT /api/workspaces/{id} — update a workspace's name, color, or description. */
+export function updateWorkspace(
+  id: string,
+  body: UpdateWorkspaceRequest,
+): Promise<WorkspaceResponse> {
+  return apiPut(`/workspaces/${encodeURIComponent(id)}`, body)
+}
+
+/** DELETE /api/workspaces/{id} — delete an empty, non-default workspace. */
+export function deleteWorkspace(id: string): Promise<void> {
+  return apiDelete(`/workspaces/${encodeURIComponent(id)}`)
+}

--- a/ui/src/lib/types/connection.ts
+++ b/ui/src/lib/types/connection.ts
@@ -36,6 +36,8 @@ export interface ConnectionProfileResponse {
   description?: string | null
   /** Always contains an ``env`` key after backend normalization (defaults to ``default``). */
   labels: Record<string, string>
+  /** Workspace this connection belongs to. Defaults to ``ws-default`` server-side. */
+  workspaceId: string
   createdAt: string
   updatedAt: string
 }
@@ -54,6 +56,8 @@ export interface CreateConnectionRequest {
   color?: string
   description?: string | null
   labels?: Record<string, string> | null
+  /** When omitted, the backend assigns the connection to the default workspace. */
+  workspaceId?: string | null
 }
 
 export interface UpdateConnectionRequest {
@@ -66,6 +70,8 @@ export interface UpdateConnectionRequest {
   color?: string
   description?: string | null
   labels?: Record<string, string> | null
+  /** Set to move the connection into a different workspace. */
+  workspaceId?: string | null
 }
 
 export interface TestConnectionRequest {

--- a/ui/src/lib/types/k8s.ts
+++ b/ui/src/lib/types/k8s.ts
@@ -492,6 +492,8 @@ export interface CreateK8sClusterRequest {
   rackConfig?: RackAwareConfig | null
   enableDynamicConfig?: boolean
   autoConnect?: boolean
+  /** Workspace to attach the auto-created connection to. Defaults to the built-in default workspace when omitted. */
+  workspaceId?: string | null
   networkPolicy?: NetworkAccessConfig | null
   k8sNodeBlockList?: string[] | null
   podScheduling?: PodSchedulingConfig | null

--- a/ui/src/lib/types/workspace.ts
+++ b/ui/src/lib/types/workspace.ts
@@ -1,0 +1,29 @@
+/**
+ * Workspace-related types mirrored from API Pydantic models.
+ * See: api/src/aerospike_cluster_manager_api/models/workspace.py
+ */
+
+/** Identifier of the built-in workspace seeded by the backend migration. */
+export const DEFAULT_WORKSPACE_ID = "ws-default"
+
+export interface WorkspaceResponse {
+  id: string
+  name: string
+  color: string
+  description?: string | null
+  isDefault: boolean
+  createdAt: string
+  updatedAt: string
+}
+
+export interface CreateWorkspaceRequest {
+  name: string
+  color?: string
+  description?: string | null
+}
+
+export interface UpdateWorkspaceRequest {
+  name?: string
+  color?: string
+  description?: string | null
+}

--- a/ui/src/stores/ui-store.ts
+++ b/ui/src/stores/ui-store.ts
@@ -6,6 +6,8 @@
 import { create } from "zustand"
 import { persist } from "zustand/middleware"
 
+import { DEFAULT_WORKSPACE_ID } from "@/lib/types/workspace"
+
 export type SidebarMode = "expanded" | "collapsed"
 export type ClustersView = "card" | "table"
 
@@ -15,11 +17,14 @@ interface UiStore {
   activeSection: string | null
   /** Preferred layout on /clusters — card grid vs. table list. */
   clustersView: ClustersView
+  /** Currently selected workspace. The sidebar dropdown drives this. */
+  currentWorkspaceId: string
 
   toggleSidebar: () => void
   setSidebarMode: (mode: SidebarMode) => void
   setActiveSection: (section: string | null) => void
   setClustersView: (view: ClustersView) => void
+  setCurrentWorkspaceId: (id: string) => void
 }
 
 export const useUiStore = create<UiStore>()(
@@ -28,6 +33,7 @@ export const useUiStore = create<UiStore>()(
       sidebarMode: "expanded",
       activeSection: null,
       clustersView: "card",
+      currentWorkspaceId: DEFAULT_WORKSPACE_ID,
 
       toggleSidebar: () =>
         set({
@@ -37,10 +43,24 @@ export const useUiStore = create<UiStore>()(
       setSidebarMode: (sidebarMode) => set({ sidebarMode }),
       setActiveSection: (activeSection) => set({ activeSection }),
       setClustersView: (clustersView) => set({ clustersView }),
+      setCurrentWorkspaceId: (currentWorkspaceId) =>
+        set({ currentWorkspaceId }),
     }),
     {
       name: "acm-renewal-ui",
-      version: 1,
+      version: 2,
+      // Bumping version invalidates pre-workspace persisted state so the
+      // hydrated store always has a valid currentWorkspaceId.
+      migrate: (persisted, version) => {
+        if (!persisted || typeof persisted !== "object") return persisted
+        if (version < 2) {
+          return {
+            ...(persisted as Record<string, unknown>),
+            currentWorkspaceId: DEFAULT_WORKSPACE_ID,
+          }
+        }
+        return persisted
+      },
     },
   ),
 )


### PR DESCRIPTION
## Summary
- Introduce Workspace as a 1-to-N grouping unit so teams managing multiple Aerospike clusters can separate them by project or environment.
- Sidebar dropdown switches workspace; cluster list filters to the active workspace; Add Connection auto-attaches to the current workspace.
- Default workspace is auto-seeded by the migration and existing connections are back-filled. Out of scope (reference image showed SaaS-only bits): RBAC/users, billing, region/db configuration.

## Changes
**Backend (api/)**
- workspaces table + connections.workspace_id with idempotent _apply_migrations() (SQLite + PostgreSQL, Alembic-free)
- Pydantic models: Workspace, Create/UpdateWorkspaceRequest, WorkspaceResponse; ConnectionProfile.workspaceId
- /api/workspaces CRUD (default cannot be deleted; non-empty workspace deletes return 409)
- /api/connections?workspace_id= filter; POST/PUT validate workspace existence

**Frontend (ui/)**
- WorkspacesDropdown atop sidebar (desktop + mobile drawer) with avatar, current-selection marker, inline Edit, Add workspace
- AddWorkspaceDialog / EditWorkspaceDialog
- ui-store.currentWorkspaceId persisted (localStorage v2 migration); URL → workspace auto-sync when navigating directly to a cluster

## Test plan
- [x] uv run ruff check src and uv run ruff format src clean
- [x] uv run pytest — 366 tests pass (24 new: workspace router + migrations + connection-workspace filtering)
- [x] npm run type-check clean
- [x] npm run lint clean
- [x] npm run test — 27 tests pass
- [ ] Manual E2E: podman compose -f compose.dev.yaml up -d → API → UI; verify Default workspace seeded, switch via dropdown, Add Connection lands in active workspace, delete non-empty workspace returns 409, delete default workspace blocked
- [ ] Restart API on existing DB → default workspace not duplicated (idempotent migration)