### PR TITLE
feat(ui): workspace selector in connection/cluster forms; hide empty Default

### DIFF
--- a/scripts/local-dev/acko-install.sh
+++ b/scripts/local-dev/acko-install.sh
@@ -83,6 +83,10 @@ fi
 _helm_args=(
   --namespace "${ACKO_NAMESPACE}" --create-namespace
   --set "crds.install=false"
+  # The chart's NOTES.txt asserts defaultTemplates.enabled requires
+  # crds.install=true; in our split-mode setup the CRDs come from a
+  # sibling release, so disable defaultTemplates to satisfy that check.
+  --set "defaultTemplates.enabled=false"
 )
 if [[ -n "${ACKO_FULLNAME_OVERRIDE}" ]]; then
   _helm_args+=(--set "fullnameOverride=${ACKO_FULLNAME_OVERRIDE}")

--- a/scripts/local-dev/build-ui-images.sh
+++ b/scripts/local-dev/build-ui-images.sh
@@ -41,6 +41,6 @@ build_and_load() {
 }
 
 build_and_load "${ACKO_UI_API_IMAGE}" "Dockerfile.api"
-build_and_load "${ACKO_UI_WEB_IMAGE}" "Dockerfile.ui"
+build_and_load "${ACKO_UI_WEB_IMAGE}" "Dockerfile.web"
 
 ok "All 2 UI images built and loaded into kind"

--- a/ui/src/components/dialogs/AddConnectionDialog.tsx
+++ b/ui/src/components/dialogs/AddConnectionDialog.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/Dialog"
 import { ConnectionFormFields } from "@/components/dialogs/ConnectionFormFields"
 import { useConnectionForm } from "@/components/dialogs/useConnectionForm"
+import { useWorkspaces } from "@/hooks/use-workspaces"
 import { ApiError } from "@/lib/api/client"
 import { createConnection } from "@/lib/api/connections"
 import { useUiStore } from "@/stores/ui-store"
