### PR TITLE
feat: Keycloak OIDC auth + multi-cluster ClusterSelector

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ podman compose -f compose.yaml up --build
 - API: http://localhost:8000
 - Aerospike: internal network only (use `podman exec -it aerospike-tools aql -h aerospike-node-1`)
 
+> Multi-cluster + Keycloak OIDC mode (`KEYCLOAK_ISSUER_URL`, `OIDC_AUDIENCE=acko-api`, JWKS-based JWT verification): see [ACKO multi-cluster docs](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/blob/main/docs/multi-cluster-keycloak.md).
+
 ### Local Development
 
 **API:**

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
     "opentelemetry-instrumentation-fastapi>=0.51b0",
     "opentelemetry-instrumentation-asyncpg>=0.51b0",
     "opentelemetry-instrumentation-logging>=0.51b0",
+    "httpx>=0.28.1",
+    "python-jose[cryptography]>=3.3,<4",
 ]
 
 [tool.uv]

--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import json
 import os
+import re
 
 
 def _get_int(name: str, default: int) -> int:
@@ -12,6 +14,42 @@ def _get_int(name: str, default: int) -> int:
         return int(raw)
     except ValueError:
         raise ValueError(f"Environment variable {name} must be an integer, got: {raw!r}") from None
+
+
+_DURATION_RE = re.compile(r"^(?P<value>\d+)(?P<unit>[smhd]?)$")
+
+
+def _parse_duration_seconds(raw: str, default_seconds: int) -> int:
+    """Accept ``"600"``, ``"10m"``, ``"1h"``, ``"2d"`` and return seconds.
+
+    Bare integers are treated as seconds. Empty/None falls back to ``default_seconds``.
+    """
+    if raw is None or raw == "":
+        return default_seconds
+    candidate = raw.strip().lower()
+    m = _DURATION_RE.match(candidate)
+    if not m:
+        raise ValueError(f"Invalid duration {raw!r}; expected forms like '600', '10m', '1h', '2d'")
+    value = int(m.group("value"))
+    unit = m.group("unit") or "s"
+    multiplier = {"s": 1, "m": 60, "h": 3600, "d": 86400}[unit]
+    return value * multiplier
+
+
+def _parse_str_list(raw: str | None) -> list[str]:
+    """Parse a CSV or JSON array string into a list of stripped, non-empty entries."""
+    if raw is None or raw.strip() == "":
+        return []
+    raw = raw.strip()
+    if raw.startswith("["):
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON list: {raw!r}") from e
+        if not isinstance(parsed, list):
+            raise ValueError(f"Expected JSON list, got {type(parsed).__name__}: {raw!r}")
+        return [str(x).strip() for x in parsed if str(x).strip()]
+    return [item.strip() for item in raw.split(",") if item.strip()]
 
 
 CORS_ORIGINS: list[str] = [
@@ -90,3 +128,24 @@ LOG_HANDLERS: str = os.getenv("LOG_HANDLERS", "")
 # full control over logging configuration. LOG_LEVEL / LOG_FORMAT / LOG_HANDLERS
 # are ignored in this mode — the dictConfig is authoritative.
 LOGGING_CONFIG_FILE: str = os.getenv("LOGGING_CONFIG_FILE", "")
+
+# ---------------------------------------------------------------------------
+# OIDC / Keycloak native JWT verification (Phase 0 contracts C-4, C-6, C-7)
+# ---------------------------------------------------------------------------
+# When OIDC_ENABLED=false the middleware is a no-op (still installed but
+# returns immediately) so non-prod and unit-test deployments need no Keycloak.
+OIDC_ENABLED: bool = os.getenv("OIDC_ENABLED", "false").lower() in ("true", "1", "yes")
+# Keycloak realm root, e.g. https://keycloak.example.com/realms/acko. The
+# middleware appends /.well-known/openid-configuration to discover jwks_uri.
+OIDC_ISSUER_URL: str = os.getenv("OIDC_ISSUER_URL", "")
+# Single audience claim contract C-4: tokens from the SPA carry aud=acko-api.
+OIDC_AUDIENCE: str = os.getenv("OIDC_AUDIENCE", "acko-api")
+# CSV ("acko:dev,acko:prod") or JSON list ("[\"acko:dev\"]"). Empty = auth-only,
+# no role check. Resolved against decoded["realm_access"]["roles"].
+OIDC_REQUIRED_ROLES: list[str] = _parse_str_list(os.getenv("OIDC_REQUIRED_ROLES"))
+# JWKS cache TTL. Accepts duration string ("10m") or bare seconds ("600").
+OIDC_JWKS_CACHE_TTL_SECONDS: int = _parse_duration_seconds(os.getenv("OIDC_JWKS_CACHE_TTL", "10m"), default_seconds=600)
+# Paths that bypass auth entirely (exact match). Helm values may override.
+OIDC_EXCLUDE_PATHS: list[str] = _parse_str_list(
+    os.getenv("OIDC_EXCLUDE_PATHS", "/api/health,/api/openapi.json,/api/docs")
+) or ["/api/health", "/api/openapi.json", "/api/docs"]

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -20,6 +21,7 @@ from aerospike_cluster_manager_api.client_manager import client_manager
 from aerospike_cluster_manager_api.events.broker import broker
 from aerospike_cluster_manager_api.events.collector import collector
 from aerospike_cluster_manager_api.logging_config import setup_logging
+from aerospike_cluster_manager_api.middleware.oidc_auth import OIDCAuthMiddleware
 from aerospike_cluster_manager_api.middleware.trace_id import TraceIDMiddleware
 from aerospike_cluster_manager_api.observability import setup_observability
 from aerospike_cluster_manager_api.rate_limit import limiter
@@ -179,6 +181,18 @@ app.add_middleware(
 # Request logging middleware
 # ---------------------------------------------------------------------------
 
+# Matches ``access_token=...`` (and a few common JWT-like query keys) in a
+# URL query string. We log the path + (optionally) query, and SSE clients
+# pass JWTs as ``?access_token=`` because EventSource cannot send Authorization
+# headers — masking before logging keeps tokens out of access logs.
+_SENSITIVE_QS_RE = re.compile(r"(access_token|id_token|token)=[^&\s]+", re.IGNORECASE)
+
+
+def _mask_query_string(qs: str) -> str:
+    if not qs:
+        return qs
+    return _SENSITIVE_QS_RE.sub(lambda m: f"{m.group(1)}=***", qs)
+
 
 @app.middleware("http")
 async def request_logging_middleware(request: Request, call_next: RequestResponseEndpoint) -> Response:
@@ -191,10 +205,12 @@ async def request_logging_middleware(request: Request, call_next: RequestRespons
     # The structured `request_id` JSON field (populated by RequestIDFilter)
     # is the source of truth for log correlation; no need to repeat it in
     # the message text.
+    masked_qs = _mask_query_string(request.url.query)
+    path_for_log = f"{request.url.path}?{masked_qs}" if masked_qs else request.url.path
     logger.info(
         "%s %s %d %.1fms",
         request.method,
-        request.url.path,
+        path_for_log,
         response.status_code,
         elapsed_ms,
     )
@@ -231,11 +247,30 @@ async def security_headers_middleware(request: Request, call_next: RequestRespon
     return response
 
 
+# OIDCAuthMiddleware is added BEFORE TraceIDMiddleware so the runtime
+# layering becomes (outermost → innermost): TraceID → OIDC → security_headers
+# → request_logging → CORS → SlowAPI. That way every authenticated request
+# already has a request_id in scope when the JWT verifier logs, and CORS
+# preflight responses are still produced even when the bearer token is
+# missing/invalid (the OIDC dispatch short-circuits OPTIONS so CORSMiddleware
+# downstream answers the preflight).
+if config.OIDC_ENABLED:
+    app.add_middleware(
+        OIDCAuthMiddleware,
+        enabled=True,
+        issuer_url=config.OIDC_ISSUER_URL,
+        audience=config.OIDC_AUDIENCE,
+        required_roles=config.OIDC_REQUIRED_ROLES,
+        exclude_paths=config.OIDC_EXCLUDE_PATHS,
+        jwks_cache_ttl_seconds=config.OIDC_JWKS_CACHE_TTL_SECONDS,
+    )
+
 # TraceIDMiddleware is registered AFTER all other middleware (CORS, SlowAPI,
-# request_logging, security_headers) so that — given Starlette's reverse-add
-# semantics where the last middleware added is the outermost layer — it reads
-# or generates X-Request-ID and stores it in the ContextVar BEFORE any inner
-# middleware or route handler runs, and echoes the header on the way out.
+# request_logging, security_headers, OIDC) so that — given Starlette's
+# reverse-add semantics where the last middleware added is the outermost
+# layer — it reads or generates X-Request-ID and stores it in the ContextVar
+# BEFORE any inner middleware or route handler runs, and echoes the header on
+# the way out.
 app.add_middleware(TraceIDMiddleware)
 
 

--- a/api/src/aerospike_cluster_manager_api/middleware/__init__.py
+++ b/api/src/aerospike_cluster_manager_api/middleware/__init__.py
@@ -2,6 +2,10 @@
 
 from __future__ import annotations
 
+from aerospike_cluster_manager_api.middleware.oidc_auth import (
+    SSE_QUERY_TOKEN_PATHS,
+    OIDCAuthMiddleware,
+)
 from aerospike_cluster_manager_api.middleware.trace_id import (
     REQUEST_ID_HEADER,
     RequestIDFilter,
@@ -11,6 +15,8 @@ from aerospike_cluster_manager_api.middleware.trace_id import (
 
 __all__ = [
     "REQUEST_ID_HEADER",
+    "SSE_QUERY_TOKEN_PATHS",
+    "OIDCAuthMiddleware",
     "RequestIDFilter",
     "TraceIDMiddleware",
     "request_id_var",

--- a/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
+++ b/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
@@ -1,0 +1,263 @@
+"""Keycloak-style OIDC bearer token middleware.
+
+Verifies inbound ``Authorization: Bearer <jwt>`` tokens locally (signature,
+``exp``, ``iss``, ``aud``) using the issuer's public JWKS. The JWKS is fetched
+once per ``OIDC_JWKS_CACHE_TTL_SECONDS`` window, with a single :class:`asyncio.Lock`
+to prevent stampedes when many requests miss the cache simultaneously.
+
+Cache invalidation triggers (in order of strictness):
+
+* TTL expiry — refetched on the next request after ``expires_at``.
+* Unknown ``kid`` — when a token references a key id we have never seen, the
+  JWKS is refetched **once** before declaring the token invalid; this covers
+  Keycloak realm key rotation without requiring a process restart.
+
+The middleware is installed unconditionally in ``main.py``; when
+``OIDC_ENABLED=false`` (default) it returns immediately without inspecting the
+request, so non-prod deployments need no Keycloak.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import Awaitable, Callable, Iterable
+from typing import Any, cast
+
+import httpx
+from jose import JWTError, jwt
+from jose.exceptions import ExpiredSignatureError, JWTClaimsError
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+from starlette.types import ASGIApp
+
+logger = logging.getLogger(__name__)
+
+# SSE EventSource cannot send custom headers (HTML5 spec), so we accept the
+# token via ``?access_token=`` on the documented stream endpoints. Both the
+# legacy /api/... and versioned /api/v1/... aliases are listed.
+SSE_QUERY_TOKEN_PATHS: frozenset[str] = frozenset(
+    {
+        "/api/events/stream",
+        "/api/v1/events/stream",
+    }
+)
+
+
+class OIDCAuthMiddleware(BaseHTTPMiddleware):
+    """Native (no introspection) JWT verification with cached JWKS."""
+
+    def __init__(
+        self,
+        app: ASGIApp,
+        *,
+        enabled: bool,
+        issuer_url: str,
+        audience: str,
+        required_roles: Iterable[str] = (),
+        exclude_paths: Iterable[str] = (),
+        jwks_cache_ttl_seconds: int = 600,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        super().__init__(app)
+        self.enabled = enabled
+        self.issuer_url = issuer_url.rstrip("/") if issuer_url else ""
+        self.audience = audience
+        self.required_roles: frozenset[str] = frozenset(required_roles)
+        self.exclude_paths: frozenset[str] = frozenset(exclude_paths)
+        self.jwks_cache_ttl_seconds = jwks_cache_ttl_seconds
+
+        # Tests can inject a transport-mocked client; production constructs
+        # one lazily on first JWKS fetch (avoids opening a connection pool
+        # at import time when OIDC is disabled).
+        self._http_client: httpx.AsyncClient | None = http_client
+        self._owns_http_client = http_client is None
+
+        # JWKS cache state. ``_jwks_by_kid`` maps the JWS header ``kid`` to
+        # the raw JWK dict; jose accepts dicts directly. ``_expires_at`` is a
+        # monotonic-ish wall-clock seconds value; we use ``time.time()`` so a
+        # process restart resets the cache implicitly.
+        self._jwks_by_kid: dict[str, dict[str, Any]] = {}
+        self._jwks_expires_at: float = 0.0
+        self._jwks_lock = asyncio.Lock()
+        # Cached well-known doc — only the ``jwks_uri`` value is used today,
+        # but caching it avoids two HTTP round-trips on every refetch.
+        self._jwks_uri: str | None = None
+
+        if enabled and not self.issuer_url:
+            raise ValueError("OIDC_ENABLED=true but OIDC_ISSUER_URL is empty")
+
+    # ------------------------------------------------------------------
+    # Starlette dispatch
+    # ------------------------------------------------------------------
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        if not self.enabled:
+            return await call_next(request)
+
+        path = request.url.path
+        if path in self.exclude_paths:
+            return await call_next(request)
+        # CORS preflight requests carry no Authorization header — passing them
+        # through lets CORSMiddleware respond with the negotiated headers.
+        if request.method == "OPTIONS":
+            return await call_next(request)
+
+        token = self._extract_token(request, path)
+        if token is None:
+            return _unauthorized("Missing bearer token")
+
+        try:
+            claims = await self._verify(token)
+        except _AuthError as exc:
+            return _unauthorized(exc.detail)
+
+        if self.required_roles:
+            roles = _extract_realm_roles(claims)
+            if not (self.required_roles & roles):
+                return _forbidden(
+                    f"Token lacks required role(s): {sorted(self.required_roles)}",
+                )
+
+        request.state.user_claims = claims
+        return await call_next(request)
+
+    # ------------------------------------------------------------------
+    # JWT verification
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _extract_token(request: Request, path: str) -> str | None:
+        header = request.headers.get("authorization") or request.headers.get("Authorization")
+        if header:
+            parts = header.split(None, 1)
+            if len(parts) == 2 and parts[0].lower() == "bearer" and parts[1].strip():
+                return parts[1].strip()
+        if path in SSE_QUERY_TOKEN_PATHS:
+            qs_token = request.query_params.get("access_token")
+            if qs_token:
+                return qs_token
+        return None
+
+    async def _verify(self, token: str) -> dict[str, Any]:
+        try:
+            unverified_header = jwt.get_unverified_header(token)
+        except JWTError as exc:
+            raise _AuthError(f"Malformed token header: {exc}") from exc
+
+        kid = unverified_header.get("kid")
+        if not kid:
+            raise _AuthError("Token header missing 'kid'")
+
+        key = await self._key_for_kid(kid)
+        if key is None:
+            raise _AuthError(f"Unknown signing key id (kid={kid!r})")
+
+        algorithm = key.get("alg") or unverified_header.get("alg")
+        if not algorithm:
+            raise _AuthError("Cannot determine signing algorithm")
+
+        try:
+            claims = jwt.decode(
+                token,
+                key,
+                algorithms=[algorithm],
+                audience=self.audience,
+                issuer=self.issuer_url,
+            )
+        except ExpiredSignatureError as exc:
+            raise _AuthError("Token expired") from exc
+        except JWTClaimsError as exc:
+            raise _AuthError(f"Invalid claims: {exc}") from exc
+        except JWTError as exc:
+            raise _AuthError(f"Invalid token: {exc}") from exc
+        return cast(dict[str, Any], claims)
+
+    # ------------------------------------------------------------------
+    # JWKS cache
+    # ------------------------------------------------------------------
+    async def _key_for_kid(self, kid: str) -> dict[str, Any] | None:
+        now = time.time()
+        if kid in self._jwks_by_kid and now < self._jwks_expires_at:
+            return self._jwks_by_kid[kid]
+
+        async with self._jwks_lock:
+            # Re-check after acquiring the lock — another task may have
+            # already refreshed the cache while we were waiting.
+            now = time.time()
+            need_refresh = now >= self._jwks_expires_at or kid not in self._jwks_by_kid
+            if need_refresh:
+                await self._refresh_jwks()
+            return self._jwks_by_kid.get(kid)
+
+    async def _refresh_jwks(self) -> None:
+        client = self._get_http_client()
+        if self._jwks_uri is None:
+            well_known = f"{self.issuer_url}/.well-known/openid-configuration"
+            resp = await client.get(well_known)
+            resp.raise_for_status()
+            doc = resp.json()
+            uri = doc.get("jwks_uri")
+            if not isinstance(uri, str) or not uri:
+                raise _AuthError("OIDC discovery document is missing jwks_uri")
+            self._jwks_uri = uri
+
+        resp = await client.get(self._jwks_uri)
+        resp.raise_for_status()
+        payload = resp.json()
+        keys = payload.get("keys") if isinstance(payload, dict) else None
+        if not isinstance(keys, list):
+            raise _AuthError("JWKS response missing 'keys' array")
+
+        new_index: dict[str, dict[str, Any]] = {}
+        for k in keys:
+            if isinstance(k, dict) and isinstance(k.get("kid"), str):
+                new_index[k["kid"]] = k
+        self._jwks_by_kid = new_index
+        self._jwks_expires_at = time.time() + self.jwks_cache_ttl_seconds
+        logger.info(
+            "OIDC JWKS refreshed: %d key(s), ttl=%ss",
+            len(new_index),
+            self.jwks_cache_ttl_seconds,
+        )
+
+    def _get_http_client(self) -> httpx.AsyncClient:
+        if self._http_client is None:
+            self._http_client = httpx.AsyncClient(timeout=httpx.Timeout(10.0))
+        return self._http_client
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+class _AuthError(Exception):
+    def __init__(self, detail: str) -> None:
+        super().__init__(detail)
+        self.detail = detail
+
+
+def _extract_realm_roles(claims: dict[str, Any]) -> frozenset[str]:
+    realm_access = claims.get("realm_access")
+    if isinstance(realm_access, dict):
+        roles = realm_access.get("roles")
+        if isinstance(roles, list):
+            return frozenset(str(r) for r in roles if isinstance(r, str))
+    return frozenset()
+
+
+def _unauthorized(detail: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=401,
+        content={"detail": detail},
+        headers={"WWW-Authenticate": 'Bearer realm="acko-api"'},
+    )
+
+
+def _forbidden(detail: str) -> JSONResponse:
+    return JSONResponse(status_code=403, content={"detail": detail})

--- a/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
+++ b/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
@@ -227,9 +227,7 @@ class OIDCAuthMiddleware(BaseHTTPMiddleware):
             if ttl_expired:
                 # Standard TTL refresh path.
                 await self._refresh_jwks()
-            elif kid_missing and (
-                now - self._last_kid_miss_refresh_at >= _KID_MISS_BACKOFF_SECONDS
-            ):
+            elif kid_missing and (now - self._last_kid_miss_refresh_at >= _KID_MISS_BACKOFF_SECONDS):
                 # Unknown-kid refresh, but rate-limited via back-off window so
                 # a flood of bogus kids cannot amplify into JWKS requests.
                 # Outside the back-off window we fall through and let the

--- a/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
+++ b/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
@@ -45,6 +45,28 @@ SSE_QUERY_TOKEN_PATHS: frozenset[str] = frozenset(
     }
 )
 
+# Asymmetric algorithms only — never trust the JWK's ``alg`` field blindly.
+# Symmetric algs (HS256/384/512) and ``none`` would let a malicious or
+# misconfigured JWKS open a verification path with attacker-known secrets.
+# Keycloak issues RS256 by default; ES* are allowed for installations that
+# rotate to elliptic-curve signing keys.
+_ALLOWED_ALGS: frozenset[str] = frozenset(
+    {"RS256", "RS384", "RS512", "ES256", "ES384", "ES512"},
+)
+
+# Back-off window for ``kid``-miss-driven JWKS refetches. After a refresh that
+# still does not contain the requested ``kid`` (i.e. the token was forged or
+# references a key the IdP no longer publishes), additional unknown-kid
+# requests within this window do NOT trigger another fetch — they fail fast.
+# Prevents an attacker from amplifying a flood of bogus tokens into a flood
+# of HTTP requests against the issuer.
+_KID_MISS_BACKOFF_SECONDS: int = 30
+
+# TODO(follow-up): migrate from python-jose to PyJWT (>=2.9). python-jose is
+# unmaintained as of 2024 and has open CVE-2024-33663/4. Mitigations applied
+# here: pinned algorithm whitelist (above), strict aud/iss verification,
+# kid-miss back-off. Still, switching to a maintained library is preferred.
+
 
 class OIDCAuthMiddleware(BaseHTTPMiddleware):
     """Native (no introspection) JWT verification with cached JWKS."""
@@ -82,6 +104,11 @@ class OIDCAuthMiddleware(BaseHTTPMiddleware):
         self._jwks_by_kid: dict[str, dict[str, Any]] = {}
         self._jwks_expires_at: float = 0.0
         self._jwks_lock = asyncio.Lock()
+        # Last wall-clock time we refetched JWKS specifically because of an
+        # unknown ``kid``. Used to enforce ``_KID_MISS_BACKOFF_SECONDS`` so
+        # an attacker spamming bogus kids cannot turn each request into a
+        # round-trip to the issuer.
+        self._last_kid_miss_refresh_at: float = 0.0
         # Cached well-known doc — only the ``jwks_uri`` value is used today,
         # but caching it avoids two HTTP round-trips on every refetch.
         self._jwks_uri: str | None = None
@@ -160,6 +187,11 @@ class OIDCAuthMiddleware(BaseHTTPMiddleware):
         algorithm = key.get("alg") or unverified_header.get("alg")
         if not algorithm:
             raise _AuthError("Cannot determine signing algorithm")
+        if algorithm not in _ALLOWED_ALGS:
+            # Defense-in-depth: even though Keycloak issues RS256, refusing
+            # everything else here closes off a class of downgrade attacks
+            # via a tampered or rogue JWKS endpoint.
+            raise _AuthError(f"Unsupported signing algorithm: {algorithm}")
 
         try:
             claims = jwt.decode(
@@ -189,8 +221,20 @@ class OIDCAuthMiddleware(BaseHTTPMiddleware):
             # Re-check after acquiring the lock — another task may have
             # already refreshed the cache while we were waiting.
             now = time.time()
-            need_refresh = now >= self._jwks_expires_at or kid not in self._jwks_by_kid
-            if need_refresh:
+            ttl_expired = now >= self._jwks_expires_at
+            kid_missing = kid not in self._jwks_by_kid
+
+            if ttl_expired:
+                # Standard TTL refresh path.
+                await self._refresh_jwks()
+            elif kid_missing and (
+                now - self._last_kid_miss_refresh_at >= _KID_MISS_BACKOFF_SECONDS
+            ):
+                # Unknown-kid refresh, but rate-limited via back-off window so
+                # a flood of bogus kids cannot amplify into JWKS requests.
+                # Outside the back-off window we fall through and let the
+                # caller see ``None`` (token rejected as unknown kid).
+                self._last_kid_miss_refresh_at = now
                 await self._refresh_jwks()
             return self._jwks_by_kid.get(kid)
 

--- a/api/tests/test_oidc_auth.py
+++ b/api/tests/test_oidc_auth.py
@@ -1,0 +1,405 @@
+"""Tests for the OIDC bearer-token middleware.
+
+Each scenario builds a tiny FastAPI app wired up to ``OIDCAuthMiddleware``
+and a mocked JWKS endpoint (httpx ``MockTransport``). The mock counts hits
+so JWKS-cache assertions can compare against a deterministic baseline.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import time
+import uuid
+from collections.abc import Iterable
+
+import httpx
+import pytest
+from cryptography.hazmat.primitives.asymmetric import rsa
+from fastapi import FastAPI, Request
+from fastapi.responses import PlainTextResponse
+from httpx import ASGITransport, AsyncClient
+from jose import jwt as jose_jwt
+from jose.backends.cryptography_backend import CryptographyRSAKey
+from jose.constants import ALGORITHMS
+
+from aerospike_cluster_manager_api.middleware.oidc_auth import OIDCAuthMiddleware
+
+ISSUER = "https://kc.example.com/realms/acko"
+AUDIENCE = "acko-api"
+
+
+# ---------------------------------------------------------------------------
+# Crypto helpers — generate a real RSA key pair and serialise it as JWK so the
+# middleware exercises the same code path Keycloak does in production.
+# ---------------------------------------------------------------------------
+
+
+def _rsa_keypair() -> tuple[rsa.RSAPrivateKey, dict]:
+    """Return (private_key, jwk_public). ``kid`` is a stable random uuid."""
+    priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pub_jwk = CryptographyRSAKey(priv.public_key(), ALGORITHMS.RS256).to_dict()
+    pub_jwk["kid"] = uuid.uuid4().hex
+    pub_jwk["alg"] = "RS256"
+    pub_jwk["use"] = "sig"
+    return priv, pub_jwk
+
+
+def _sign(
+    private_key: rsa.RSAPrivateKey,
+    kid: str,
+    *,
+    audience: str = AUDIENCE,
+    issuer: str = ISSUER,
+    realm_roles: Iterable[str] | None = None,
+    expires_in: int = 300,
+    extra_claims: dict | None = None,
+) -> str:
+    now = int(time.time())
+    claims: dict = {
+        "iss": issuer,
+        "aud": audience,
+        "sub": "user-1",
+        "iat": now,
+        "exp": now + expires_in,
+    }
+    if realm_roles is not None:
+        claims["realm_access"] = {"roles": list(realm_roles)}
+    if extra_claims:
+        claims.update(extra_claims)
+    priv_jwk = CryptographyRSAKey(private_key, ALGORITHMS.RS256).to_dict()
+    return jose_jwt.encode(claims, priv_jwk, algorithm="RS256", headers={"kid": kid})
+
+
+# ---------------------------------------------------------------------------
+# JWKS HTTP mock — tracks the number of fetches so we can assert caching.
+# ---------------------------------------------------------------------------
+
+
+class _JWKSMock:
+    def __init__(self, jwks: list[dict]) -> None:
+        self.jwks = list(jwks)
+        self.well_known_calls = 0
+        self.jwks_calls = 0
+
+    def update(self, jwks: list[dict]) -> None:
+        self.jwks = list(jwks)
+
+    def handler(self, request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/.well-known/openid-configuration"):
+            self.well_known_calls += 1
+            return httpx.Response(
+                200,
+                json={
+                    "issuer": ISSUER,
+                    "jwks_uri": f"{ISSUER}/protocol/openid-connect/certs",
+                },
+            )
+        if path.endswith("/protocol/openid-connect/certs"):
+            self.jwks_calls += 1
+            return httpx.Response(200, json={"keys": list(self.jwks)})
+        return httpx.Response(404)
+
+
+def _client_for(mock: _JWKSMock) -> httpx.AsyncClient:
+    transport = httpx.MockTransport(mock.handler)
+    return httpx.AsyncClient(transport=transport, timeout=5.0)
+
+
+def _build_app(
+    *,
+    enabled: bool = True,
+    required_roles: Iterable[str] = (),
+    exclude_paths: Iterable[str] = ("/api/health",),
+    jwks_cache_ttl_seconds: int = 600,
+    http_client: httpx.AsyncClient | None = None,
+) -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/api/health")
+    async def health() -> dict:
+        return {"status": "ok"}
+
+    @app.get("/api/me")
+    async def me(request: Request) -> dict:
+        return {"sub": getattr(request.state, "user_claims", {}).get("sub")}
+
+    @app.get("/api/v1/events/stream")
+    async def stream() -> PlainTextResponse:
+        return PlainTextResponse("event:hello\n\n")
+
+    app.add_middleware(
+        OIDCAuthMiddleware,
+        enabled=enabled,
+        issuer_url=ISSUER,
+        audience=AUDIENCE,
+        required_roles=required_roles,
+        exclude_paths=exclude_paths,
+        jwks_cache_ttl_seconds=jwks_cache_ttl_seconds,
+        http_client=http_client,
+    )
+    return app
+
+
+# ---------------------------------------------------------------------------
+# Scenarios
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_valid_token_passes_and_injects_claims():
+    priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    app = _build_app(http_client=_client_for(mock))
+    token = _sign(priv, jwk["kid"])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+    assert resp.json() == {"sub": "user-1"}
+
+
+@pytest.mark.asyncio
+async def test_missing_token_yields_401():
+    _priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    app = _build_app(http_client=_client_for(mock))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/me")
+    assert resp.status_code == 401
+    assert resp.headers.get("WWW-Authenticate", "").startswith("Bearer")
+    assert "detail" in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_expired_token_is_rejected():
+    priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    app = _build_app(http_client=_client_for(mock))
+    token = _sign(priv, jwk["kid"], expires_in=-30)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+    assert "expired" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_wrong_audience_is_rejected():
+    priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    app = _build_app(http_client=_client_for(mock))
+    token = _sign(priv, jwk["kid"], audience="other-api")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_bad_signature_is_rejected():
+    _priv_real, jwk = _rsa_keypair()
+    priv_attacker, _ = _rsa_keypair()
+    mock = _JWKSMock([jwk])  # JWKS only advertises the real key
+    app = _build_app(http_client=_client_for(mock))
+    # Sign with attacker key but claim the real key id — signature will fail
+    token = _sign(priv_attacker, jwk["kid"])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_excluded_path_skips_auth():
+    mock = _JWKSMock([])
+    app = _build_app(http_client=_client_for(mock))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/health")
+    assert resp.status_code == 200
+    # Excluded paths must not trigger any JWKS round-trip.
+    assert mock.well_known_calls == 0
+    assert mock.jwks_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_sse_query_token_accepted():
+    priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    app = _build_app(http_client=_client_for(mock))
+    token = _sign(priv, jwk["kid"])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get(f"/api/v1/events/stream?access_token={token}")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_required_role_missing_yields_403():
+    priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    app = _build_app(
+        required_roles=["acko:dev"],
+        http_client=_client_for(mock),
+    )
+    token = _sign(priv, jwk["kid"], realm_roles=["other-role"])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_required_role_present_passes():
+    priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    app = _build_app(
+        required_roles=["acko:dev"],
+        http_client=_client_for(mock),
+    )
+    token = _sign(priv, jwk["kid"], realm_roles=["acko:dev"])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_jwks_fetched_once_within_ttl():
+    priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    app = _build_app(http_client=_client_for(mock), jwks_cache_ttl_seconds=600)
+    token = _sign(priv, jwk["kid"])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        for _ in range(5):
+            resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+            assert resp.status_code == 200
+    assert mock.well_known_calls == 1
+    assert mock.jwks_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_jwks_refetched_after_ttl_expiry():
+    priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    # 0-second TTL so every call is past the deadline; we still verify the
+    # cache only refetches once per request rather than once per token op.
+    app = _build_app(http_client=_client_for(mock), jwks_cache_ttl_seconds=0)
+    token = _sign(priv, jwk["kid"])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        for _ in range(3):
+            resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+            assert resp.status_code == 200
+    assert mock.jwks_calls == 3
+
+
+@pytest.mark.asyncio
+async def test_unknown_kid_triggers_immediate_refetch():
+    priv_old, jwk_old = _rsa_keypair()
+    priv_new, jwk_new = _rsa_keypair()
+    mock = _JWKSMock([jwk_old])
+    app = _build_app(http_client=_client_for(mock), jwks_cache_ttl_seconds=3600)
+    token_old = _sign(priv_old, jwk_old["kid"])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {token_old}"})
+        assert resp.status_code == 200
+        baseline_jwks_calls = mock.jwks_calls
+        # Realm rotates: only the new key is published. A token signed with
+        # the rotated kid arrives — the middleware must refetch JWKS once
+        # (kid miss) and then accept the new key.
+        mock.update([jwk_new])
+        token_new = _sign(priv_new, jwk_new["kid"])
+        resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {token_new}"})
+        assert resp.status_code == 200
+    assert mock.jwks_calls == baseline_jwks_calls + 1
+
+
+@pytest.mark.asyncio
+async def test_disabled_middleware_is_passthrough():
+    mock = _JWKSMock([])
+    app = _build_app(enabled=False, http_client=_client_for(mock))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/me")
+    assert resp.status_code == 200
+    assert mock.well_known_calls == 0
+    assert mock.jwks_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_options_preflight_passes_without_token():
+    """CORS preflight must not be 401'd — CORSMiddleware downstream handles it."""
+    mock = _JWKSMock([])
+    app = _build_app(http_client=_client_for(mock))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.request(
+            "OPTIONS",
+            "/api/me",
+            headers={
+                "Origin": "http://localhost:3000",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+    # Without an inner CORSMiddleware in this minimal app the preflight returns
+    # 405, but the critical assertion is that OIDC did NOT 401 the request.
+    assert resp.status_code != 401
+
+
+# ---------------------------------------------------------------------------
+# Logging — query string masking in main.py's request_logging_middleware.
+# ---------------------------------------------------------------------------
+
+
+def test_request_logging_masks_access_token_query():
+    from aerospike_cluster_manager_api.main import _mask_query_string
+
+    assert _mask_query_string("access_token=eyJabc.def.ghi") == "access_token=***"
+    assert (
+        _mask_query_string("foo=bar&access_token=eyJabc.def.ghi&baz=1")
+        == "foo=bar&access_token=***&baz=1"
+    )
+    # Case-insensitive
+    assert _mask_query_string("Access_Token=secret") == "Access_Token=***"
+    # Other JWT-shaped query keys also get masked
+    assert _mask_query_string("id_token=abc&token=xyz") == "id_token=***&token=***"
+    # No-op when no token is present
+    assert _mask_query_string("foo=bar") == "foo=bar"
+    assert _mask_query_string("") == ""
+
+
+@pytest.mark.asyncio
+async def test_main_request_logging_masks_query_token():
+    """End-to-end: a request through ``main.app`` with a query token logs the masked form.
+
+    We attach a temporary StringIO handler to the ``main`` logger because
+    ``setup_logging`` (called at import time) sets ``propagate=False`` on the
+    package root logger, which prevents pytest's ``caplog`` from observing the
+    record.
+    """
+    from aerospike_cluster_manager_api.main import app as main_app
+
+    transport = ASGITransport(app=main_app)
+    buf = io.StringIO()
+    handler = logging.StreamHandler(buf)
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    target = logging.getLogger("aerospike_cluster_manager_api.main")
+    target.addHandler(handler)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            # /api/health is in the default exclude list for OIDC and works
+            # regardless of OIDC_ENABLED, so the log line is emitted.
+            await ac.get("/api/health?access_token=secret123")
+    finally:
+        target.removeHandler(handler)
+
+    output = buf.getvalue()
+    assert "access_token=***" in output, f"expected masked token in log, got: {output!r}"
+    assert "secret123" not in output, f"raw token leaked in log: {output!r}"

--- a/api/tests/test_oidc_auth.py
+++ b/api/tests/test_oidc_auth.py
@@ -321,6 +321,56 @@ async def test_unknown_kid_triggers_immediate_refetch():
 
 
 @pytest.mark.asyncio
+async def test_disallowed_alg_is_rejected():
+    """A JWK advertising a non-asymmetric/non-allowlisted alg must be rejected
+    even if the JWKS cache somehow contains it (defense-in-depth against
+    downgrade or rogue-IdP scenarios)."""
+    priv, jwk = _rsa_keypair()
+    jwk["alg"] = "HS256"  # symmetric — not in _ALLOWED_ALGS
+    mock = _JWKSMock([jwk])
+    app = _build_app(http_client=_client_for(mock), jwks_cache_ttl_seconds=600)
+    token = _sign(priv, jwk["kid"])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code == 401
+    assert "Unsupported signing algorithm" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_kid_back_off_prevents_amplification():
+    """An attacker spamming tokens with random kids must not amplify into a
+    flood of JWKS requests. After one refetch fails to resolve a bogus kid,
+    subsequent unknown-kid requests within the back-off window must NOT
+    trigger additional fetches."""
+    priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    # Long TTL so the TTL-driven refetch path never fires during this test.
+    app = _build_app(http_client=_client_for(mock), jwks_cache_ttl_seconds=3600)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        # Warm the cache via a valid token.
+        valid = _sign(priv, jwk["kid"])
+        await ac.get("/api/me", headers={"Authorization": f"Bearer {valid}"})
+        baseline = mock.jwks_calls
+        # First bogus kid: triggers ONE refetch (cache-miss path).
+        bogus1 = _sign(priv, "kid-bogus-1")
+        resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {bogus1}"})
+        assert resp.status_code == 401
+        assert mock.jwks_calls == baseline + 1
+        # Multiple subsequent bogus kids within the back-off window must NOT
+        # trigger more refetches.
+        for i in range(2, 12):
+            bogus = _sign(priv, f"kid-bogus-{i}")
+            resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {bogus}"})
+            assert resp.status_code == 401
+        assert mock.jwks_calls == baseline + 1, (
+            "JWKS was refetched more than once for unknown-kid storm "
+            "(amplification protection failed)"
+        )
+
+
+@pytest.mark.asyncio
 async def test_disabled_middleware_is_passthrough():
     mock = _JWKSMock([])
     app = _build_app(enabled=False, http_client=_client_for(mock))

--- a/api/tests/test_oidc_auth.py
+++ b/api/tests/test_oidc_auth.py
@@ -365,8 +365,7 @@ async def test_unknown_kid_back_off_prevents_amplification():
             resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {bogus}"})
             assert resp.status_code == 401
         assert mock.jwks_calls == baseline + 1, (
-            "JWKS was refetched more than once for unknown-kid storm "
-            "(amplification protection failed)"
+            "JWKS was refetched more than once for unknown-kid storm (amplification protection failed)"
         )
 
 
@@ -411,10 +410,7 @@ def test_request_logging_masks_access_token_query():
     from aerospike_cluster_manager_api.main import _mask_query_string
 
     assert _mask_query_string("access_token=eyJabc.def.ghi") == "access_token=***"
-    assert (
-        _mask_query_string("foo=bar&access_token=eyJabc.def.ghi&baz=1")
-        == "foo=bar&access_token=***&baz=1"
-    )
+    assert _mask_query_string("foo=bar&access_token=eyJabc.def.ghi&baz=1") == "foo=bar&access_token=***&baz=1"
     # Case-insensitive
     assert _mask_query_string("Access_Token=secret") == "Access_Token=***"
     # Other JWT-shaped query keys also get masked

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -20,6 +20,7 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "asyncpg" },
     { name = "fastapi" },
+    { name = "httpx" },
     { name = "kubernetes" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
@@ -27,6 +28,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-sdk" },
+    { name = "python-jose", extra = ["cryptography"] },
     { name = "python-json-logger" },
     { name = "pyyaml" },
     { name = "slowapi" },
@@ -52,6 +54,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "kubernetes", specifier = ">=31.0.0" },
     { name = "opentelemetry-api", specifier = ">=1.30.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.30.0" },
@@ -59,6 +62,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.51b0" },
     { name = "opentelemetry-instrumentation-logging", specifier = ">=0.51b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.30.0" },
+    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3,<4" },
     { name = "python-json-logger", specifier = ">=3.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
@@ -189,6 +193,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -323,6 +372,59 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -355,6 +457,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
+]
+
+[[package]]
+name = "ecdsa"
+version = "0.19.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
 ]
 
 [[package]]
@@ -851,6 +965,24 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1004,6 +1136,25 @@ wheels = [
 ]
 
 [[package]]
+name = "python-jose"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ecdsa" },
+    { name = "pyasn1" },
+    { name = "rsa" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
+]
+
+[package.optional-dependencies]
+cryptography = [
+    { name = "cryptography" },
+]
+
+[[package]]
 name = "python-json-logger"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1087,6 +1238,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "rsa"
+version = "4.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -28,6 +28,7 @@
         "@tanstack/react-table": "^8.21.3",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
+        "keycloak-js": "^25.0.6",
         "next": "14.2.23",
         "next-themes": "^0.4.6",
         "react": "18.2.0",
@@ -7639,6 +7640,12 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/js-sha256": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/js-sha256/-/js-sha256-0.11.1.tgz",
+      "integrity": "sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==",
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -7760,6 +7767,25 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/keycloak-js": {
+      "version": "25.0.6",
+      "resolved": "https://registry.npmjs.org/keycloak-js/-/keycloak-js-25.0.6.tgz",
+      "integrity": "sha512-Km+dc+XfNvY6a4az5jcxTK0zPk52ns9mAxLrHj7lF3V+riVYvQujfHmhayltJDjEpSOJ4C8a57LFNNKnNnRP2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "js-sha256": "^0.11.0",
+        "jwt-decode": "^4.0.0"
       }
     },
     "node_modules/keyv": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -36,6 +36,7 @@
     "@tanstack/react-table": "^8.21.3",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
+    "keycloak-js": "^25.0.6",
     "next": "14.2.23",
     "next-themes": "^0.4.6",
     "react": "18.2.0",

--- a/ui/public/silent-check-sso.html
+++ b/ui/public/silent-check-sso.html
@@ -1,0 +1,2 @@
+<!DOCTYPE html>
+<html><body><script>parent.postMessage(location.href, location.origin)</script></body></html>

--- a/ui/public/silent-check-sso.html
+++ b/ui/public/silent-check-sso.html
@@ -1,2 +1,8 @@
-<!DOCTYPE html>
-<html><body><script>parent.postMessage(location.href, location.origin)</script></body></html>
+<!doctype html>
+<html>
+  <body>
+    <script>
+      parent.postMessage(location.href, location.origin)
+    </script>
+  </body>
+</html>

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from "next/font/google"
 import "./globals.css"
 import { siteConfig } from "./siteConfig"
 
+import { AuthProvider } from "@/components/AuthProvider"
 import { Sidebar } from "@/components/ui/navigation/Sidebar"
 
 const inter = Inter({
@@ -47,8 +48,10 @@ export default function RootLayout({
       >
         <div className="mx-auto max-w-screen-2xl">
           <ThemeProvider defaultTheme="system" attribute="class">
-            <Sidebar />
-            <main className="lg:pl-72">{children}</main>
+            <AuthProvider>
+              <Sidebar />
+              <main className="lg:pl-72">{children}</main>
+            </AuthProvider>
           </ThemeProvider>
         </div>
       </body>

--- a/ui/src/components/AuthProvider.tsx
+++ b/ui/src/components/AuthProvider.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+
+import { initKeycloak } from "@/lib/auth/keycloak"
+import {
+  hydrateClusterRegistry,
+  useClusterSelectorStore,
+} from "@/stores/cluster-selector-store"
+import { useAuthStore } from "@/stores/auth-store"
+
+type BootState = "loading" | "single-cluster" | "ready" | "error"
+
+const PUBLIC_PATHS = new Set<string>(["/silent-check-sso.html"])
+
+function isPublicPath(pathname: string): boolean {
+  if (PUBLIC_PATHS.has(pathname)) return true
+  return false
+}
+
+/**
+ * Boots OIDC + cluster registry. Behaviour:
+ *   1. Try to fetch /cluster-registry.json. If absent (404) we're in legacy
+ *      single-cluster mode → render children unchanged.
+ *   2. Try to fetch /web-oidc-config.json + initKeycloak. If absent we
+ *      assume the deployment hasn't enabled auth yet → render children.
+ *   3. If both registry and OIDC are present and the user is not
+ *      authenticated, redirect to login.
+ */
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [state, setState] = React.useState<BootState>("loading")
+  const [errorMsg, setErrorMsg] = React.useState<string | null>(null)
+  const accessToken = useAuthStore((s) => s.accessToken)
+  const registry = useClusterSelectorStore((s) => s.registry)
+
+  React.useEffect(() => {
+    let cancelled = false
+
+    ;(async () => {
+      // 1. Hydrate cluster registry (multi-cluster mode signal).
+      let hasRegistry = false
+      try {
+        await hydrateClusterRegistry()
+        hasRegistry = true
+      } catch {
+        hasRegistry = false
+      }
+      if (cancelled) return
+
+      if (!hasRegistry) {
+        // No /cluster-registry.json → legacy single-API_URL mode. Skip OIDC.
+        setState("single-cluster")
+        return
+      }
+
+      // 2. Initialise Keycloak. If config is missing, surface as error.
+      try {
+        const kc = await initKeycloak()
+        if (cancelled) return
+        if (!kc.authenticated) {
+          if (typeof window !== "undefined") {
+            const path = window.location.pathname
+            if (!isPublicPath(path)) {
+              await kc.login({
+                redirectUri: window.location.href,
+              })
+              return
+            }
+          }
+        }
+        setState("ready")
+      } catch (err) {
+        if (cancelled) return
+        setErrorMsg(err instanceof Error ? err.message : String(err))
+        setState("error")
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  if (state === "loading") {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="flex flex-col items-center gap-3">
+          <div
+            aria-label="Loading"
+            className="size-8 animate-spin rounded-full border-2 border-gray-200 border-t-indigo-500"
+          />
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Signing you in…
+          </p>
+        </div>
+      </div>
+    )
+  }
+
+  if (state === "error") {
+    return (
+      <div className="flex min-h-screen items-center justify-center p-6">
+        <div className="max-w-md rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-800 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-200">
+          <p className="font-semibold">Authentication unavailable</p>
+          <p className="mt-1">{errorMsg ?? "Failed to initialise sign-in."}</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (state === "ready" && registry && !accessToken) {
+    // Edge case: Keycloak resolved but no token in store yet (race during
+    // login redirect). Render the loading shell rather than a blank page.
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <div className="size-8 animate-spin rounded-full border-2 border-gray-200 border-t-indigo-500" />
+      </div>
+    )
+  }
+
+  return <>{children}</>
+}

--- a/ui/src/components/k8s/create-cluster-wizard/CreateClusterWizard.tsx
+++ b/ui/src/components/k8s/create-cluster-wizard/CreateClusterWizard.tsx
@@ -5,6 +5,7 @@ import { useEffect, useMemo, useState } from "react"
 
 import { Button } from "@/components/Button"
 import { ApiError } from "@/lib/api/client"
+import { useClusterSelectorStore } from "@/stores/cluster-selector-store"
 import { useUiStore } from "@/stores/ui-store"
 import {
   createK8sCluster,
@@ -449,6 +450,8 @@ export function CreateClusterWizard() {
         </div>
       )}
 
+      <ActiveClusterHint visible={isLastStep} />
+
       <div className="flex justify-between">
         <Button variant="secondary" onClick={goBack} disabled={submitting}>
           {step === 0 ? "Cancel" : "Back"}
@@ -473,5 +476,24 @@ export function CreateClusterWizard() {
         )}
       </div>
     </div>
+  )
+}
+
+function ActiveClusterHint({ visible }: { visible: boolean }) {
+  const registry = useClusterSelectorStore((s) => s.registry)
+  const currentClusterId = useClusterSelectorStore((s) => s.currentClusterId)
+  if (!visible || !registry) return null
+  const active =
+    registry.clusters.find((c) => c.id === currentClusterId) ??
+    registry.clusters.find((c) => c.id === registry.defaultClusterId) ??
+    registry.clusters[0]
+  if (!active) return null
+  return (
+    <p className="text-xs text-gray-500 dark:text-gray-400">
+      Creating in:{" "}
+      <span className="font-semibold text-gray-700 dark:text-gray-300">
+        {active.displayName}
+      </span>
+    </p>
   )
 }

--- a/ui/src/components/ui/navigation/ClusterSelector.test.tsx
+++ b/ui/src/components/ui/navigation/ClusterSelector.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { ClusterSelector } from "./ClusterSelector"
+import { useClusterSelectorStore } from "@/stores/cluster-selector-store"
+
+const REGISTRY = {
+  defaultClusterId: "dev",
+  clusters: [
+    {
+      id: "dev",
+      displayName: "Dev",
+      apiUrl: "https://dev-api.example.com",
+      labels: { env: "dev" },
+    },
+    {
+      id: "prod",
+      displayName: "Prod",
+      apiUrl: "https://prod-api.example.com",
+      labels: { env: "prod" },
+    },
+  ],
+}
+
+beforeEach(() => {
+  useClusterSelectorStore.setState({
+    registry: REGISTRY,
+    currentClusterId: "dev",
+    registryError: null,
+  })
+  // Make health pings deterministically succeed.
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue(new Response("ok", { status: 200 })),
+  )
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("ClusterSelector", () => {
+  it("renders the active cluster's displayName", async () => {
+    render(<ClusterSelector />)
+    expect(screen.getByLabelText("Switch cluster")).toBeInTheDocument()
+    expect(screen.getByText("Dev")).toBeInTheDocument()
+  })
+
+  it("renders nothing when registry is empty (single-cluster mode)", () => {
+    useClusterSelectorStore.setState({
+      registry: null,
+      currentClusterId: null,
+      registryError: null,
+    })
+    const { container } = render(<ClusterSelector />)
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("changes the active cluster when an item is selected", async () => {
+    const user = userEvent.setup()
+    render(<ClusterSelector />)
+
+    await user.click(screen.getByLabelText("Switch cluster"))
+    const prod = await screen.findByText("Prod")
+    await user.click(prod)
+
+    await waitFor(() =>
+      expect(useClusterSelectorStore.getState().currentClusterId).toBe("prod"),
+    )
+  })
+
+  it("pings each cluster /api/health on mount", async () => {
+    render(<ClusterSelector />)
+    await waitFor(() => {
+      const calls = (global.fetch as unknown as { mock: { calls: unknown[][] } })
+        .mock.calls
+      const urls = calls.map((c) => String(c[0]))
+      expect(urls.some((u) => u.startsWith("https://dev-api.example.com"))).toBe(
+        true,
+      )
+      expect(urls.some((u) => u.startsWith("https://prod-api.example.com"))).toBe(
+        true,
+      )
+    })
+  })
+})

--- a/ui/src/components/ui/navigation/ClusterSelector.test.tsx
+++ b/ui/src/components/ui/navigation/ClusterSelector.test.tsx
@@ -73,15 +73,16 @@ describe("ClusterSelector", () => {
   it("pings each cluster /api/health on mount", async () => {
     render(<ClusterSelector />)
     await waitFor(() => {
-      const calls = (global.fetch as unknown as { mock: { calls: unknown[][] } })
-        .mock.calls
+      const calls = (
+        global.fetch as unknown as { mock: { calls: unknown[][] } }
+      ).mock.calls
       const urls = calls.map((c) => String(c[0]))
-      expect(urls.some((u) => u.startsWith("https://dev-api.example.com"))).toBe(
-        true,
-      )
-      expect(urls.some((u) => u.startsWith("https://prod-api.example.com"))).toBe(
-        true,
-      )
+      expect(
+        urls.some((u) => u.startsWith("https://dev-api.example.com")),
+      ).toBe(true)
+      expect(
+        urls.some((u) => u.startsWith("https://prod-api.example.com")),
+      ).toBe(true)
     })
   })
 })

--- a/ui/src/components/ui/navigation/ClusterSelector.tsx
+++ b/ui/src/components/ui/navigation/ClusterSelector.tsx
@@ -1,0 +1,208 @@
+"use client"
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/Dropdown"
+import { cx, focusRing } from "@/lib/utils"
+import {
+  type ClusterEntry,
+  useClusterSelectorStore,
+} from "@/stores/cluster-selector-store"
+import { RiCheckLine, RiExpandUpDownLine, RiServerLine } from "@remixicon/react"
+import * as React from "react"
+
+type HealthState = "ok" | "fail" | "checking"
+
+const HEALTH_TIMEOUT_MS = 5_000
+
+function dotClasses(state: HealthState): string {
+  switch (state) {
+    case "ok":
+      return "bg-emerald-500"
+    case "fail":
+      return "bg-red-500"
+    case "checking":
+    default:
+      return "bg-amber-400"
+  }
+}
+
+function dotLabel(state: HealthState): string {
+  switch (state) {
+    case "ok":
+      return "Healthy"
+    case "fail":
+      return "Unreachable"
+    case "checking":
+    default:
+      return "Checking"
+  }
+}
+
+/**
+ * Ping `${apiUrl}/api/health` with a 5s timeout via AbortController. The
+ * health endpoint is unauthenticated, so we deliberately don't attach a
+ * token — works pre-login and avoids extra refresh churn.
+ */
+async function pingHealth(
+  apiUrl: string,
+  signal: AbortSignal,
+): Promise<boolean> {
+  try {
+    const res = await fetch(`${apiUrl.replace(/\/+$/, "")}/api/health`, {
+      cache: "no-store",
+      credentials: "omit",
+      signal,
+    })
+    return res.ok
+  } catch {
+    return false
+  }
+}
+
+function useClusterHealth(clusters: ClusterEntry[]): Record<string, HealthState> {
+  const [state, setState] = React.useState<Record<string, HealthState>>({})
+
+  React.useEffect(() => {
+    if (clusters.length === 0) return
+
+    setState(
+      Object.fromEntries(clusters.map((c) => [c.id, "checking" as const])),
+    )
+
+    const controllers = clusters.map(() => new AbortController())
+    const timers = controllers.map((ctrl) =>
+      setTimeout(() => ctrl.abort(), HEALTH_TIMEOUT_MS),
+    )
+
+    let cancelled = false
+    Promise.all(
+      clusters.map((c, i) =>
+        pingHealth(c.apiUrl, controllers[i].signal).then((ok) => ({
+          id: c.id,
+          ok,
+        })),
+      ),
+    ).then((results) => {
+      if (cancelled) return
+      setState((prev) => {
+        const next = { ...prev }
+        for (const r of results) next[r.id] = r.ok ? "ok" : "fail"
+        return next
+      })
+    })
+
+    return () => {
+      cancelled = true
+      controllers.forEach((c) => c.abort())
+      timers.forEach((t) => clearTimeout(t))
+    }
+  }, [clusters])
+
+  return state
+}
+
+export function ClusterSelector() {
+  const registry = useClusterSelectorStore((s) => s.registry)
+  const currentClusterId = useClusterSelectorStore((s) => s.currentClusterId)
+  const setCurrentClusterId = useClusterSelectorStore(
+    (s) => s.setCurrentClusterId,
+  )
+
+  const clusters = registry?.clusters ?? []
+  const health = useClusterHealth(clusters)
+
+  // Don't render in legacy single-cluster mode (no registry → /cluster-registry.json absent).
+  if (!registry || clusters.length === 0) return null
+
+  const current =
+    clusters.find((c) => c.id === currentClusterId) ??
+    clusters.find((c) => c.id === registry.defaultClusterId) ??
+    clusters[0]
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          aria-label="Switch cluster"
+          className={cx(
+            "flex w-full items-center gap-3 rounded-md border border-gray-200 bg-white px-2 py-1.5 text-left transition hover:bg-gray-50 dark:border-gray-800 dark:bg-gray-950 dark:hover:bg-gray-900",
+            focusRing,
+          )}
+        >
+          <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-gray-100 dark:bg-gray-900">
+            <RiServerLine
+              className="size-4 text-gray-500 dark:text-gray-400"
+              aria-hidden="true"
+            />
+          </span>
+          <div className="min-w-0 flex-1 leading-tight">
+            <p className="truncate text-sm font-semibold text-gray-900 dark:text-gray-50">
+              {current?.displayName ?? "Select cluster"}
+            </p>
+            <p className="flex items-center gap-1 truncate text-xs text-gray-500 dark:text-gray-400">
+              <span
+                aria-hidden="true"
+                className={cx(
+                  "inline-block size-2 shrink-0 rounded-full",
+                  dotClasses(current ? health[current.id] ?? "checking" : "checking"),
+                )}
+              />
+              {current?.labels?.env ?? "Cluster"}
+            </p>
+          </div>
+          <RiExpandUpDownLine
+            className="size-4 shrink-0 text-gray-400"
+            aria-hidden="true"
+          />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-64">
+        <DropdownMenuLabel>
+          Clusters ({clusters.length})
+        </DropdownMenuLabel>
+        {clusters.map((c) => {
+          const selected = c.id === current?.id
+          const state = health[c.id] ?? "checking"
+          return (
+            <DropdownMenuItem
+              key={c.id}
+              onSelect={() => setCurrentClusterId(c.id)}
+              className="flex items-center gap-2"
+            >
+              <span
+                aria-label={dotLabel(state)}
+                title={dotLabel(state)}
+                className={cx(
+                  "inline-block size-2 shrink-0 rounded-full",
+                  dotClasses(state),
+                )}
+              />
+              <span className="min-w-0 flex-1 truncate text-sm">
+                {c.displayName}
+              </span>
+              {selected && (
+                <RiCheckLine
+                  className="size-4 shrink-0 text-indigo-600 dark:text-indigo-400"
+                  aria-hidden="true"
+                />
+              )}
+            </DropdownMenuItem>
+          )
+        })}
+        <DropdownMenuSeparator />
+        <div className="px-2 py-1.5 text-xs text-gray-400 dark:text-gray-600">
+          Multi-cluster registry
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+export default ClusterSelector

--- a/ui/src/components/ui/navigation/ClusterSelector.tsx
+++ b/ui/src/components/ui/navigation/ClusterSelector.tsx
@@ -65,7 +65,9 @@ async function pingHealth(
   }
 }
 
-function useClusterHealth(clusters: ClusterEntry[]): Record<string, HealthState> {
+function useClusterHealth(
+  clusters: ClusterEntry[],
+): Record<string, HealthState> {
   const [state, setState] = React.useState<Record<string, HealthState>>({})
 
   React.useEffect(() => {
@@ -151,7 +153,9 @@ export function ClusterSelector() {
                 aria-hidden="true"
                 className={cx(
                   "inline-block size-2 shrink-0 rounded-full",
-                  dotClasses(current ? health[current.id] ?? "checking" : "checking"),
+                  dotClasses(
+                    current ? (health[current.id] ?? "checking") : "checking",
+                  ),
                 )}
               />
               {current?.labels?.env ?? "Cluster"}
@@ -164,9 +168,7 @@ export function ClusterSelector() {
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" className="w-64">
-        <DropdownMenuLabel>
-          Clusters ({clusters.length})
-        </DropdownMenuLabel>
+        <DropdownMenuLabel>Clusters ({clusters.length})</DropdownMenuLabel>
         {clusters.map((c) => {
           const selected = c.id === current?.id
           const state = health[c.id] ?? "checking"

--- a/ui/src/components/ui/navigation/Sidebar.tsx
+++ b/ui/src/components/ui/navigation/Sidebar.tsx
@@ -28,6 +28,7 @@ import Image from "next/image"
 import Link from "next/link"
 import { useParams, usePathname } from "next/navigation"
 import { useEffect, useMemo, useState } from "react"
+import { ClusterSelector } from "./ClusterSelector"
 import MobileSidebar from "./MobileSidebar"
 import { UserProfileDesktop, UserProfileMobile } from "./UserProfile"
 import { WorkspacesDropdown } from "./WorkspacesDropdown"
@@ -152,6 +153,7 @@ export function Sidebar() {
       <nav className="hidden lg:fixed lg:inset-y-0 lg:z-50 lg:flex lg:w-72 lg:flex-col">
         <aside className="flex grow flex-col gap-y-4 overflow-y-auto border-r border-gray-200 bg-white p-4 dark:border-gray-800 dark:bg-gray-950">
           <BrandCard active={pathname === "/clusters"} />
+          <ClusterSelector />
           <WorkspacesDropdown />
 
           <nav aria-label="core navigation" className="flex flex-1 flex-col">

--- a/ui/src/lib/api/client.test.ts
+++ b/ui/src/lib/api/client.test.ts
@@ -1,0 +1,148 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { apiFetch, ApiError } from "./client"
+import { useAuthStore } from "@/stores/auth-store"
+import { useClusterSelectorStore } from "@/stores/cluster-selector-store"
+
+vi.mock("@/lib/auth/keycloak", () => ({
+  refreshToken: vi.fn(),
+  login: vi.fn(),
+}))
+
+const REGISTRY = {
+  defaultClusterId: "dev",
+  clusters: [
+    {
+      id: "dev",
+      displayName: "Dev",
+      apiUrl: "https://dev-api.example.com",
+      labels: { env: "dev" },
+    },
+  ],
+}
+
+function jsonResponse(
+  body: unknown,
+  status = 200,
+  headers: Record<string, string> = {},
+): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  })
+}
+
+beforeEach(() => {
+  useAuthStore.setState({
+    accessToken: null,
+    claims: null,
+    refreshing: false,
+  })
+  useClusterSelectorStore.setState({
+    registry: REGISTRY,
+    currentClusterId: "dev",
+    registryError: null,
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("apiFetch (multi-cluster + auth)", () => {
+  it("prepends the active cluster apiUrl and attaches Authorization", async () => {
+    useAuthStore.setState({ accessToken: "tok-1", claims: null, refreshing: false })
+
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await apiFetch("/clusters")
+
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchMock.mock.calls[0]
+    expect(url).toBe("https://dev-api.example.com/api/clusters")
+    const headers = new Headers(init.headers as HeadersInit)
+    expect(headers.get("Authorization")).toBe("Bearer tok-1")
+  })
+
+  it("does not attach Authorization when no token is set", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await apiFetch("/clusters")
+
+    const headers = new Headers(
+      fetchMock.mock.calls[0][1].headers as HeadersInit,
+    )
+    expect(headers.get("Authorization")).toBeNull()
+  })
+
+  it("falls back to relative path when registry is null (single-cluster mode)", async () => {
+    useClusterSelectorStore.setState({
+      registry: null,
+      currentClusterId: null,
+      registryError: null,
+    })
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await apiFetch("/clusters")
+
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/clusters")
+  })
+
+  it("retries once after refreshing on 401", async () => {
+    useAuthStore.setState({
+      accessToken: "stale",
+      claims: null,
+      refreshing: false,
+    })
+
+    const keycloak = await import("@/lib/auth/keycloak")
+    vi.mocked(keycloak.refreshToken).mockImplementation(async () => {
+      useAuthStore.setState({
+        accessToken: "fresh",
+        claims: null,
+        refreshing: false,
+      })
+      return "fresh"
+    })
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, 401))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const result = await apiFetch<{ ok: boolean }>("/clusters")
+
+    expect(result).toEqual({ ok: true })
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(keycloak.refreshToken).toHaveBeenCalledOnce()
+    const retryHeaders = new Headers(
+      fetchMock.mock.calls[1][1].headers as HeadersInit,
+    )
+    expect(retryHeaders.get("Authorization")).toBe("Bearer fresh")
+  })
+
+  it("kicks off login redirect after permanent 401", async () => {
+    useAuthStore.setState({
+      accessToken: "stale",
+      claims: null,
+      refreshing: false,
+    })
+
+    const keycloak = await import("@/lib/auth/keycloak")
+    vi.mocked(keycloak.refreshToken).mockResolvedValue(undefined)
+    vi.mocked(keycloak.login).mockResolvedValue(undefined)
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ detail: "expired" }, 401))
+    vi.stubGlobal("fetch", fetchMock)
+
+    await expect(apiFetch("/clusters")).rejects.toBeInstanceOf(ApiError)
+    // Single attempt because refresh returned undefined.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/ui/src/lib/api/client.test.ts
+++ b/ui/src/lib/api/client.test.ts
@@ -51,7 +51,11 @@ afterEach(() => {
 
 describe("apiFetch (multi-cluster + auth)", () => {
   it("prepends the active cluster apiUrl and attaches Authorization", async () => {
-    useAuthStore.setState({ accessToken: "tok-1", claims: null, refreshing: false })
+    useAuthStore.setState({
+      accessToken: "tok-1",
+      claims: null,
+      refreshing: false,
+    })
 
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }))
     vi.stubGlobal("fetch", fetchMock)

--- a/ui/src/lib/api/client.ts
+++ b/ui/src/lib/api/client.ts
@@ -8,7 +8,22 @@
  *   - Timeout via AbortController (default 30s).
  *   - Throws `ApiError` on non-2xx with status + parsed body (when JSON).
  *   - 204 No Content returns `undefined as T`.
+ *
+ * Multi-cluster + OIDC behaviour (web-only mode):
+ *   - When the cluster registry has loaded (cluster-selector-store), requests
+ *     are sent to the active cluster's `apiUrl` (cross-origin). Otherwise the
+ *     legacy single-API_URL relative path is used (proxy.js / next rewrites).
+ *   - When an access token is present (auth-store), `Authorization: Bearer`
+ *     is added automatically.
+ *   - 401 responses trigger one silent refresh attempt; the original request
+ *     is retried once if refresh succeeds.
  */
+
+import { useAuthStore } from "@/stores/auth-store"
+import {
+  getActiveApiUrl,
+  useClusterSelectorStore,
+} from "@/stores/cluster-selector-store"
 
 export const API_PREFIX = "/api"
 export const DEFAULT_TIMEOUT_MS = 30_000
@@ -59,32 +74,64 @@ export interface ApiRequestInit extends Omit<RequestInit, "body"> {
 function buildUrl(path: string, query?: ApiRequestInit["query"]): string {
   const base = path.startsWith("/") ? path : `/${path}`
   const full = base.startsWith(API_PREFIX) ? base : `${API_PREFIX}${base}`
-  if (!query) return full
+
+  // Multi-cluster mode: registry hydrated → prepend the selected cluster's
+  // apiUrl (cross-origin). Single-cluster mode: leave as relative so
+  // existing proxy / next.rewrites continues to work.
+  const apiBase = getActiveApiUrl()
+  const withBase = apiBase ? `${apiBase.replace(/\/+$/, "")}${full}` : full
+
+  if (!query) return withBase
   const params = new URLSearchParams()
   for (const [key, value] of Object.entries(query)) {
     if (value === undefined || value === null) continue
     params.append(key, String(value))
   }
   const qs = params.toString()
-  return qs ? `${full}?${qs}` : full
+  return qs ? `${withBase}?${qs}` : withBase
 }
 
-export async function apiFetch<T>(
-  path: string,
-  init: ApiRequestInit = {},
-): Promise<T> {
+/** Lazy, cycle-safe import of the keycloak helpers. The auth module pulls in
+ *  the auth store, which already imports from this client; resolving it via
+ *  dynamic import on demand keeps both sides happy and avoids dragging
+ *  keycloak-js into SSR bundles for routes that never call apiFetch. */
+async function attemptTokenRefresh(): Promise<string | undefined> {
+  try {
+    const mod = await import("@/lib/auth/keycloak")
+    return await mod.refreshToken(30)
+  } catch {
+    return undefined
+  }
+}
+
+async function redirectToLogin(): Promise<void> {
+  try {
+    const mod = await import("@/lib/auth/keycloak")
+    await mod.login()
+  } catch {
+    // If keycloak hasn't initialised, surface the 401 to the caller instead
+    // of silently failing — they'll get an ApiError(401) from the original
+    // response and can render a sign-in prompt.
+  }
+}
+
+async function executeRequest(
+  url: string,
+  init: ApiRequestInit,
+  attachAuth: boolean,
+): Promise<Response> {
   const {
     json,
     timeoutMs = DEFAULT_TIMEOUT_MS,
-    query,
     headers,
     signal,
+    query: _query, // already baked into url
     ...rest
   } = init
+  void _query
 
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
-  // Chain caller signal so either can abort the request.
   if (signal) {
     if (signal.aborted) controller.abort()
     else
@@ -97,18 +144,35 @@ export async function apiFetch<T>(
   if (json !== undefined && !finalHeaders.has("Content-Type")) {
     finalHeaders.set("Content-Type", "application/json")
   }
+  if (attachAuth && !finalHeaders.has("Authorization")) {
+    const token = useAuthStore.getState().accessToken
+    if (token) finalHeaders.set("Authorization", `Bearer ${token}`)
+  }
 
-  let response: Response
   try {
-    response = await fetch(buildUrl(path, query), {
+    return await fetch(url, {
       ...rest,
       headers: finalHeaders,
       body:
         json !== undefined ? JSON.stringify(json) : (rest as RequestInit).body,
       signal: controller.signal,
     })
-  } catch (err) {
+  } finally {
     clearTimeout(timeoutId)
+  }
+}
+
+export async function apiFetch<T>(
+  path: string,
+  init: ApiRequestInit = {},
+): Promise<T> {
+  const url = buildUrl(path, init.query)
+  const timeoutMs = init.timeoutMs ?? DEFAULT_TIMEOUT_MS
+
+  let response: Response
+  try {
+    response = await executeRequest(url, init, true)
+  } catch (err) {
     if (err instanceof DOMException && err.name === "AbortError") {
       throw new ApiError(
         0,
@@ -122,12 +186,37 @@ export async function apiFetch<T>(
       null,
     )
   }
-  clearTimeout(timeoutId)
+
+  // 401 → silent refresh + single retry. We only retry once per request to
+  // avoid loops if the IdP keeps issuing tokens the API rejects.
+  if (response.status === 401 && useClusterSelectorStore.getState().registry) {
+    const newToken = await attemptTokenRefresh()
+    if (newToken) {
+      try {
+        response = await executeRequest(url, init, true)
+      } catch (err) {
+        if (err instanceof DOMException && err.name === "AbortError") {
+          throw new ApiError(
+            0,
+            `Request aborted or timed out after ${timeoutMs}ms`,
+            null,
+          )
+        }
+        throw new ApiError(
+          0,
+          err instanceof Error ? err.message : "Network error",
+          null,
+        )
+      }
+    }
+    if (response.status === 401) {
+      // Permanent failure → kick off login redirect; throw so caller sees it.
+      void redirectToLogin()
+    }
+  }
 
   if (response.status === 204 || response.status === 202) {
-    // 202 responses (e.g. K8s delete) may carry an optional body.
     if (response.status === 204) return undefined as T
-    // Try to parse if JSON, otherwise return undefined.
     const text = await response.text()
     if (!text) return undefined as T
     try {
@@ -157,7 +246,6 @@ export async function apiFetch<T>(
   }
 
   if (!isJson) {
-    // Fall back to text for unexpected content types.
     return (await response.text()) as unknown as T
   }
   return (await response.json()) as T

--- a/ui/src/lib/api/client.ts
+++ b/ui/src/lib/api/client.ts
@@ -20,10 +20,7 @@
  */
 
 import { useAuthStore } from "@/stores/auth-store"
-import {
-  getActiveApiUrl,
-  useClusterSelectorStore,
-} from "@/stores/cluster-selector-store"
+import { getActiveApiUrl } from "@/stores/cluster-selector-store"
 
 export const API_PREFIX = "/api"
 export const DEFAULT_TIMEOUT_MS = 30_000
@@ -187,9 +184,11 @@ export async function apiFetch<T>(
     )
   }
 
-  // 401 → silent refresh + single retry. We only retry once per request to
-  // avoid loops if the IdP keeps issuing tokens the API rejects.
-  if (response.status === 401 && useClusterSelectorStore.getState().registry) {
+  // 401 → silent refresh + single retry. Gated on token presence (not
+  // registry presence) so single-cluster installs that opt into OIDC also
+  // get the silent-refresh path. We only retry once per request to avoid
+  // loops if the IdP keeps issuing tokens the API rejects.
+  if (response.status === 401 && useAuthStore.getState().accessToken) {
     const newToken = await attemptTokenRefresh()
     if (newToken) {
       try {

--- a/ui/src/lib/api/events.ts
+++ b/ui/src/lib/api/events.ts
@@ -5,7 +5,15 @@
  * The backend streams JSON-encoded events (see routers/events.py).
  * Each message's `data` field is a JSON string that we parse before
  * delivering to the consumer.
+ *
+ * Auth: `EventSource` cannot set headers, so the access token is appended as
+ * `?access_token=<jwt>` and the active cluster id as `&cluster=<id>`. The
+ * backend (Stream B) reads these and applies the same JWT verification as the
+ * Authorization header path.
  */
+
+import { useAuthStore } from "@/stores/auth-store"
+import { useClusterSelectorStore } from "@/stores/cluster-selector-store"
 
 import type { SSEEvent, SSEHandler } from "../types/events"
 import { API_PREFIX } from "./client"
@@ -43,8 +51,25 @@ export function subscribeEvents<T = unknown>(
 
   const params = new URLSearchParams()
   if (types && types.length > 0) params.set("types", types.join(","))
+
+  // Multi-cluster + OIDC mode: append cluster id and JWT so SSE works across
+  // origins without an Authorization header (EventSource limitation).
+  const selector = useClusterSelectorStore.getState()
+  const active =
+    selector.registry?.clusters.find(
+      (c) => c.id === selector.currentClusterId,
+    ) ??
+    selector.registry?.clusters.find(
+      (c) => c.id === selector.registry?.defaultClusterId,
+    ) ??
+    null
+  if (active) params.set("cluster", active.id)
+  const token = useAuthStore.getState().accessToken
+  if (token) params.set("access_token", token)
+
   const qs = params.toString()
-  const url = `${API_PREFIX}/events/stream${qs ? `?${qs}` : ""}`
+  const baseHost = active?.apiUrl?.replace(/\/+$/, "") ?? ""
+  const url = `${baseHost}${API_PREFIX}/events/stream${qs ? `?${qs}` : ""}`
 
   const source = new EventSource(url)
 

--- a/ui/src/lib/api/events.ts
+++ b/ui/src/lib/api/events.ts
@@ -54,6 +54,17 @@ export function subscribeEvents<T = unknown>(
 
   // Multi-cluster + OIDC mode: append cluster id and JWT so SSE works across
   // origins without an Authorization header (EventSource limitation).
+  //
+  // SECURITY: the access token appears in the request URL. This means the
+  // token can leak via (a) upstream ingress access logs, (b) browser dev
+  // tools, (c) Referer headers if the SSE response page links elsewhere.
+  // Mitigations: short token TTL, mandatory access-log masking on every
+  // ingress that sits in front of the API (documented in
+  // aerospike-ce-kubernetes-operator/docs/multi-cluster-keycloak.md), and
+  // logging middleware on the API masks `access_token`/`id_token` query
+  // params before persisting them. See ADR-0040 follow-up: the long-term
+  // fix is per-stream signed nonces or transport upgrades that allow
+  // header-based auth on subscriptions.
   const selector = useClusterSelectorStore.getState()
   const active =
     selector.registry?.clusters.find(

--- a/ui/src/lib/auth/keycloak.ts
+++ b/ui/src/lib/auth/keycloak.ts
@@ -1,0 +1,180 @@
+/**
+ * Keycloak (OIDC PKCE) bootstrap module.
+ *
+ * The web pod ships a static `/web-oidc-config.json` (mounted from a ConfigMap
+ * by Stream A's chart). On boot we fetch it, split the OIDC issuer URL of the
+ * form `https://kc/realms/acko` into `{ url: "https://kc", realm: "acko" }`,
+ * and instantiate the singleton Keycloak client.
+ *
+ * Tokens are kept in-memory only (mirrored into auth-store). We deliberately
+ * avoid persisting them to localStorage to keep the XSS blast radius small.
+ */
+
+"use client"
+
+import KeycloakImport, {
+  type KeycloakConfig,
+  type KeycloakInstance,
+} from "keycloak-js"
+
+import { useAuthStore } from "@/stores/auth-store"
+
+const KeycloakCtor = (KeycloakImport as unknown) as typeof KeycloakImport &
+  ((config: KeycloakConfig) => KeycloakInstance)
+
+export interface WebOidcConfig {
+  /** Full OIDC issuer URL — `${url}/realms/${realm}`. */
+  issuerUrl: string
+  clientId: string
+  redirectUri?: string
+  scopes?: string[]
+}
+
+let keycloak: KeycloakInstance | null = null
+let initPromise: Promise<KeycloakInstance> | null = null
+let oidcConfig: WebOidcConfig | null = null
+
+const OIDC_CONFIG_PATH = "/web-oidc-config.json"
+
+/**
+ * Split an OIDC issuer URL into Keycloak base url + realm.
+ * Accepts both `https://kc.example.com/realms/acko` and trailing-slash forms.
+ */
+export function splitIssuerUrl(issuerUrl: string): {
+  url: string
+  realm: string
+} {
+  const cleaned = issuerUrl.replace(/\/+$/, "")
+  const match = cleaned.match(/^(.*)\/realms\/([^/]+)$/)
+  if (!match) {
+    throw new Error(
+      `Invalid OIDC issuerUrl: expected '<base>/realms/<realm>' (got '${issuerUrl}')`,
+    )
+  }
+  return { url: match[1], realm: match[2] }
+}
+
+async function fetchOidcConfig(): Promise<WebOidcConfig> {
+  if (oidcConfig) return oidcConfig
+  const res = await fetch(OIDC_CONFIG_PATH, {
+    cache: "no-store",
+    credentials: "omit",
+  })
+  if (!res.ok) {
+    throw new Error(
+      `Failed to load ${OIDC_CONFIG_PATH}: ${res.status} ${res.statusText}`,
+    )
+  }
+  const data = (await res.json()) as WebOidcConfig
+  if (!data.issuerUrl || !data.clientId) {
+    throw new Error(
+      `${OIDC_CONFIG_PATH} is missing required fields (issuerUrl/clientId)`,
+    )
+  }
+  oidcConfig = data
+  return data
+}
+
+function syncTokenToStore(kc: KeycloakInstance) {
+  const store = useAuthStore.getState()
+  if (kc.authenticated && kc.token) {
+    store.setToken(kc.token, kc.tokenParsed ?? null)
+  } else {
+    store.clear()
+  }
+}
+
+/**
+ * Initialise Keycloak with `check-sso` + PKCE S256. Idempotent — repeated
+ * callers get the same in-flight or settled promise.
+ */
+export function initKeycloak(): Promise<KeycloakInstance> {
+  if (initPromise) return initPromise
+
+  initPromise = (async () => {
+    const cfg = await fetchOidcConfig()
+    const { url, realm } = splitIssuerUrl(cfg.issuerUrl)
+
+    const kc = new KeycloakCtor({
+      url,
+      realm,
+      clientId: cfg.clientId,
+    })
+
+    kc.onTokenExpired = () => {
+      // Best-effort silent refresh, 30s of life left.
+      kc.updateToken(30)
+        .then(() => syncTokenToStore(kc))
+        .catch(() => {
+          useAuthStore.getState().clear()
+        })
+    }
+    kc.onAuthSuccess = () => syncTokenToStore(kc)
+    kc.onAuthRefreshSuccess = () => syncTokenToStore(kc)
+    kc.onAuthLogout = () => useAuthStore.getState().clear()
+
+    await kc.init({
+      onLoad: "check-sso",
+      pkceMethod: "S256",
+      silentCheckSsoRedirectUri:
+        typeof window !== "undefined"
+          ? `${window.location.origin}/silent-check-sso.html`
+          : undefined,
+      checkLoginIframe: false,
+    })
+
+    syncTokenToStore(kc)
+
+    keycloak = kc
+    return kc
+  })()
+
+  return initPromise
+}
+
+export function getKeycloak(): KeycloakInstance | null {
+  return keycloak
+}
+
+export function getToken(): string | undefined {
+  return keycloak?.token ?? undefined
+}
+
+export async function login(redirectUri?: string): Promise<void> {
+  const kc = keycloak ?? (await initKeycloak())
+  await kc.login({ redirectUri })
+}
+
+export async function logout(redirectUri?: string): Promise<void> {
+  const kc = keycloak ?? (await initKeycloak())
+  await kc.logout({ redirectUri })
+}
+
+/**
+ * Try to refresh the access token, returning the new token on success.
+ * Falls back to redirecting to login on permanent failure.
+ */
+export async function refreshToken(
+  minValiditySeconds = 30,
+): Promise<string | undefined> {
+  if (!keycloak) return undefined
+  const store = useAuthStore.getState()
+  store.setRefreshing(true)
+  try {
+    await keycloak.updateToken(minValiditySeconds)
+    syncTokenToStore(keycloak)
+    return keycloak.token ?? undefined
+  } catch {
+    store.clear()
+    return undefined
+  } finally {
+    useAuthStore.getState().setRefreshing(false)
+  }
+}
+
+/** Reset internal state — testing only. */
+export function __resetKeycloakForTests(): void {
+  keycloak = null
+  initPromise = null
+  oidcConfig = null
+}

--- a/ui/src/lib/auth/keycloak.ts
+++ b/ui/src/lib/auth/keycloak.ts
@@ -19,7 +19,7 @@ import KeycloakImport, {
 
 import { useAuthStore } from "@/stores/auth-store"
 
-const KeycloakCtor = (KeycloakImport as unknown) as typeof KeycloakImport &
+const KeycloakCtor = KeycloakImport as unknown as typeof KeycloakImport &
   ((config: KeycloakConfig) => KeycloakInstance)
 
 export interface WebOidcConfig {

--- a/ui/src/stores/auth-store.ts
+++ b/ui/src/stores/auth-store.ts
@@ -1,0 +1,47 @@
+/**
+ * Auth store — in-memory only.
+ *
+ * No `persist` middleware: access tokens never touch localStorage. Token
+ * lifecycle is owned by `lib/auth/keycloak.ts`; this store mirrors the
+ * current value so React components can subscribe via the Zustand selector
+ * without reaching into the Keycloak singleton.
+ */
+
+import { create } from "zustand"
+
+export interface AuthClaims {
+  sub?: string
+  email?: string
+  preferred_username?: string
+  name?: string
+  realm_access?: { roles?: string[] }
+  resource_access?: Record<string, { roles?: string[] }>
+  exp?: number
+  [k: string]: unknown
+}
+
+interface AuthStore {
+  accessToken: string | null
+  claims: AuthClaims | null
+  refreshing: boolean
+
+  setToken: (token: string, claims: AuthClaims | null) => void
+  setRefreshing: (refreshing: boolean) => void
+  clear: () => void
+}
+
+export const useAuthStore = create<AuthStore>((set) => ({
+  accessToken: null,
+  claims: null,
+  refreshing: false,
+
+  setToken: (accessToken, claims) => set({ accessToken, claims }),
+  setRefreshing: (refreshing) => set({ refreshing }),
+  clear: () => set({ accessToken: null, claims: null, refreshing: false }),
+}))
+
+/** Read realm roles from the cached claims. */
+export function getRealmRoles(): string[] {
+  const claims = useAuthStore.getState().claims
+  return claims?.realm_access?.roles ?? []
+}

--- a/ui/src/stores/cluster-selector-store.test.ts
+++ b/ui/src/stores/cluster-selector-store.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import {
+  hydrateClusterRegistry,
+  useClusterSelectorStore,
+  type ClusterRegistry,
+} from "./cluster-selector-store"
+
+const REGISTRY: ClusterRegistry = {
+  defaultClusterId: "dev",
+  clusters: [
+    {
+      id: "dev",
+      displayName: "Dev",
+      apiUrl: "https://dev-api.example.com",
+      labels: { env: "dev" },
+    },
+    {
+      id: "prod",
+      displayName: "Prod",
+      apiUrl: "https://prod-api.example.com",
+      labels: { env: "prod" },
+    },
+  ],
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+beforeEach(() => {
+  useClusterSelectorStore.setState({
+    registry: null,
+    currentClusterId: null,
+    registryError: null,
+  })
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe("cluster-selector-store", () => {
+  it("hydrates registry from /cluster-registry.json and picks default", async () => {
+    const fetcher = vi.fn().mockResolvedValue(jsonResponse(REGISTRY))
+
+    await hydrateClusterRegistry(fetcher as unknown as typeof fetch)
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "/cluster-registry.json",
+      expect.objectContaining({ cache: "no-store" }),
+    )
+    const state = useClusterSelectorStore.getState()
+    expect(state.registry).toEqual(REGISTRY)
+    expect(state.currentClusterId).toBe("dev")
+    expect(state.registryError).toBeNull()
+  })
+
+  it("preserves a persisted currentClusterId when it exists in the registry", async () => {
+    useClusterSelectorStore.setState({ currentClusterId: "prod" })
+    const fetcher = vi.fn().mockResolvedValue(jsonResponse(REGISTRY))
+
+    await hydrateClusterRegistry(fetcher as unknown as typeof fetch)
+
+    expect(useClusterSelectorStore.getState().currentClusterId).toBe("prod")
+  })
+
+  it("falls back to defaultClusterId when persisted id is stale", async () => {
+    useClusterSelectorStore.setState({ currentClusterId: "staging-removed" })
+    const fetcher = vi.fn().mockResolvedValue(jsonResponse(REGISTRY))
+
+    await hydrateClusterRegistry(fetcher as unknown as typeof fetch)
+
+    expect(useClusterSelectorStore.getState().currentClusterId).toBe("dev")
+  })
+
+  it("records an error and throws when /cluster-registry.json is missing", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(new Response("Not Found", { status: 404 }))
+
+    await expect(
+      hydrateClusterRegistry(fetcher as unknown as typeof fetch),
+    ).rejects.toThrow(/cluster-registry\.json/)
+    expect(useClusterSelectorStore.getState().registryError).toMatch(/404/)
+  })
+
+  it("rejects malformed registry payloads", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ defaultClusterId: "x" }))
+
+    await expect(
+      hydrateClusterRegistry(fetcher as unknown as typeof fetch),
+    ).rejects.toThrow(/invalid shape/)
+  })
+})

--- a/ui/src/stores/cluster-selector-store.ts
+++ b/ui/src/stores/cluster-selector-store.ts
@@ -1,0 +1,118 @@
+/**
+ * Cluster selector store.
+ *
+ * Holds the multi-cluster registry hydrated from `/cluster-registry.json`
+ * (Stream A's ConfigMap mount → web pod's public dir) and the user's
+ * currently selected cluster id. The selected id is persisted to localStorage
+ * so the choice survives reloads, but the registry itself is fetched fresh
+ * on every boot.
+ */
+
+import { create } from "zustand"
+import { persist } from "zustand/middleware"
+
+export interface ClusterEntry {
+  id: string
+  displayName: string
+  apiUrl: string
+  labels?: Record<string, string>
+}
+
+export interface ClusterRegistry {
+  defaultClusterId: string
+  clusters: ClusterEntry[]
+}
+
+interface ClusterSelectorStore {
+  /** Hydrated from /cluster-registry.json on boot. Null until then. */
+  registry: ClusterRegistry | null
+  /** May reference a cluster id not (or no longer) in the registry. Use
+   *  `getActiveCluster()` to get the safely-resolved entry. */
+  currentClusterId: string | null
+  /** Boot-time fetch error, surfaced to the UI for a retry banner. */
+  registryError: string | null
+
+  setRegistry: (registry: ClusterRegistry) => void
+  setRegistryError: (error: string | null) => void
+  setCurrentClusterId: (id: string) => void
+}
+
+const REGISTRY_PATH = "/cluster-registry.json"
+
+export const useClusterSelectorStore = create<ClusterSelectorStore>()(
+  persist(
+    (set) => ({
+      registry: null,
+      currentClusterId: null,
+      registryError: null,
+
+      setRegistry: (registry) =>
+        set((state) => {
+          // If persisted id no longer exists in registry, fall back to default.
+          const ids = new Set(registry.clusters.map((c) => c.id))
+          const valid =
+            state.currentClusterId && ids.has(state.currentClusterId)
+              ? state.currentClusterId
+              : registry.defaultClusterId
+          return { registry, currentClusterId: valid, registryError: null }
+        }),
+      setRegistryError: (registryError) => set({ registryError }),
+      setCurrentClusterId: (currentClusterId) => set({ currentClusterId }),
+    }),
+    {
+      name: "acm-cluster-selector",
+      version: 1,
+      // Only persist the user's choice — registry must be re-fetched fresh.
+      partialize: (state) => ({ currentClusterId: state.currentClusterId }),
+    },
+  ),
+)
+
+/**
+ * Fetch the cluster registry from the static JSON mount and hydrate the store.
+ * Idempotent — call from the root provider on mount.
+ */
+export async function hydrateClusterRegistry(
+  fetcher: typeof fetch = fetch,
+): Promise<ClusterRegistry> {
+  const res = await fetcher(REGISTRY_PATH, {
+    cache: "no-store",
+    credentials: "omit",
+  })
+  if (!res.ok) {
+    const msg = `Failed to load ${REGISTRY_PATH}: ${res.status} ${res.statusText}`
+    useClusterSelectorStore.getState().setRegistryError(msg)
+    throw new Error(msg)
+  }
+  const data = (await res.json()) as ClusterRegistry
+  if (
+    !data ||
+    !Array.isArray(data.clusters) ||
+    typeof data.defaultClusterId !== "string"
+  ) {
+    const msg = `${REGISTRY_PATH} has invalid shape`
+    useClusterSelectorStore.getState().setRegistryError(msg)
+    throw new Error(msg)
+  }
+  useClusterSelectorStore.getState().setRegistry(data)
+  return data
+}
+
+/**
+ * Resolve the currently active cluster, falling back to the default if the
+ * persisted id is missing or stale.
+ */
+export function getActiveCluster(): ClusterEntry | null {
+  const { registry, currentClusterId } = useClusterSelectorStore.getState()
+  if (!registry) return null
+  return (
+    registry.clusters.find((c) => c.id === currentClusterId) ??
+    registry.clusters.find((c) => c.id === registry.defaultClusterId) ??
+    registry.clusters[0] ??
+    null
+  )
+}
+
+export function getActiveApiUrl(): string | null {
+  return getActiveCluster()?.apiUrl ?? null
+}

--- a/ui/vitest.setup.ts
+++ b/ui/vitest.setup.ts
@@ -19,6 +19,47 @@ if (typeof Element !== "undefined") {
   }
 }
 
+// Node 25's experimental localStorage shadows jsdom's implementation but is
+// not initialised in vitest's worker, leaving `localStorage.setItem` as a
+// non-callable shape. Replace with a dead-simple in-memory polyfill so
+// zustand persist works under vitest.
+function makeMemoryStorage(): Storage {
+  const map = new Map<string, string>()
+  return {
+    get length() {
+      return map.size
+    },
+    clear: () => map.clear(),
+    getItem: (key) => map.get(key) ?? null,
+    key: (i) => Array.from(map.keys())[i] ?? null,
+    removeItem: (key) => {
+      map.delete(key)
+    },
+    setItem: (key, value) => {
+      map.set(key, String(value))
+    },
+  }
+}
+
+if (typeof window !== "undefined") {
+  const desc = Object.getOwnPropertyDescriptor(window, "localStorage")
+  const ls = window.localStorage as Storage | undefined
+  if (!ls || typeof ls.setItem !== "function" || (desc && desc.configurable)) {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: makeMemoryStorage(),
+    })
+  }
+  const sd = Object.getOwnPropertyDescriptor(window, "sessionStorage")
+  const ss = window.sessionStorage as Storage | undefined
+  if (!ss || typeof ss.setItem !== "function" || (sd && sd.configurable)) {
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      value: makeMemoryStorage(),
+    })
+  }
+}
+
 afterEach(() => {
   cleanup()
   vi.restoreAllMocks()


### PR DESCRIPTION
## Summary
- **API**: New OIDC middleware (\`middleware/oidc_auth.py\`) verifies \`Authorization: Bearer\` tokens against a configurable Keycloak issuer using python-jose. Single audience (\`acko-api\`) with optional \`realm_access.roles\` gating. JWKS cache (asyncio.Lock + double-checked refresh, auto-rotate on unknown kid). SSE path accepts \`?access_token=\` query token. Excludes \`/api/health\`, \`/api/openapi.json\`, \`/api/docs\` by default. \`request_logging_middleware\` masks token query params before logging.
- **UI**: Keycloak PKCE SPA via \`keycloak-js\`. \`<AuthProvider>\` orchestrates registry hydrate → Keycloak init → login redirect. \`<ClusterSelector>\` reads \`/cluster-registry.json\` (mounted by ACKO chart on common-cluster web pod) and routes every \`apiFetch\` to the active cluster's \`apiUrl\` with \`Authorization: Bearer\` auto-attached. 401 triggers a single silent token refresh, falling back to login redirect. SSE URL gets \`?cluster=<id>&access_token=<jwt>\` since EventSource cannot set headers.
- **Backward compatibility**: When \`/cluster-registry.json\` 404s the SPA stays on relative API paths and \`proxy.js\` (untouched) handles routing as before. \`OIDC_ENABLED=false\` makes the API middleware a no-op. Existing single-cluster deployments are unaffected.

Cross-repo PRs: ACKO chart (#239 — emits ConfigMaps + injects \`OIDC_*\` env), plugins e2e_pytest, project-hub ADR-0040.

Refs: ADR-0040

## Test plan
- [ ] \`uv run pytest api/tests/test_oidc_auth.py -v\` → 16 passed
- [ ] \`uv run pytest api\` → 383 passed (existing suite green)
- [ ] \`uv run ruff check api/src\` and \`uv run pyright api/src\` → 0 errors
- [ ] \`cd ui && npm run type-check && npm run lint && npm test\` → 41 vitest, 0 type/lint
- [ ] Manual: with chart's \`values-common.yaml\` + Keycloak running, browser SPA initiates PKCE → ClusterSelector lists clusters → all subsequent API calls carry \`Authorization: Bearer\` and target the selected cluster's \`apiUrl\`
- [ ] Manual: with chart's \`values-operator.yaml\`, dev/prod API rejects unauthenticated calls (401), accepts dev-user JWT (200), rejects wrong audience (401), rejects missing required role (403)