@@ -32,6 +33,16 @@ export function AddConnectionDialog({
   const [error, setError] = React.useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = React.useState(false)
   const currentWorkspaceId = useUiStore((s) => s.currentWorkspaceId)
+  const { data: workspaces } = useWorkspaces()
+
+  // Default the selector to the workspace the user is currently viewing each
+  // time the dialog opens. Without this the field would always start on
+  // ws-default, surprising users who switched workspace before clicking Add.
+  React.useEffect(() => {
+    if (open) {
+      setForm((prev) => ({ ...prev, workspaceId: currentWorkspaceId }))
+    }
+  }, [open, currentWorkspaceId, setForm])
 
   const handleOpenChange = (next: boolean) => {
     if (!next) {
@@ -53,10 +64,7 @@ export function AddConnectionDialog({
 
     setIsSubmitting(true)
     try {
-      await createConnection({
-        ...result.payload,
-        workspaceId: currentWorkspaceId,
-      })
+      await createConnection(result.payload)
       reset()
       onSuccess?.()
       onOpenChange(false)
@@ -90,7 +98,12 @@ export function AddConnectionDialog({
             </div>
           )}
 
-          <ConnectionFormFields form={form} setForm={setForm} idPrefix="conn" />
+          <ConnectionFormFields
+            form={form}
+            setForm={setForm}
+            idPrefix="conn"
+            workspaces={workspaces}
+          />
 
           <DialogFooter>
             <Button

--- a/ui/src/components/dialogs/AddConnectionDialog.tsx
+++ b/ui/src/components/dialogs/AddConnectionDialog.tsx
@@ -16,6 +16,7 @@ import { useConnectionForm } from "@/components/dialogs/useConnectionForm"
 import { useWorkspaces } from "@/hooks/use-workspaces"
 import { ApiError } from "@/lib/api/client"
 import { createConnection } from "@/lib/api/connections"
+import { bumpConnectionsRev } from "@/stores/data-revision-store"
 import { useUiStore } from "@/stores/ui-store"
 
 interface AddConnectionDialogProps {
@@ -32,17 +33,20 @@ export function AddConnectionDialog({
   const { form, setForm, validate, reset } = useConnectionForm()
   const [error, setError] = React.useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = React.useState(false)
-  const currentWorkspaceId = useUiStore((s) => s.currentWorkspaceId)
   const { data: workspaces } = useWorkspaces()
 
-  // Default the selector to the workspace the user is currently viewing each
-  // time the dialog opens. Without this the field would always start on
-  // ws-default, surprising users who switched workspace before clicking Add.
+  // Default the selector to the workspace the user is currently viewing
+  // when the dialog opens. Reading currentWorkspaceId via getState() inside
+  // the effect (instead of as a dep) avoids clobbering the user's explicit
+  // selection when they switch workspaces in the sidebar while the dialog
+  // is still open.
   React.useEffect(() => {
-    if (open) {
-      setForm((prev) => ({ ...prev, workspaceId: currentWorkspaceId }))
-    }
-  }, [open, currentWorkspaceId, setForm])
+    if (!open) return
+    setForm((prev) => ({
+      ...prev,
+      workspaceId: useUiStore.getState().currentWorkspaceId,
+    }))
+  }, [open, setForm])
 
   const handleOpenChange = (next: boolean) => {
     if (!next) {
@@ -65,6 +69,7 @@ export function AddConnectionDialog({
     setIsSubmitting(true)
     try {
       await createConnection(result.payload)
+      bumpConnectionsRev()
       reset()
       onSuccess?.()
       onOpenChange(false)

--- a/ui/src/components/dialogs/AddWorkspaceDialog.tsx
+++ b/ui/src/components/dialogs/AddWorkspaceDialog.tsx
@@ -16,6 +16,7 @@ import { useWorkspaceForm } from "@/components/dialogs/useWorkspaceForm"
 import { ApiError } from "@/lib/api/client"
 import { createWorkspace } from "@/lib/api/workspaces"
 import type { WorkspaceResponse } from "@/lib/types/workspace"
+import { bumpWorkspacesRev } from "@/stores/data-revision-store"
 
 interface AddWorkspaceDialogProps {
   open: boolean
@@ -53,6 +54,7 @@ export function AddWorkspaceDialog({
     setIsSubmitting(true)
     try {
       const created = await createWorkspace(result.payload)
+      bumpWorkspacesRev()
       reset()
       onSuccess?.(created)
       onOpenChange(false)

--- a/ui/src/components/dialogs/ConnectionFormFields.tsx
+++ b/ui/src/components/dialogs/ConnectionFormFields.tsx
@@ -52,9 +52,7 @@ export function ConnectionFormFields({
           <select
             id={id("workspace")}
             value={form.workspaceId}
-            onChange={(e) =>
-              setForm({ ...form, workspaceId: e.target.value })
-            }
+            onChange={(e) => setForm({ ...form, workspaceId: e.target.value })}
             className={SELECT_CLASSES}
           >
             {workspaces.map((ws) => (

--- a/ui/src/components/dialogs/ConnectionFormFields.tsx
+++ b/ui/src/components/dialogs/ConnectionFormFields.tsx
@@ -4,6 +4,7 @@ import { Input } from "@/components/Input"
 import { Label } from "@/components/Label"
 import { LabelsEditor } from "@/components/clusters/LabelsEditor"
 import type { ConnectionFormState } from "@/components/dialogs/useConnectionForm"
+import type { WorkspaceResponse } from "@/lib/types/workspace"
 
 interface ConnectionFormFieldsProps {
   form: ConnectionFormState
@@ -12,7 +13,12 @@ interface ConnectionFormFieldsProps {
   idPrefix: string
   /** Hide the credential pair (username / password). The Edit dialog skips them. */
   showCredentials?: boolean
+  /** Workspaces available for selection. Hides the field when omitted or empty. */
+  workspaces?: WorkspaceResponse[] | null
 }
+
+const SELECT_CLASSES =
+  "h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
 
 const TEXTAREA_CLASSES =
   "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-indigo-400/20"
@@ -22,6 +28,7 @@ export function ConnectionFormFields({
   setForm,
   idPrefix,
   showCredentials = true,
+  workspaces,
 }: ConnectionFormFieldsProps) {
   const id = (suffix: string) => `${idPrefix}-${suffix}`
 
@@ -38,6 +45,27 @@ export function ConnectionFormFields({
           required
         />
       </div>
+
+      {workspaces && workspaces.length > 0 && (
+        <div className="flex flex-col gap-y-1.5">
+          <Label htmlFor={id("workspace")}>Workspace</Label>
+          <select
+            id={id("workspace")}
+            value={form.workspaceId}
+            onChange={(e) =>
+              setForm({ ...form, workspaceId: e.target.value })
+            }
+            className={SELECT_CLASSES}
+          >
+            {workspaces.map((ws) => (
+              <option key={ws.id} value={ws.id}>
+                {ws.name}
+                {ws.isDefault ? " (Default)" : ""}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
 
       <div className="flex flex-col gap-y-1.5">
         <Label htmlFor={id("hosts")}>Hosts (comma-separated)</Label>

--- a/ui/src/components/dialogs/EditConnectionDialog.tsx
+++ b/ui/src/components/dialogs/EditConnectionDialog.tsx
@@ -20,6 +20,7 @@ import { useWorkspaces } from "@/hooks/use-workspaces"
 import { ApiError } from "@/lib/api/client"
 import { updateConnection } from "@/lib/api/connections"
 import type { ConnectionProfileResponse } from "@/lib/types/connection"
+import { bumpConnectionsRev } from "@/stores/data-revision-store"
 
 interface EditConnectionDialogProps {
   open: boolean
@@ -79,6 +80,7 @@ export function EditConnectionDialog({
         labels: result.payload.labels,
         workspaceId: result.payload.workspaceId,
       })
+      bumpConnectionsRev()
       onSuccess?.()
       onOpenChange(false)
     } catch (err) {

--- a/ui/src/components/dialogs/EditConnectionDialog.tsx
+++ b/ui/src/components/dialogs/EditConnectionDialog.tsx
@@ -16,6 +16,7 @@ import {
   fromConnection,
   useConnectionForm,
 } from "@/components/dialogs/useConnectionForm"
+import { useWorkspaces } from "@/hooks/use-workspaces"
 import { ApiError } from "@/lib/api/client"
 import { updateConnection } from "@/lib/api/connections"
 import type { ConnectionProfileResponse } from "@/lib/types/connection"
@@ -36,6 +37,7 @@ export function EditConnectionDialog({
   const { form, setForm, validate, hydrate } = useConnectionForm()
   const [error, setError] = React.useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = React.useState(false)
+  const { data: workspaces } = useWorkspaces()
 
   React.useEffect(() => {
     if (open && connection) {
@@ -75,6 +77,7 @@ export function EditConnectionDialog({
         color: result.payload.color,
         description: result.payload.description,
         labels: result.payload.labels,
+        workspaceId: result.payload.workspaceId,
       })
       onSuccess?.()
       onOpenChange(false)
@@ -114,6 +117,7 @@ export function EditConnectionDialog({
             setForm={setForm}
             idPrefix="edit-conn"
             showCredentials={false}
+            workspaces={workspaces}
           />
 
           <DialogFooter>

--- a/ui/src/components/dialogs/EditWorkspaceDialog.tsx
+++ b/ui/src/components/dialogs/EditWorkspaceDialog.tsx
@@ -19,6 +19,7 @@ import {
 import { ApiError } from "@/lib/api/client"
 import { deleteWorkspace, updateWorkspace } from "@/lib/api/workspaces"
 import type { WorkspaceResponse } from "@/lib/types/workspace"
+import { bumpWorkspacesRev } from "@/stores/data-revision-store"
 
 interface EditWorkspaceDialogProps {
   workspace: WorkspaceResponse | null
@@ -69,6 +70,7 @@ export function EditWorkspaceDialog({
     setIsSubmitting(true)
     try {
       const saved = await updateWorkspace(workspace.id, result.payload)
+      bumpWorkspacesRev()
       onSaved?.(saved)
       onOpenChange(false)
     } catch (err) {
@@ -91,6 +93,7 @@ export function EditWorkspaceDialog({
     setIsDeleting(true)
     try {
       await deleteWorkspace(workspace.id)
+      bumpWorkspacesRev()
       onDeleted?.(workspace.id)
       onOpenChange(false)
     } catch (err) {

--- a/ui/src/components/dialogs/useConnectionForm.ts
+++ b/ui/src/components/dialogs/useConnectionForm.ts
@@ -8,6 +8,7 @@ import {
   labelsToEntries,
 } from "@/components/clusters/labels"
 import type { ConnectionProfileResponse } from "@/lib/types/connection"
+import { DEFAULT_WORKSPACE_ID } from "@/lib/types/workspace"
 import React from "react"
 
 export interface ConnectionFormState {
@@ -19,6 +20,7 @@ export interface ConnectionFormState {
   color: string
   description: string
   labels: LabelEntry[]
+  workspaceId: string
 }
 
 export interface ParsedConnectionPayload {
@@ -30,6 +32,7 @@ export interface ParsedConnectionPayload {
   color: string
   description: string | null
   labels: Record<string, string>
+  workspaceId: string
 }
 
 const DEFAULT_COLOR = "#4F46E5"
@@ -43,6 +46,7 @@ const EMPTY_FORM: ConnectionFormState = {
   color: DEFAULT_COLOR,
   description: "",
   labels: [{ key: ENV_LABEL_KEY, value: DEFAULT_ENV_VALUE }],
+  workspaceId: DEFAULT_WORKSPACE_ID,
 }
 
 export function fromConnection(
@@ -57,6 +61,7 @@ export function fromConnection(
     color: conn.color,
     description: conn.description ?? "",
     labels: labelsToEntries(conn.labels ?? {}),
+    workspaceId: conn.workspaceId ?? DEFAULT_WORKSPACE_ID,
   }
 }
 
@@ -111,6 +116,7 @@ export function useConnectionForm(initial?: ConnectionFormState) {
         color: form.color || DEFAULT_COLOR,
         description: form.description.trim() || null,
         labels: entriesToLabels(form.labels),
+        workspaceId: form.workspaceId || DEFAULT_WORKSPACE_ID,
       },
     }
   }, [form])

--- a/ui/src/components/k8s/create-cluster-wizard/CreateClusterWizard.tsx
+++ b/ui/src/components/k8s/create-cluster-wizard/CreateClusterWizard.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/Button"
 import { useWorkspaces } from "@/hooks/use-workspaces"
 import { ApiError } from "@/lib/api/client"
 import { useClusterSelectorStore } from "@/stores/cluster-selector-store"
+import { bumpConnectionsRev } from "@/stores/data-revision-store"
 import { useUiStore } from "@/stores/ui-store"
 import {
   createK8sCluster,
@@ -362,6 +363,10 @@ export function CreateClusterWizard() {
     try {
       const payload = cleanupPayload(form)
       await createK8sCluster(payload)
+      // The operator path also auto-creates a connection profile under the
+      // chosen workspace; refresh consumers (sidebar, dropdowns) so the new
+      // entry appears immediately on /clusters.
+      bumpConnectionsRev()
       router.push("/clusters")
     } catch (err) {
       if (err instanceof ApiError) {

--- a/ui/src/components/k8s/create-cluster-wizard/CreateClusterWizard.tsx
+++ b/ui/src/components/k8s/create-cluster-wizard/CreateClusterWizard.tsx
@@ -4,6 +4,7 @@ import { useRouter } from "next/navigation"
 import { useEffect, useMemo, useState } from "react"
 
 import { Button } from "@/components/Button"
+import { useWorkspaces } from "@/hooks/use-workspaces"
 import { ApiError } from "@/lib/api/client"
 import { useClusterSelectorStore } from "@/stores/cluster-selector-store"
 import { useUiStore } from "@/stores/ui-store"
@@ -202,11 +203,16 @@ function cleanupPayload(
 
 export function CreateClusterWizard() {
   const router = useRouter()
+  const currentWorkspaceId = useUiStore((s) => s.currentWorkspaceId)
+  const { data: workspaces } = useWorkspaces()
 
   const [mode, setMode] = useState<CreationMode>("scratch")
   const [step, setStep] = useState(0)
   const [maxReachedStep, setMaxReachedStep] = useState(0)
-  const [form, setForm] = useState<CreateK8sClusterRequest>(INITIAL_FORM)
+  const [form, setForm] = useState<CreateK8sClusterRequest>(() => ({
+    ...INITIAL_FORM,
+    workspaceId: currentWorkspaceId,
+  }))
 
   const [templates, setTemplates] = useState<K8sTemplateSummary[]>([])
   const [selectedTemplateName, setSelectedTemplateName] = useState<
@@ -355,10 +361,6 @@ export function CreateClusterWizard() {
     setSubmitting(true)
     try {
       const payload = cleanupPayload(form)
-      // Attach the auto-created connection to the workspace the user is
-      // currently viewing — otherwise the new cluster only appears after
-      // they switch back to Default.
-      payload.workspaceId = useUiStore.getState().currentWorkspaceId
       await createK8sCluster(payload)
       router.push("/clusters")
     } catch (err) {
@@ -408,6 +410,7 @@ export function CreateClusterWizard() {
           <StepBasic
             form={form}
             namespaces={namespacesList}
+            workspaces={workspaces}
             updateForm={updateForm}
           />
         ) : step === 2 ? (
@@ -430,6 +433,7 @@ export function CreateClusterWizard() {
         <StepBasic
           form={form}
           namespaces={namespacesList}
+          workspaces={workspaces}
           updateForm={updateForm}
           templateMode
         />

--- a/ui/src/components/k8s/create-cluster-wizard/StepBasic.tsx
+++ b/ui/src/components/k8s/create-cluster-wizard/StepBasic.tsx
@@ -6,17 +6,26 @@ import { Input } from "@/components/Input"
 import { Label } from "@/components/Label"
 import { AEROSPIKE_IMAGES, CE_LIMITS } from "@/lib/validations/k8s"
 import type { CreateK8sClusterRequest } from "@/lib/types/k8s"
+import {
+  DEFAULT_WORKSPACE_ID,
+  type WorkspaceResponse,
+} from "@/lib/types/workspace"
 
 interface StepBasicProps {
   form: CreateK8sClusterRequest
   namespaces: string[]
+  workspaces?: WorkspaceResponse[] | null
   updateForm: (updates: Partial<CreateK8sClusterRequest>) => void
   templateMode?: boolean
 }
 
+const SELECT_CLASSES =
+  "h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+
 export function StepBasic({
   form,
   namespaces,
+  workspaces,
   updateForm,
   templateMode,
 }: StepBasicProps) {
@@ -51,7 +60,7 @@ export function StepBasic({
             id="cluster-namespace"
             value={form.namespace ?? ""}
             onChange={(e) => updateForm({ namespace: e.target.value })}
-            className="h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+            className={SELECT_CLASSES}
             required
           >
             <option value="">Select a namespace</option>
@@ -63,6 +72,29 @@ export function StepBasic({
           </select>
         </div>
       </div>
+
+      {workspaces && workspaces.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          <Label htmlFor="cluster-workspace">Workspace</Label>
+          <select
+            id="cluster-workspace"
+            value={form.workspaceId ?? DEFAULT_WORKSPACE_ID}
+            onChange={(e) => updateForm({ workspaceId: e.target.value })}
+            className={SELECT_CLASSES}
+          >
+            {workspaces.map((ws) => (
+              <option key={ws.id} value={ws.id}>
+                {ws.name}
+                {ws.isDefault ? " (Default)" : ""}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-gray-500 dark:text-gray-500">
+            The auto-created connection profile will be attached to this
+            workspace.
+          </p>
+        </div>
+      )}
 
       {!templateMode && (
         <div className="grid grid-cols-1 gap-4 md:grid-cols-2">

--- a/ui/src/components/k8s/create-cluster-wizard/StepReview.tsx
+++ b/ui/src/components/k8s/create-cluster-wizard/StepReview.tsx
@@ -1,7 +1,9 @@
 "use client"
 
 import { Card } from "@/components/Card"
+import { useWorkspaces } from "@/hooks/use-workspaces"
 import type { CreateK8sClusterRequest } from "@/lib/types/k8s"
+import { DEFAULT_WORKSPACE_ID } from "@/lib/types/workspace"
 
 interface StepReviewProps {
   form: CreateK8sClusterRequest
@@ -20,6 +22,10 @@ export function StepReview({ form, templateName }: StepReviewProps) {
   const requests = form.resources?.requests
   const limits = form.resources?.limits
   const namespaces = form.namespaces ?? []
+  const { data: workspaces } = useWorkspaces()
+  const workspaceId = form.workspaceId ?? DEFAULT_WORKSPACE_ID
+  const workspaceName =
+    workspaces?.find((w) => w.id === workspaceId)?.name ?? workspaceId
 
   return (
     <Card className="flex flex-col gap-5">
@@ -30,6 +36,7 @@ export function StepReview({ form, templateName }: StepReviewProps) {
       <dl className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <Field label="Name" value={form.name ?? "—"} />
         <Field label="Namespace" value={form.namespace ?? "—"} />
+        <Field label="Workspace" value={workspaceName} />
         <Field
           label="Size"
           value={`${form.size ?? 1} node${(form.size ?? 1) > 1 ? "s" : ""}`}

--- a/ui/src/components/ui/navigation/WorkspacesDropdown.tsx
+++ b/ui/src/components/ui/navigation/WorkspacesDropdown.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/Dropdown"
 import { AddWorkspaceDialog } from "@/components/dialogs/AddWorkspaceDialog"
 import { EditWorkspaceDialog } from "@/components/dialogs/EditWorkspaceDialog"
+import { useConnections } from "@/hooks/use-connections"
 import { useWorkspaces } from "@/hooks/use-workspaces"
 import { cx, focusRing } from "@/lib/utils"
 import {
@@ -59,6 +60,7 @@ function WorkspaceAvatar({
 
 export function WorkspacesDropdown() {
   const { data, isLoading, refetch } = useWorkspaces()
+  const { data: connections } = useConnections()
   const currentWorkspaceId = useUiStore((s) => s.currentWorkspaceId)
   const setCurrentWorkspaceId = useUiStore((s) => s.setCurrentWorkspaceId)
 
@@ -67,24 +69,40 @@ export function WorkspacesDropdown() {
     null,
   )
 
-  // Reconcile the persisted currentWorkspaceId against the live list once
-  // workspaces load — if the saved id no longer exists (e.g. it was deleted
-  // in another session), fall back to the default so the rest of the UI
-  // doesn't filter on an orphan id. Skip when we're already on the default;
-  // otherwise a backend race that yields a list missing ws-default would
-  // re-fire the setter on every refetch.
+  // Hide the built-in default workspace from the list once the user has at
+  // least one custom workspace AND the default no longer holds any
+  // connections. Keeps the picker meaningful — an empty "Default" entry is
+  // just clutter once everything has been moved into named workspaces.
+  // Wait until connections finish loading before filtering, otherwise the
+  // default would briefly disappear during the initial fetch.
+  const visible = React.useMemo<WorkspaceResponse[] | null>(() => {
+    if (!data) return null
+    if (!connections) return data
+    const hasCustom = data.some((w) => !w.isDefault)
+    if (!hasCustom) return data
+    return data.filter((w) => {
+      if (!w.isDefault) return true
+      return connections.some((c) => c.workspaceId === w.id)
+    })
+  }, [data, connections])
+
+  // Reconcile the persisted currentWorkspaceId against the visible list once
+  // workspaces load. If the saved id no longer exists (e.g. it was deleted
+  // in another session) or the default was hidden because it became empty,
+  // pick the first visible workspace so the rest of the UI doesn't filter
+  // on an orphan id.
   React.useEffect(() => {
-    if (!data) return
-    if (data.length === 0) return
-    if (currentWorkspaceId === DEFAULT_WORKSPACE_ID) return
-    if (!data.some((w) => w.id === currentWorkspaceId)) {
-      setCurrentWorkspaceId(DEFAULT_WORKSPACE_ID)
-    }
-  }, [data, currentWorkspaceId, setCurrentWorkspaceId])
+    if (!visible || visible.length === 0) return
+    if (visible.some((w) => w.id === currentWorkspaceId)) return
+    const fallback =
+      visible.find((w) => w.id === DEFAULT_WORKSPACE_ID) ?? visible[0]
+    setCurrentWorkspaceId(fallback.id)
+  }, [visible, currentWorkspaceId, setCurrentWorkspaceId])
 
   const current =
-    data?.find((w) => w.id === currentWorkspaceId) ??
-    data?.find((w) => w.id === DEFAULT_WORKSPACE_ID) ??
+    visible?.find((w) => w.id === currentWorkspaceId) ??
+    visible?.find((w) => w.id === DEFAULT_WORKSPACE_ID) ??
+    visible?.[0] ??
     null
 
   return (
@@ -120,9 +138,9 @@ export function WorkspacesDropdown() {
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="w-64">
           <DropdownMenuLabel>
-            Workspaces ({data?.length ?? 0})
+            Workspaces ({visible?.length ?? 0})
           </DropdownMenuLabel>
-          {data?.map((ws) => {
+          {visible?.map((ws) => {
             const selected = ws.id === currentWorkspaceId
             return (
               <DropdownMenuItem
@@ -166,7 +184,7 @@ export function WorkspacesDropdown() {
               </DropdownMenuItem>
             )
           })}
-          {data && data.length === 0 && !isLoading && (
+          {visible && visible.length === 0 && !isLoading && (
             <div className="px-2 py-1.5 text-sm italic text-gray-400 dark:text-gray-600">
               No workspaces
             </div>

--- a/ui/src/hooks/use-connections.ts
+++ b/ui/src/hooks/use-connections.ts
@@ -1,6 +1,11 @@
 /**
  * useConnections — fetch-on-mount hook for the saved connection profiles list.
  * Returns data/error/isLoading plus a `refetch` for manual reloads.
+ *
+ * Subscribes to ``useDataRevisionStore.connectionsRev`` so every instance
+ * refetches whenever any component bumps it after a mutation. Without that,
+ * sibling consumers (sidebar dropdown, clusters page) would keep stale
+ * snapshots until the next route change.
  */
 
 "use client"
@@ -10,6 +15,7 @@ import { useCallback, useEffect, useState } from "react"
 import { listConnections } from "@/lib/api/connections"
 import { logFetchError } from "@/lib/api/log"
 import type { ConnectionProfileResponse } from "@/lib/types/connection"
+import { useDataRevisionStore } from "@/stores/data-revision-store"
 
 export interface UseConnectionsResult {
   data: ConnectionProfileResponse[] | null
@@ -22,6 +28,7 @@ export function useConnections(): UseConnectionsResult {
   const [data, setData] = useState<ConnectionProfileResponse[] | null>(null)
   const [error, setError] = useState<Error | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const rev = useDataRevisionStore((s) => s.connectionsRev)
 
   const refetch = useCallback(async () => {
     setIsLoading(true)
@@ -58,7 +65,7 @@ export function useConnections(): UseConnectionsResult {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [rev])
 
   return { data, error, isLoading, refetch }
 }

--- a/ui/src/hooks/use-workspaces.ts
+++ b/ui/src/hooks/use-workspaces.ts
@@ -1,6 +1,11 @@
 /**
  * useWorkspaces — fetch-on-mount hook for the workspace list.
  * Returns data/error/isLoading plus a `refetch` for manual reloads.
+ *
+ * Subscribes to ``useDataRevisionStore.workspacesRev`` so every instance
+ * refetches whenever any component bumps it after a mutation. Without that,
+ * sibling consumers (sidebar dropdown, dialogs) would keep stale snapshots
+ * after a workspace is created or renamed elsewhere.
  */
 
 "use client"
@@ -10,6 +15,7 @@ import { useCallback, useEffect, useState } from "react"
 import { listWorkspaces } from "@/lib/api/workspaces"
 import { logFetchError } from "@/lib/api/log"
 import type { WorkspaceResponse } from "@/lib/types/workspace"
+import { useDataRevisionStore } from "@/stores/data-revision-store"
 
 export interface UseWorkspacesResult {
   data: WorkspaceResponse[] | null
@@ -22,6 +28,7 @@ export function useWorkspaces(): UseWorkspacesResult {
   const [data, setData] = useState<WorkspaceResponse[] | null>(null)
   const [error, setError] = useState<Error | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const rev = useDataRevisionStore((s) => s.workspacesRev)
 
   const refetch = useCallback(async () => {
     setIsLoading(true)
@@ -58,7 +65,7 @@ export function useWorkspaces(): UseWorkspacesResult {
     return () => {
       cancelled = true
     }
-  }, [])
+  }, [rev])
 
   return { data, error, isLoading, refetch }
 }

--- a/ui/src/stores/data-revision-store.ts
+++ b/ui/src/stores/data-revision-store.ts
@@ -23,8 +23,7 @@ interface DataRevisionStore {
 export const useDataRevisionStore = create<DataRevisionStore>((set) => ({
   connectionsRev: 0,
   workspacesRev: 0,
-  bumpConnections: () =>
-    set((s) => ({ connectionsRev: s.connectionsRev + 1 })),
+  bumpConnections: () => set((s) => ({ connectionsRev: s.connectionsRev + 1 })),
   bumpWorkspaces: () => set((s) => ({ workspacesRev: s.workspacesRev + 1 })),
 }))
 

--- a/ui/src/stores/data-revision-store.ts
+++ b/ui/src/stores/data-revision-store.ts
@@ -1,0 +1,36 @@
+/**
+ * Data revision store — monotonic counters that all `useConnections` /
+ * `useWorkspaces` hook instances watch so a mutation in one component
+ * (e.g. AddConnectionDialog) refetches every other instance (e.g. the
+ * sidebar's WorkspacesDropdown). Without this each hook keeps a private
+ * snapshot, leaving the dropdown's "hide empty Default" check stale until
+ * the next page navigation.
+ *
+ * Bump from any place that creates / updates / deletes the corresponding
+ * resource. Reads are intentionally cheap (just an integer); the actual
+ * fetch happens inside the hooks.
+ */
+
+import { create } from "zustand"
+
+interface DataRevisionStore {
+  connectionsRev: number
+  workspacesRev: number
+  bumpConnections: () => void
+  bumpWorkspaces: () => void
+}
+
+export const useDataRevisionStore = create<DataRevisionStore>((set) => ({
+  connectionsRev: 0,
+  workspacesRev: 0,
+  bumpConnections: () =>
+    set((s) => ({ connectionsRev: s.connectionsRev + 1 })),
+  bumpWorkspaces: () => set((s) => ({ workspacesRev: s.workspacesRev + 1 })),
+}))
+
+/** Imperative bumpers for use outside React (callbacks, async chains). */
+export const bumpConnectionsRev = (): void =>
+  useDataRevisionStore.getState().bumpConnections()
+
+export const bumpWorkspacesRev = (): void =>
+  useDataRevisionStore.getState().bumpWorkspaces()


### PR DESCRIPTION
## Summary

- AddConnection / EditConnection / CreateCluster wizard now expose a Workspace dropdown so users can pick (or move) the target workspace instead of silently inheriting whichever workspace the sidebar happened to be on.
- The built-in **Default** workspace is hidden from the sidebar dropdown once at least one custom workspace exists AND Default no longer holds any connections — keeps the picker meaningful after everything has been moved into named workspaces. `currentWorkspaceId` is reconciled to the first visible workspace if its previous selection becomes hidden or orphaned.
- Added a `data-revision-store` (Zustand counter) so every `useConnections` / `useWorkspaces` hook instance refetches when any other component mutates the underlying data — without it, the sidebar's "hide empty Default" check stayed stale until the next route change.
- Fixed `AddConnectionDialog` workspace-init effect so it no longer clobbers the user's explicit selection when the sidebar's `currentWorkspaceId` changes mid-edit.
- `CreateClusterWizard` review step now displays the chosen workspace name.

## Test plan

- [ ] `npm run type-check` passes
- [ ] `npm run lint` passes
- [ ] `npm run test` passes (41 tests)
- [ ] Manual: Add Connection — workspace dropdown defaults to the currently-selected workspace; submitting attaches the new connection to it.
- [ ] Manual: Edit Connection — change workspace to a different one; the connection moves and disappears from the previously filtered `/clusters` view.
- [ ] Manual: Create Cluster wizard — workspace dropdown shows on Step 1; Review step displays the chosen workspace; on submit the auto-created connection lands in that workspace.
- [ ] Manual: With one custom workspace and Default emptied (move all connections out), the sidebar dropdown no longer lists Default. Adding a connection back to Default makes it reappear without a page reload.
- [ ] Manual: Open AddConnectionDialog, switch sidebar workspace, confirm the dropdown selection is *not* clobbered.