### PR TITLE
feat(api): MCP server Phase 1 (21 tools)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,7 +85,7 @@ K8S_MANAGEMENT_ENABLED=false
 # Mounts an MCP (Model Context Protocol) server at /mcp on the same FastAPI
 # port. Used by Claude Code plugins (see aerospike-ce-ecosystem-plugins) and
 # any MCP-aware AI client (Claude Desktop, Cursor, etc.) to read and operate
-# Aerospike clusters via 21 tools (Voyager parity).
+# Aerospike clusters via 21 tools (records, query, asinfo, connections).
 #
 # SECURITY: When ACM_MCP_ENABLED=true, the API process refuses to start
 # unless EITHER OIDC is enabled (OIDC_ENABLED=true + OIDC_ISSUER_URL) OR
@@ -109,7 +109,7 @@ K8S_MANAGEMENT_ENABLED=false
 # deployments where you have independently verified the port is not
 # reachable from the internet or other untrusted peers.
 # ACM_MCP_ALLOW_ANONYMOUS=false
-# Voyager-style call-time gate: read_only blocks the 10 mutation tools at
+# Call-time gate: read_only blocks the 10 mutation tools at
 # call time. full allows everything. Default is read_only.
 # ACM_MCP_ACCESS_PROFILE=read_only
 

--- a/.env.example
+++ b/.env.example
@@ -86,12 +86,29 @@ K8S_MANAGEMENT_ENABLED=false
 # port. Used by Claude Code plugins (see aerospike-ce-ecosystem-plugins) and
 # any MCP-aware AI client (Claude Desktop, Cursor, etc.) to read and operate
 # Aerospike clusters via 21 tools (Voyager parity).
+#
+# SECURITY: When ACM_MCP_ENABLED=true, the API process refuses to start
+# unless EITHER OIDC is enabled (OIDC_ENABLED=true + OIDC_ISSUER_URL) OR
+# a shared-secret bearer token is configured (ACM_MCP_TOKEN=...). For any
+# non-localhost deployment one of those two MUST be set — the MCP surface
+# can drive cluster mutations (create/update/delete records, truncate
+# sets, asinfo) and exposing it anonymously to an open network is a
+# remote-control vulnerability. The opt-out below exists ONLY for genuine
+# loopback / sealed-network deployments where the operator has verified
+# the port is not reachable from untrusted peers.
 # ACM_MCP_ENABLED=false
 # ACM_MCP_PATH=/mcp
 # Optional shared-secret bearer token. When set, requests must include
 # `Authorization: Bearer <token>` unless OIDC has already authenticated.
 # Empty string defers entirely to OIDC.
 # ACM_MCP_TOKEN=
+# Bypass the anonymous-exposure refusal. Setting this to true allows the
+# API to start with ACM_MCP_ENABLED=true even when neither OIDC nor a
+# bearer token is configured — i.e. the /mcp surface will accept any
+# unauthenticated request. ONLY enable on localhost / trusted-network
+# deployments where you have independently verified the port is not
+# reachable from the internet or other untrusted peers.
+# ACM_MCP_ALLOW_ANONYMOUS=false
 # Voyager-style call-time gate: read_only blocks the 10 mutation tools at
 # call time. full allows everything. Default is read_only.
 # ACM_MCP_ACCESS_PROFILE=read_only

--- a/.env.example
+++ b/.env.example
@@ -81,6 +81,21 @@ K8S_MANAGEMENT_ENABLED=false
 # SSE_HEARTBEAT_INTERVAL=15
 # SSE_MAX_CONNECTIONS=50
 
+# ─── MCP Server ────────────────────────────────────────────────────────────
+# Mounts an MCP (Model Context Protocol) server at /mcp on the same FastAPI
+# port. Used by Claude Code plugins (see aerospike-ce-ecosystem-plugins) and
+# any MCP-aware AI client (Claude Desktop, Cursor, etc.) to read and operate
+# Aerospike clusters via 21 tools (Voyager parity).
+# ACM_MCP_ENABLED=false
+# ACM_MCP_PATH=/mcp
+# Optional shared-secret bearer token. When set, requests must include
+# `Authorization: Bearer <token>` unless OIDC has already authenticated.
+# Empty string defers entirely to OIDC.
+# ACM_MCP_TOKEN=
+# Voyager-style call-time gate: read_only blocks the 10 mutation tools at
+# call time. full allows everything. Default is read_only.
+# ACM_MCP_ACCESS_PROFILE=read_only
+
 # ─── Logging ───────────────────────────────────────────────────────────────
 # LOG_LEVEL=INFO
 # LOG_FORMAT=text   # "text" (human-readable) or "json" (structured)

--- a/README.md
+++ b/README.md
@@ -976,10 +976,9 @@ The MCP transport is mounted at `/mcp` on the same port as the REST API (default
 ### Register the endpoint with Claude Code
 
 ```bash
-claude mcp add aerospike-local \
-  --transport http \
-  --url http://localhost:8000/mcp \
-  --header "Authorization: Bearer $ACM_MCP_TOKEN"
+claude mcp add --transport http aerospike-local \
+  http://localhost:8000/mcp \
+  -H "Authorization: Bearer $ACM_MCP_TOKEN"
 ```
 
 Or run the `acm-mcp-init` skill from the ecosystem plugin to register one or more endpoints (multi-cluster ACKO friendly).

--- a/README.md
+++ b/README.md
@@ -960,7 +960,7 @@ claude plugin install aerospike-ce-ecosystem
 
 ## MCP Server
 
-Cluster Manager can expose itself as a [Model Context Protocol](https://modelcontextprotocol.io/) server (Voyager-parity, 21 tools) so Claude Code plugins and external MCP-aware AI clients (Claude Desktop, Cursor) can read and operate clusters directly.
+Cluster Manager can expose itself as a [Model Context Protocol](https://modelcontextprotocol.io/) server (21 tools) so Claude Code plugins and external MCP-aware AI clients (Claude Desktop, Cursor) can read and operate clusters directly.
 
 ### Enable
 

--- a/README.md
+++ b/README.md
@@ -958,6 +958,50 @@ claude plugin marketplace add aerospike-ce-ecosystem/aerospike-ce-ecosystem-plug
 claude plugin install aerospike-ce-ecosystem
 ```
 
+## MCP Server
+
+Cluster Manager can expose itself as a [Model Context Protocol](https://modelcontextprotocol.io/) server (Voyager-parity, 21 tools) so Claude Code plugins and external MCP-aware AI clients (Claude Desktop, Cursor) can read and operate clusters directly.
+
+### Enable
+
+```bash
+ACM_MCP_ENABLED=true \
+ACM_MCP_TOKEN=$(openssl rand -hex 16) \
+ACM_MCP_ACCESS_PROFILE=read_only \
+uv run uvicorn aerospike_cluster_manager_api.main:app --reload
+```
+
+The MCP transport is mounted at `/mcp` on the same port as the REST API (default 8000), uses Streamable HTTP, and shares OIDC + OTel + lifespan with the rest of the app.
+
+### Register the endpoint with Claude Code
+
+```bash
+claude mcp add aerospike-local \
+  --transport http \
+  --url http://localhost:8000/mcp \
+  --header "Authorization: Bearer $ACM_MCP_TOKEN"
+```
+
+Or run the `acm-mcp-init` skill from the ecosystem plugin to register one or more endpoints (multi-cluster ACKO friendly).
+
+### Tools (21)
+
+| Category | Tools |
+|----------|-------|
+| Connection (8) | `create_connection`, `get_connection`, `update_connection`, `delete_connection`, `list_connections`, `connect`, `disconnect`, `test_connection` |
+| Cluster info (3) | `list_namespaces`, `list_sets`, `get_nodes` |
+| Record (7) | `get_record`, `record_exists`, `create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set` |
+| Query (1) | `query` |
+| Info (2) | `execute_info`, `execute_info_on_node` |
+
+### Access profile
+
+`ACM_MCP_ACCESS_PROFILE=read_only` (default) blocks the 10 mutation tools (`create_*`, `update_*`, `delete_*`, `truncate_set`, `execute_info*`) at call time with `code="access_denied"`. Tools remain visible — clients see the rejection only when they invoke a write. Set to `full` to allow everything.
+
+### Auth
+
+The `/mcp` mount inherits the existing `OIDCAuthMiddleware`. Optionally set `ACM_MCP_TOKEN` for an OR-combined bearer-token gate (useful for headless agents that cannot run the OAuth Authorization Code flow).
+
 ## License
 
 This project is licensed under the [Apache License 2.0](LICENSE).

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "asyncpg>=0.30.0",
     "fastapi>=0.115.0",
     "kubernetes>=31.0.0",
+    "mcp>=1.0,<2",
     "python-json-logger>=3.0.0",
     "pyyaml>=6.0",
     "slowapi>=0.1.9",

--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -176,6 +176,15 @@ OIDC_EXCLUDE_PATHS: list[str] = _parse_str_list(
 # applies via the OIDC middleware when ``OIDC_ENABLED`` is true.
 ACM_MCP_ENABLED: bool = _get_bool("ACM_MCP_ENABLED", False)
 ACM_MCP_PATH: str = os.getenv("ACM_MCP_PATH", "/mcp")
+# M2 — validate ACM_MCP_PATH at import time so a misconfigured deployment
+# (e.g. ``ACM_MCP_PATH=mcp`` without leading slash, or ``ACM_MCP_PATH=/``
+# which would shadow every route) fails loudly on process start instead
+# of producing a quietly-broken mount. Canonicalize by trimming the
+# trailing slash so the path-segment check in ``mcp/auth.py`` (M1) and
+# the FastAPI ``app.mount`` call agree on the same string.
+if not ACM_MCP_PATH.startswith("/") or ACM_MCP_PATH == "/":
+    raise ValueError(f"ACM_MCP_PATH must start with '/' and not be '/' alone; got {ACM_MCP_PATH!r}")
+ACM_MCP_PATH = ACM_MCP_PATH.rstrip("/")
 # Optional shared-secret bearer token for the ``/mcp`` surface. When set
 # alongside ``ACM_MCP_ENABLED=true``, the MCPBearerTokenMiddleware enforces
 # ``Authorization: Bearer <token>`` on requests that OIDC has not already
@@ -187,3 +196,11 @@ ACM_MCP_TOKEN: str = os.getenv("ACM_MCP_TOKEN", "")
 # at the call site even though the registry still advertises them. ``FULL``
 # allows all tools. See ``mcp/access_profile.py`` for the WRITE list.
 ACM_MCP_ACCESS_PROFILE: AccessProfile = parse_profile(os.getenv("ACM_MCP_ACCESS_PROFILE", "read_only"))
+# B2 — escape hatch for the anonymous-MCP-exposure refusal in main.py.
+# Without this flag the API process refuses to start when
+# ``ACM_MCP_ENABLED=true`` AND OIDC is disabled AND ``ACM_MCP_TOKEN`` is
+# empty, because that combination publishes the MCP surface to the
+# entire network with no auth. Operators who are genuinely on a localhost
+# loopback or behind a sealed-off ingress can opt back in here, but the
+# refusal is the default for a reason.
+ACM_MCP_ALLOW_ANONYMOUS: bool = _get_bool("ACM_MCP_ALLOW_ANONYMOUS", False)

--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -192,7 +192,7 @@ ACM_MCP_PATH = ACM_MCP_PATH.rstrip("/")
 # and defers to OIDC. Used by clients that cannot perform a full OAuth
 # Authorization Code flow (CI agents, headless scripts).
 ACM_MCP_TOKEN: str = os.getenv("ACM_MCP_TOKEN", "")
-# Voyager-style call-time gate. ``READ_ONLY`` (default) blocks WRITE tools
+# Call-time access gate. ``READ_ONLY`` (default) blocks WRITE tools
 # at the call site even though the registry still advertises them. ``FULL``
 # allows all tools. See ``mcp/access_profile.py`` for the WRITE list.
 ACM_MCP_ACCESS_PROFILE: AccessProfile = parse_profile(os.getenv("ACM_MCP_ACCESS_PROFILE", "read_only"))

--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -176,6 +176,13 @@ OIDC_EXCLUDE_PATHS: list[str] = _parse_str_list(
 # applies via the OIDC middleware when ``OIDC_ENABLED`` is true.
 ACM_MCP_ENABLED: bool = _get_bool("ACM_MCP_ENABLED", False)
 ACM_MCP_PATH: str = os.getenv("ACM_MCP_PATH", "/mcp")
+# Optional shared-secret bearer token for the ``/mcp`` surface. When set
+# alongside ``ACM_MCP_ENABLED=true``, the MCPBearerTokenMiddleware enforces
+# ``Authorization: Bearer <token>`` on requests that OIDC has not already
+# authenticated. Empty string (default) disables the bearer leg entirely
+# and defers to OIDC. Used by clients that cannot perform a full OAuth
+# Authorization Code flow (CI agents, headless scripts).
+ACM_MCP_TOKEN: str = os.getenv("ACM_MCP_TOKEN", "")
 # Voyager-style call-time gate. ``READ_ONLY`` (default) blocks WRITE tools
 # at the call site even though the registry still advertises them. ``FULL``
 # allows all tools. See ``mcp/access_profile.py`` for the WRITE list.

--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -4,6 +4,8 @@ import json
 import os
 import re
 
+from aerospike_cluster_manager_api.mcp.access_profile import AccessProfile, parse_profile
+
 
 def _get_int(name: str, default: int) -> int:
     """Parse an integer environment variable with validation."""
@@ -174,3 +176,7 @@ OIDC_EXCLUDE_PATHS: list[str] = _parse_str_list(
 # applies via the OIDC middleware when ``OIDC_ENABLED`` is true.
 ACM_MCP_ENABLED: bool = _get_bool("ACM_MCP_ENABLED", False)
 ACM_MCP_PATH: str = os.getenv("ACM_MCP_PATH", "/mcp")
+# Voyager-style call-time gate. ``READ_ONLY`` (default) blocks WRITE tools
+# at the call site even though the registry still advertises them. ``FULL``
+# allows all tools. See ``mcp/access_profile.py`` for the WRITE list.
+ACM_MCP_ACCESS_PROFILE: AccessProfile = parse_profile(os.getenv("ACM_MCP_ACCESS_PROFILE", "read_only"))

--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -16,6 +16,19 @@ def _get_int(name: str, default: int) -> int:
         raise ValueError(f"Environment variable {name} must be an integer, got: {raw!r}") from None
 
 
+def _get_bool(name: str, default: bool) -> bool:
+    """Parse a boolean environment variable.
+
+    Accepts ``1``/``true``/``yes``/``on`` (case-insensitive, surrounding
+    whitespace ignored) as truthy. Anything else is falsy. Unset returns
+    the supplied default.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
 _DURATION_RE = re.compile(r"^(?P<value>\d+)(?P<unit>[smhd]?)$")
 
 
@@ -149,3 +162,15 @@ OIDC_JWKS_CACHE_TTL_SECONDS: int = _parse_duration_seconds(os.getenv("OIDC_JWKS_
 OIDC_EXCLUDE_PATHS: list[str] = _parse_str_list(
     os.getenv("OIDC_EXCLUDE_PATHS", "/api/health,/api/openapi.json,/api/docs")
 ) or ["/api/health", "/api/openapi.json", "/api/docs"]
+
+# ---------------------------------------------------------------------------
+# MCP (Model Context Protocol) server — phase 1
+# ---------------------------------------------------------------------------
+# When enabled, ``main.py`` mounts the FastMCP streamable-http transport at
+# ``ACM_MCP_PATH``. The mount is opt-in so deployments that don't need the
+# AI/agent surface pay no extra import or routing cost. The path is kept
+# outside ``/api/*`` on purpose — REST and MCP serve different consumers
+# and should be reasoned about as independent surfaces. Authentication still
+# applies via the OIDC middleware when ``OIDC_ENABLED`` is true.
+ACM_MCP_ENABLED: bool = _get_bool("ACM_MCP_ENABLED", False)
+ACM_MCP_PATH: str = os.getenv("ACM_MCP_PATH", "/mcp")

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -52,6 +52,9 @@ setup_logging(config.LOG_LEVEL, config.LOG_FORMAT)
 logger = logging.getLogger(__name__)
 
 
+_mcp_app = None  # populated below when ACM_MCP_ENABLED so lifespan can drive its session_manager
+
+
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     logger.info("Starting Aerospike Cluster Manager API")
@@ -62,7 +65,15 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     if config.SSE_ENABLED:
         await collector.start()
 
-    yield
+    # FastMCP's streamable_http_app spawns a session_manager whose async task
+    # group is bootstrapped in its OWN lifespan. Mounted Starlette sub-apps
+    # do NOT share lifespan with the parent FastAPI, so we drive the MCP
+    # session_manager from here directly.
+    if _mcp_app is not None:
+        async with _mcp_app.session_manager.run():
+            yield
+    else:
+        yield
 
     if config.SSE_ENABLED:
         await collector.stop()

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -269,38 +269,44 @@ async def security_headers_middleware(request: Request, call_next: RequestRespon
 
 
 # OIDCAuthMiddleware is added BEFORE TraceIDMiddleware so the runtime
-# layering becomes (outermost → innermost): TraceID → OIDC → security_headers
-# → request_logging → CORS → SlowAPI. That way every authenticated request
-# already has a request_id in scope when the JWT verifier logs, and CORS
-# preflight responses are still produced even when the bearer token is
-# missing/invalid (the OIDC dispatch short-circuits OPTIONS so CORSMiddleware
-# downstream answers the preflight).
-# The MCP bearer-token middleware is installed BEFORE OIDC in the
+# layering becomes (outermost → innermost): TraceID → MCP → OIDC →
+# security_headers → request_logging → CORS → SlowAPI. That way every
+# authenticated request already has a request_id in scope when the JWT
+# verifier logs, and CORS preflight responses are still produced even
+# when the bearer token is missing/invalid (the OIDC dispatch
+# short-circuits OPTIONS so CORSMiddleware downstream answers the
+# preflight).
+# The MCP bearer-token middleware is installed AFTER OIDC in the
 # ``add_middleware`` order so that — given Starlette's reverse-add
-# semantics — it runs AFTER OIDC at request time. That ordering is
-# critical: by the time MCPBearerTokenMiddleware.dispatch() runs, OIDC
-# has already had a chance to set ``request.state.user``, which the MCP
-# middleware reads to short-circuit the bearer check (OIDC-OR-bearer).
+# semantics — it runs BEFORE OIDC at request time. That ordering is
+# critical for the OIDC-OR-bearer gate: a bearer-only token (opaque,
+# not a JWT) must be accepted/rejected by MCP middleware *before* OIDC
+# tries to JWT-verify it and 401s on the way in. On a successful
+# bearer match MCP middleware sets a sentinel ``request.state.user_claims``
+# so the inner OIDCAuthMiddleware defers (it short-circuits when
+# user_claims is already populated). When OIDC is enabled and the
+# bearer doesn't match, MCP middleware falls through and lets OIDC try
+# the header as a JWT — preserving the documented OR semantic.
 # We install only when ``ACM_MCP_ENABLED=true`` — when the mount itself
 # is off, the path doesn't exist and the middleware would be dead weight.
-if config.ACM_MCP_ENABLED:
-    # B2 — refuse to start when the MCP surface would be unauthenticated.
-    # OIDC OR a shared-secret bearer token must be configured, otherwise
-    # ``/mcp/*`` would be open to any network peer that can reach the API
-    # port. ``ACM_MCP_ALLOW_ANONYMOUS=true`` is the documented escape
-    # hatch for localhost-only or trusted-network deployments.
-    if not config.OIDC_ENABLED and not config.ACM_MCP_TOKEN and not config.ACM_MCP_ALLOW_ANONYMOUS:
-        raise RuntimeError(
-            "ACM_MCP_ENABLED=true but neither OIDC nor ACM_MCP_TOKEN is configured. "
-            "Refusing to start an anonymous MCP surface. Set OIDC_ENABLED=true and "
-            "OIDC_ISSUER_URL, OR set ACM_MCP_TOKEN to a shared secret, OR set "
-            "ACM_MCP_ALLOW_ANONYMOUS=true if you have verified the deployment is "
-            "isolated to localhost / a trusted network."
-        )
-
-    from aerospike_cluster_manager_api.mcp.auth import MCPBearerTokenMiddleware
-
-    app.add_middleware(MCPBearerTokenMiddleware)
+# B2 — refuse to start when the MCP surface would be unauthenticated.
+# OIDC OR a shared-secret bearer token must be configured, otherwise
+# ``/mcp/*`` would be open to any network peer that can reach the API
+# port. ``ACM_MCP_ALLOW_ANONYMOUS=true`` is the documented escape
+# hatch for localhost-only or trusted-network deployments.
+if (
+    config.ACM_MCP_ENABLED
+    and not config.OIDC_ENABLED
+    and not config.ACM_MCP_TOKEN
+    and not config.ACM_MCP_ALLOW_ANONYMOUS
+):
+    raise RuntimeError(
+        "ACM_MCP_ENABLED=true but neither OIDC nor ACM_MCP_TOKEN is configured. "
+        "Refusing to start an anonymous MCP surface. Set OIDC_ENABLED=true and "
+        "OIDC_ISSUER_URL, OR set ACM_MCP_TOKEN to a shared secret, OR set "
+        "ACM_MCP_ALLOW_ANONYMOUS=true if you have verified the deployment is "
+        "isolated to localhost / a trusted network."
+    )
 
 if config.OIDC_ENABLED:
     app.add_middleware(
@@ -312,6 +318,11 @@ if config.OIDC_ENABLED:
         exclude_paths=config.OIDC_EXCLUDE_PATHS,
         jwks_cache_ttl_seconds=config.OIDC_JWKS_CACHE_TTL_SECONDS,
     )
+
+if config.ACM_MCP_ENABLED:
+    from aerospike_cluster_manager_api.mcp.auth import MCPBearerTokenMiddleware
+
+    app.add_middleware(MCPBearerTokenMiddleware)
 
 # TraceIDMiddleware is registered AFTER all other middleware (CORS, SlowAPI,
 # request_logging, security_headers, OIDC) so that — given Starlette's

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -431,6 +431,18 @@ for r in _routers:
 app.include_router(v1_router)
 app.include_router(api_router)
 
+# ---------------------------------------------------------------------------
+# MCP (Model Context Protocol) — opt-in mount
+# ---------------------------------------------------------------------------
+# Mounted AFTER the REST router includes so the MCP path stays a sibling of
+# /api/* (different consumer, different auth/UX). The import is local so a
+# disabled flag pays no import cost at startup.
+if config.ACM_MCP_ENABLED:
+    from aerospike_cluster_manager_api.mcp.server import build_mcp_app
+
+    _mcp_app = build_mcp_app()
+    app.mount(config.ACM_MCP_PATH, _mcp_app.streamable_http_app())
+
 # FastAPIInstrumentor wraps every route handler with a server span. The
 # wiring is a no-op when OTel is disabled (NoOp tracer). We exclude the
 # health and docs endpoints from instrumentation because they're high-volume

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -52,6 +52,16 @@ setup_logging(config.LOG_LEVEL, config.LOG_FORMAT)
 logger = logging.getLogger(__name__)
 
 
+# ORDERING INVARIANT: this module-global is SET by the MCP mount block
+# below at module-import time (see ``if config.ACM_MCP_ENABLED:`` further
+# down — it assigns ``_mcp_app = build_mcp_app()``), and READ by
+# ``lifespan()`` at FastAPI startup to drive the FastMCP session_manager.
+# The two events happen in different phases of the process lifecycle, so
+# leaving the variable as a module-level binding (rather than a closure
+# or app.state attribute) is intentional. Don't move this declaration
+# below the mount block — Python would still resolve the name at call
+# time, but the explicit ``None`` default is what makes the
+# else-branch in lifespan() correct when MCP is disabled.
 _mcp_app = None  # populated below when ACM_MCP_ENABLED so lifespan can drive its session_manager
 
 
@@ -274,6 +284,20 @@ async def security_headers_middleware(request: Request, call_next: RequestRespon
 # We install only when ``ACM_MCP_ENABLED=true`` — when the mount itself
 # is off, the path doesn't exist and the middleware would be dead weight.
 if config.ACM_MCP_ENABLED:
+    # B2 — refuse to start when the MCP surface would be unauthenticated.
+    # OIDC OR a shared-secret bearer token must be configured, otherwise
+    # ``/mcp/*`` would be open to any network peer that can reach the API
+    # port. ``ACM_MCP_ALLOW_ANONYMOUS=true`` is the documented escape
+    # hatch for localhost-only or trusted-network deployments.
+    if not config.OIDC_ENABLED and not config.ACM_MCP_TOKEN and not config.ACM_MCP_ALLOW_ANONYMOUS:
+        raise RuntimeError(
+            "ACM_MCP_ENABLED=true but neither OIDC nor ACM_MCP_TOKEN is configured. "
+            "Refusing to start an anonymous MCP surface. Set OIDC_ENABLED=true and "
+            "OIDC_ISSUER_URL, OR set ACM_MCP_TOKEN to a shared secret, OR set "
+            "ACM_MCP_ALLOW_ANONYMOUS=true if you have verified the deployment is "
+            "isolated to localhost / a trusted network."
+        )
+
     from aerospike_cluster_manager_api.mcp.auth import MCPBearerTokenMiddleware
 
     app.add_middleware(MCPBearerTokenMiddleware)

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -254,6 +254,19 @@ async def security_headers_middleware(request: Request, call_next: RequestRespon
 # preflight responses are still produced even when the bearer token is
 # missing/invalid (the OIDC dispatch short-circuits OPTIONS so CORSMiddleware
 # downstream answers the preflight).
+# The MCP bearer-token middleware is installed BEFORE OIDC in the
+# ``add_middleware`` order so that — given Starlette's reverse-add
+# semantics — it runs AFTER OIDC at request time. That ordering is
+# critical: by the time MCPBearerTokenMiddleware.dispatch() runs, OIDC
+# has already had a chance to set ``request.state.user``, which the MCP
+# middleware reads to short-circuit the bearer check (OIDC-OR-bearer).
+# We install only when ``ACM_MCP_ENABLED=true`` — when the mount itself
+# is off, the path doesn't exist and the middleware would be dead weight.
+if config.ACM_MCP_ENABLED:
+    from aerospike_cluster_manager_api.mcp.auth import MCPBearerTokenMiddleware
+
+    app.add_middleware(MCPBearerTokenMiddleware)
+
 if config.OIDC_ENABLED:
     app.add_middleware(
         OIDCAuthMiddleware,

--- a/api/src/aerospike_cluster_manager_api/mcp/__init__.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/__init__.py
@@ -1,0 +1,6 @@
+"""ACM MCP server package.
+
+Hosts the Model Context Protocol surface for the Aerospike Cluster
+Manager API. Tools, registry, access profile, auth, serializers and
+errors are added in subsequent tasks (A.7+).
+"""

--- a/api/src/aerospike_cluster_manager_api/mcp/access_profile.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/access_profile.py
@@ -29,6 +29,12 @@ class AccessProfile(StrEnum):
     READ_ONLY = "read_only"
 
 
+# Kept in sync with ``@tool(mutation=True)`` decorations via the
+# registry-time consistency assertion in ``mcp/registry.py`` (M3). When
+# you add a new mutation tool you MUST update both this set and the
+# decorator on the tool function — the assertion will refuse the import
+# if they disagree, which is the desired behavior (fail loudly rather
+# than silently fail-open under READ_ONLY).
 WRITE_TOOLS: frozenset[str] = frozenset(
     {
         "create_connection",

--- a/api/src/aerospike_cluster_manager_api/mcp/access_profile.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/access_profile.py
@@ -1,6 +1,6 @@
 """MCP access profile gate.
 
-A Voyager-style read-only mode for the MCP surface: the registry exposes
+A call-time read-only mode for the MCP surface: the registry exposes
 all tools to the model, but ``is_blocked`` rejects writes at call time
 when the deployment is configured ``READ_ONLY``. Keeping the gate at the
 call site (rather than at registration time) means the same FastMCP

--- a/api/src/aerospike_cluster_manager_api/mcp/access_profile.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/access_profile.py
@@ -1,0 +1,64 @@
+"""MCP access profile gate.
+
+A Voyager-style read-only mode for the MCP surface: the registry exposes
+all tools to the model, but ``is_blocked`` rejects writes at call time
+when the deployment is configured ``READ_ONLY``. Keeping the gate at the
+call site (rather than at registration time) means the same FastMCP
+instance can serve both read-only and full deployments — only the
+profile differs.
+
+This module is intentionally dependency-free (stdlib only). ``config.py``
+imports from here, so importing ``config`` back from this module would
+create a cycle. Don't.
+
+Authoritative WRITE list — do not extend without updating
+``docs/plans/2026-05-07-acm-mcp-design.md`` Section 4. ``execute_info``
+and ``execute_info_on_node`` are WRITE because asinfo can mutate cluster
+configuration (``set-config``, ``recluster``, etc.).
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+
+class AccessProfile(StrEnum):
+    """Deployment-level capability gate for MCP tool calls."""
+
+    FULL = "full"
+    READ_ONLY = "read_only"
+
+
+WRITE_TOOLS: frozenset[str] = frozenset(
+    {
+        "create_connection",
+        "update_connection",
+        "delete_connection",
+        "create_record",
+        "update_record",
+        "delete_record",
+        "delete_bin",
+        "truncate_set",
+        "execute_info",
+        "execute_info_on_node",
+    }
+)
+
+
+def is_blocked(tool_name: str, profile: AccessProfile) -> bool:
+    """Return True iff ``tool_name`` must be rejected under ``profile``.
+
+    Unknown tool names are not blocked (default-allow). The MCP registry
+    decides which names exist; this gate only filters what's allowed to
+    run within that set.
+    """
+    return profile is AccessProfile.READ_ONLY and tool_name in WRITE_TOOLS
+
+
+def parse_profile(value: str) -> AccessProfile:
+    """Parse a case-insensitive profile string. Raises ``ValueError`` on unknown."""
+    try:
+        return AccessProfile(value.strip().lower())
+    except ValueError as e:
+        valid = ", ".join(p.value for p in AccessProfile)
+        raise ValueError(f"Unknown access profile {value!r}; valid values: {valid}") from e

--- a/api/src/aerospike_cluster_manager_api/mcp/auth.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/auth.py
@@ -1,0 +1,105 @@
+"""MCP bearer-token middleware (OIDC-OR-bearer).
+
+The middleware sits in front of the MCP mount and applies an
+OR-combined gate with the existing OIDC middleware:
+
+* It runs ONLY on requests whose ``url.path`` begins with
+  ``config.ACM_MCP_PATH`` (default ``/mcp``). Non-MCP paths are
+  passed through unchanged regardless of token settings.
+
+* If ``ACM_MCP_TOKEN`` is unset, the middleware delegates entirely
+  to OIDC — it does not 401 on its own. This is the production
+  default for deployments that secure the MCP surface via the same
+  Keycloak realm as the REST API.
+
+* If ``ACM_MCP_TOKEN`` is set, the request passes when EITHER:
+    - OIDC has already authenticated the request (i.e.
+      ``request.state.user`` is non-None), OR
+    - The ``Authorization`` header carries a matching
+      ``Bearer <token>`` value.
+  Otherwise the middleware returns ``401 {"detail": "MCP authentication
+  required"}``.
+
+Token comparison uses :func:`secrets.compare_digest` so the wall-clock
+cost is independent of the prefix match length — which closes a timing
+side-channel in naive ``==`` comparisons. The configured and supplied
+tokens are NEVER logged.
+
+Wiring lives in :mod:`aerospike_cluster_manager_api.main`. The
+middleware is installed only when ``ACM_MCP_ENABLED=true``; when that
+flag is false the MCP mount itself does not exist, so installing the
+middleware would be dead weight.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import JSONResponse, Response
+
+from aerospike_cluster_manager_api import config
+
+logger = logging.getLogger(__name__)
+
+
+_UNAUTHORIZED_BODY: dict[str, str] = {"detail": "MCP authentication required"}
+
+
+class MCPBearerTokenMiddleware(BaseHTTPMiddleware):
+    """Bearer-token gate for the ``/mcp/*`` mount.
+
+    See module docstring for the full truth table. This class
+    intentionally has no ``__init__`` overrides — all knobs come from
+    :mod:`aerospike_cluster_manager_api.config` and are read at
+    request time, so test code can monkeypatch + ``importlib.reload``
+    the config module without re-instantiating the middleware.
+    """
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: RequestResponseEndpoint,
+    ) -> Response:
+        # Read path-prefix from config at request time so deployments
+        # that override ACM_MCP_PATH still gate correctly.
+        if not request.url.path.startswith(config.ACM_MCP_PATH):
+            return await call_next(request)
+
+        token = config.ACM_MCP_TOKEN
+        if not token:
+            # No MCP-specific token configured. Defer to OIDC, which
+            # runs unconditionally on all paths in main.py's middleware
+            # stack. If OIDC is also disabled, the request is anonymous
+            # — that's the operator's choice.
+            return await call_next(request)
+
+        # OR-leg #1: already authenticated via OIDC.
+        if getattr(request.state, "user", None) is not None:
+            return await call_next(request)
+
+        # OR-leg #2: bearer header matches the configured token.
+        header = request.headers.get("authorization", "")
+        if not header.lower().startswith("bearer "):
+            logger.warning(
+                "MCP request rejected: missing or non-bearer Authorization header (path=%s)",
+                request.url.path,
+            )
+            return JSONResponse(_UNAUTHORIZED_BODY, status_code=401)
+
+        # ``split(" ", 1)`` after the lower-case prefix check above is
+        # safe because the header is known to start with ``bearer <space>``.
+        supplied = header.split(" ", 1)[1].strip()
+        if not supplied or not secrets.compare_digest(supplied, token):
+            # Do NOT log the supplied or configured token — this branch
+            # is the most likely to leak secrets if a future maintainer
+            # adds debug logging carelessly.
+            logger.warning(
+                "MCP request rejected: bearer token mismatch (path=%s)",
+                request.url.path,
+            )
+            return JSONResponse(_UNAUTHORIZED_BODY, status_code=401)
+
+        return await call_next(request)

--- a/api/src/aerospike_cluster_manager_api/mcp/auth.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/auth.py
@@ -14,11 +14,12 @@ OR-combined gate with the existing OIDC middleware:
 
 * If ``ACM_MCP_TOKEN`` is set, the request passes when EITHER:
     - OIDC has already authenticated the request (i.e.
-      ``request.state.user`` is non-None), OR
+      ``request.state.user_claims`` is non-None), OR
     - The ``Authorization`` header carries a matching
       ``Bearer <token>`` value.
   Otherwise the middleware returns ``401 {"detail": "MCP authentication
-  required"}``.
+  required"}`` with a ``WWW-Authenticate: Bearer realm="acm-mcp"``
+  header so RFC-7235-compliant clients know the challenge scheme.
 
 Token comparison uses :func:`secrets.compare_digest` so the wall-clock
 cost is independent of the prefix match length — which closes a timing
@@ -46,6 +47,17 @@ logger = logging.getLogger(__name__)
 
 
 _UNAUTHORIZED_BODY: dict[str, str] = {"detail": "MCP authentication required"}
+_UNAUTHORIZED_HEADERS: dict[str, str] = {"WWW-Authenticate": 'Bearer realm="acm-mcp"'}
+
+
+def _unauthorized() -> JSONResponse:
+    """Build the canonical 401 response for the MCP gate.
+
+    Centralized so both call sites (missing/non-bearer header and
+    bearer token mismatch) emit the same body AND the same
+    ``WWW-Authenticate`` challenge header (M4).
+    """
+    return JSONResponse(_UNAUTHORIZED_BODY, status_code=401, headers=_UNAUTHORIZED_HEADERS)
 
 
 class MCPBearerTokenMiddleware(BaseHTTPMiddleware):
@@ -64,8 +76,14 @@ class MCPBearerTokenMiddleware(BaseHTTPMiddleware):
         call_next: RequestResponseEndpoint,
     ) -> Response:
         # Read path-prefix from config at request time so deployments
-        # that override ACM_MCP_PATH still gate correctly.
-        if not request.url.path.startswith(config.ACM_MCP_PATH):
+        # that override ACM_MCP_PATH still gate correctly. We compare on
+        # path-segment boundaries (M1): exact match against ``base`` OR
+        # path begins with ``base + "/"``. A naive ``startswith(base)``
+        # would let ``/mcp-evil/foo`` slip past the gate when
+        # ACM_MCP_PATH is ``/mcp``.
+        path = request.url.path
+        base = config.ACM_MCP_PATH
+        if path != base and not path.startswith(base.rstrip("/") + "/"):
             return await call_next(request)
 
         token = config.ACM_MCP_TOKEN
@@ -88,12 +106,23 @@ class MCPBearerTokenMiddleware(BaseHTTPMiddleware):
                 "MCP request rejected: missing or non-bearer Authorization header (path=%s)",
                 request.url.path,
             )
-            return JSONResponse(_UNAUTHORIZED_BODY, status_code=401)
+            return _unauthorized()
 
         # ``split(" ", 1)`` after the lower-case prefix check above is
         # safe because the header is known to start with ``bearer <space>``.
         supplied = header.split(" ", 1)[1].strip()
-        if not supplied or not secrets.compare_digest(supplied, token):
+        # ``secrets.compare_digest`` raises TypeError on non-ASCII ``str``
+        # inputs (e.g. ``Bearer café``). Encode to UTF-8 bytes inside a
+        # try/except so a hostile or malformed header can never crash the
+        # middleware — any encoding error is treated as auth failure (B1).
+        # The constant-time guarantee is preserved by feeding both sides
+        # equal-length-handling bytes; ``compare_digest`` itself handles
+        # length mismatches in constant time relative to the longer input.
+        try:
+            ok = secrets.compare_digest(supplied.encode("utf-8"), token.encode("utf-8"))
+        except Exception:
+            ok = False
+        if not supplied or not ok:
             # Do NOT log the supplied or configured token — this branch
             # is the most likely to leak secrets if a future maintainer
             # adds debug logging carelessly.
@@ -101,6 +130,6 @@ class MCPBearerTokenMiddleware(BaseHTTPMiddleware):
                 "MCP request rejected: bearer token mismatch (path=%s)",
                 request.url.path,
             )
-            return JSONResponse(_UNAUTHORIZED_BODY, status_code=401)
+            return _unauthorized()
 
         return await call_next(request)

--- a/api/src/aerospike_cluster_manager_api/mcp/auth.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/auth.py
@@ -1,30 +1,40 @@
 """MCP bearer-token middleware (OIDC-OR-bearer).
 
 The middleware sits in front of the MCP mount and applies an
-OR-combined gate with the existing OIDC middleware:
+OR-combined gate with the existing OIDC middleware. It is installed
+OUTSIDE OIDC at request time (added LAST in main.py) so the bearer
+leg runs first and can short-circuit past OIDC.
 
 * It runs ONLY on requests whose ``url.path`` begins with
   ``config.ACM_MCP_PATH`` (default ``/mcp``). Non-MCP paths are
-  passed through unchanged regardless of token settings.
+  passed through unchanged regardless of token settings. Path matching
+  is on segment boundaries (exact match or ``base + "/"``) so a route
+  named ``/mcp-evil/...`` cannot impersonate the MCP surface.
 
 * If ``ACM_MCP_TOKEN`` is unset, the middleware delegates entirely
   to OIDC — it does not 401 on its own. This is the production
   default for deployments that secure the MCP surface via the same
   Keycloak realm as the REST API.
 
-* If ``ACM_MCP_TOKEN`` is set, the request passes when EITHER:
-    - OIDC has already authenticated the request (i.e.
-      ``request.state.user_claims`` is non-None), OR
-    - The ``Authorization`` header carries a matching
-      ``Bearer <token>`` value.
-  Otherwise the middleware returns ``401 {"detail": "MCP authentication
-  required"}`` with a ``WWW-Authenticate: Bearer realm="acm-mcp"``
-  header so RFC-7235-compliant clients know the challenge scheme.
+* If ``ACM_MCP_TOKEN`` is set:
+    - Bearer matches the configured token → set a sentinel
+      ``request.state.user_claims = {"sub": "mcp-bearer", ...}`` so
+      :class:`OIDCAuthMiddleware` defers, and pass through.
+    - Bearer mismatch (or no Authorization header) and OIDC is
+      enabled → fall through to OIDC, which will authenticate the
+      request as a JWT or 401 itself (the OR semantic).
+    - Bearer mismatch (or no Authorization header) and OIDC is
+      disabled → 401 ``{"detail": "MCP authentication required"}``
+      with a ``WWW-Authenticate: Bearer realm="acm-mcp"`` header so
+      RFC-7235-compliant clients know the challenge scheme.
 
 Token comparison uses :func:`secrets.compare_digest` so the wall-clock
 cost is independent of the prefix match length — which closes a timing
-side-channel in naive ``==`` comparisons. The configured and supplied
-tokens are NEVER logged.
+side-channel in naive ``==`` comparisons. Inputs are UTF-8-encoded
+inside a try/except so a hostile or malformed header (non-ASCII bytes,
+encoding errors) can never crash the middleware; any failure is
+treated as auth failure. The configured and supplied tokens are NEVER
+logged.
 
 Wiring lives in :mod:`aerospike_cluster_manager_api.main`. The
 middleware is installed only when ``ACM_MCP_ENABLED=true``; when that
@@ -94,42 +104,56 @@ class MCPBearerTokenMiddleware(BaseHTTPMiddleware):
             # — that's the operator's choice.
             return await call_next(request)
 
-        # OR-leg #1: already authenticated via OIDC. The OIDC middleware
-        # writes ``request.state.user_claims`` on success.
+        # OR-leg #1: already authenticated upstream (rare — usually
+        # OIDC runs INNER to this middleware, but a future stack might
+        # add another auth layer outside us).
         if getattr(request.state, "user_claims", None) is not None:
             return await call_next(request)
 
         # OR-leg #2: bearer header matches the configured token.
         header = request.headers.get("authorization", "")
-        if not header.lower().startswith("bearer "):
-            logger.warning(
-                "MCP request rejected: missing or non-bearer Authorization header (path=%s)",
-                request.url.path,
-            )
-            return _unauthorized()
+        if header.lower().startswith("bearer "):
+            # ``split(" ", 1)`` after the lower-case prefix check above is
+            # safe because the header is known to start with ``bearer <space>``.
+            supplied = header.split(" ", 1)[1].strip()
+            # ``secrets.compare_digest`` raises TypeError on non-ASCII ``str``
+            # inputs (e.g. ``Bearer café``). Encode to UTF-8 bytes inside a
+            # try/except so a hostile or malformed header can never crash the
+            # middleware — any encoding error is treated as auth failure (B1).
+            try:
+                ok = bool(supplied) and secrets.compare_digest(supplied.encode("utf-8"), token.encode("utf-8"))
+            except Exception:
+                ok = False
+            if ok:
+                # Bearer matches — set a sentinel claim so the inner
+                # OIDCAuthMiddleware defers (it short-circuits when
+                # user_claims is already populated) and the request
+                # reaches the MCP mount without OIDC trying to verify
+                # an opaque token as a JWT.
+                request.state.user_claims = {"sub": "mcp-bearer", "_mcp_bearer": True}
+                return await call_next(request)
+            # Bearer-shaped header but mismatch. If OIDC is enabled,
+            # give it a chance to verify the header as a JWT (the
+            # OIDC-OR-bearer semantic). If OIDC is disabled, we are the
+            # only gate, so 401.
+            if not config.OIDC_ENABLED:
+                # Do NOT log the supplied or configured token — this branch
+                # is the most likely to leak secrets if a future maintainer
+                # adds debug logging carelessly.
+                logger.warning(
+                    "MCP request rejected: bearer token mismatch (path=%s)",
+                    request.url.path,
+                )
+                return _unauthorized()
+            # OIDC will run next; let it try (or 401 itself).
+            return await call_next(request)
 
-        # ``split(" ", 1)`` after the lower-case prefix check above is
-        # safe because the header is known to start with ``bearer <space>``.
-        supplied = header.split(" ", 1)[1].strip()
-        # ``secrets.compare_digest`` raises TypeError on non-ASCII ``str``
-        # inputs (e.g. ``Bearer café``). Encode to UTF-8 bytes inside a
-        # try/except so a hostile or malformed header can never crash the
-        # middleware — any encoding error is treated as auth failure (B1).
-        # The constant-time guarantee is preserved by feeding both sides
-        # equal-length-handling bytes; ``compare_digest`` itself handles
-        # length mismatches in constant time relative to the longer input.
-        try:
-            ok = secrets.compare_digest(supplied.encode("utf-8"), token.encode("utf-8"))
-        except Exception:
-            ok = False
-        if not supplied or not ok:
-            # Do NOT log the supplied or configured token — this branch
-            # is the most likely to leak secrets if a future maintainer
-            # adds debug logging carelessly.
-            logger.warning(
-                "MCP request rejected: bearer token mismatch (path=%s)",
-                request.url.path,
-            )
-            return _unauthorized()
-
-        return await call_next(request)
+        # No bearer-shaped Authorization header. Fall through to OIDC if
+        # enabled; otherwise 401 — there is no other auth gate.
+        if config.OIDC_ENABLED:
+            return await call_next(request)
+        logger.warning(
+            "MCP request rejected: missing or non-bearer Authorization header (path=%s)",
+            request.url.path,
+        )
+        return _unauthorized()

--- a/api/src/aerospike_cluster_manager_api/mcp/auth.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/auth.py
@@ -76,8 +76,9 @@ class MCPBearerTokenMiddleware(BaseHTTPMiddleware):
             # — that's the operator's choice.
             return await call_next(request)
 
-        # OR-leg #1: already authenticated via OIDC.
-        if getattr(request.state, "user", None) is not None:
+        # OR-leg #1: already authenticated via OIDC. The OIDC middleware
+        # writes ``request.state.user_claims`` on success.
+        if getattr(request.state, "user_claims", None) is not None:
             return await call_next(request)
 
         # OR-leg #2: bearer header matches the configured token.

--- a/api/src/aerospike_cluster_manager_api/mcp/errors.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/errors.py
@@ -1,0 +1,127 @@
+"""CE-aware MCP error mapping.
+
+The MCP tool wrappers (B.1+) and the registry decorator (A.12) call
+:func:`map_aerospike_errors` to translate aerospike-py exceptions and
+service-layer domain errors into :class:`MCPToolError` instances with
+stable, user-facing wording.
+
+Wire-message wording follows
+``docs/plans/2026-05-07-acm-mcp-design.md`` Section 4.
+
+Design notes:
+
+* :class:`MCPToolError` is a plain :class:`Exception` subclass — keeps
+  ``except`` clauses in the registry decorator simple and avoids any
+  framework coupling (no fastapi/HTTPException).
+* Only specific known aerospike-py subclasses are mapped. The base
+  :class:`aerospike_py.exception.AerospikeError` is intentionally **not**
+  caught: unknown errors propagate so the registry can log them and
+  return a generic ``isError`` block without masking real bugs.
+* :func:`raise_ce_unsupported` is the canonical helper for code paths
+  that hit enterprise-only features (XDR shipping, TLS, etc.) — keeps
+  Phase 2 K8s tooling consistent with Phase 1 wording.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from collections.abc import Iterator
+from typing import Any
+
+import aerospike_py
+
+from aerospike_cluster_manager_api.services.clusters_service import (
+    NamespaceConfigError,
+    NamespaceNotFoundError,
+    NodeNotFoundError,
+)
+from aerospike_cluster_manager_api.services.connections_service import (
+    ConnectionNotFoundError,
+    WorkspaceNotFoundError,
+)
+from aerospike_cluster_manager_api.services.records_service import (
+    InvalidPkPattern,
+    PrimaryKeyMissing,
+    SetRequiredForPkLookup,
+)
+
+
+class MCPToolError(Exception):
+    """Wire-level error surfaced as an MCP ``isError`` content block.
+
+    ``code`` is an optional machine-readable hint (e.g. ``"record_not_found"``)
+    that the registry decorator can attach to OTel spans or the structured
+    log line. The user-facing message is the standard exception ``str()``.
+    """
+
+    def __init__(self, message: str, *, code: str | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def raise_ce_unsupported(feature: str) -> None:
+    """Raise an :class:`MCPToolError` for an enterprise-only code path.
+
+    Used by Phase 2 K8s tooling and any tool wrapper that hits an
+    enterprise-only feature (XDR shipping, TLS, ACL beyond CE limits).
+    The wording matches Section 4 of the design doc verbatim.
+    """
+    raise MCPToolError(
+        f"This operation is not supported on Aerospike CE 8.1: {feature}",
+        code="ce_unsupported",
+    )
+
+
+def _record_ident(ns: str | None, set_name: str | None, key: Any) -> str:
+    """Format a ``"{ns}/{set}/{key}"`` suffix for record-level errors.
+
+    Returns an empty string if any of the three are missing — callers
+    fall back to the bare ``"Record not found"`` form in that case.
+    """
+    if ns is None or set_name is None or key is None:
+        return ""
+    return f": {ns}/{set_name}/{key}"
+
+
+@contextlib.contextmanager
+def map_aerospike_errors(
+    *,
+    ns: str | None = None,
+    set_name: str | None = None,
+    key: Any = None,
+) -> Iterator[None]:
+    """Translate known errors into :class:`MCPToolError`.
+
+    Optional ``ns``/``set_name``/``key`` provide context for record-level
+    messages — when all three are supplied, the wire message includes
+    ``": {ns}/{set}/{key}"`` so the model can address the bad record
+    directly. Otherwise the bare form is used.
+
+    Other exceptions (including the aerospike-py base
+    :class:`aerospike_py.exception.AerospikeError`) propagate unchanged
+    so the caller's ``except`` chain can log/diagnose them without the
+    mapping layer hiding the original stack.
+    """
+    try:
+        yield
+    except aerospike_py.RecordNotFound as e:
+        raise MCPToolError(
+            f"Record not found{_record_ident(ns, set_name, key)}",
+            code="record_not_found",
+        ) from e
+    except aerospike_py.RecordExistsError as e:
+        raise MCPToolError(
+            f"Record already exists{_record_ident(ns, set_name, key)}",
+            code="record_exists",
+        ) from e
+    except (
+        ConnectionNotFoundError,
+        WorkspaceNotFoundError,
+        NamespaceNotFoundError,
+        NodeNotFoundError,
+        NamespaceConfigError,
+        InvalidPkPattern,
+        SetRequiredForPkLookup,
+        PrimaryKeyMissing,
+    ) as e:
+        raise MCPToolError(str(e), code=type(e).__name__) from e

--- a/api/src/aerospike_cluster_manager_api/mcp/errors.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/errors.py
@@ -30,6 +30,7 @@ from typing import Any
 
 import aerospike_py
 
+from aerospike_cluster_manager_api.predicate import UnknownPredicateOperator
 from aerospike_cluster_manager_api.services.clusters_service import (
     NamespaceConfigError,
     NamespaceNotFoundError,
@@ -114,6 +115,21 @@ def map_aerospike_errors(
             f"Record already exists{_record_ident(ns, set_name, key)}",
             code="record_exists",
         ) from e
+    except aerospike_py.BackpressureError as e:
+        # Production-grade signal: client-side concurrent-op queue is
+        # saturated. Surface a stable code so model-side wrappers (and
+        # operator dashboards) can apply retry-with-backoff. The message
+        # carries the underlying client wording so context isn't lost.
+        raise MCPToolError(
+            f"Aerospike client is saturated; retry with backoff: {e}",
+            code="backpressure",
+        ) from e
+    except UnknownPredicateOperator as e:
+        # Predicate dispatch table did not recognise the operator — input
+        # validation failure on the caller's side. Surfaces as the same
+        # ``invalid_argument`` family the SDK reserves for malformed
+        # tool arguments.
+        raise MCPToolError(str(e), code="invalid_argument") from e
     except (
         ConnectionNotFoundError,
         WorkspaceNotFoundError,

--- a/api/src/aerospike_cluster_manager_api/mcp/registry.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/registry.py
@@ -34,7 +34,7 @@ from typing import Any
 from mcp.server.fastmcp import FastMCP
 
 from aerospike_cluster_manager_api import config
-from aerospike_cluster_manager_api.mcp.access_profile import AccessProfile, is_blocked
+from aerospike_cluster_manager_api.mcp.access_profile import WRITE_TOOLS, AccessProfile, is_blocked
 from aerospike_cluster_manager_api.mcp.errors import MCPToolError, map_aerospike_errors
 
 
@@ -53,6 +53,13 @@ class ToolMetadata:
 
 
 _REGISTRY: list[ToolMetadata] = []
+
+# Tracks FastMCP instances that ``register_all`` has already populated,
+# keyed by ``id(mcp)``. If ``build_mcp_app()`` is invoked twice in the
+# same process (e.g. test fixtures, hot reload), re-running
+# ``mcp.add_tool(...)`` would raise FastMCP's "duplicate tool name"
+# error. Skipping the second call is idempotent and cheap.
+_REGISTERED_MCP_IDS: set[int] = set()
 
 
 def tool(
@@ -84,6 +91,24 @@ def tool(
         if any(entry.name == tool_name for entry in _REGISTRY):
             raise ValueError(f"Duplicate tool registration: {tool_name}")
 
+        # M3 — registry-time consistency check. WRITE_TOOLS is the
+        # authoritative list consulted by the call-time access profile
+        # gate; the @tool(mutation=...) flag is purely declarative. If
+        # the two ever drift (someone adds a mutation tool but forgets
+        # to add it to WRITE_TOOLS, or vice versa), the read_only
+        # profile silently fails open. Catching the drift at import
+        # time forces the conflict to surface as a startup error rather
+        # than a security regression discovered in production. The
+        # call-site is_blocked() check below stays as defense-in-depth.
+        expected_mutation = tool_name in WRITE_TOOLS
+        if mutation != expected_mutation:
+            raise ValueError(
+                f"Tool {tool_name!r} mutation flag ({mutation}) disagrees with "
+                f"WRITE_TOOLS membership ({expected_mutation}). "
+                "Update mcp/access_profile.WRITE_TOOLS or the @tool(mutation=...) "
+                "flag so they agree."
+            )
+
         is_async = inspect.iscoroutinefunction(func)
 
         @functools.wraps(func)
@@ -109,10 +134,15 @@ def register_all(mcp: FastMCP) -> int:
     """Wire every accumulated tool into ``mcp`` and return the count.
 
     Called once by :func:`build_mcp_app` (B.6). Invoking it on an empty
-    registry returns ``0`` and leaves ``mcp`` untouched.
+    registry returns ``0`` and leaves ``mcp`` untouched. If the same
+    ``mcp`` instance is passed twice (re-entry guard), the second call
+    is a no-op so we don't trip FastMCP's duplicate-name error.
     """
+    if id(mcp) in _REGISTERED_MCP_IDS:
+        return len(_REGISTRY)
     for entry in _REGISTRY:
         mcp.add_tool(entry.func, name=entry.name)
+    _REGISTERED_MCP_IDS.add(id(mcp))
     return len(_REGISTRY)
 
 
@@ -134,3 +164,4 @@ def _reset_for_tests() -> None:
     :func:`register_all` exactly once from :func:`build_mcp_app`.
     """
     _REGISTRY.clear()
+    _REGISTERED_MCP_IDS.clear()

--- a/api/src/aerospike_cluster_manager_api/mcp/registry.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/registry.py
@@ -1,0 +1,136 @@
+"""MCP tool registration decorator (registry).
+
+Phase 1 tools (B.1+) decorate themselves with :func:`tool` at import time.
+Each decoration:
+
+* records :class:`ToolMetadata` (name, category, mutation, callable) in
+  the module-level ``_REGISTRY`` accumulator;
+* wraps the function with the access-profile gate (A.8) — mutation tools
+  named in ``access_profile.WRITE_TOOLS`` raise
+  :class:`MCPToolError` with ``code="access_denied"`` under the
+  ``READ_ONLY`` profile, **before** the body runs;
+* wraps the function with :func:`map_aerospike_errors` (A.11) so known
+  service-layer errors surface as :class:`MCPToolError` with stable codes
+  while everything else propagates so the registry / OTel pipeline can
+  log the real bug.
+
+The decorator returns the *wrapped* form so tests and other callers that
+bypass FastMCP still see the gate. ``register_all(mcp)`` is invoked once
+from :func:`build_mcp_app` (B.6) to flush the accumulator into a single
+:class:`FastMCP` instance via :meth:`FastMCP.add_tool`.
+
+Read the module docstring of :mod:`access_profile` for why blocking is
+done at the call site rather than at registration time.
+"""
+
+from __future__ import annotations
+
+import functools
+import inspect
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from aerospike_cluster_manager_api import config
+from aerospike_cluster_manager_api.mcp.access_profile import AccessProfile, is_blocked
+from aerospike_cluster_manager_api.mcp.errors import MCPToolError, map_aerospike_errors
+
+
+@dataclass(frozen=True)
+class ToolMetadata:
+    """Snapshot of a registered tool — exposed for autodiscovery / docs.
+
+    ``func`` is the *wrapped* callable (with access-profile + error-mapping
+    already applied). Direct callers see the same gate as FastMCP would.
+    """
+
+    name: str
+    category: str
+    mutation: bool
+    func: Callable[..., Any]
+
+
+_REGISTRY: list[ToolMetadata] = []
+
+
+def tool(
+    *,
+    category: str,
+    mutation: bool = False,
+    name: str | None = None,
+) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+    """Register a function as an MCP tool.
+
+    Parameters
+    ----------
+    category:
+        Free-form grouping label (e.g. ``"record"``, ``"connection"``,
+        ``"cluster"``) used by introspection and docs generation.
+    mutation:
+        ``True`` for tools that mutate state. Combined with the
+        :data:`access_profile.WRITE_TOOLS` list to decide whether the
+        ``READ_ONLY`` profile must reject the call. Tools whose names are
+        not in ``WRITE_TOOLS`` run under ``READ_ONLY`` regardless of this
+        flag (default-allow); the flag is purely for introspection.
+    name:
+        Optional override; defaults to ``func.__name__``. Must be unique
+        across the registry — duplicates raise :class:`ValueError`.
+    """
+
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
+        tool_name = name or func.__name__
+        if any(entry.name == tool_name for entry in _REGISTRY):
+            raise ValueError(f"Duplicate tool registration: {tool_name}")
+
+        is_async = inspect.iscoroutinefunction(func)
+
+        @functools.wraps(func)
+        async def wrapped(*args: Any, **kwargs: Any) -> Any:
+            profile: AccessProfile = config.ACM_MCP_ACCESS_PROFILE
+            if mutation and is_blocked(tool_name, profile):
+                raise MCPToolError(
+                    f"Tool '{tool_name}' is disabled by access profile '{profile.value}'.",
+                    code="access_denied",
+                )
+            with map_aerospike_errors():
+                if is_async:
+                    return await func(*args, **kwargs)
+                return func(*args, **kwargs)
+
+        _REGISTRY.append(ToolMetadata(name=tool_name, category=category, mutation=mutation, func=wrapped))
+        return wrapped
+
+    return decorator
+
+
+def register_all(mcp: FastMCP) -> int:
+    """Wire every accumulated tool into ``mcp`` and return the count.
+
+    Called once by :func:`build_mcp_app` (B.6). Invoking it on an empty
+    registry returns ``0`` and leaves ``mcp`` untouched.
+    """
+    for entry in _REGISTRY:
+        mcp.add_tool(entry.func, name=entry.name)
+    return len(_REGISTRY)
+
+
+def registered_tools() -> list[ToolMetadata]:
+    """Return a snapshot copy of the current registry.
+
+    Useful for introspection (docs, ``__repr__``, telemetry); callers
+    should not mutate the result — modifying the returned list does not
+    affect the registry.
+    """
+    return list(_REGISTRY)
+
+
+def _reset_for_tests() -> None:
+    """Test helper: clear the module-level registry. **Not for production.**
+
+    Phase 1 tool modules decorate at import time, so tests reset between
+    cases to avoid cross-test bleed. Production code calls
+    :func:`register_all` exactly once from :func:`build_mcp_app`.
+    """
+    _REGISTRY.clear()

--- a/api/src/aerospike_cluster_manager_api/mcp/serializers.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/serializers.py
@@ -1,0 +1,205 @@
+"""JSON-safe serialisation for aerospike-py records and bin values.
+
+Sibling to :mod:`aerospike_cluster_manager_api.converters` — that module
+returns a Pydantic ``AerospikeRecord`` shaped for the REST wire format
+(camelCase fields, ``digest`` as hex). The MCP protocol embeds tool results
+as JSON inside ``text``/``json`` content blocks, so the serializers here
+emit a slightly different envelope tuned for AI clients:
+
+* ``key``: ``{"namespace", "set", "user_key" | (omitted), "digest"}`` —
+  ``user_key`` is omitted when the source record only carries a digest;
+  ``digest`` is always base64 (round-trip safe across wire formats and
+  more compact than hex).
+* ``meta``: ``{"generation", "expiration", ...}`` — ``ttl`` from
+  aerospike-py is renamed to ``expiration`` to match the more standard
+  naming. Any extra fields surfaced by ``RecordMetadata`` (e.g.
+  ``last_update_time``) flow through unchanged.
+* ``bins``: ``{bin_name: serialised_value}`` — recursed via
+  :func:`serialize_value`.
+
+Bytes convention
+----------------
+Aerospike CDT supports raw ``bytes`` particles. JSON has no native byte
+type, and emitting bytes as a bare string would collide with regular
+string bins. We wrap them in a marker dict::
+
+    {"_aerospike_bytes_b64": "<base64>"}
+
+This is also used for ``user_key`` when it is bytes. The marker key is
+exported as :data:`BYTES_MARKER_KEY` so downstream callers (MCP clients,
+tests) can recognise and round-trip the value safely.
+
+Module dependencies are intentionally limited to the standard library +
+``aerospike_py``; no FastAPI or Pydantic so the same module is reusable
+from MCP tool handlers without dragging in HTTP framework symbols.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from aerospike_py import Record
+
+# Public marker key for bytes values. Pinned via test so any change here is
+# a breaking change for downstream consumers.
+BYTES_MARKER_KEY = "_aerospike_bytes_b64"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def serialize_value(value: Any) -> Any:
+    """Convert *value* into a JSON-safe Python primitive.
+
+    Recursively handles lists, tuples, and dicts (including the GeoJSON
+    dict shape ``{"type": ..., "coordinates": [...]}`` which is just a
+    regular dict in aerospike-py). ``bytes`` and ``bytearray`` are
+    wrapped in the marker dict described in the module docstring.
+
+    Map keys that are not strings are coerced via :func:`str` so the
+    result is :func:`json.dumps`-compatible; this matches what the
+    Aerospike server itself does for non-string map keys when surfaced
+    over the REST API.
+    """
+    # bool must come before int because ``isinstance(True, int)`` is True.
+    if isinstance(value, bool) or value is None:
+        return value
+    if isinstance(value, (int, float, str)):
+        return value
+    if isinstance(value, (bytes, bytearray)):
+        return _encode_bytes(value)
+    if isinstance(value, Mapping):
+        return {str(k): serialize_value(v) for k, v in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [serialize_value(v) for v in value]
+    # Anything else (e.g. an unexpected NamedTuple) is forced through
+    # ``str`` rather than crashing — being lossy beats blocking a tool call.
+    return str(value)
+
+
+def serialize_bins(bins: Mapping[str, Any]) -> dict[str, Any]:
+    """Convert a ``{bin_name: value}`` mapping into JSON-safe form.
+
+    Bin names are always strings on the wire; the value side runs through
+    :func:`serialize_value` so nested CDTs (lists/maps) and bytes are
+    handled correctly.
+    """
+    return {str(name): serialize_value(value) for name, value in bins.items()}
+
+
+def serialize_record(record: Record) -> dict[str, Any]:
+    """Convert an aerospike-py :class:`Record` into a JSON-safe dict.
+
+    The output shape is::
+
+        {
+          "key":  {"namespace": str, "set": str,
+                   "user_key": <serialised>,    # omitted if None
+                   "digest":   <base64> | None},
+          "meta": {"generation": int, "expiration": int, ...},
+          "bins": {bin_name: serialised_value, ...},
+        }
+
+    ``meta`` accepts both the modern :class:`RecordMetadata` NamedTuple
+    and the legacy ``dict`` shape. Any extra fields on the source meta
+    (e.g. ``last_update_time``) pass through unchanged so AI clients can
+    surface them when present.
+    """
+    return {
+        "key": _serialize_key(record.key),
+        "meta": _serialize_meta(record.meta),
+        "bins": serialize_bins(record.bins or {}),
+    }
+
+
+def serialize_records(records: Iterable[Record]) -> list[dict[str, Any]]:
+    """Apply :func:`serialize_record` to each record in *records*."""
+    return [serialize_record(rec) for rec in records]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _encode_bytes(value: bytes | bytearray) -> dict[str, str]:
+    """Wrap *value* in the documented base64 marker dict."""
+    return {BYTES_MARKER_KEY: base64.b64encode(bytes(value)).decode("ascii")}
+
+
+def _serialize_key(key: Any) -> dict[str, Any]:
+    """Serialise the aerospike-py key tuple ``(ns, set, user_key, digest)``.
+
+    Mirrors :func:`converters._serialise_key` but emits the MCP shape:
+    ``user_key`` is included only when present, and ``digest`` is base64
+    rather than hex. Tolerates partial tuples (any of the trailing fields
+    may be absent or ``None``) so the function does not raise on edge
+    cases like digest-only or namespace-only records returned by certain
+    info commands.
+    """
+    if key is None:
+        key = ()
+
+    namespace = key[0] if len(key) > 0 else ""
+    set_name = key[1] if len(key) > 1 else ""
+    raw_user_key = key[2] if len(key) > 2 else None
+    raw_digest = key[3] if len(key) > 3 else None
+
+    result: dict[str, Any] = {
+        "namespace": namespace if namespace is not None else "",
+        "set": set_name if set_name is not None else "",
+        "digest": _encode_digest(raw_digest),
+    }
+    if raw_user_key is not None:
+        result["user_key"] = serialize_value(raw_user_key)
+    return result
+
+
+def _encode_digest(digest: Any) -> str | None:
+    """Encode a digest value as base64, or None if it isn't bytes."""
+    if isinstance(digest, (bytes, bytearray)):
+        return base64.b64encode(bytes(digest)).decode("ascii")
+    return None
+
+
+def _serialize_meta(meta: Any) -> dict[str, Any]:
+    """Normalise meta into ``{"generation", "expiration", ...}``.
+
+    aerospike-py exposes meta as a :class:`RecordMetadata` NamedTuple
+    (``gen``, ``ttl``) on the read path; certain legacy/test code uses a
+    plain dict. We accept both and pass any extra fields through so the
+    MCP client gets every piece of metadata the server returned.
+    """
+    if meta is None:
+        return {"generation": 0, "expiration": 0}
+
+    if isinstance(meta, Mapping):
+        result: dict[str, Any] = {
+            "generation": int(meta.get("gen", 0) or 0),
+            "expiration": int(meta.get("ttl", 0) or 0),
+        }
+        for key, value in meta.items():
+            if key in ("gen", "ttl"):
+                continue
+            result[str(key)] = serialize_value(value)
+        return result
+
+    # NamedTuple-like (e.g. RecordMetadata)
+    if hasattr(meta, "_asdict"):
+        as_dict = meta._asdict()
+        result = {
+            "generation": int(as_dict.pop("gen", 0) or 0),
+            "expiration": int(as_dict.pop("ttl", 0) or 0),
+        }
+        for key, value in as_dict.items():
+            result[str(key)] = serialize_value(value)
+        return result
+
+    # Bare object with gen/ttl attributes — best effort.
+    gen = getattr(meta, "gen", 0)
+    ttl = getattr(meta, "ttl", 0)
+    return {"generation": int(gen or 0), "expiration": int(ttl or 0)}

--- a/api/src/aerospike_cluster_manager_api/mcp/server.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/server.py
@@ -1,0 +1,12 @@
+"""ACM MCP server factory.
+
+Builds an empty :class:`FastMCP` instance. Tools, lifespan, and
+transport mounting are wired in later tasks (A.7+).
+"""
+
+from mcp.server.fastmcp import FastMCP
+
+
+def build_mcp_app() -> FastMCP:
+    """Construct the ACM MCP server. Tools registered in later tasks."""
+    return FastMCP("aerospike-cluster-manager")

--- a/api/src/aerospike_cluster_manager_api/mcp/server.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/server.py
@@ -1,12 +1,18 @@
 """ACM MCP server factory.
 
-Builds an empty :class:`FastMCP` instance. Tools, lifespan, and
-transport mounting are wired in later tasks (A.7+).
+Builds the :class:`FastMCP` instance, imports each tools submodule (which
+runs the ``@tool(...)`` decorators at import time), then flushes the
+registry into the FastMCP app.
 """
 
 from mcp.server.fastmcp import FastMCP
 
+from aerospike_cluster_manager_api.mcp import tools  # noqa: F401  — import side-effects only
+from aerospike_cluster_manager_api.mcp.registry import register_all
+
 
 def build_mcp_app() -> FastMCP:
-    """Construct the ACM MCP server. Tools registered in later tasks."""
-    return FastMCP("aerospike-cluster-manager")
+    """Construct the ACM MCP server with all decorated tools registered."""
+    mcp = FastMCP("aerospike-cluster-manager")
+    register_all(mcp)
+    return mcp

--- a/api/src/aerospike_cluster_manager_api/mcp/server.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/server.py
@@ -12,7 +12,14 @@ from aerospike_cluster_manager_api.mcp.registry import register_all
 
 
 def build_mcp_app() -> FastMCP:
-    """Construct the ACM MCP server with all decorated tools registered."""
-    mcp = FastMCP("aerospike-cluster-manager")
+    """Construct the ACM MCP server with all decorated tools registered.
+
+    ``streamable_http_path="/"`` keeps the inner Streamable-HTTP route at
+    the root of the FastMCP sub-app, so when ``main.py`` mounts the sub-app
+    at ``/mcp`` (``ACM_MCP_PATH``) clients can reach the transport at
+    exactly ``/mcp`` rather than the doubled ``/mcp/mcp`` produced by the
+    SDK default.
+    """
+    mcp = FastMCP("aerospike-cluster-manager", streamable_http_path="/")
     register_all(mcp)
     return mcp

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/__init__.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/__init__.py
@@ -1,0 +1,8 @@
+"""MCP tool modules.
+
+Each submodule registers its tools at import time via the ``@tool(...)``
+decorator from :mod:`aerospike_cluster_manager_api.mcp.registry`. The
+auto-discovery wiring in B.6 imports each submodule so the decorator
+side-effects fire before :func:`register_all` flushes the accumulator
+into the :class:`FastMCP` instance built by :func:`build_mcp_app`.
+"""

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/__init__.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/__init__.py
@@ -8,6 +8,13 @@ into the :class:`FastMCP` instance built by :func:`build_mcp_app`.
 
 Adding a new tool category? Import the module here AND keep
 ``access_profile.WRITE_TOOLS`` in sync with any new mutation tools.
+
+The ``@tool`` decorator's name uniqueness check is enforced at import
+time — duplicate tool names raise :class:`ValueError` from
+:func:`mcp.registry.tool` and abort the module import, which in turn
+fails ``build_mcp_app`` at startup. Adding a tool with a name that
+collides with an existing one is therefore caught immediately rather
+than silently shadowing the prior registration.
 """
 
 from aerospike_cluster_manager_api.mcp.tools import (  # noqa: F401  — import side-effects only

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/__init__.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/__init__.py
@@ -2,7 +2,18 @@
 
 Each submodule registers its tools at import time via the ``@tool(...)``
 decorator from :mod:`aerospike_cluster_manager_api.mcp.registry`. The
-auto-discovery wiring in B.6 imports each submodule so the decorator
+auto-discovery wiring imports each submodule so the decorator
 side-effects fire before :func:`register_all` flushes the accumulator
 into the :class:`FastMCP` instance built by :func:`build_mcp_app`.
+
+Adding a new tool category? Import the module here AND keep
+``access_profile.WRITE_TOOLS`` in sync with any new mutation tools.
 """
+
+from aerospike_cluster_manager_api.mcp.tools import (  # noqa: F401  — import side-effects only
+    cluster_info,
+    connections,
+    info_commands,
+    query,
+    records,
+)

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/cluster_info.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/cluster_info.py
@@ -1,0 +1,86 @@
+"""MCP tools for Aerospike cluster inspection (Voyager parity).
+
+This module exposes 3 read-only tools that wrap the existing service layer
+(:mod:`aerospike_cluster_manager_api.services.clusters_service`) and the
+live-client pool (:mod:`aerospike_cluster_manager_api.client_manager`):
+
+* ``list_namespaces`` — namespace names defined on the cluster
+* ``list_sets`` — per-set object/byte counts within a namespace
+* ``get_nodes`` — per-node build/edition/uptime/connection metadata
+
+Design notes:
+
+* All 3 tools require an explicit ``conn_id`` — there's no implicit "default
+  cluster" fallback. Voyager parity: every cluster-scoped call names its
+  cluster.
+* ``client_manager.get_client`` raises :class:`ValueError` when the profile
+  is missing; we re-raise as :class:`ConnectionNotFoundError` so the
+  registry's error map produces the stable ``code="ConnectionNotFoundError"``
+  wire shape used by :func:`mcp.tools.connections.connect`.
+* ``SetInfo`` and ``ClusterNode`` are pydantic models (not NamedTuples), so
+  serialisation goes through ``model_dump()`` — same pattern as B.1.
+* Tools are registered with ``mutation=False``; they are absent from
+  :data:`access_profile.WRITE_TOOLS`, so the read-only profile permits them.
+* The ``@tool`` decorator already wraps every body in the access-profile
+  gate and ``map_aerospike_errors`` — do **not** apply them again here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aerospike_cluster_manager_api.client_manager import client_manager
+from aerospike_cluster_manager_api.mcp.registry import tool
+from aerospike_cluster_manager_api.services import clusters_service
+from aerospike_cluster_manager_api.services.connections_service import (
+    ConnectionNotFoundError,
+)
+
+
+async def _get_client(conn_id: str) -> Any:
+    """Resolve a live ``AsyncClient`` for ``conn_id``.
+
+    ``client_manager.get_client`` raises :class:`ValueError` when the profile
+    is unknown. We translate that into :class:`ConnectionNotFoundError` so
+    the registry's error map produces the canonical
+    ``code="ConnectionNotFoundError"`` wire shape — matching
+    :func:`mcp.tools.connections.connect`.
+    """
+    try:
+        return await client_manager.get_client(conn_id)
+    except ValueError as e:
+        raise ConnectionNotFoundError(conn_id) from e
+
+
+@tool(category="cluster_info", mutation=False)
+async def list_namespaces(conn_id: str) -> list[str]:
+    """List all namespaces defined on the connected Aerospike cluster."""
+    client = await _get_client(conn_id)
+    return await clusters_service.list_namespaces(client)
+
+
+@tool(category="cluster_info", mutation=False)
+async def list_sets(conn_id: str, namespace: str) -> list[dict[str, Any]]:
+    """List sets within a namespace, with object counts and byte sizes.
+
+    Returns a list of ``SetInfo`` dicts (``name``, ``namespace``,
+    ``objects``, ``tombstones``, ``memoryDataBytes``, ``stopWritesCount``,
+    ``nodeCount``, ``totalNodes``). Raises ``MCPToolError`` with
+    ``code="NamespaceNotFoundError"`` when the namespace is unknown.
+    """
+    client = await _get_client(conn_id)
+    sets = await clusters_service.list_sets(client, namespace)
+    return [s.model_dump() for s in sets]
+
+
+@tool(category="cluster_info", mutation=False)
+async def get_nodes(conn_id: str) -> list[dict[str, Any]]:
+    """List nodes in the cluster with build/edition/uptime/connection metadata.
+
+    Returns a list of ``ClusterNode`` dicts (``name``, ``address``, ``port``,
+    ``build``, ``edition``, ``clusterSize``, ``uptime``, ``clientConnections``,
+    ``statistics``).
+    """
+    client = await _get_client(conn_id)
+    nodes = await clusters_service.get_nodes(client, conn_id)
+    return [n.model_dump() for n in nodes]

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/cluster_info.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/cluster_info.py
@@ -1,4 +1,4 @@
-"""MCP tools for Aerospike cluster inspection (Voyager parity).
+"""MCP tools for Aerospike cluster inspection.
 
 This module exposes 3 read-only tools that wrap the existing service layer
 (:mod:`aerospike_cluster_manager_api.services.clusters_service`) and the
@@ -11,8 +11,7 @@ live-client pool (:mod:`aerospike_cluster_manager_api.client_manager`):
 Design notes:
 
 * All 3 tools require an explicit ``conn_id`` — there's no implicit "default
-  cluster" fallback. Voyager parity: every cluster-scoped call names its
-  cluster.
+  cluster" fallback; every cluster-scoped call names its cluster.
 * ``client_manager.get_client`` raises :class:`ValueError` when the profile
   is missing; we re-raise as :class:`ConnectionNotFoundError` so the
   registry's error map produces the stable ``code="ConnectionNotFoundError"``

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/connections.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/connections.py
@@ -1,0 +1,198 @@
+"""MCP tools for Aerospike connection profile management (Voyager parity).
+
+This module exposes 8 connection tools that wrap the existing service
+layer (:mod:`aerospike_cluster_manager_api.services.connections_service`)
+and the live-client pool (:mod:`aerospike_cluster_manager_api.client_manager`):
+
+* ``create_connection`` — create a new profile (mutation)
+* ``get_connection`` — fetch one profile by id
+* ``update_connection`` — partial update of a profile (mutation)
+* ``delete_connection`` — delete a profile and close its live client (mutation)
+* ``list_connections`` — list all profiles, optionally filtered by workspace
+* ``connect`` — open / re-use a live ``AsyncClient`` and return a status snapshot
+* ``disconnect`` — close and evict the live client for a connection
+* ``test_connection`` — probe Aerospike connectivity without persisting
+
+Design notes:
+
+* Tools accept simple Python types (``str``, ``int``, ``list``, ``dict``)
+  so the MCP SDK can derive a JSON Schema directly from the type hints.
+* Field names are snake_case at the MCP boundary (idiomatic Python /
+  MCP). Where the underlying pydantic request model uses camelCase
+  (e.g. ``workspaceId``), the tool translates at construction time.
+* Returns are always JSON-serialisable. Pydantic responses are
+  ``model_dump()``-ed; the SDK does not always know how to serialise
+  pydantic instances.
+* The ``@tool`` decorator already wraps every body in the access-profile
+  gate and ``map_aerospike_errors`` — do **not** apply them again here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aerospike_cluster_manager_api.client_manager import client_manager
+from aerospike_cluster_manager_api.constants import INFO_NAMESPACES
+from aerospike_cluster_manager_api.info_parser import parse_list
+from aerospike_cluster_manager_api.mcp.registry import tool
+from aerospike_cluster_manager_api.models.connection import (
+    CreateConnectionRequest,
+    TestConnectionRequest,
+    UpdateConnectionRequest,
+)
+from aerospike_cluster_manager_api.services import connections_service
+from aerospike_cluster_manager_api.services.connections_service import (
+    ConnectionNotFoundError,
+)
+
+
+@tool(category="connection", mutation=True)
+async def create_connection(
+    name: str,
+    hosts: list[str],
+    port: int = 3000,
+    username: str | None = None,
+    password: str | None = None,
+    color: str = "#0097D3",
+    description: str | None = None,
+    labels: dict[str, str] | None = None,
+    workspace_id: str | None = None,
+) -> dict[str, Any]:
+    """Create a new Aerospike connection profile.
+
+    Returns the persisted profile (without the password). Falls back to
+    the built-in default workspace when ``workspace_id`` is omitted.
+    """
+    payload = CreateConnectionRequest(
+        name=name,
+        hosts=hosts,
+        port=port,
+        username=username,
+        password=password,
+        color=color,
+        description=description,
+        labels=labels,
+        workspaceId=workspace_id,
+    )
+    result = await connections_service.create_connection(payload)
+    return result.model_dump()
+
+
+@tool(category="connection", mutation=False)
+async def get_connection(conn_id: str) -> dict[str, Any]:
+    """Fetch a connection profile by id."""
+    result = await connections_service.get_connection(conn_id)
+    return result.model_dump()
+
+
+@tool(category="connection", mutation=True)
+async def update_connection(
+    conn_id: str,
+    name: str | None = None,
+    hosts: list[str] | None = None,
+    port: int | None = None,
+    username: str | None = None,
+    password: str | None = None,
+    color: str | None = None,
+    description: str | None = None,
+    labels: dict[str, str] | None = None,
+    workspace_id: str | None = None,
+) -> dict[str, Any]:
+    """Apply a partial update to a connection profile.
+
+    Only fields explicitly supplied (non-``None``) are updated.
+    """
+    update_kwargs: dict[str, Any] = {}
+    if name is not None:
+        update_kwargs["name"] = name
+    if hosts is not None:
+        update_kwargs["hosts"] = hosts
+    if port is not None:
+        update_kwargs["port"] = port
+    if username is not None:
+        update_kwargs["username"] = username
+    if password is not None:
+        update_kwargs["password"] = password
+    if color is not None:
+        update_kwargs["color"] = color
+    if description is not None:
+        update_kwargs["description"] = description
+    if labels is not None:
+        update_kwargs["labels"] = labels
+    if workspace_id is not None:
+        update_kwargs["workspaceId"] = workspace_id
+
+    payload = UpdateConnectionRequest(**update_kwargs)
+    result = await connections_service.update_connection(conn_id, payload)
+    return result.model_dump()
+
+
+@tool(category="connection", mutation=True)
+async def delete_connection(conn_id: str) -> dict[str, Any]:
+    """Delete a connection profile and close its cached client.
+
+    Idempotent — deleting a missing connection is a no-op.
+    """
+    await connections_service.delete_connection(conn_id)
+    return {"deleted": True, "conn_id": conn_id}
+
+
+@tool(category="connection", mutation=False)
+async def list_connections(workspace_id: str | None = None) -> list[dict[str, Any]]:
+    """List all connection profiles, optionally filtered by workspace id."""
+    results = await connections_service.list_connections(workspace_id)
+    return [item.model_dump() for item in results]
+
+
+@tool(category="connection", mutation=False)
+async def connect(conn_id: str) -> dict[str, Any]:
+    """Establish (or re-use) a live ``AsyncClient`` for the connection.
+
+    Returns a small status snapshot so the model can confirm the cluster
+    is reachable: number of nodes seen by the client and the namespace
+    list visible from a random node.
+    """
+    try:
+        client = await client_manager.get_client(conn_id)
+    except ValueError as e:
+        # client_manager raises ValueError when the profile is missing.
+        # Re-raise as the canonical service-layer error so the registry's
+        # error map produces a stable code — matches get_connection's wire
+        # shape rather than leaking a generic ValueError.
+        raise ConnectionNotFoundError(conn_id) from e
+
+    node_names = client.get_node_names()
+    ns_raw = await client.info_random_node(INFO_NAMESPACES)
+    namespaces = parse_list(ns_raw)
+    return {
+        "connected": True,
+        "conn_id": conn_id,
+        "node_count": len(node_names),
+        "namespaces": namespaces,
+    }
+
+
+@tool(category="connection", mutation=False)
+async def disconnect(conn_id: str) -> dict[str, Any]:
+    """Close and evict the live client for the given connection.
+
+    No-op when no live client is currently cached.
+    """
+    await client_manager.close_client(conn_id)
+    return {"disconnected": True, "conn_id": conn_id}
+
+
+@tool(category="connection", mutation=False)
+async def test_connection(
+    hosts: list[str],
+    port: int = 3000,
+    username: str | None = None,
+    password: str | None = None,
+) -> dict[str, Any]:
+    """Probe Aerospike connectivity without persisting a profile.
+
+    Returns ``{"success": bool, "message": str}`` — never raises;
+    the underlying service layer captures any error as ``success=False``.
+    """
+    payload = TestConnectionRequest(hosts=hosts, port=port, username=username, password=password)
+    return await connections_service.test_connection(payload)

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/connections.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/connections.py
@@ -29,6 +29,7 @@ Design notes:
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from aerospike_cluster_manager_api.client_manager import client_manager
@@ -45,6 +46,8 @@ from aerospike_cluster_manager_api.services.connections_service import (
     ConnectionNotFoundError,
 )
 
+logger = logging.getLogger(__name__)
+
 
 @tool(category="connection", mutation=True)
 async def create_connection(
@@ -57,11 +60,18 @@ async def create_connection(
     description: str | None = None,
     labels: dict[str, str] | None = None,
     workspace_id: str | None = None,
+    cluster_name: str | None = None,
 ) -> dict[str, Any]:
     """Create a new Aerospike connection profile.
 
     Returns the persisted profile (without the password). Falls back to
     the built-in default workspace when ``workspace_id`` is omitted.
+    ``cluster_name`` is the optional cluster identifier used by the
+    Aerospike client tend (``cluster-name`` policy) — leave unset to
+    discover the cluster name dynamically.
+
+    Mutation: requires ``ACM_MCP_ACCESS_PROFILE=full``; returns
+    ``code=access_denied`` under READ_ONLY.
     """
     payload = CreateConnectionRequest(
         name=name,
@@ -73,6 +83,7 @@ async def create_connection(
         description=description,
         labels=labels,
         workspaceId=workspace_id,
+        clusterName=cluster_name,
     )
     result = await connections_service.create_connection(payload)
     return result.model_dump()
@@ -97,10 +108,16 @@ async def update_connection(
     description: str | None = None,
     labels: dict[str, str] | None = None,
     workspace_id: str | None = None,
+    cluster_name: str | None = None,
 ) -> dict[str, Any]:
     """Apply a partial update to a connection profile.
 
     Only fields explicitly supplied (non-``None``) are updated.
+    ``cluster_name`` is the optional cluster identifier (``cluster-name``
+    tend policy); pass it to update or set it.
+
+    Mutation: requires ``ACM_MCP_ACCESS_PROFILE=full``; returns
+    ``code=access_denied`` under READ_ONLY.
     """
     update_kwargs: dict[str, Any] = {}
     if name is not None:
@@ -121,6 +138,8 @@ async def update_connection(
         update_kwargs["labels"] = labels
     if workspace_id is not None:
         update_kwargs["workspaceId"] = workspace_id
+    if cluster_name is not None:
+        update_kwargs["clusterName"] = cluster_name
 
     payload = UpdateConnectionRequest(**update_kwargs)
     result = await connections_service.update_connection(conn_id, payload)
@@ -132,6 +151,9 @@ async def delete_connection(conn_id: str) -> dict[str, Any]:
     """Delete a connection profile and close its cached client.
 
     Idempotent — deleting a missing connection is a no-op.
+
+    Mutation: requires ``ACM_MCP_ACCESS_PROFILE=full``; returns
+    ``code=access_denied`` under READ_ONLY.
     """
     await connections_service.delete_connection(conn_id)
     return {"deleted": True, "conn_id": conn_id}
@@ -151,6 +173,10 @@ async def connect(conn_id: str) -> dict[str, Any]:
     Returns a small status snapshot so the model can confirm the cluster
     is reachable: number of nodes seen by the client and the namespace
     list visible from a random node.
+
+    Side effect: modifies the shared ``client_manager`` cache. Concurrent
+    or read-only MCP clients sharing the same workspace see the impact
+    even though this tool is declared ``mutation=False``.
     """
     try:
         client = await client_manager.get_client(conn_id)
@@ -177,6 +203,10 @@ async def disconnect(conn_id: str) -> dict[str, Any]:
     """Close and evict the live client for the given connection.
 
     No-op when no live client is currently cached.
+
+    Side effect: modifies the shared ``client_manager`` cache. Concurrent
+    or read-only MCP clients sharing the same workspace see the impact
+    even though this tool is declared ``mutation=False``.
     """
     await client_manager.close_client(conn_id)
     return {"disconnected": True, "conn_id": conn_id}
@@ -193,6 +223,21 @@ async def test_connection(
 
     Returns ``{"success": bool, "message": str}`` — never raises;
     the underlying service layer captures any error as ``success=False``.
+    Failure messages are normalised to a generic ``"connection test
+    failed"`` so we don't leak host/port or driver internals to the model;
+    the original exception text is logged structurally for operators.
     """
     payload = TestConnectionRequest(hosts=hosts, port=port, username=username, password=password)
-    return await connections_service.test_connection(payload)
+    result = await connections_service.test_connection(payload)
+    if not result.success:
+        # M2 hardening: surface a generic message to the LLM, but keep
+        # the operator-visible detail in the structured log so an SRE
+        # debugging a flapping cluster still has the underlying error.
+        logger.warning(
+            "MCP test_connection failure: hosts=%s port=%s detail=%s",
+            hosts,
+            port,
+            result.message,
+        )
+        return {"success": False, "message": "connection test failed"}
+    return {"success": True, "message": result.message}

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/connections.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/connections.py
@@ -1,4 +1,4 @@
-"""MCP tools for Aerospike connection profile management (Voyager parity).
+"""MCP tools for Aerospike connection profile management.
 
 This module exposes 8 connection tools that wrap the existing service
 layer (:mod:`aerospike_cluster_manager_api.services.connections_service`)

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/info_commands.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/info_commands.py
@@ -1,0 +1,44 @@
+"""MCP info command tools — ``execute_info`` and ``execute_info_on_node``.
+
+Both are classified as **mutation** in :mod:`mcp.access_profile` because
+asinfo can change cluster configuration (``set-config``, ``recluster``,
+etc.). Under ``READ_ONLY`` profile they are blocked at call time.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aerospike_py
+
+from aerospike_cluster_manager_api.client_manager import client_manager
+from aerospike_cluster_manager_api.mcp.registry import tool
+from aerospike_cluster_manager_api.services import clusters_service
+from aerospike_cluster_manager_api.services.connections_service import ConnectionNotFoundError
+
+
+async def _get_client(conn_id: str) -> aerospike_py.AsyncClient:
+    try:
+        return await client_manager.get_client(conn_id)
+    except ValueError as e:
+        raise ConnectionNotFoundError(conn_id) from e
+
+
+@tool(category="info", mutation=True)
+async def execute_info(conn_id: str, command: str) -> dict[str, Any]:
+    """Run an asinfo command on every node and return per-node responses.
+
+    Returns ``{"nodes": [{"node": str, "error_code": int | None, "response":
+    str}, ...]}``.
+    """
+    client = await _get_client(conn_id)
+    results = await clusters_service.execute_info(client, command)
+    return {"nodes": [{"node": r.node_name, "error_code": r.error_code, "response": r.response} for r in results]}
+
+
+@tool(category="info", mutation=True)
+async def execute_info_on_node(conn_id: str, command: str, node_name: str) -> dict[str, str]:
+    """Run an asinfo command on a single node and return the response."""
+    client = await _get_client(conn_id)
+    response = await clusters_service.execute_info_on_node(client, command, node_name)
+    return {"node": node_name, "response": response}

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/info_commands.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/info_commands.py
@@ -30,6 +30,19 @@ async def execute_info(conn_id: str, command: str) -> dict[str, Any]:
 
     Returns ``{"nodes": [{"node": str, "error_code": int | None, "response":
     str}, ...]}``.
+
+    WARNING: This tool is gated by ``ACM_MCP_ACCESS_PROFILE`` since some
+    asinfo commands write (``set-config``, ``recluster``,
+    ``truncate-namespace``). Under ``READ_ONLY`` profile this tool returns
+    ``code=access_denied`` for ALL commands — including read-only ones such
+    as ``namespaces``, ``version``, and ``roster:`` — because the access
+    gate operates on tool name, not command content. Use ``list_namespaces``,
+    ``list_sets``, and ``get_nodes`` for safe diagnostic reads under
+    ``READ_ONLY``. A read-only ``execute_info`` whitelist is a Phase 2
+    design item.
+
+    Mutation: requires ``ACM_MCP_ACCESS_PROFILE=full``; returns
+    ``code=access_denied`` under READ_ONLY.
     """
     client = await _get_client(conn_id)
     results = await clusters_service.execute_info(client, command)
@@ -38,7 +51,21 @@ async def execute_info(conn_id: str, command: str) -> dict[str, Any]:
 
 @tool(category="info", mutation=True)
 async def execute_info_on_node(conn_id: str, command: str, node_name: str) -> dict[str, str]:
-    """Run an asinfo command on a single node and return the response."""
+    """Run an asinfo command on a single node and return the response.
+
+    WARNING: This tool is gated by ``ACM_MCP_ACCESS_PROFILE`` since some
+    asinfo commands write (``set-config``, ``recluster``,
+    ``truncate-namespace``). Under ``READ_ONLY`` profile this tool returns
+    ``code=access_denied`` for ALL commands — including read-only ones such
+    as ``namespaces``, ``version``, and ``roster:`` — because the access
+    gate operates on tool name, not command content. Use ``list_namespaces``,
+    ``list_sets``, and ``get_nodes`` for safe diagnostic reads under
+    ``READ_ONLY``. A read-only ``execute_info`` whitelist is a Phase 2
+    design item.
+
+    Mutation: requires ``ACM_MCP_ACCESS_PROFILE=full``; returns
+    ``code=access_denied`` under READ_ONLY.
+    """
     client = await _get_client(conn_id)
     response = await clusters_service.execute_info_on_node(client, command, node_name)
     return {"node": node_name, "response": response}

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/query.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/query.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Literal
 
 import aerospike_py
 
 from aerospike_cluster_manager_api.client_manager import client_manager
+from aerospike_cluster_manager_api.constants import MAX_QUERY_RECORDS
 from aerospike_cluster_manager_api.mcp.registry import tool
 from aerospike_cluster_manager_api.mcp.serializers import serialize_record
 from aerospike_cluster_manager_api.models.query import QueryPredicate, QueryRequest
@@ -27,21 +28,44 @@ async def query(
     namespace: str,
     set_name: str | None = None,
     primary_key: str | None = None,
-    predicate: dict[str, Any] | None = None,
+    predicate_bin: str | None = None,
+    predicate_operator: Literal["equals", "between", "contains", "geo_within_region", "geo_contains_point"]
+    | None = None,
+    predicate_value: Any = None,
+    predicate_value2: Any = None,
     select_bins: list[str] | None = None,
     max_records: int | None = 100,
-    pk_type: str = "auto",
+    pk_type: Literal["auto", "string", "int", "bytes"] = "auto",
 ) -> dict[str, Any]:
     """Run a query: PK lookup if ``primary_key`` is provided, otherwise a scan.
 
+    Predicate scans are described inline via ``predicate_bin``,
+    ``predicate_operator``, ``predicate_value`` (and optionally
+    ``predicate_value2`` for ``between``). Both ``predicate_bin`` and
+    ``predicate_operator`` must be supplied together — partial input is
+    rejected.
+
     Returns ``{"records": [...], "execution_time_ms": int, "scanned_records":
-    int, "returned_records": int}``. Records are serialised via
-    :func:`mcp.serializers.serialize_record` so binary, GeoJSON, and CDT
-    bins round-trip through JSON safely.
+    int, "returned_records": int, "truncated": bool}``. ``truncated`` is True
+    when the service capped the result at the effective ``max_records`` limit
+    (``min(max_records, MAX_QUERY_RECORDS)``); the model should re-issue with
+    a tighter filter or a higher ``max_records`` to retrieve the rest. Records
+    are serialised via :func:`mcp.serializers.serialize_record` so binary,
+    GeoJSON, and CDT bins round-trip through JSON safely.
     """
     client = await _get_client(conn_id)
 
-    pred_model = QueryPredicate.model_validate(predicate) if predicate is not None else None
+    pred_model: QueryPredicate | None = None
+    if predicate_bin is not None or predicate_operator is not None:
+        if predicate_bin is None or predicate_operator is None:
+            raise ValueError("predicate_bin and predicate_operator must be provided together")
+        pred_model = QueryPredicate(
+            bin=predicate_bin,
+            operator=predicate_operator,
+            value=predicate_value,
+            value2=predicate_value2,
+        )
+
     body = QueryRequest(
         namespace=namespace,
         set=set_name,
@@ -49,12 +73,22 @@ async def query(
         selectBins=select_bins,
         maxRecords=max_records,
         primaryKey=primary_key,
-        pkType=pk_type,  # type: ignore[arg-type]
+        pkType=pk_type,
     )
     result = await query_service.execute_query(client, body)
+
+    # Truncation signal: the service caps results at
+    # ``min(max_records or MAX_QUERY_RECORDS, MAX_QUERY_RECORDS)``. When the
+    # returned count hits that cap, more records likely exist server-side.
+    # Phase 1-B's service layer does not expose an explicit "truncated"
+    # field yet, so we compute it from the request-side cap math.
+    effective_limit = min(max_records or MAX_QUERY_RECORDS, MAX_QUERY_RECORDS)
+    truncated = result.returned_records >= effective_limit
+
     return {
         "records": [serialize_record(r) for r in result.records],
         "execution_time_ms": result.execution_time_ms,
         "scanned_records": result.scanned_records,
         "returned_records": result.returned_records,
+        "truncated": truncated,
     }

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/query.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/query.py
@@ -1,0 +1,60 @@
+"""MCP query tool — runs PK lookup or predicate scan via ``query_service``."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import aerospike_py
+
+from aerospike_cluster_manager_api.client_manager import client_manager
+from aerospike_cluster_manager_api.mcp.registry import tool
+from aerospike_cluster_manager_api.mcp.serializers import serialize_record
+from aerospike_cluster_manager_api.models.query import QueryPredicate, QueryRequest
+from aerospike_cluster_manager_api.services import query_service
+from aerospike_cluster_manager_api.services.connections_service import ConnectionNotFoundError
+
+
+async def _get_client(conn_id: str) -> aerospike_py.AsyncClient:
+    try:
+        return await client_manager.get_client(conn_id)
+    except ValueError as e:
+        raise ConnectionNotFoundError(conn_id) from e
+
+
+@tool(category="query", mutation=False)
+async def query(
+    conn_id: str,
+    namespace: str,
+    set_name: str | None = None,
+    primary_key: str | None = None,
+    predicate: dict[str, Any] | None = None,
+    select_bins: list[str] | None = None,
+    max_records: int | None = 100,
+    pk_type: str = "auto",
+) -> dict[str, Any]:
+    """Run a query: PK lookup if ``primary_key`` is provided, otherwise a scan.
+
+    Returns ``{"records": [...], "execution_time_ms": int, "scanned_records":
+    int, "returned_records": int}``. Records are serialised via
+    :func:`mcp.serializers.serialize_record` so binary, GeoJSON, and CDT
+    bins round-trip through JSON safely.
+    """
+    client = await _get_client(conn_id)
+
+    pred_model = QueryPredicate.model_validate(predicate) if predicate is not None else None
+    body = QueryRequest(
+        namespace=namespace,
+        set=set_name,
+        predicate=pred_model,
+        selectBins=select_bins,
+        maxRecords=max_records,
+        primaryKey=primary_key,
+        pkType=pk_type,  # type: ignore[arg-type]
+    )
+    result = await query_service.execute_query(client, body)
+    return {
+        "records": [serialize_record(r) for r in result.records],
+        "execution_time_ms": result.execution_time_ms,
+        "scanned_records": result.scanned_records,
+        "returned_records": result.returned_records,
+    }

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/records.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/records.py
@@ -115,6 +115,9 @@ async def create_record(
     :class:`MCPToolError` with ``code="record_exists"``.
 
     Returns ``{"created": True, "key": {...}}``.
+
+    Mutation: requires ``ACM_MCP_ACCESS_PROFILE=full``; returns
+    ``code=access_denied`` under READ_ONLY.
     """
     client = await _get_client(conn_id)
     await records_service.create_record(client, namespace, set_name, str(key), bins)
@@ -135,6 +138,9 @@ async def update_record(
     :class:`MCPToolError` with ``code="record_not_found"``.
 
     Returns ``{"updated": True, "key": {...}}``.
+
+    Mutation: requires ``ACM_MCP_ACCESS_PROFILE=full``; returns
+    ``code=access_denied`` under READ_ONLY.
     """
     client = await _get_client(conn_id)
     await records_service.update_record(client, namespace, set_name, str(key), bins)
@@ -152,6 +158,9 @@ async def delete_record(
 
     Returns ``{"deleted": True, "key": {...}}``. Missing records surface as
     :class:`MCPToolError` with ``code="record_not_found"``.
+
+    Mutation: requires ``ACM_MCP_ACCESS_PROFILE=full``; returns
+    ``code=access_denied`` under READ_ONLY.
     """
     client = await _get_client(conn_id)
     await records_service.delete_record(client, namespace, set_name, str(key))
@@ -173,6 +182,9 @@ async def delete_bin(
     something the tool papers over.
 
     Returns ``{"bin_deleted": True, "bin": "...", "key": {...}}``.
+
+    Mutation: requires ``ACM_MCP_ACCESS_PROFILE=full``; returns
+    ``code=access_denied`` under READ_ONLY.
     """
     client = await _get_client(conn_id)
     await records_service.delete_bin(client, namespace, set_name, str(key), bin_name)
@@ -196,6 +208,9 @@ async def truncate_set(
     omitted, every record currently in the set is cleared.
 
     Returns ``{"truncated": True, "namespace": "...", "set": "..."}``.
+
+    Mutation: requires ``ACM_MCP_ACCESS_PROFILE=full``; returns
+    ``code=access_denied`` under READ_ONLY.
     """
     client = await _get_client(conn_id)
     await records_service.truncate_set(client, namespace, set_name, before_lut=before_lut)

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/records.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/records.py
@@ -1,0 +1,202 @@
+"""MCP tools for Aerospike record CRUD (Voyager parity).
+
+This module exposes 7 record tools that wrap the existing service layer
+(:mod:`aerospike_cluster_manager_api.services.records_service`) and the
+live-client pool (:mod:`aerospike_cluster_manager_api.client_manager`):
+
+* ``get_record`` — read by primary key
+* ``record_exists`` — existence probe (no bins fetched)
+* ``create_record`` — create-only write (mutation)
+* ``update_record`` — update-only write (mutation)
+* ``delete_record`` — remove a record (mutation)
+* ``delete_bin`` — remove a single bin from a record (mutation)
+* ``truncate_set`` — drop every record in a set, optionally up to a LUT (mutation)
+
+Design notes:
+
+* Tools accept simple Python types (``str``, ``int``, ``dict``) so the
+  MCP SDK can derive a JSON Schema directly from the type hints.
+* Reads return ``serialize_record`` envelopes (see :mod:`mcp.serializers`)
+  so CDT bytes round-trip safely as the documented base64 marker dict.
+* Mutations return small ack dicts so the model can confirm side-effects:
+  ``{"created": True, ...}``, ``{"updated": True, ...}``, etc.
+* Keys are ``str | int`` at the MCP boundary — Voyager parity. The service
+  layer's auto pk-type heuristic resolves numeric strings into integers
+  automatically, so the model can speak in either form. We always pass
+  ``"auto"`` from this module; advanced pk-type semantics stay below the
+  REST surface.
+* The ``@tool`` decorator already wraps every body in the access-profile
+  gate and ``map_aerospike_errors`` — do **not** apply them again here.
+* ``client_manager.get_client`` raises :class:`ValueError` when the profile
+  is missing; we re-raise as :class:`ConnectionNotFoundError` so the
+  registry's error map produces the canonical
+  ``code="ConnectionNotFoundError"`` wire shape, matching the read-side
+  tools (B.1, B.2).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from aerospike_cluster_manager_api.client_manager import client_manager
+from aerospike_cluster_manager_api.mcp.registry import tool
+from aerospike_cluster_manager_api.mcp.serializers import serialize_record
+from aerospike_cluster_manager_api.services import records_service
+from aerospike_cluster_manager_api.services.connections_service import (
+    ConnectionNotFoundError,
+)
+
+
+async def _get_client(conn_id: str) -> Any:
+    """Resolve a live ``AsyncClient`` for ``conn_id``.
+
+    See module docstring — translates ``ValueError`` (the shape
+    ``client_manager`` raises for unknown profiles) into the canonical
+    :class:`ConnectionNotFoundError` so the registry error map produces a
+    stable wire code.
+    """
+    try:
+        return await client_manager.get_client(conn_id)
+    except ValueError as e:
+        raise ConnectionNotFoundError(conn_id) from e
+
+
+def _key_envelope(namespace: str, set_name: str, key: str | int) -> dict[str, Any]:
+    """Build the ``{"namespace", "set", "pk"}`` ack envelope used by writes."""
+    return {"namespace": namespace, "set": set_name, "pk": key}
+
+
+@tool(category="record", mutation=False)
+async def get_record(
+    conn_id: str,
+    namespace: str,
+    set_name: str,
+    key: str | int,
+) -> dict[str, Any]:
+    """Fetch a single record by ``(namespace, set, key)``.
+
+    Returns the standard MCP record envelope: ``{"key", "meta", "bins"}``
+    (see :mod:`mcp.serializers`). ``MCPToolError`` with
+    ``code="record_not_found"`` is raised when no record exists at the key.
+    """
+    client = await _get_client(conn_id)
+    record = await records_service.get_record(client, namespace, set_name, str(key))
+    return serialize_record(record)
+
+
+@tool(category="record", mutation=False)
+async def record_exists(
+    conn_id: str,
+    namespace: str,
+    set_name: str,
+    key: str | int,
+) -> dict[str, Any]:
+    """Probe whether a record exists at ``(namespace, set, key)``.
+
+    Returns ``{"exists": bool}`` — never raises ``record_not_found``.
+    Useful for cheap pre-flight checks before larger reads.
+    """
+    client = await _get_client(conn_id)
+    exists = await records_service.record_exists(client, namespace, set_name, str(key))
+    return {"exists": exists}
+
+
+@tool(category="record", mutation=True)
+async def create_record(
+    conn_id: str,
+    namespace: str,
+    set_name: str,
+    key: str | int,
+    bins: dict[str, Any],
+) -> dict[str, Any]:
+    """Create a record, failing if one already exists at the same key.
+
+    Uses the ``CREATE_ONLY`` write policy; collisions surface as
+    :class:`MCPToolError` with ``code="record_exists"``.
+
+    Returns ``{"created": True, "key": {...}}``.
+    """
+    client = await _get_client(conn_id)
+    await records_service.create_record(client, namespace, set_name, str(key), bins)
+    return {"created": True, "key": _key_envelope(namespace, set_name, key)}
+
+
+@tool(category="record", mutation=True)
+async def update_record(
+    conn_id: str,
+    namespace: str,
+    set_name: str,
+    key: str | int,
+    bins: dict[str, Any],
+) -> dict[str, Any]:
+    """Update an existing record, failing if it is absent.
+
+    Uses the ``UPDATE_ONLY`` write policy; missing records surface as
+    :class:`MCPToolError` with ``code="record_not_found"``.
+
+    Returns ``{"updated": True, "key": {...}}``.
+    """
+    client = await _get_client(conn_id)
+    await records_service.update_record(client, namespace, set_name, str(key), bins)
+    return {"updated": True, "key": _key_envelope(namespace, set_name, key)}
+
+
+@tool(category="record", mutation=True)
+async def delete_record(
+    conn_id: str,
+    namespace: str,
+    set_name: str,
+    key: str | int,
+) -> dict[str, Any]:
+    """Delete a record by ``(namespace, set, key)``.
+
+    Returns ``{"deleted": True, "key": {...}}``. Missing records surface as
+    :class:`MCPToolError` with ``code="record_not_found"``.
+    """
+    client = await _get_client(conn_id)
+    await records_service.delete_record(client, namespace, set_name, str(key))
+    return {"deleted": True, "key": _key_envelope(namespace, set_name, key)}
+
+
+@tool(category="record", mutation=True)
+async def delete_bin(
+    conn_id: str,
+    namespace: str,
+    set_name: str,
+    key: str | int,
+    bin_name: str,
+) -> dict[str, Any]:
+    """Remove a single bin from a record (sets the bin to nil server-side).
+
+    Note that removing the last bin from a record makes the whole record
+    disappear server-side — this is standard Aerospike behaviour and not
+    something the tool papers over.
+
+    Returns ``{"bin_deleted": True, "bin": "...", "key": {...}}``.
+    """
+    client = await _get_client(conn_id)
+    await records_service.delete_bin(client, namespace, set_name, str(key), bin_name)
+    return {
+        "bin_deleted": True,
+        "bin": bin_name,
+        "key": _key_envelope(namespace, set_name, key),
+    }
+
+
+@tool(category="record", mutation=True)
+async def truncate_set(
+    conn_id: str,
+    namespace: str,
+    set_name: str,
+    before_lut: int | None = None,
+) -> dict[str, Any]:
+    """Truncate every record in ``namespace.set_name`` (or up to ``before_lut``).
+
+    ``before_lut`` is the cutoff in nanoseconds since CITRUS epoch — when
+    omitted, every record currently in the set is cleared.
+
+    Returns ``{"truncated": True, "namespace": "...", "set": "..."}``.
+    """
+    client = await _get_client(conn_id)
+    await records_service.truncate_set(client, namespace, set_name, before_lut=before_lut)
+    return {"truncated": True, "namespace": namespace, "set": set_name}

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/records.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/records.py
@@ -1,4 +1,4 @@
-"""MCP tools for Aerospike record CRUD (Voyager parity).
+"""MCP tools for Aerospike record CRUD.
 
 This module exposes 7 record tools that wrap the existing service layer
 (:mod:`aerospike_cluster_manager_api.services.records_service`) and the
@@ -20,7 +20,7 @@ Design notes:
   so CDT bytes round-trip safely as the documented base64 marker dict.
 * Mutations return small ack dicts so the model can confirm side-effects:
   ``{"created": True, ...}``, ``{"updated": True, ...}``, etc.
-* Keys are ``str | int`` at the MCP boundary — Voyager parity. The service
+* Keys are ``str | int`` at the MCP boundary. The service
   layer's auto pk-type heuristic resolves numeric strings into integers
   automatically, so the model can speak in either form. We always pass
   ``"auto"`` from this module; advanced pk-type semantics stay below the

--- a/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
+++ b/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
@@ -127,6 +127,15 @@ class OIDCAuthMiddleware(BaseHTTPMiddleware):
         if not self.enabled:
             return await call_next(request)
 
+        # If an outer middleware (e.g. MCPBearerTokenMiddleware running for
+        # /mcp paths) has already authenticated this request, defer to it.
+        # This is what makes the documented OIDC-OR-bearer gate on /mcp work
+        # when both OIDC_ENABLED=true and ACM_MCP_TOKEN are configured: the
+        # bearer-only token would otherwise fail JWT decode here and 401
+        # before MCP middleware ever runs.
+        if getattr(request.state, "user_claims", None) is not None:
+            return await call_next(request)
+
         path = request.url.path
         if path in self.exclude_paths:
             return await call_next(request)

--- a/api/src/aerospike_cluster_manager_api/models/connection.py
+++ b/api/src/aerospike_cluster_manager_api/models/connection.py
@@ -91,13 +91,13 @@ class CreateConnectionRequest(BaseModel):
 class UpdateConnectionRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
-    name: str | None = Field(None, min_length=1, max_length=255)
-    hosts: list[str] | None = Field(None, min_length=1)
-    port: int | None = Field(None, ge=1, le=65535)
+    name: str | None = Field(default=None, min_length=1, max_length=255)
+    hosts: list[str] | None = Field(default=None, min_length=1)
+    port: int | None = Field(default=None, ge=1, le=65535)
     clusterName: str | None = None
     username: str | None = None
     password: str | None = None
-    color: str | None = Field(None, pattern=r"^#[0-9a-fA-F]{6}$")
+    color: str | None = Field(default=None, pattern=r"^#[0-9a-fA-F]{6}$")
     description: str | None = None
     labels: dict[str, str] | None = None
     workspaceId: str | None = None

--- a/api/src/aerospike_cluster_manager_api/pk.py
+++ b/api/src/aerospike_cluster_manager_api/pk.py
@@ -1,0 +1,146 @@
+"""Shared primary-key helpers — HTTP-free domain logic.
+
+This module is the single source of truth for translating a string-form
+primary key (as it appears in URLs, request bodies, MCP arguments) into
+the typed value Aerospike expects, and for performing a read with a
+particle-type fallback when ``pk_type='auto'`` guesses wrong.
+
+Design rules:
+
+* This module **must not** import ``fastapi`` or any HTTP-shaping
+  libraries — the same code is reused by service-layer callers (which
+  raise domain exceptions) and by MCP tool wrappers.
+* Domain failures surface as ``ValueError`` subclasses defined here.
+  HTTP-boundary callers (``utils.py``) catch them and re-raise as
+  :class:`fastapi.HTTPException` with the right status code; the MCP
+  error mapper translates them via :func:`mcp.errors.map_aerospike_errors`.
+
+Previously these helpers were duplicated three times — ``services.query_service``,
+``services.records_service``, and ``utils`` each carried a near byte-identical
+copy, plus their own ``PkType`` ``Literal``. This module collapses them.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+import aerospike_py
+from aerospike_py import Record
+from aerospike_py.exception import RecordNotFound
+
+# Explicit PK particle type selector. ``auto`` is a heuristic that tries
+# the most likely type then retries the alternate type on NOT_FOUND.
+PkType = Literal["auto", "string", "int", "bytes"]
+
+
+# ---------------------------------------------------------------------------
+# Domain exceptions — also surfaced from services that re-export them.
+# ---------------------------------------------------------------------------
+
+
+class PrimaryKeyMissing(ValueError):
+    """Raised when a write request omits one of namespace/set/pk."""
+
+    def __init__(self, field: str) -> None:
+        super().__init__(f"Missing required key field: {field}")
+        self.field = field
+
+
+class SetRequiredForPkLookup(ValueError):
+    """Raised when a PK lookup is run without a ``set`` scope.
+
+    Aerospike addresses records via ``(namespace, set, pk)`` tuples, so a
+    PK lookup without a set is meaningless. Disallowed at the service
+    boundary.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Set is required for primary key lookup")
+
+
+# ---------------------------------------------------------------------------
+# Resolver
+# ---------------------------------------------------------------------------
+
+
+def resolve_pk(pk: str, pk_type: PkType = "auto") -> str | int | bytes:
+    """Resolve a string primary key into the typed value Aerospike expects.
+
+    Aerospike keys are digested as RIPEMD-160(set || particle_type_byte || key_bytes),
+    so the particle type must match how the record was originally written.
+    If the caller knows the type, they should pass it explicitly via
+    ``pk_type``.
+
+    Behavior:
+        - ``"string"``: return ``pk`` as-is.
+        - ``"int"``: return ``int(pk)`` (raises :class:`ValueError` if not parseable).
+        - ``"bytes"``: return ``bytes.fromhex(pk)`` (raises :class:`ValueError` on invalid hex).
+        - ``"auto"``: best-effort heuristic. Treats any digit-only PK
+          (including negative) as an integer, preserving leading-zero strings.
+          The heuristic is wrong for numeric-string keys, so callers that do
+          reads should pair this with :func:`get_with_pk_fallback`.
+    """
+    if pk_type == "string":
+        return pk
+    if pk_type == "int":
+        try:
+            return int(pk)
+        except ValueError as exc:
+            raise ValueError(f"pk_type=int but pk is not an integer: {pk!r}") from exc
+    if pk_type == "bytes":
+        try:
+            return bytes.fromhex(pk)
+        except ValueError as exc:
+            raise ValueError(f"pk_type=bytes but pk is not valid hex: {pk!r}") from exc
+
+    # ``auto``: numeric-string heuristic. Preserves leading-zero strings so
+    # something like "00042" stays a string rather than collapsing to 42.
+    try:
+        as_int = int(pk)
+        if str(as_int) == pk:
+            return as_int
+    except ValueError:
+        pass
+    return pk
+
+
+async def get_with_pk_fallback(
+    client: aerospike_py.AsyncClient,
+    key_tuple: tuple[str, str, str | int | bytes],
+    pk_raw: str,
+    pk_type: PkType,
+    policy: dict[str, Any],
+) -> Record:
+    """Read a record, retrying the alternate PK type if ``auto`` resolved wrong.
+
+    When ``pk_type == "auto"`` and the first attempt raises
+    :class:`aerospike_py.exception.RecordNotFound`, retry with the
+    alternate string/int particle type (whichever the heuristic did *not*
+    pick). This makes the record browser work for both INTEGER-keyed and
+    STRING-keyed sets without the caller having to know upfront which
+    one the record was written with.
+
+    Explicit pk types (``string`` / ``int`` / ``bytes``) never fall back —
+    if the caller asserted a type, propagate the NOT_FOUND as-is so the
+    caller knows the key is genuinely absent under that type.
+    """
+    try:
+        return await client.get(key_tuple, policy=policy)
+    except RecordNotFound:
+        if pk_type != "auto":
+            raise
+        # Heuristic picked one type; try the opposite. If the alternate
+        # type isn't applicable (e.g. non-numeric string can't become int),
+        # keep propagating the original RecordNotFound — never leak ValueError.
+        first = key_tuple[2]
+        alt: str | int | None = None
+        if isinstance(first, int):
+            alt = pk_raw  # retry as raw string
+        elif isinstance(first, str):
+            try:
+                alt = int(first)
+            except ValueError:
+                alt = None  # no integer alternative → fall through to re-raise
+        if alt is None:
+            raise
+        return await client.get((key_tuple[0], key_tuple[1], alt), policy=policy)

--- a/api/src/aerospike_cluster_manager_api/predicate.py
+++ b/api/src/aerospike_cluster_manager_api/predicate.py
@@ -1,0 +1,73 @@
+"""Shared predicate-builder — HTTP-free domain logic.
+
+This module is the single source of truth for translating a
+:class:`~aerospike_cluster_manager_api.models.query.QueryPredicate` into
+the predicate tuple aerospike-py expects on a query's ``where`` clause.
+
+Design rules:
+
+* Must not import ``fastapi`` or any HTTP-shaping libraries — service
+  callers (``query_service``, ``records_service``) and MCP tool wrappers
+  share the same code.
+* Unknown operators surface as :class:`UnknownPredicateOperator` (a
+  :class:`ValueError` subclass). HTTP-boundary callers (``utils.py``)
+  catch it and re-raise as :class:`fastapi.HTTPException` with status
+  400; the MCP error mapper translates it via
+  :func:`mcp.errors.map_aerospike_errors` to ``code="invalid_argument"``.
+
+Previously :func:`utils.build_predicate` raised
+:class:`fastapi.HTTPException` directly, leaking HTTP coupling into the
+service layer (services imported it locally to dodge the issue). This
+module fixes the leak.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from aerospike_cluster_manager_api.models.query import QueryPredicate
+
+
+class UnknownPredicateOperator(ValueError):
+    """Raised when a :class:`QueryPredicate` carries an unrecognised operator.
+
+    The pydantic model enumerates the supported operators in its
+    ``Literal``, so this should only fire when a future operator is added
+    to the schema before the dispatch table here is updated — defensive
+    rather than load-bearing.
+    """
+
+    def __init__(self, operator: str) -> None:
+        super().__init__(f"Unknown predicate operator: {operator}")
+        self.operator = operator
+
+
+def build_predicate(pred: QueryPredicate) -> tuple[Any, ...]:
+    """Convert a :class:`QueryPredicate` into an Aerospike predicate tuple.
+
+    Used by both ``services.query_service`` and ``services.records_service``
+    via ``q.where(build_predicate(...))``.
+
+    Raises:
+        UnknownPredicateOperator: ``pred.operator`` is not in the dispatch
+            table. The HTTP boundary translates this to status 400 via
+            :func:`utils.build_predicate`.
+    """
+    from aerospike_py import INDEX_TYPE_LIST, predicates
+
+    op = pred.operator
+    if op == "equals":
+        return predicates.equals(pred.bin, pred.value)
+    if op == "between":
+        return predicates.between(pred.bin, pred.value, pred.value2)
+    if op == "contains":
+        return predicates.contains(pred.bin, INDEX_TYPE_LIST, pred.value)
+    if op == "geo_within_region":
+        geo = pred.value if isinstance(pred.value, str) else json.dumps(pred.value)
+        return predicates.geo_within_geojson_region(pred.bin, geo)
+    if op == "geo_contains_point":
+        geo = pred.value if isinstance(pred.value, str) else json.dumps(pred.value)
+        return predicates.geo_contains_geojson_point(pred.bin, geo)
+    raise UnknownPredicateOperator(op)

--- a/api/src/aerospike_cluster_manager_api/routers/clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/clusters.py
@@ -1,38 +1,20 @@
 from __future__ import annotations
 
-import asyncio
 import logging
 
 from fastapi import APIRouter, HTTPException
 
-from aerospike_cluster_manager_api.constants import (
-    INFO_BUILD,
-    INFO_EDITION,
-    INFO_NAMESPACES,
-    INFO_SERVICE,
-    INFO_STATISTICS,
-    NS_SUM_KEYS,
-    info_namespace,
-    info_sets,
-)
 from aerospike_cluster_manager_api.dependencies import AerospikeClient, VerifiedConnId
-from aerospike_cluster_manager_api.info_parser import (
-    aggregate_node_kv,
-    aggregate_set_records,
-    parse_kv_pairs,
-    parse_list,
-    safe_bool,
-    safe_int,
-)
 from aerospike_cluster_manager_api.models.cluster import (
     ClusterInfo,
-    ClusterNode,
     CreateNamespaceRequest,
-    NamespaceInfo,
-    SetInfo,
 )
 from aerospike_cluster_manager_api.models.common import MessageResponse
-from aerospike_cluster_manager_api.services.info_cache import info_cache
+from aerospike_cluster_manager_api.services import clusters_service
+from aerospike_cluster_manager_api.services.clusters_service import (
+    NamespaceConfigError,
+    NamespaceNotFoundError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -46,132 +28,7 @@ router = APIRouter(prefix="/clusters", tags=["clusters"])
 )
 async def get_cluster(client: AerospikeClient, conn_id: VerifiedConnId) -> ClusterInfo:
     """Retrieve full cluster information including nodes, namespaces, and sets."""
-    # --- Phase 1: All node-level calls in parallel ---
-    # get_node_names() is synchronous — call it before the async gather
-    node_names = client.get_node_names()
-    info_all_stats, info_all_build, info_all_edition, info_all_service = await asyncio.gather(
-        client.info_all(INFO_STATISTICS),
-        info_cache.get_or_fetch(conn_id, INFO_BUILD, lambda: client.info_all(INFO_BUILD)),
-        info_cache.get_or_fetch(conn_id, INFO_EDITION, lambda: client.info_all(INFO_EDITION)),
-        client.info_all(INFO_SERVICE),
-    )
-
-    node_map: dict[str, dict] = {}
-    for name, _err, resp in info_all_stats:
-        node_map.setdefault(name, {})["stats"] = parse_kv_pairs(resp)
-    for name, _err, resp in info_all_build:
-        node_map.setdefault(name, {})["build"] = resp.strip()
-    for name, _err, resp in info_all_edition:
-        node_map.setdefault(name, {})["edition"] = resp.strip()
-    for name, _err, resp in info_all_service:
-        node_map.setdefault(name, {})["service"] = resp.strip()
-
-    nodes: list[ClusterNode] = []
-    for name in node_names:
-        info = node_map.get(name, {})
-        stats = info.get("stats", {})
-        service = info.get("service", "")
-        addr, port = ([*service.split(":"), "3000"])[:2] if service else ("", "3000")
-
-        nodes.append(
-            ClusterNode(
-                name=name,
-                address=addr,
-                port=safe_int(port, 3000),
-                build=info.get("build", ""),
-                edition=info.get("edition", ""),
-                clusterSize=safe_int(stats.get("cluster_size"), 1),
-                uptime=safe_int(stats.get("uptime")),
-                clientConnections=safe_int(stats.get("client_connections")),
-                statistics=stats,
-            )
-        )
-
-    # --- Phase 2: Namespace list ---
-    ns_raw = await client.info_random_node(INFO_NAMESPACES)
-    ns_names = parse_list(ns_raw)
-
-    total_nodes = len(node_names)
-
-    # --- Phase 3: All namespace info calls in parallel ---
-    if ns_names:
-        ns_tasks = []
-        for ns_name in ns_names:
-            ns_tasks.append(client.info_all(info_namespace(ns_name)))
-            ns_tasks.append(client.info_all(info_sets(ns_name)))
-        ns_results = await asyncio.gather(*ns_tasks)
-    else:
-        ns_results = []
-
-    namespaces: list[NamespaceInfo] = []
-    for i, ns_name in enumerate(ns_names):
-        ns_all = ns_results[i * 2]
-        sets_all = ns_results[i * 2 + 1]
-
-        ns_stats = aggregate_node_kv(ns_all, keys_to_sum=NS_SUM_KEYS)
-
-        replication_factor = safe_int(ns_stats.get("replication-factor"), 1)
-        effective_rf = min(replication_factor, total_nodes) if total_nodes > 0 else 1
-
-        raw_objects = safe_int(ns_stats.get("objects"))
-        unique_objects = raw_objects // effective_rf if effective_rf > 0 else raw_objects
-
-        # CE 8 uses unified data_used_bytes/data_total_bytes for both memory and device.
-        # Fall back to legacy memory_used_bytes/memory-size for older versions.
-        memory_used = (
-            safe_int(ns_stats.get("data_used_bytes"))
-            if "data_used_bytes" in ns_stats
-            else safe_int(ns_stats.get("memory_used_bytes"))
-        )
-        memory_total = (
-            safe_int(ns_stats.get("data_total_bytes"))
-            if "data_total_bytes" in ns_stats
-            else safe_int(ns_stats.get("memory-size"))
-        )
-        device_used = safe_int(ns_stats.get("device_used_bytes"))
-        device_total = safe_int(ns_stats.get("device-total-bytes"))
-
-        memory_free_pct = 0
-        if memory_total > 0:
-            memory_free_pct = int((1 - memory_used / memory_total) * 100)
-
-        agg_sets = aggregate_set_records(sets_all, replication_factor)
-        sets = [
-            SetInfo(
-                name=s["name"],
-                namespace=ns_name,
-                objects=s["objects"],
-                tombstones=s["tombstones"],
-                memoryDataBytes=s["memory_data_bytes"],
-                stopWritesCount=s["stop_writes_count"],
-                nodeCount=s["node_count"],
-                totalNodes=total_nodes,
-            )
-            for s in agg_sets
-        ]
-
-        namespaces.append(
-            NamespaceInfo(
-                name=ns_name,
-                objects=unique_objects,
-                memoryUsed=memory_used,
-                memoryTotal=memory_total,
-                memoryFreePct=memory_free_pct,
-                deviceUsed=device_used,
-                deviceTotal=device_total,
-                replicationFactor=replication_factor,
-                stopWrites=safe_bool(ns_stats.get("stop_writes")),
-                hwmBreached=safe_bool(ns_stats.get("hwm_breached")),
-                highWaterMemoryPct=safe_int(ns_stats.get("high-water-memory-pct")),
-                highWaterDiskPct=safe_int(ns_stats.get("high-water-disk-pct")),
-                nsupPeriod=safe_int(ns_stats.get("nsup-period")),
-                defaultTtl=safe_int(ns_stats.get("default-ttl")),
-                allowTtlWithoutNsup=safe_bool(ns_stats.get("allow-ttl-without-nsup")),
-                sets=sets,
-            )
-        )
-
-    return ClusterInfo(connectionId=conn_id, nodes=nodes, namespaces=namespaces)
+    return await clusters_service.get_cluster_info(client, conn_id)
 
 
 @router.post(
@@ -183,26 +40,17 @@ async def get_cluster(client: AerospikeClient, conn_id: VerifiedConnId) -> Clust
 )
 async def configure_namespace(body: CreateNamespaceRequest, client: AerospikeClient) -> MessageResponse:
     """Update runtime-tunable parameters of an existing Aerospike namespace."""
-    ns_raw = await client.info_random_node(INFO_NAMESPACES)
-    existing = parse_list(ns_raw)
-    if body.name not in existing:
+    try:
+        message = await clusters_service.configure_namespace(client, body)
+    except NamespaceNotFoundError as exc:
         raise HTTPException(
             status_code=400,
             detail=(
-                f"Namespace '{body.name}' does not exist. "
+                f"Namespace '{exc.namespace}' does not exist. "
                 "Aerospike does not support dynamic namespace creation. "
                 "Namespaces must be defined in aerospike.conf and require a server restart."
             ),
-        )
-
-    cmd = (
-        f"set-config:context=namespace;id={body.name}"
-        f";memory-size={body.memorySize}"
-        f";replication-factor={body.replicationFactor}"
-    )
-    resp = await client.info_random_node(cmd)
-
-    if resp.strip().lower() != "ok":
-        raise HTTPException(status_code=400, detail=f"Failed to configure namespace '{body.name}': {resp.strip()}")
-
-    return MessageResponse(message=f"Namespace '{body.name}' configured successfully")
+        ) from exc
+    except NamespaceConfigError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return MessageResponse(message=message)

--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -1,33 +1,31 @@
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
-import uuid
-from datetime import UTC, datetime
 from typing import Any
 
-import aerospike_py
+import aerospike_py  # noqa: F401  — re-exported for tests that patch via this module path
 from aerospike_py.exception import AerospikeError, AerospikeTimeoutError, ClusterError
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from starlette.responses import Response
 
-from aerospike_cluster_manager_api import db
 from aerospike_cluster_manager_api.client_manager import client_manager
 from aerospike_cluster_manager_api.constants import INFO_BUILD, INFO_EDITION, INFO_NAMESPACES
-from aerospike_cluster_manager_api.dependencies import VerifiedConnectionProfile, _get_verified_connection
+from aerospike_cluster_manager_api.dependencies import _get_verified_connection
 from aerospike_cluster_manager_api.info_parser import parse_kv_pairs, parse_list, safe_int
 from aerospike_cluster_manager_api.models.connection import (
-    ConnectionProfile,
     ConnectionProfileResponse,
     ConnectionStatus,
     CreateConnectionRequest,
     TestConnectionRequest,
     UpdateConnectionRequest,
 )
-from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID
 from aerospike_cluster_manager_api.rate_limit import limiter
-from aerospike_cluster_manager_api.utils import parse_host_port
+from aerospike_cluster_manager_api.services import connections_service
+from aerospike_cluster_manager_api.services.connections_service import (
+    ConnectionNotFoundError,
+    WorkspaceNotFoundError,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -39,45 +37,29 @@ async def list_connections(
     workspace_id: str | None = Query(default=None, description="Filter by workspace id."),
 ) -> list[ConnectionProfileResponse]:
     """Retrieve all saved Aerospike connection profiles, optionally filtered by workspace."""
-    if workspace_id is not None:
-        ws = await db.get_workspace(workspace_id)
-        if not ws:
-            raise HTTPException(status_code=404, detail=f"Workspace '{workspace_id}' not found")
-    profiles = await db.get_all_connections(workspace_id)
-    return [ConnectionProfileResponse.from_profile(p) for p in profiles]
+    try:
+        return await connections_service.list_connections(workspace_id)
+    except WorkspaceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.post("", status_code=201, summary="Create connection", description="Create a new Aerospike connection profile.")
 @limiter.limit("10/minute")
 async def create_connection(request: Request, body: CreateConnectionRequest) -> ConnectionProfileResponse:
     """Create a new Aerospike connection profile."""
-    workspace_id = body.workspaceId or DEFAULT_WORKSPACE_ID
-    if not await db.get_workspace(workspace_id):
-        raise HTTPException(status_code=404, detail=f"Workspace '{workspace_id}' not found")
-    now = datetime.now(UTC).isoformat()
-    conn = ConnectionProfile(
-        id=f"conn-{uuid.uuid4().hex[:12]}",
-        name=body.name,
-        hosts=body.hosts,
-        port=body.port,
-        clusterName=body.clusterName,
-        username=body.username,
-        password=body.password,
-        color=body.color,
-        description=body.description,
-        labels=body.labels or {},
-        workspaceId=workspace_id,
-        createdAt=now,
-        updatedAt=now,
-    )
-    await db.create_connection(conn)
-    return ConnectionProfileResponse.from_profile(conn)
+    try:
+        return await connections_service.create_connection(body)
+    except WorkspaceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.get("/{conn_id}", summary="Get connection", description="Retrieve a single connection profile by its ID.")
-async def get_connection(conn: VerifiedConnectionProfile) -> ConnectionProfileResponse:
+async def get_connection(conn_id: str = Depends(_get_verified_connection)) -> ConnectionProfileResponse:
     """Retrieve a single connection profile by its ID."""
-    return ConnectionProfileResponse.from_profile(conn)
+    try:
+        return await connections_service.get_connection(conn_id)
+    except ConnectionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.put(
@@ -88,15 +70,12 @@ async def update_connection(
     conn_id: str = Depends(_get_verified_connection),
 ) -> ConnectionProfileResponse:
     """Update an existing connection profile with new settings."""
-    update_data = body.model_dump(exclude_unset=True, by_alias=False)
-    if "workspaceId" in update_data and update_data["workspaceId"] is not None:
-        target_ws = update_data["workspaceId"]
-        if not await db.get_workspace(target_ws):
-            raise HTTPException(status_code=404, detail=f"Workspace '{target_ws}' not found")
-    conn = await db.update_connection(conn_id, update_data)
-    if not conn:
-        raise HTTPException(status_code=404, detail=f"Connection '{conn_id}' not found")
-    return ConnectionProfileResponse.from_profile(conn)
+    try:
+        return await connections_service.update_connection(conn_id, body)
+    except ConnectionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except WorkspaceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.get(
@@ -179,41 +158,28 @@ async def get_connection_health(conn_id: str = Depends(_get_verified_connection)
         )
     except AerospikeTimeoutError as exc:
         logger.warning("Health check timed out for connection '%s'", conn_id, exc_info=True)
-        return Response(
-            content=ConnectionStatus(
-                connected=False, nodeCount=0, namespaceCount=0, error=str(exc), errorType="timeout"
-            ).model_dump_json(),
-            media_type="application/json",
-            headers={"Retry-After": "30"},
-        )
+        return _disconnected_health(str(exc), "timeout")
     except ConnectionRefusedError as exc:
         logger.warning("Connection refused for '%s'", conn_id, exc_info=True)
-        return Response(
-            content=ConnectionStatus(
-                connected=False, nodeCount=0, namespaceCount=0, error=str(exc), errorType="connection_refused"
-            ).model_dump_json(),
-            media_type="application/json",
-            headers={"Retry-After": "30"},
-        )
+        return _disconnected_health(str(exc), "connection_refused")
     except ClusterError as exc:
         logger.warning("Cluster error for connection '%s'", conn_id, exc_info=True)
-        return Response(
-            content=ConnectionStatus(
-                connected=False, nodeCount=0, namespaceCount=0, error=str(exc), errorType="cluster_error"
-            ).model_dump_json(),
-            media_type="application/json",
-            headers={"Retry-After": "30"},
-        )
+        return _disconnected_health(str(exc), "cluster_error")
     except (AerospikeError, OSError) as exc:
         logger.warning("Health check failed for connection '%s'", conn_id, exc_info=True)
         error_type = "auth_error" if isinstance(exc, AerospikeError) and "security" in str(exc).lower() else "unknown"
-        return Response(
-            content=ConnectionStatus(
-                connected=False, nodeCount=0, namespaceCount=0, error=str(exc), errorType=error_type
-            ).model_dump_json(),
-            media_type="application/json",
-            headers={"Retry-After": "30"},
-        )
+        return _disconnected_health(str(exc), error_type)
+
+
+def _disconnected_health(error: str, error_type: str) -> Response:
+    """Build a JSON Response for the ``connected=false`` health-check shape."""
+    return Response(
+        content=ConnectionStatus(
+            connected=False, nodeCount=0, namespaceCount=0, error=error, errorType=error_type
+        ).model_dump_json(),
+        media_type="application/json",
+        headers={"Retry-After": "30"},
+    )
 
 
 @router.post(
@@ -222,28 +188,9 @@ async def get_connection_health(conn_id: str = Depends(_get_verified_connection)
     description="Test connectivity to an Aerospike cluster without saving the profile.",
 )
 @limiter.limit("5/minute")
-async def test_connection(request: Request, body: TestConnectionRequest) -> dict:
+async def test_connection(request: Request, body: TestConnectionRequest) -> dict[str, Any]:
     """Test connectivity to an Aerospike cluster without saving the profile."""
-    try:
-        hosts = [parse_host_port(h, body.port) for h in body.hosts]
-
-        config: dict[str, Any] = {"hosts": hosts}
-        if body.username and body.password:
-            config["user"] = body.username
-            config["password"] = body.password
-
-        client = aerospike_py.AsyncClient(config)
-        await client.connect()
-        try:
-            if not client.is_connected():
-                return {"success": False, "message": "Failed to connect"}
-            return {"success": True, "message": "Connected successfully"}
-        finally:
-            with contextlib.suppress(AerospikeError, OSError):
-                await client.close()
-    except Exception as e:
-        logger.exception("Test connection failed")
-        return {"success": False, "message": str(e)}
+    return await connections_service.test_connection(body)
 
 
 @router.delete(
@@ -255,6 +202,5 @@ async def test_connection(request: Request, body: TestConnectionRequest) -> dict
 @limiter.limit("10/minute")
 async def delete_connection(request: Request, conn_id: str = Depends(_get_verified_connection)) -> Response:
     """Delete a connection profile and close its active client."""
-    await db.delete_connection(conn_id)
-    await client_manager.close_client(conn_id)
+    await connections_service.delete_connection(conn_id)
     return Response(status_code=204)

--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -2,11 +2,9 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
 
-import aerospike_py  # noqa: F401  — re-exported for tests that patch via this module path
 from aerospike_py.exception import AerospikeError, AerospikeTimeoutError, ClusterError
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
 from starlette.responses import Response
 
 from aerospike_cluster_manager_api.client_manager import client_manager
@@ -54,8 +52,13 @@ async def create_connection(request: Request, body: CreateConnectionRequest) -> 
 
 
 @router.get("/{conn_id}", summary="Get connection", description="Retrieve a single connection profile by its ID.")
-async def get_connection(conn_id: str = Depends(_get_verified_connection)) -> ConnectionProfileResponse:
-    """Retrieve a single connection profile by its ID."""
+async def get_connection(conn_id: str = Path()) -> ConnectionProfileResponse:
+    """Retrieve a single connection profile by its ID.
+
+    The service raises :class:`ConnectionNotFoundError` for missing ids, so
+    the dedicated existence-check dependency is redundant — dropping it
+    halves the database round trips on this hot path.
+    """
     try:
         return await connections_service.get_connection(conn_id)
     except ConnectionNotFoundError as exc:
@@ -67,9 +70,15 @@ async def get_connection(conn_id: str = Depends(_get_verified_connection)) -> Co
 )
 async def update_connection(
     body: UpdateConnectionRequest,
-    conn_id: str = Depends(_get_verified_connection),
+    conn_id: str = Path(),
 ) -> ConnectionProfileResponse:
-    """Update an existing connection profile with new settings."""
+    """Update an existing connection profile with new settings.
+
+    The service's :func:`update_connection` raises
+    :class:`ConnectionNotFoundError` when the id is missing, so the
+    existence-check dependency is redundant — drop it to avoid the
+    duplicate ``db.get_connection`` round trip on each PUT.
+    """
     try:
         return await connections_service.update_connection(conn_id, body)
     except ConnectionNotFoundError as exc:
@@ -188,9 +197,10 @@ def _disconnected_health(error: str, error_type: str) -> Response:
     description="Test connectivity to an Aerospike cluster without saving the profile.",
 )
 @limiter.limit("5/minute")
-async def test_connection(request: Request, body: TestConnectionRequest) -> dict[str, Any]:
+async def test_connection(request: Request, body: TestConnectionRequest) -> dict[str, bool | str]:
     """Test connectivity to an Aerospike cluster without saving the profile."""
-    return await connections_service.test_connection(body)
+    result = await connections_service.test_connection(body)
+    return {"success": result.success, "message": result.message}
 
 
 @router.delete(

--- a/api/src/aerospike_cluster_manager_api/routers/query.py
+++ b/api/src/aerospike_cluster_manager_api/routers/query.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
 import logging
-import time
 
-from aerospike_py.exception import AerospikeError, RecordNotFound
 from fastapi import APIRouter, HTTPException
 
-from aerospike_cluster_manager_api.constants import MAX_QUERY_RECORDS, POLICY_QUERY, POLICY_READ
 from aerospike_cluster_manager_api.converters import record_to_model
 from aerospike_cluster_manager_api.dependencies import AerospikeClient
 from aerospike_cluster_manager_api.models.query import QueryRequest, QueryResponse
-from aerospike_cluster_manager_api.utils import build_predicate, get_with_pk_fallback, resolve_pk
+from aerospike_cluster_manager_api.services import query_service
+from aerospike_cluster_manager_api.services.query_service import SetRequiredForPkLookup
 
 logger = logging.getLogger(__name__)
 
@@ -24,67 +22,17 @@ router = APIRouter(prefix="/query", tags=["query"])
 )
 async def execute_query(body: QueryRequest, client: AerospikeClient) -> QueryResponse:
     """Execute a query against Aerospike using primary key lookup, predicate filter, or full scan."""
-    start_time = time.monotonic()
-
-    if body.primaryKey:
-        if not body.set:
-            raise HTTPException(status_code=400, detail="Set is required for primary key lookup")
-
-        # pk_type=auto retries the alternate particle type on NOT_FOUND so
-        # numeric-string keys are resolvable even when the heuristic guesses int.
-        resolved = resolve_pk(body.primaryKey, body.pkType)
-        try:
-            raw_result = await get_with_pk_fallback(
-                client,
-                (body.namespace, body.set, resolved),
-                body.primaryKey,
-                body.pkType,
-                POLICY_READ,
-            )
-            raw_results = [raw_result]
-        except RecordNotFound:
-            raw_results = []
-
-        elapsed_ms = int((time.monotonic() - start_time) * 1000)
-        records = [record_to_model(r) for r in raw_results]
-        return QueryResponse(
-            records=records,
-            executionTimeMs=elapsed_ms,
-            scannedRecords=len(records),
-            returnedRecords=len(records),
-        )
-
-    q = client.query(body.namespace, body.set or "")
-    if body.predicate:
-        q.where(build_predicate(body.predicate))
-    if body.selectBins:
-        q.select(*body.selectBins)
-
-    # Apply server-side max_records limit to prevent OOM.
-    # Note: with max_records the server stops after returning this many matching
-    # records, so scannedRecords reflects the returned count (lower bound), not
-    # the true number of records examined by the server.
-    effective_limit = min(body.maxRecords or MAX_QUERY_RECORDS, MAX_QUERY_RECORDS)
-    policy = {**POLICY_QUERY, "max_records": effective_limit}
-    # See issue #259: empty / sparse namespaces can make the underlying scan raise.
-    # Treat as no records rather than 500.
     try:
-        raw_results = await q.results(policy)
-    except AerospikeError:
-        logger.exception(
-            "Query failed for ns=%s set=%s; returning empty result",
-            body.namespace,
-            body.set,
-        )
-        raw_results = []
-
-    elapsed_ms = int((time.monotonic() - start_time) * 1000)
-
-    records = [record_to_model(r) for r in raw_results]
+        result = await query_service.execute_query(client, body)
+    except SetRequiredForPkLookup as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ValueError as exc:
+        # Explicit pk_type with unparseable pk → 400.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     return QueryResponse(
-        records=records,
-        executionTimeMs=elapsed_ms,
-        scannedRecords=len(records),
-        returnedRecords=len(records),
+        records=[record_to_model(r) for r in result.records],
+        executionTimeMs=result.execution_time_ms,
+        scannedRecords=result.scanned_records,
+        returnedRecords=result.returned_records,
     )

--- a/api/src/aerospike_cluster_manager_api/routers/records.py
+++ b/api/src/aerospike_cluster_manager_api/routers/records.py
@@ -1,70 +1,29 @@
 from __future__ import annotations
 
 import logging
-import time
-from typing import Any, Literal
+from typing import Literal
 
-from aerospike_py import exp
-from aerospike_py.exception import AerospikeError, RecordNotFound
-from aerospike_py.types import WriteMeta
 from fastapi import APIRouter, HTTPException, Query
 from starlette.responses import Response
 
-from aerospike_cluster_manager_api.constants import (
-    MAX_QUERY_RECORDS,
-    POLICY_QUERY,
-    POLICY_READ,
-    POLICY_WRITE,
-    info_namespace,
-    info_sets,
-)
 from aerospike_cluster_manager_api.converters import record_to_model
 from aerospike_cluster_manager_api.dependencies import AerospikeClient
-from aerospike_cluster_manager_api.expression_builder import (
-    InvalidPkPatternError,
-    build_expression,
-    build_pk_filter_expression,
-)
-from aerospike_cluster_manager_api.info_parser import aggregate_node_kv, aggregate_set_records, safe_int
 from aerospike_cluster_manager_api.models.query import FilteredQueryRequest, FilteredQueryResponse
 from aerospike_cluster_manager_api.models.record import (
     AerospikeRecord,
     RecordListResponse,
     RecordWriteRequest,
 )
-from aerospike_cluster_manager_api.utils import (
-    build_predicate,
-    get_with_pk_fallback,
-    resolve_pk,
+from aerospike_cluster_manager_api.services import records_service
+from aerospike_cluster_manager_api.services.records_service import (
+    InvalidPkPattern,
+    PrimaryKeyMissing,
+    SetRequiredForPkLookup,
 )
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/records", tags=["records"])
-
-
-async def _get_set_object_count(client: Any, ns: str, set_name: str) -> int:
-    """Get the approximate object count for a set via info command.
-
-    Fetches the namespace replication-factor to de-duplicate counts
-    across nodes, matching the same approach used in clusters.py.
-    """
-    if not set_name:
-        return 0
-    try:
-        # Resolve replication factor from namespace info (same pattern as clusters.py)
-        ns_all = await client.info_all(info_namespace(ns))
-        ns_stats = aggregate_node_kv(ns_all)
-        replication_factor = safe_int(ns_stats.get("replication-factor"), 1)
-
-        sets_all = await client.info_all(info_sets(ns))
-        agg = aggregate_set_records(sets_all, replication_factor)
-        for s in agg:
-            if s["name"] == set_name:
-                return s["objects"]
-    except (AerospikeError, OSError):
-        logger.debug("Failed to get set object count for %s.%s", ns, set_name, exc_info=True)
-    return 0
 
 
 @router.get(
@@ -87,31 +46,14 @@ async def get_records(
     surfaces as HTTP 422 (``RustPanicError``). Per-record skipping is not
     available without an aerospike-core fork.
     """
-    set_total = await _get_set_object_count(client, ns, set)
-
-    limit = min(pageSize, MAX_QUERY_RECORDS)
-    policy = {**POLICY_QUERY, "max_records": limit}
-    q = client.query(ns, set)
-    # Empty / sparse namespaces can make the underlying scan raise
-    # (issue #259). Treat those as "no records" and return an empty page rather
-    # than the opaque 500 the user sees today. RustPanicError (#280) is *not*
-    # caught here — that's a real per-stream blocker handled by its dedicated
-    # 422 exception handler.
-    try:
-        raw_results = await q.results(policy)
-    except AerospikeError:
-        logger.exception("Query failed for ns=%s set=%s; returning empty page", ns, set)
-        raw_results = []
-
-    records = [record_to_model(r) for r in raw_results]
-
+    result = await records_service.list_records(client, ns, set, page_size=pageSize)
     return RecordListResponse(
-        records=records,
-        total=set_total,
-        page=1,
-        pageSize=pageSize,
-        hasMore=set_total > len(raw_results),
-        totalEstimated=True,
+        records=[record_to_model(r) for r in result.records],
+        total=result.total,
+        page=result.page,
+        pageSize=result.page_size,
+        hasMore=result.has_more,
+        totalEstimated=result.total_estimated,
     )
 
 
@@ -134,8 +76,11 @@ async def get_record_detail(
     (e.g. ``"23404907"``) was stored as STRING but would otherwise be probed
     as INTEGER. Pass an explicit ``pk_type`` to disable the fallback.
     """
-    resolved = resolve_pk(pk, pk_type)
-    raw_result = await get_with_pk_fallback(client, (ns, set, resolved), pk, pk_type, POLICY_READ)
+    try:
+        raw_result = await records_service.get_record(client, ns, set, pk, pk_type)
+    except ValueError as exc:
+        # Explicit pk_type with unparseable pk → 400.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return record_to_model(raw_result)
 
 
@@ -153,18 +98,12 @@ async def put_record(body: RecordWriteRequest, client: AerospikeClient) -> Aeros
     so callers that care should pass an explicit ``pk_type`` to avoid creating
     a record under a particle type that subsequent reads can't find.
     """
-    k = body.key
-    if not k.namespace or not k.set or not k.pk:
-        raise HTTPException(status_code=400, detail="Missing required key fields: namespace, set, pk")
-
-    key_tuple = (k.namespace, k.set, resolve_pk(k.pk, body.pk_type))
-
-    meta: WriteMeta | None = None
-    if body.ttl is not None:
-        meta = WriteMeta(ttl=body.ttl)
-
-    await client.put(key_tuple, body.bins, meta=meta, policy=POLICY_WRITE)
-    result = await client.get(key_tuple, policy=POLICY_READ)
+    try:
+        result = await records_service.put_record(client, body)
+    except PrimaryKeyMissing as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return record_to_model(result)
 
 
@@ -188,7 +127,10 @@ async def delete_record(
     record at the *other* type stays put), and a fallback could mask that
     fact. Pass an explicit ``pk_type`` to be sure of which record gets removed.
     """
-    await client.remove((ns, set, resolve_pk(pk, pk_type)))
+    try:
+        await records_service.delete_record(client, ns, set, pk, pk_type)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return Response(status_code=204)
 
 
@@ -202,144 +144,21 @@ async def get_filtered_records(
     client: AerospikeClient,
 ) -> FilteredQueryResponse:
     """Scan records with optional expression filters and pagination."""
-    start_time = time.monotonic()
-
-    pk_target = body.pk_pattern or body.primary_key
-
-    # Set is required for any PK-targeted query (exact, prefix, or regex):
-    # an unscoped namespace scan with a regex would dwarf the user's intent
-    # and is what the InfoBanner caveat warns against.
-    if pk_target and not body.set:
-        raise HTTPException(status_code=400, detail="Set is required for primary key lookup")
-
-    # PK lookup short-circuit (exact mode). Falls back to the alternate
-    # particle type on NOT_FOUND when pk_type=auto so numeric-string keys
-    # (stored as STRING) are still found even though auto's heuristic resolves
-    # them as INTEGER. Prefix/regex modes skip this branch and run a scan.
-    if pk_target and body.pk_match_mode == "exact":
-        # Set was already required above for PK-targeted queries.
-        assert body.set is not None
-        resolved = resolve_pk(pk_target, body.pk_type)
-        try:
-            raw_result = await get_with_pk_fallback(
-                client,
-                (body.namespace, body.set, resolved),
-                pk_target,
-                body.pk_type,
-                POLICY_READ,
-            )
-            raw_results = [raw_result]
-        except RecordNotFound:
-            raw_results = []
-
-        elapsed_ms = int((time.monotonic() - start_time) * 1000)
-        records = [record_to_model(r) for r in raw_results]
-        return FilteredQueryResponse(
-            records=records,
-            total=len(records),
-            page=1,
-            pageSize=body.page_size,
-            hasMore=False,
-            executionTimeMs=elapsed_ms,
-            scannedRecords=len(records),
-            returnedRecords=len(records),
-        )
-
-    # Build expressions BEFORE constructing the query — validating user input
-    # up front means a bad pattern surfaces as 400 without ever touching the
-    # client.query path.
-    pk_expr: dict | None = None
     try:
-        if pk_target is not None:
-            if body.pk_match_mode == "prefix":
-                pk_expr = build_pk_filter_expression(pk_target, "prefix")
-            elif body.pk_match_mode == "regex":
-                pk_expr = build_pk_filter_expression(pk_target, "regex")
-    except InvalidPkPatternError as e:
-        raise HTTPException(status_code=400, detail=str(e)) from e
-
-    bin_expr = build_expression(body.filters) if body.filters else None
-
-    # Build query
-    q = client.query(body.namespace, body.set or "")
-
-    if body.predicate:
-        q.where(build_predicate(body.predicate))
-
-    if body.select_bins:
-        q.select(*body.select_bins)
-
-    # Build policy with server-side max_records limit to prevent OOM.
-    #
-    # For paginated filter queries we fetch ONE extra record beyond the page
-    # size so we can detect "is there at least one more record" without an
-    # extra round trip. The fetched +1 record is dropped before responding.
-    # This makes `hasMore` accurate. The true `total` for filter-mode queries
-    # cannot be obtained without a separate count-only scan (which would
-    # double cluster load) — `totalEstimated=True` plus a lower-bound
-    # `total` are reported instead. See issue #284.
-    has_filters = body.filters is not None or body.predicate is not None or pk_expr is not None
-    fetch_limit = min(
-        body.max_records or MAX_QUERY_RECORDS,
-        MAX_QUERY_RECORDS,
-        body.page_size + 1,
-    )
-
-    policy: dict[str, Any] = {**POLICY_QUERY, "max_records": fetch_limit}
-    if bin_expr is not None and pk_expr is not None:
-        policy["filter_expression"] = exp.and_(pk_expr, bin_expr)
-    elif pk_expr is not None:
-        policy["filter_expression"] = pk_expr
-    elif bin_expr is not None:
-        policy["filter_expression"] = bin_expr
-
-    try:
-        raw_results = await q.results(policy)
-    except AerospikeError:
-        # The empty/sparse-namespace failure mode (issue #259) is the reason
-        # this catch exists. Log at exception level so operators can still
-        # find the underlying cause in logs — pattern + filter context goes
-        # in the message so user-supplied PK patterns are reproducible.
-        logger.exception(
-            "Filtered query failed for ns=%s set=%s pk_mode=%s pk_pattern=%r has_filters=%s; returning empty page",
-            body.namespace,
-            body.set,
-            body.pk_match_mode,
-            pk_target,
-            body.filters is not None,
-        )
-        raw_results = []
-
-    elapsed_ms = int((time.monotonic() - start_time) * 1000)
-    fetched = len(raw_results)
-    has_more = fetched > body.page_size
-    if has_more:
-        raw_results = raw_results[: body.page_size]
-    returned = len(raw_results)
-
-    records = [record_to_model(r) for r in raw_results]
-
-    # Determine total and scanned counts.
-    # With server-side max_records, the returned count is capped — it does not
-    # reflect the true number of records scanned by the Aerospike server.
-    # For unfiltered scans we use the info command to get the real set size.
-    if has_filters:
-        set_total = returned + (1 if has_more else 0)  # lower bound
-        scanned = returned  # lower bound; actual server-side scan may be higher
-        total_estimated = True
-    else:
-        set_total = await _get_set_object_count(client, body.namespace, body.set or "")
-        scanned = set_total  # info-based: represents all objects in the set
-        total_estimated = True
+        result = await records_service.filter_records(client, body)
+    except SetRequiredForPkLookup as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except InvalidPkPattern as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     return FilteredQueryResponse(
-        records=records,
-        total=set_total,
-        page=1,
-        pageSize=body.page_size,
-        hasMore=has_more,
-        executionTimeMs=elapsed_ms,
-        scannedRecords=scanned,
-        returnedRecords=returned,
-        totalEstimated=total_estimated,
+        records=[record_to_model(r) for r in result.records],
+        total=result.total,
+        page=result.page,
+        pageSize=result.page_size,
+        hasMore=result.has_more,
+        executionTimeMs=result.execution_time_ms,
+        scannedRecords=result.scanned_records,
+        returnedRecords=result.returned_records,
+        totalEstimated=result.total_estimated,
     )

--- a/api/src/aerospike_cluster_manager_api/services/clusters_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/clusters_service.py
@@ -1,0 +1,349 @@
+"""Business logic for Aerospike cluster inspection and namespace configuration.
+
+These functions are the single source of truth for the cluster read-path:
+
+* ``list_namespaces`` / ``list_sets`` / ``get_nodes`` — primitives that drive
+  the dashboard, and are also exposed verbatim by the MCP tool layer added
+  in a later task.
+* ``execute_info`` / ``execute_info_on_node`` — thin wrappers around the
+  Aerospike info protocol so MCP tools can run arbitrary diagnostic
+  commands without each redoing parameter validation.
+* ``get_cluster_info`` — the full composition used by the
+  ``GET /clusters/{conn_id}`` endpoint.
+* ``configure_namespace`` — dynamic ``set-config`` for a runtime-tunable
+  namespace.
+
+To stay reusable from both HTTP and MCP entry points, this module **must not**
+import ``fastapi`` or other HTTP-shaping libraries.  Domain failures are
+signalled by plain exceptions defined here, which the router translates to
+HTTP status codes and MCP tools translate to MCP error responses.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import aerospike_py
+from aerospike_py.types import InfoNodeResult
+
+from aerospike_cluster_manager_api.constants import (
+    INFO_BUILD,
+    INFO_EDITION,
+    INFO_NAMESPACES,
+    INFO_SERVICE,
+    INFO_STATISTICS,
+    NS_SUM_KEYS,
+    info_namespace,
+    info_sets,
+)
+from aerospike_cluster_manager_api.info_parser import (
+    aggregate_node_kv,
+    aggregate_set_records,
+    parse_kv_pairs,
+    parse_list,
+    safe_bool,
+    safe_int,
+)
+from aerospike_cluster_manager_api.models.cluster import (
+    ClusterInfo,
+    ClusterNode,
+    CreateNamespaceRequest,
+    NamespaceInfo,
+    SetInfo,
+)
+from aerospike_cluster_manager_api.services.info_cache import info_cache
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Domain exceptions
+# ---------------------------------------------------------------------------
+
+
+class NamespaceNotFoundError(LookupError):
+    """Raised when a referenced namespace does not exist on the cluster."""
+
+    def __init__(self, namespace: str) -> None:
+        super().__init__(f"Namespace '{namespace}' not found")
+        self.namespace = namespace
+
+
+class NodeNotFoundError(LookupError):
+    """Raised when a per-node info call cannot be satisfied for the named node."""
+
+    def __init__(self, node_name: str) -> None:
+        super().__init__(f"Node '{node_name}' not found or returned no usable response")
+        self.node_name = node_name
+
+
+class NamespaceConfigError(ValueError):
+    """Raised when ``set-config`` returns a non-OK response."""
+
+    def __init__(self, namespace: str, response: str) -> None:
+        super().__init__(f"Failed to configure namespace '{namespace}': {response}")
+        self.namespace = namespace
+        self.response = response
+
+
+# ---------------------------------------------------------------------------
+# Primitives
+# ---------------------------------------------------------------------------
+
+
+async def list_namespaces(client: aerospike_py.AsyncClient) -> list[str]:
+    """Return the namespace names defined on the cluster."""
+    raw = await client.info_random_node(INFO_NAMESPACES)
+    return parse_list(raw)
+
+
+async def list_sets(client: aerospike_py.AsyncClient, namespace: str) -> list[SetInfo]:
+    """Return aggregated ``SetInfo`` for ``namespace``.
+
+    Raises ``NamespaceNotFoundError`` if ``namespace`` is not present on the
+    cluster.
+    """
+    existing = await list_namespaces(client)
+    if namespace not in existing:
+        raise NamespaceNotFoundError(namespace)
+
+    node_names = client.get_node_names()
+    total_nodes = len(node_names)
+
+    ns_all, sets_all = await asyncio.gather(
+        client.info_all(info_namespace(namespace)),
+        client.info_all(info_sets(namespace)),
+    )
+
+    ns_stats = aggregate_node_kv(ns_all, keys_to_sum=NS_SUM_KEYS)
+    replication_factor = safe_int(ns_stats.get("replication-factor"), 1)
+
+    agg_sets = aggregate_set_records(sets_all, replication_factor)
+    return [
+        SetInfo(
+            name=s["name"],
+            namespace=namespace,
+            objects=s["objects"],
+            tombstones=s["tombstones"],
+            memoryDataBytes=s["memory_data_bytes"],
+            stopWritesCount=s["stop_writes_count"],
+            nodeCount=s["node_count"],
+            totalNodes=total_nodes,
+        )
+        for s in agg_sets
+    ]
+
+
+async def get_nodes(client: aerospike_py.AsyncClient, conn_id: str) -> list[ClusterNode]:
+    """Return per-node cluster status for ``conn_id``.
+
+    Static info commands (``build``, ``edition``) are served from
+    ``info_cache`` to avoid hammering the cluster on frequently polled
+    endpoints.
+    """
+    # get_node_names() is synchronous — call it before the async gather
+    node_names = client.get_node_names()
+    info_all_stats, info_all_build, info_all_edition, info_all_service = await asyncio.gather(
+        client.info_all(INFO_STATISTICS),
+        info_cache.get_or_fetch(conn_id, INFO_BUILD, lambda: client.info_all(INFO_BUILD)),
+        info_cache.get_or_fetch(conn_id, INFO_EDITION, lambda: client.info_all(INFO_EDITION)),
+        client.info_all(INFO_SERVICE),
+    )
+
+    node_map: dict[str, dict] = {}
+    for name, _err, resp in info_all_stats:
+        node_map.setdefault(name, {})["stats"] = parse_kv_pairs(resp)
+    for name, _err, resp in info_all_build:
+        node_map.setdefault(name, {})["build"] = resp.strip()
+    for name, _err, resp in info_all_edition:
+        node_map.setdefault(name, {})["edition"] = resp.strip()
+    for name, _err, resp in info_all_service:
+        node_map.setdefault(name, {})["service"] = resp.strip()
+
+    nodes: list[ClusterNode] = []
+    for name in node_names:
+        info = node_map.get(name, {})
+        stats = info.get("stats", {})
+        service = info.get("service", "")
+        addr, port = ([*service.split(":"), "3000"])[:2] if service else ("", "3000")
+
+        nodes.append(
+            ClusterNode(
+                name=name,
+                address=addr,
+                port=safe_int(port, 3000),
+                build=info.get("build", ""),
+                edition=info.get("edition", ""),
+                clusterSize=safe_int(stats.get("cluster_size"), 1),
+                uptime=safe_int(stats.get("uptime")),
+                clientConnections=safe_int(stats.get("client_connections")),
+                statistics=stats,
+            )
+        )
+    return nodes
+
+
+async def execute_info(client: aerospike_py.AsyncClient, command: str) -> list[InfoNodeResult]:
+    """Run an info command on every node and return the per-node responses.
+
+    Thin wrapper around :py:meth:`aerospike_py.AsyncClient.info_all` exposed
+    as a service entry point so MCP tools and HTTP routes can share argument
+    validation / logging in one place.
+
+    Returns:
+        A list of :class:`aerospike_py.types.InfoNodeResult` named tuples
+        ``(node_name, error_code, response)`` — one per node in the cluster.
+    """
+    return await client.info_all(command)
+
+
+async def execute_info_on_node(client: aerospike_py.AsyncClient, command: str, node_name: str) -> str:
+    """Run an info command and return the response from ``node_name``.
+
+    aerospike-py only exposes ``info_all`` and ``info_random_node`` — there
+    is no native single-node info call.  We fan out via ``info_all`` and
+    pick the response whose tuple matches ``node_name``.
+
+    Raises ``NodeNotFoundError`` if the node does not respond, returns an
+    error code, or is not part of the cluster.
+    """
+    results = await client.info_all(command)
+    for name, err, resp in results:
+        if name == node_name:
+            if err:
+                raise NodeNotFoundError(node_name)
+            return resp
+    raise NodeNotFoundError(node_name)
+
+
+# ---------------------------------------------------------------------------
+# Composed read & write
+# ---------------------------------------------------------------------------
+
+
+async def get_cluster_info(client: aerospike_py.AsyncClient, conn_id: str) -> ClusterInfo:
+    """Return the full ``ClusterInfo`` payload for ``conn_id``.
+
+    Composition order:
+
+    1. Per-node status via :func:`get_nodes` (Phase 1).
+    2. Namespace list (Phase 2).
+    3. Per-namespace ``namespace/<ns>`` and ``sets/<ns>`` info_all in
+       parallel (Phase 3) — same shape as the legacy router behaviour.
+    """
+    nodes = await get_nodes(client, conn_id)
+    total_nodes = len(nodes)
+
+    ns_names = await list_namespaces(client)
+
+    if ns_names:
+        ns_tasks = []
+        for ns_name in ns_names:
+            ns_tasks.append(client.info_all(info_namespace(ns_name)))
+            ns_tasks.append(client.info_all(info_sets(ns_name)))
+        ns_results = await asyncio.gather(*ns_tasks)
+    else:
+        ns_results = []
+
+    namespaces: list[NamespaceInfo] = []
+    for i, ns_name in enumerate(ns_names):
+        ns_all = ns_results[i * 2]
+        sets_all = ns_results[i * 2 + 1]
+
+        ns_stats = aggregate_node_kv(ns_all, keys_to_sum=NS_SUM_KEYS)
+
+        replication_factor = safe_int(ns_stats.get("replication-factor"), 1)
+        effective_rf = min(replication_factor, total_nodes) if total_nodes > 0 else 1
+
+        raw_objects = safe_int(ns_stats.get("objects"))
+        unique_objects = raw_objects // effective_rf if effective_rf > 0 else raw_objects
+
+        # CE 8 uses unified data_used_bytes/data_total_bytes for both memory and device.
+        # Fall back to legacy memory_used_bytes/memory-size for older versions.
+        memory_used = (
+            safe_int(ns_stats.get("data_used_bytes"))
+            if "data_used_bytes" in ns_stats
+            else safe_int(ns_stats.get("memory_used_bytes"))
+        )
+        memory_total = (
+            safe_int(ns_stats.get("data_total_bytes"))
+            if "data_total_bytes" in ns_stats
+            else safe_int(ns_stats.get("memory-size"))
+        )
+        device_used = safe_int(ns_stats.get("device_used_bytes"))
+        device_total = safe_int(ns_stats.get("device-total-bytes"))
+
+        memory_free_pct = 0
+        if memory_total > 0:
+            memory_free_pct = int((1 - memory_used / memory_total) * 100)
+
+        agg_sets = aggregate_set_records(sets_all, replication_factor)
+        sets = [
+            SetInfo(
+                name=s["name"],
+                namespace=ns_name,
+                objects=s["objects"],
+                tombstones=s["tombstones"],
+                memoryDataBytes=s["memory_data_bytes"],
+                stopWritesCount=s["stop_writes_count"],
+                nodeCount=s["node_count"],
+                totalNodes=total_nodes,
+            )
+            for s in agg_sets
+        ]
+
+        namespaces.append(
+            NamespaceInfo(
+                name=ns_name,
+                objects=unique_objects,
+                memoryUsed=memory_used,
+                memoryTotal=memory_total,
+                memoryFreePct=memory_free_pct,
+                deviceUsed=device_used,
+                deviceTotal=device_total,
+                replicationFactor=replication_factor,
+                stopWrites=safe_bool(ns_stats.get("stop_writes")),
+                hwmBreached=safe_bool(ns_stats.get("hwm_breached")),
+                highWaterMemoryPct=safe_int(ns_stats.get("high-water-memory-pct")),
+                highWaterDiskPct=safe_int(ns_stats.get("high-water-disk-pct")),
+                nsupPeriod=safe_int(ns_stats.get("nsup-period")),
+                defaultTtl=safe_int(ns_stats.get("default-ttl")),
+                allowTtlWithoutNsup=safe_bool(ns_stats.get("allow-ttl-without-nsup")),
+                sets=sets,
+            )
+        )
+
+    return ClusterInfo(connectionId=conn_id, nodes=nodes, namespaces=namespaces)
+
+
+async def configure_namespace(client: aerospike_py.AsyncClient, body: CreateNamespaceRequest) -> str:
+    """Apply runtime-tunable ``set-config`` to an existing namespace.
+
+    Aerospike does not support dynamic namespace creation — namespaces must
+    be defined in ``aerospike.conf`` and the server restarted.  This call
+    only updates parameters on a namespace that already exists.
+
+    Raises:
+        NamespaceNotFoundError: ``body.name`` is not a known namespace.
+        NamespaceConfigError: the cluster rejected the ``set-config`` call.
+
+    Returns:
+        A success message suitable for direct inclusion in an HTTP or MCP
+        response.
+    """
+    existing = await list_namespaces(client)
+    if body.name not in existing:
+        raise NamespaceNotFoundError(body.name)
+
+    cmd = (
+        f"set-config:context=namespace;id={body.name}"
+        f";memory-size={body.memorySize}"
+        f";replication-factor={body.replicationFactor}"
+    )
+    resp = await client.info_random_node(cmd)
+
+    if resp.strip().lower() != "ok":
+        raise NamespaceConfigError(body.name, resp.strip())
+
+    return f"Namespace '{body.name}' configured successfully"

--- a/api/src/aerospike_cluster_manager_api/services/clusters_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/clusters_service.py
@@ -104,6 +104,12 @@ async def list_sets(client: aerospike_py.AsyncClient, namespace: str) -> list[Se
     Raises ``NamespaceNotFoundError`` if ``namespace`` is not present on the
     cluster.
     """
+    # TODO: drop the existence check (currently 1 extra info round-trip)
+    # once the failure mode of ``info_namespace`` / ``info_sets`` against a
+    # missing namespace is well-defined enough to surface a clean
+    # ``NamespaceNotFoundError`` from the natural error. Today the info
+    # commands return an empty/garbage payload that aggregates to "no sets",
+    # which would silently swallow a typoed namespace.
     existing = await list_namespaces(client)
     if namespace not in existing:
         raise NamespaceNotFoundError(namespace)

--- a/api/src/aerospike_cluster_manager_api/services/connections_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/connections_service.py
@@ -19,7 +19,7 @@ import contextlib
 import logging
 import uuid
 from datetime import UTC, datetime
-from typing import Any
+from typing import Any, NamedTuple
 
 import aerospike_py
 from aerospike_py.exception import AerospikeError
@@ -58,6 +58,25 @@ class WorkspaceNotFoundError(LookupError):
     def __init__(self, workspace_id: str) -> None:
         super().__init__(f"Workspace '{workspace_id}' not found")
         self.workspace_id = workspace_id
+
+
+# ---------------------------------------------------------------------------
+# Result containers
+# ---------------------------------------------------------------------------
+
+
+class TestConnectionResult(NamedTuple):
+    """Outcome of a non-persisting connectivity probe.
+
+    Mirrors the existing service-surface convention (``QueryResult``,
+    ``ListRecordsResult``) so HTTP and MCP wrappers can map fields to
+    their preferred wire format. ``success`` is a boolean for easy
+    short-circuit checks; ``message`` carries either the success
+    summary or the error text.
+    """
+
+    success: bool
+    message: str
 
 
 # ---------------------------------------------------------------------------
@@ -141,18 +160,23 @@ async def update_connection(conn_id: str, payload: UpdateConnectionRequest) -> C
 async def delete_connection(conn_id: str) -> None:
     """Delete a connection profile and close its cached Aerospike client.
 
-    Idempotent: deleting a missing connection is a no-op (mirrors the
-    router's pre-refactor behaviour, which always returned 204).
+    Idempotent: deleting a missing connection is a no-op. The HTTP router
+    still gates on existence via the ``_get_verified_connection``
+    dependency — so the wire-level ``DELETE`` keeps its 404-on-missing
+    semantics — while MCP tool callers see the idempotent behaviour
+    directly. (The pre-refactor router returned 404 from inside the
+    handler; the new layout pushes that gate up to the dependency.)
     """
     await db.delete_connection(conn_id)
     await client_manager.close_client(conn_id)
 
 
-async def test_connection(req: TestConnectionRequest) -> dict[str, Any]:
+async def test_connection(req: TestConnectionRequest) -> TestConnectionResult:
     """Probe Aerospike connectivity without persisting a profile.
 
-    Returns ``{"success": bool, "message": str}``. Never raises — any error
-    is captured and surfaced as ``success=False``.
+    Returns a :class:`TestConnectionResult`. Never raises — any error is
+    captured and surfaced as ``success=False`` so HTTP/MCP wrappers can
+    forward the wire shape unchanged.
     """
     try:
         hosts = [parse_host_port(h, req.port) for h in req.hosts]
@@ -166,11 +190,11 @@ async def test_connection(req: TestConnectionRequest) -> dict[str, Any]:
         await client.connect()
         try:
             if not client.is_connected():
-                return {"success": False, "message": "Failed to connect"}
-            return {"success": True, "message": "Connected successfully"}
+                return TestConnectionResult(success=False, message="Failed to connect")
+            return TestConnectionResult(success=True, message="Connected successfully")
         finally:
             with contextlib.suppress(AerospikeError, OSError):
                 await client.close()
     except Exception as e:
         logger.exception("Test connection failed")
-        return {"success": False, "message": str(e)}
+        return TestConnectionResult(success=False, message=str(e))

--- a/api/src/aerospike_cluster_manager_api/services/connections_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/connections_service.py
@@ -1,0 +1,176 @@
+"""Business logic for Aerospike connection profile management.
+
+These functions are the single source of truth for the connection lifecycle
+(list / get / create / update / delete / test). They are called by both:
+
+* the HTTP router (``routers/connections.py``) — which wraps them in
+  HTTPException translation, rate-limiting, and FastAPI dependencies, and
+* the MCP tool layer (added in a later task) — which calls them directly
+  from MCP tool handlers.
+
+To stay reusable from both sides, this module **must not** import ``fastapi``
+or other HTTP-shaping libraries. Domain failures are signalled by plain
+exceptions defined here, which the router translates to HTTP status codes.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+import aerospike_py
+from aerospike_py.exception import AerospikeError
+
+from aerospike_cluster_manager_api import db
+from aerospike_cluster_manager_api.client_manager import client_manager
+from aerospike_cluster_manager_api.models.connection import (
+    ConnectionProfile,
+    ConnectionProfileResponse,
+    CreateConnectionRequest,
+    TestConnectionRequest,
+    UpdateConnectionRequest,
+)
+from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID
+from aerospike_cluster_manager_api.utils import parse_host_port
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Domain exceptions
+# ---------------------------------------------------------------------------
+
+
+class ConnectionNotFoundError(LookupError):
+    """Raised when a connection profile is not found by id."""
+
+    def __init__(self, conn_id: str) -> None:
+        super().__init__(f"Connection '{conn_id}' not found")
+        self.conn_id = conn_id
+
+
+class WorkspaceNotFoundError(LookupError):
+    """Raised when a referenced workspace does not exist."""
+
+    def __init__(self, workspace_id: str) -> None:
+        super().__init__(f"Workspace '{workspace_id}' not found")
+        self.workspace_id = workspace_id
+
+
+# ---------------------------------------------------------------------------
+# Service entry points
+# ---------------------------------------------------------------------------
+
+
+async def list_connections(workspace_id: str | None) -> list[ConnectionProfileResponse]:
+    """Return all saved connection profiles, optionally filtered by workspace.
+
+    Raises ``WorkspaceNotFoundError`` if a non-None ``workspace_id`` is
+    provided and no such workspace exists.
+    """
+    if workspace_id is not None:
+        ws = await db.get_workspace(workspace_id)
+        if not ws:
+            raise WorkspaceNotFoundError(workspace_id)
+    profiles = await db.get_all_connections(workspace_id)
+    return [ConnectionProfileResponse.from_profile(p) for p in profiles]
+
+
+async def get_connection(conn_id: str) -> ConnectionProfileResponse:
+    """Return the connection profile with id ``conn_id``.
+
+    Raises ``ConnectionNotFoundError`` if no such profile exists.
+    """
+    conn = await db.get_connection(conn_id)
+    if not conn:
+        raise ConnectionNotFoundError(conn_id)
+    return ConnectionProfileResponse.from_profile(conn)
+
+
+async def create_connection(payload: CreateConnectionRequest) -> ConnectionProfileResponse:
+    """Persist a new connection profile and return it (without password).
+
+    Falls back to ``DEFAULT_WORKSPACE_ID`` when the request omits the workspace.
+    Raises ``WorkspaceNotFoundError`` if the resolved workspace does not exist.
+    """
+    workspace_id = payload.workspaceId or DEFAULT_WORKSPACE_ID
+    if not await db.get_workspace(workspace_id):
+        raise WorkspaceNotFoundError(workspace_id)
+
+    now = datetime.now(UTC).isoformat()
+    conn = ConnectionProfile(
+        id=f"conn-{uuid.uuid4().hex[:12]}",
+        name=payload.name,
+        hosts=payload.hosts,
+        port=payload.port,
+        clusterName=payload.clusterName,
+        username=payload.username,
+        password=payload.password,
+        color=payload.color,
+        description=payload.description,
+        labels=payload.labels or {},
+        workspaceId=workspace_id,
+        createdAt=now,
+        updatedAt=now,
+    )
+    await db.create_connection(conn)
+    return ConnectionProfileResponse.from_profile(conn)
+
+
+async def update_connection(conn_id: str, payload: UpdateConnectionRequest) -> ConnectionProfileResponse:
+    """Apply a partial update to ``conn_id`` and return the new state.
+
+    Raises ``ConnectionNotFoundError`` if the connection does not exist, or
+    ``WorkspaceNotFoundError`` if the request moves it to a missing workspace.
+    """
+    update_data = payload.model_dump(exclude_unset=True, by_alias=False)
+    if "workspaceId" in update_data and update_data["workspaceId"] is not None:
+        target_ws = update_data["workspaceId"]
+        if not await db.get_workspace(target_ws):
+            raise WorkspaceNotFoundError(target_ws)
+
+    conn = await db.update_connection(conn_id, update_data)
+    if not conn:
+        raise ConnectionNotFoundError(conn_id)
+    return ConnectionProfileResponse.from_profile(conn)
+
+
+async def delete_connection(conn_id: str) -> None:
+    """Delete a connection profile and close its cached Aerospike client.
+
+    Idempotent: deleting a missing connection is a no-op (mirrors the
+    router's pre-refactor behaviour, which always returned 204).
+    """
+    await db.delete_connection(conn_id)
+    await client_manager.close_client(conn_id)
+
+
+async def test_connection(req: TestConnectionRequest) -> dict[str, Any]:
+    """Probe Aerospike connectivity without persisting a profile.
+
+    Returns ``{"success": bool, "message": str}``. Never raises — any error
+    is captured and surfaced as ``success=False``.
+    """
+    try:
+        hosts = [parse_host_port(h, req.port) for h in req.hosts]
+
+        config: dict[str, Any] = {"hosts": hosts}
+        if req.username and req.password:
+            config["user"] = req.username
+            config["password"] = req.password
+
+        client = aerospike_py.AsyncClient(config)
+        await client.connect()
+        try:
+            if not client.is_connected():
+                return {"success": False, "message": "Failed to connect"}
+            return {"success": True, "message": "Connected successfully"}
+        finally:
+            with contextlib.suppress(AerospikeError, OSError):
+                await client.close()
+    except Exception as e:
+        logger.exception("Test connection failed")
+        return {"success": False, "message": str(e)}

--- a/api/src/aerospike_cluster_manager_api/services/query_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/query_service.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Any, Literal, NamedTuple
+from typing import Any, NamedTuple
 
 import aerospike_py
 from aerospike_py import Record
@@ -31,30 +31,26 @@ from aerospike_py.exception import AerospikeError, RecordNotFound
 
 from aerospike_cluster_manager_api.constants import MAX_QUERY_RECORDS, POLICY_QUERY, POLICY_READ
 from aerospike_cluster_manager_api.models.query import QueryRequest
+from aerospike_cluster_manager_api.pk import (
+    PkType,
+    SetRequiredForPkLookup,
+    get_with_pk_fallback,
+    resolve_pk,
+)
+from aerospike_cluster_manager_api.predicate import build_predicate
 
 logger = logging.getLogger(__name__)
 
 
-# Explicit PK particle type selector. ``auto`` is a heuristic that tries the
-# most likely type then falls back on RecordNotFound. Same shape as the
-# records_service equivalent.
-PkType = Literal["auto", "string", "int", "bytes"]
-
-
-# ---------------------------------------------------------------------------
-# Domain exceptions
-# ---------------------------------------------------------------------------
-
-
-class SetRequiredForPkLookup(ValueError):
-    """Raised when a PK lookup is run without a ``set`` scope.
-
-    Aerospike addresses records via ``(namespace, set, pk)`` tuples, so a PK
-    lookup without a set is meaningless. Disallowed at the service boundary.
-    """
-
-    def __init__(self) -> None:
-        super().__init__("Set is required for primary key lookup")
+# ``PkType`` and ``SetRequiredForPkLookup`` are re-exported from this module
+# for backward compatibility. The canonical home is
+# :mod:`aerospike_cluster_manager_api.pk`.
+__all__ = [
+    "PkType",
+    "QueryResult",
+    "SetRequiredForPkLookup",
+    "execute_query",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -80,74 +76,6 @@ class QueryResult(NamedTuple):
     execution_time_ms: int
     scanned_records: int
     returned_records: int
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers
-# ---------------------------------------------------------------------------
-
-
-def _resolve_pk(pk: str, pk_type: PkType) -> str | int | bytes:
-    """Resolve a string primary key into the typed value Aerospike expects.
-
-    Mirrors ``utils.resolve_pk`` but raises ``ValueError`` instead of
-    HTTPException so the service stays HTTP-free. The router catches the
-    ``ValueError`` and translates it to HTTP 400.
-    """
-    if pk_type == "string":
-        return pk
-    if pk_type == "int":
-        try:
-            return int(pk)
-        except ValueError as exc:
-            raise ValueError(f"pk_type=int but pk is not an integer: {pk!r}") from exc
-    if pk_type == "bytes":
-        try:
-            return bytes.fromhex(pk)
-        except ValueError as exc:
-            raise ValueError(f"pk_type=bytes but pk is not valid hex: {pk!r}") from exc
-
-    # ``auto``: numeric-string heuristic. Preserves leading-zero strings.
-    try:
-        as_int = int(pk)
-        if str(as_int) == pk:
-            return as_int
-    except ValueError:
-        pass
-    return pk
-
-
-async def _get_with_pk_fallback(
-    client: aerospike_py.AsyncClient,
-    key_tuple: tuple[str, str, str | int | bytes],
-    pk_raw: str,
-    pk_type: PkType,
-    policy: dict[str, Any],
-) -> Record:
-    """Read with retry-on-NOT-FOUND for ``auto`` PK type.
-
-    When ``pk_type == "auto"`` and the first attempt raises
-    ``RecordNotFound``, retry with the alternate string/int particle type
-    (whichever the heuristic did *not* pick). Explicit pk types never fall
-    back — propagate the NOT_FOUND so callers see a genuinely absent key.
-    """
-    try:
-        return await client.get(key_tuple, policy=policy)
-    except RecordNotFound:
-        if pk_type != "auto":
-            raise
-        first = key_tuple[2]
-        alt: str | int | None = None
-        if isinstance(first, int):
-            alt = pk_raw  # retry as raw string
-        elif isinstance(first, str):
-            try:
-                alt = int(first)
-            except ValueError:
-                alt = None
-        if alt is None:
-            raise
-        return await client.get((key_tuple[0], key_tuple[1], alt), policy=policy)
 
 
 # ---------------------------------------------------------------------------
@@ -188,9 +116,9 @@ async def execute_query(client: aerospike_py.AsyncClient, body: QueryRequest) ->
         if not body.set:
             raise SetRequiredForPkLookup()
 
-        resolved = _resolve_pk(body.primaryKey, body.pkType)
+        resolved = resolve_pk(body.primaryKey, body.pkType)
         try:
-            raw_record = await _get_with_pk_fallback(
+            raw_record = await get_with_pk_fallback(
                 client,
                 (body.namespace, body.set, resolved),
                 body.primaryKey,
@@ -212,12 +140,9 @@ async def execute_query(client: aerospike_py.AsyncClient, body: QueryRequest) ->
     # ---- Scan branch ------------------------------------------------------
     q = client.query(body.namespace, body.set or "")
     if body.predicate:
-        # Local import keeps utils.build_predicate's HTTPException-aware
-        # implementation out of the service's signature surface. The router
-        # catches ``HTTPException`` directly; service callers via MCP would
-        # surface the exception as a generic error.
-        from aerospike_cluster_manager_api.utils import build_predicate
-
+        # build_predicate raises ``UnknownPredicateOperator`` (a ``ValueError``)
+        # for unknown operators — the HTTP router catches it via
+        # ``utils.build_predicate``'s adapter, MCP tools via the error mapper.
         q.where(build_predicate(body.predicate))
     if body.selectBins:
         q.select(*body.selectBins)

--- a/api/src/aerospike_cluster_manager_api/services/query_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/query_service.py
@@ -1,0 +1,250 @@
+"""Business logic for ad-hoc Aerospike queries.
+
+This module backs the ``POST /query/{conn_id}`` endpoint. It is the single
+source of truth for query execution and is called by both:
+
+* the HTTP router (``routers/query.py``) — which wraps the result in
+  HTTPException translation, FastAPI dependencies, and ``record_to_model``
+  conversion to the wire-format ``AerospikeRecord``, and
+* the MCP tool layer (added in a later task) — which calls it directly from
+  MCP tool handlers.
+
+To stay reusable from both sides, this module **must not** import ``fastapi``
+or other HTTP-shaping libraries. Domain failures are signalled by plain
+exceptions defined here, which the router translates to HTTP status codes.
+
+CDT (lists, maps, geojson) bin values are returned as the raw aerospike-py
+``Record`` NamedTuple — JSON-safe serialization is intentionally deferred to
+the dedicated serializer layer (Phase 1 task A.10), so this module never
+mutates bin contents.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Literal, NamedTuple
+
+import aerospike_py
+from aerospike_py import Record
+from aerospike_py.exception import AerospikeError, RecordNotFound
+
+from aerospike_cluster_manager_api.constants import MAX_QUERY_RECORDS, POLICY_QUERY, POLICY_READ
+from aerospike_cluster_manager_api.models.query import QueryRequest
+
+logger = logging.getLogger(__name__)
+
+
+# Explicit PK particle type selector. ``auto`` is a heuristic that tries the
+# most likely type then falls back on RecordNotFound. Same shape as the
+# records_service equivalent.
+PkType = Literal["auto", "string", "int", "bytes"]
+
+
+# ---------------------------------------------------------------------------
+# Domain exceptions
+# ---------------------------------------------------------------------------
+
+
+class SetRequiredForPkLookup(ValueError):
+    """Raised when a PK lookup is run without a ``set`` scope.
+
+    Aerospike addresses records via ``(namespace, set, pk)`` tuples, so a PK
+    lookup without a set is meaningless. Disallowed at the service boundary.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Set is required for primary key lookup")
+
+
+# ---------------------------------------------------------------------------
+# Result container
+# ---------------------------------------------------------------------------
+
+
+class QueryResult(NamedTuple):
+    """Outcome of a query/scan call.
+
+    ``records`` is a list of raw aerospike-py ``Record`` NamedTuples. The
+    router converts each one via ``converters.record_to_model`` before
+    returning to clients; CDT-safe serialization is left to a dedicated
+    serializer layer.
+
+    ``scanned_records`` and ``returned_records`` are equal in this layer
+    because the underlying aerospike-py scan does not expose an exact count
+    distinct from the returned records once ``max_records`` is applied. They
+    are kept as separate fields to mirror the wire-format ``QueryResponse``.
+    """
+
+    records: list[Record]
+    execution_time_ms: int
+    scanned_records: int
+    returned_records: int
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_pk(pk: str, pk_type: PkType) -> str | int | bytes:
+    """Resolve a string primary key into the typed value Aerospike expects.
+
+    Mirrors ``utils.resolve_pk`` but raises ``ValueError`` instead of
+    HTTPException so the service stays HTTP-free. The router catches the
+    ``ValueError`` and translates it to HTTP 400.
+    """
+    if pk_type == "string":
+        return pk
+    if pk_type == "int":
+        try:
+            return int(pk)
+        except ValueError as exc:
+            raise ValueError(f"pk_type=int but pk is not an integer: {pk!r}") from exc
+    if pk_type == "bytes":
+        try:
+            return bytes.fromhex(pk)
+        except ValueError as exc:
+            raise ValueError(f"pk_type=bytes but pk is not valid hex: {pk!r}") from exc
+
+    # ``auto``: numeric-string heuristic. Preserves leading-zero strings.
+    try:
+        as_int = int(pk)
+        if str(as_int) == pk:
+            return as_int
+    except ValueError:
+        pass
+    return pk
+
+
+async def _get_with_pk_fallback(
+    client: aerospike_py.AsyncClient,
+    key_tuple: tuple[str, str, str | int | bytes],
+    pk_raw: str,
+    pk_type: PkType,
+    policy: dict[str, Any],
+) -> Record:
+    """Read with retry-on-NOT-FOUND for ``auto`` PK type.
+
+    When ``pk_type == "auto"`` and the first attempt raises
+    ``RecordNotFound``, retry with the alternate string/int particle type
+    (whichever the heuristic did *not* pick). Explicit pk types never fall
+    back — propagate the NOT_FOUND so callers see a genuinely absent key.
+    """
+    try:
+        return await client.get(key_tuple, policy=policy)
+    except RecordNotFound:
+        if pk_type != "auto":
+            raise
+        first = key_tuple[2]
+        alt: str | int | None = None
+        if isinstance(first, int):
+            alt = pk_raw  # retry as raw string
+        elif isinstance(first, str):
+            try:
+                alt = int(first)
+            except ValueError:
+                alt = None
+        if alt is None:
+            raise
+        return await client.get((key_tuple[0], key_tuple[1], alt), policy=policy)
+
+
+# ---------------------------------------------------------------------------
+# Service entry point
+# ---------------------------------------------------------------------------
+
+
+async def execute_query(client: aerospike_py.AsyncClient, body: QueryRequest) -> QueryResult:
+    """Execute a query against Aerospike.
+
+    Two execution paths, selected by ``body.primaryKey``:
+
+    1. **PK lookup** — when ``body.primaryKey`` is set. Resolves the PK via
+       ``body.pkType`` (``"auto"`` retries the alternate particle type on
+       NOT_FOUND so numeric-string keys are resolvable even when the
+       heuristic guesses int). Returns at most one record. ``RecordNotFound``
+       is treated as an empty result rather than propagating.
+
+    2. **Scan** — when no ``primaryKey``. Optionally applies a predicate
+       (legacy secondary-index path) and a ``select_bins`` projection. The
+       server-side ``max_records`` policy is capped at ``MAX_QUERY_RECORDS``
+       to prevent OOM. Empty/sparse namespaces can make the underlying scan
+       raise (aerospike-py issue #259) — those are caught and surfaced as
+       an empty result instead of a 500.
+
+    Raises:
+        SetRequiredForPkLookup: ``primaryKey`` provided without a ``set``.
+        ValueError: explicit ``pkType`` rejected the resolved value.
+
+    Returns:
+        ``QueryResult`` with raw aerospike-py ``Record`` NamedTuples. The
+        router converts each one via ``record_to_model`` for the wire format.
+    """
+    start_time = time.monotonic()
+
+    # ---- PK lookup branch -------------------------------------------------
+    if body.primaryKey:
+        if not body.set:
+            raise SetRequiredForPkLookup()
+
+        resolved = _resolve_pk(body.primaryKey, body.pkType)
+        try:
+            raw_record = await _get_with_pk_fallback(
+                client,
+                (body.namespace, body.set, resolved),
+                body.primaryKey,
+                body.pkType,
+                POLICY_READ,
+            )
+            raw_results: list[Record] = [raw_record]
+        except RecordNotFound:
+            raw_results = []
+
+        elapsed_ms = int((time.monotonic() - start_time) * 1000)
+        return QueryResult(
+            records=raw_results,
+            execution_time_ms=elapsed_ms,
+            scanned_records=len(raw_results),
+            returned_records=len(raw_results),
+        )
+
+    # ---- Scan branch ------------------------------------------------------
+    q = client.query(body.namespace, body.set or "")
+    if body.predicate:
+        # Local import keeps utils.build_predicate's HTTPException-aware
+        # implementation out of the service's signature surface. The router
+        # catches ``HTTPException`` directly; service callers via MCP would
+        # surface the exception as a generic error.
+        from aerospike_cluster_manager_api.utils import build_predicate
+
+        q.where(build_predicate(body.predicate))
+    if body.selectBins:
+        q.select(*body.selectBins)
+
+    # Apply server-side max_records limit to prevent OOM. With max_records
+    # the server stops after returning this many matching records, so
+    # scanned_records reflects the returned count (lower bound), not the true
+    # number of records examined by the server.
+    effective_limit = min(body.maxRecords or MAX_QUERY_RECORDS, MAX_QUERY_RECORDS)
+    policy: dict[str, Any] = {**POLICY_QUERY, "max_records": effective_limit}
+
+    # See aerospike-py issue #259: empty / sparse namespaces can make the
+    # underlying scan raise. Treat as no records rather than 500.
+    try:
+        raw_results = await q.results(policy)
+    except AerospikeError:
+        logger.exception(
+            "Query failed for ns=%s set=%s; returning empty result",
+            body.namespace,
+            body.set,
+        )
+        raw_results = []
+
+    elapsed_ms = int((time.monotonic() - start_time) * 1000)
+    return QueryResult(
+        records=raw_results,
+        execution_time_ms=elapsed_ms,
+        scanned_records=len(raw_results),
+        returned_records=len(raw_results),
+    )

--- a/api/src/aerospike_cluster_manager_api/services/records_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/records_service.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Any, Literal, NamedTuple
+from typing import Any, NamedTuple
 
 import aerospike_py
 from aerospike_py import Record, exp
@@ -50,14 +50,40 @@ from aerospike_cluster_manager_api.info_parser import (
 )
 from aerospike_cluster_manager_api.models.query import FilteredQueryRequest
 from aerospike_cluster_manager_api.models.record import RecordWriteRequest
+from aerospike_cluster_manager_api.pk import (
+    PkType,
+    PrimaryKeyMissing,
+    SetRequiredForPkLookup,
+    get_with_pk_fallback,
+    resolve_pk,
+)
+from aerospike_cluster_manager_api.predicate import build_predicate
 
 logger = logging.getLogger(__name__)
 
 
-# Explicit PK particle type selector. ``auto`` is a heuristic that tries the
-# most likely type then falls back on RecordNotFound. See ``utils.resolve_pk``
-# for the resolution rules.
-PkType = Literal["auto", "string", "int", "bytes"]
+# ``PkType``, ``PrimaryKeyMissing``, and ``SetRequiredForPkLookup`` are
+# re-exported from this module for backward compatibility (``mcp.errors``
+# and tests still import them from here). Their canonical home is
+# :mod:`aerospike_cluster_manager_api.pk`.
+__all__ = [
+    "FilterRecordsResult",
+    "InvalidPkPattern",
+    "ListRecordsResult",
+    "PkType",
+    "PrimaryKeyMissing",
+    "SetRequiredForPkLookup",
+    "create_record",
+    "delete_bin",
+    "delete_record",
+    "filter_records",
+    "get_record",
+    "list_records",
+    "put_record",
+    "record_exists",
+    "truncate_set",
+    "update_record",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -70,25 +96,6 @@ class InvalidPkPattern(ValueError):
 
     def __init__(self, message: str) -> None:
         super().__init__(message)
-
-
-class SetRequiredForPkLookup(ValueError):
-    """Raised when a PK-targeted query is run without a ``set`` scope.
-
-    An unscoped namespace scan with a regex would dwarf the user's intent and
-    is disallowed at the service boundary.
-    """
-
-    def __init__(self) -> None:
-        super().__init__("Set is required for primary key lookup")
-
-
-class PrimaryKeyMissing(ValueError):
-    """Raised when a write request omits one of namespace/set/pk."""
-
-    def __init__(self, field: str) -> None:
-        super().__init__(f"Missing required key field: {field}")
-        self.field = field
 
 
 # ---------------------------------------------------------------------------
@@ -137,69 +144,6 @@ class FilterRecordsResult(NamedTuple):
 # ---------------------------------------------------------------------------
 
 
-def _resolve_pk(pk: str, pk_type: PkType) -> str | int | bytes:
-    """Resolve a string primary key into the typed value Aerospike expects.
-
-    Mirrors ``utils.resolve_pk`` but raises ``ValueError`` instead of
-    HTTPException so the service stays HTTP-free. The router catches the
-    ``ValueError`` and translates it to HTTP 400.
-    """
-    if pk_type == "string":
-        return pk
-    if pk_type == "int":
-        try:
-            return int(pk)
-        except ValueError as exc:
-            raise ValueError(f"pk_type=int but pk is not an integer: {pk!r}") from exc
-    if pk_type == "bytes":
-        try:
-            return bytes.fromhex(pk)
-        except ValueError as exc:
-            raise ValueError(f"pk_type=bytes but pk is not valid hex: {pk!r}") from exc
-
-    # ``auto``: numeric-string heuristic. Preserves leading-zero strings.
-    try:
-        as_int = int(pk)
-        if str(as_int) == pk:
-            return as_int
-    except ValueError:
-        pass
-    return pk
-
-
-async def _get_with_pk_fallback(
-    client: aerospike_py.AsyncClient,
-    key_tuple: tuple[str, str, str | int | bytes],
-    pk_raw: str,
-    pk_type: PkType,
-    policy: dict[str, Any],
-) -> Record:
-    """Read with retry-on-NOT-FOUND for ``auto`` PK type.
-
-    When ``pk_type == "auto"`` and the first attempt raises
-    ``RecordNotFound``, retry with the alternate string/int particle type
-    (whichever the heuristic did *not* pick). Explicit pk types never fall
-    back — propagate the NOT_FOUND so callers see a genuinely absent key.
-    """
-    try:
-        return await client.get(key_tuple, policy=policy)
-    except RecordNotFound:
-        if pk_type != "auto":
-            raise
-        first = key_tuple[2]
-        alt: str | int | None = None
-        if isinstance(first, int):
-            alt = pk_raw  # retry as raw string
-        elif isinstance(first, str):
-            try:
-                alt = int(first)
-            except ValueError:
-                alt = None
-        if alt is None:
-            raise
-        return await client.get((key_tuple[0], key_tuple[1], alt), policy=policy)
-
-
 async def _get_set_object_count(client: aerospike_py.AsyncClient, ns: str, set_name: str) -> int:
     """Approximate object count for a set via the namespace/sets info commands.
 
@@ -246,8 +190,8 @@ async def get_record(
         RecordNotFound: the record does not exist (after auto fallback).
         ValueError: ``pk_type`` was explicit but ``pk`` could not be parsed.
     """
-    resolved = _resolve_pk(pk, pk_type)
-    return await _get_with_pk_fallback(client, (namespace, set_name, resolved), pk, pk_type, POLICY_READ)
+    resolved = resolve_pk(pk, pk_type)
+    return await get_with_pk_fallback(client, (namespace, set_name, resolved), pk, pk_type, POLICY_READ)
 
 
 async def delete_record(
@@ -270,7 +214,7 @@ async def delete_record(
             HTTP semantics they want.
         ValueError: ``pk_type`` was explicit but ``pk`` could not be parsed.
     """
-    resolved = _resolve_pk(pk, pk_type)
+    resolved = resolve_pk(pk, pk_type)
     await client.remove((namespace, set_name, resolved))
 
 
@@ -291,7 +235,7 @@ async def record_exists(
     Raises:
         ValueError: ``pk_type`` was explicit but ``pk`` could not be parsed.
     """
-    resolved = _resolve_pk(pk, pk_type)
+    resolved = resolve_pk(pk, pk_type)
     try:
         result = await client.exists((namespace, set_name, resolved), policy=POLICY_READ)
     except RecordNotFound:
@@ -317,7 +261,7 @@ async def create_record(
         RecordExistsError: a record already exists at ``(namespace, set, pk)``.
         ValueError: ``pk_type`` was explicit but ``pk`` could not be parsed.
     """
-    resolved = _resolve_pk(pk, pk_type)
+    resolved = resolve_pk(pk, pk_type)
     policy = {**POLICY_WRITE, "exists": aerospike_py.POLICY_EXISTS_CREATE_ONLY}
     await client.put((namespace, set_name, resolved), bins, policy=policy)
 
@@ -342,7 +286,7 @@ async def update_record(
         RecordNotFound: no record exists at ``(namespace, set, pk)``.
         ValueError: ``pk_type`` was explicit but ``pk`` could not be parsed.
     """
-    resolved = _resolve_pk(pk, pk_type)
+    resolved = resolve_pk(pk, pk_type)
     policy = {**POLICY_WRITE, "exists": aerospike_py.POLICY_EXISTS_UPDATE_ONLY}
     await client.put((namespace, set_name, resolved), bins, policy=policy)
 
@@ -366,7 +310,7 @@ async def delete_bin(
         RecordNotFound: the record does not exist.
         ValueError: ``pk_type`` was explicit but ``pk`` could not be parsed.
     """
-    resolved = _resolve_pk(pk, pk_type)
+    resolved = resolve_pk(pk, pk_type)
     await client.remove_bin((namespace, set_name, resolved), [bin_name])
 
 
@@ -416,7 +360,7 @@ async def put_record(client: aerospike_py.AsyncClient, body: RecordWriteRequest)
     if not k.pk:
         raise PrimaryKeyMissing("pk")
 
-    key_tuple = (k.namespace, k.set, _resolve_pk(k.pk, body.pk_type))
+    key_tuple = (k.namespace, k.set, resolve_pk(k.pk, body.pk_type))
 
     meta: WriteMeta | None = None
     if body.ttl is not None:
@@ -488,9 +432,9 @@ async def filter_records(client: aerospike_py.AsyncClient, body: FilteredQueryRe
     # NOT_FOUND when pk_type='auto'. Prefix/regex skip this branch.
     if pk_target and body.pk_match_mode == "exact":
         assert body.set is not None
-        resolved = _resolve_pk(pk_target, body.pk_type)
+        resolved = resolve_pk(pk_target, body.pk_type)
         try:
-            raw_record = await _get_with_pk_fallback(
+            raw_record = await get_with_pk_fallback(
                 client,
                 (body.namespace, body.set, resolved),
                 pk_target,
@@ -533,10 +477,9 @@ async def filter_records(client: aerospike_py.AsyncClient, body: FilteredQueryRe
     q = client.query(body.namespace, body.set or "")
 
     if body.predicate:
-        # Local import keeps utils.build_predicate's HTTPException-aware
-        # implementation out of the service's signature surface.
-        from aerospike_cluster_manager_api.utils import build_predicate
-
+        # build_predicate raises ``UnknownPredicateOperator`` (a ``ValueError``)
+        # for unknown operators — the HTTP router catches it via
+        # ``utils.build_predicate``'s adapter, MCP tools via the error mapper.
         q.where(build_predicate(body.predicate))
 
     if body.select_bins:

--- a/api/src/aerospike_cluster_manager_api/services/records_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/records_service.py
@@ -1,0 +1,494 @@
+"""Business logic for Aerospike record CRUD and scan operations.
+
+These functions are the single source of truth for the records read/write
+path. They are called by both:
+
+* the HTTP router (``routers/records.py``) — which wraps them in
+  HTTPException translation, FastAPI dependencies, and ``record_to_model``
+  conversion to the wire-format ``AerospikeRecord``, and
+* the MCP tool layer (added in a later task) — which calls them directly
+  from MCP tool handlers.
+
+To stay reusable from both sides, this module **must not** import ``fastapi``
+or other HTTP-shaping libraries. Domain failures are signalled by plain
+exceptions defined here, which the router translates to HTTP status codes.
+
+CDT (lists, maps, geojson) bin values are returned as the raw aerospike-py
+``Record`` NamedTuple — JSON-safe serialization is intentionally deferred to
+the dedicated serializer layer (Phase 1 task A.10), so this module never
+mutates bin contents.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Literal, NamedTuple
+
+import aerospike_py
+from aerospike_py import Record, exp
+from aerospike_py.exception import AerospikeError, RecordNotFound
+from aerospike_py.types import WriteMeta
+
+from aerospike_cluster_manager_api.constants import (
+    MAX_QUERY_RECORDS,
+    POLICY_QUERY,
+    POLICY_READ,
+    POLICY_WRITE,
+    info_namespace,
+    info_sets,
+)
+from aerospike_cluster_manager_api.expression_builder import (
+    InvalidPkPatternError,
+    build_expression,
+    build_pk_filter_expression,
+)
+from aerospike_cluster_manager_api.info_parser import (
+    aggregate_node_kv,
+    aggregate_set_records,
+    safe_int,
+)
+from aerospike_cluster_manager_api.models.query import FilteredQueryRequest
+from aerospike_cluster_manager_api.models.record import RecordWriteRequest
+
+logger = logging.getLogger(__name__)
+
+
+# Explicit PK particle type selector. ``auto`` is a heuristic that tries the
+# most likely type then falls back on RecordNotFound. See ``utils.resolve_pk``
+# for the resolution rules.
+PkType = Literal["auto", "string", "int", "bytes"]
+
+
+# ---------------------------------------------------------------------------
+# Domain exceptions
+# ---------------------------------------------------------------------------
+
+
+class InvalidPkPattern(ValueError):
+    """Raised when a PK pattern (prefix/regex) cannot be compiled."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+
+
+class SetRequiredForPkLookup(ValueError):
+    """Raised when a PK-targeted query is run without a ``set`` scope.
+
+    An unscoped namespace scan with a regex would dwarf the user's intent and
+    is disallowed at the service boundary.
+    """
+
+    def __init__(self) -> None:
+        super().__init__("Set is required for primary key lookup")
+
+
+class PrimaryKeyMissing(ValueError):
+    """Raised when a write request omits one of namespace/set/pk."""
+
+    def __init__(self, field: str) -> None:
+        super().__init__(f"Missing required key field: {field}")
+        self.field = field
+
+
+# ---------------------------------------------------------------------------
+# Result containers
+# ---------------------------------------------------------------------------
+
+
+class ListRecordsResult(NamedTuple):
+    """Outcome of a paginated list/scan call.
+
+    ``records`` is a list of raw aerospike-py ``Record`` NamedTuples. The
+    router converts each one via ``converters.record_to_model`` before
+    returning to clients; CDT-safe serialization is left to a dedicated
+    serializer layer.
+    """
+
+    records: list[Record]
+    total: int
+    page: int
+    page_size: int
+    has_more: bool
+    total_estimated: bool
+
+
+class FilterRecordsResult(NamedTuple):
+    """Outcome of a paginated filter/scan call.
+
+    ``scanned_records`` and ``returned_records`` are lower bounds when
+    ``total_estimated`` is True (the server-side filter scan does not
+    expose an exact count without a separate count-only query).
+    """
+
+    records: list[Record]
+    total: int
+    page: int
+    page_size: int
+    has_more: bool
+    execution_time_ms: int
+    scanned_records: int
+    returned_records: int
+    total_estimated: bool
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_pk(pk: str, pk_type: PkType) -> str | int | bytes:
+    """Resolve a string primary key into the typed value Aerospike expects.
+
+    Mirrors ``utils.resolve_pk`` but raises ``ValueError`` instead of
+    HTTPException so the service stays HTTP-free. The router catches the
+    ``ValueError`` and translates it to HTTP 400.
+    """
+    if pk_type == "string":
+        return pk
+    if pk_type == "int":
+        try:
+            return int(pk)
+        except ValueError as exc:
+            raise ValueError(f"pk_type=int but pk is not an integer: {pk!r}") from exc
+    if pk_type == "bytes":
+        try:
+            return bytes.fromhex(pk)
+        except ValueError as exc:
+            raise ValueError(f"pk_type=bytes but pk is not valid hex: {pk!r}") from exc
+
+    # ``auto``: numeric-string heuristic. Preserves leading-zero strings.
+    try:
+        as_int = int(pk)
+        if str(as_int) == pk:
+            return as_int
+    except ValueError:
+        pass
+    return pk
+
+
+async def _get_with_pk_fallback(
+    client: aerospike_py.AsyncClient,
+    key_tuple: tuple[str, str, str | int | bytes],
+    pk_raw: str,
+    pk_type: PkType,
+    policy: dict[str, Any],
+) -> Record:
+    """Read with retry-on-NOT-FOUND for ``auto`` PK type.
+
+    When ``pk_type == "auto"`` and the first attempt raises
+    ``RecordNotFound``, retry with the alternate string/int particle type
+    (whichever the heuristic did *not* pick). Explicit pk types never fall
+    back — propagate the NOT_FOUND so callers see a genuinely absent key.
+    """
+    try:
+        return await client.get(key_tuple, policy=policy)
+    except RecordNotFound:
+        if pk_type != "auto":
+            raise
+        first = key_tuple[2]
+        alt: str | int | None = None
+        if isinstance(first, int):
+            alt = pk_raw  # retry as raw string
+        elif isinstance(first, str):
+            try:
+                alt = int(first)
+            except ValueError:
+                alt = None
+        if alt is None:
+            raise
+        return await client.get((key_tuple[0], key_tuple[1], alt), policy=policy)
+
+
+async def _get_set_object_count(client: aerospike_py.AsyncClient, ns: str, set_name: str) -> int:
+    """Approximate object count for a set via the namespace/sets info commands.
+
+    Fetches the namespace replication-factor first to de-duplicate counts
+    across nodes, matching the same approach used in ``clusters_service``.
+    """
+    if not set_name:
+        return 0
+    try:
+        ns_all = await client.info_all(info_namespace(ns))
+        ns_stats = aggregate_node_kv(ns_all)
+        replication_factor = safe_int(ns_stats.get("replication-factor"), 1)
+
+        sets_all = await client.info_all(info_sets(ns))
+        agg = aggregate_set_records(sets_all, replication_factor)
+        for s in agg:
+            if s["name"] == set_name:
+                return s["objects"]
+    except (AerospikeError, OSError):
+        logger.debug("Failed to get set object count for %s.%s", ns, set_name, exc_info=True)
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Service entry points — single record CRUD
+# ---------------------------------------------------------------------------
+
+
+async def get_record(
+    client: aerospike_py.AsyncClient,
+    namespace: str,
+    set_name: str,
+    pk: str,
+    pk_type: PkType = "auto",
+) -> Record:
+    """Fetch a single record by ``(namespace, set, pk)``.
+
+    Resolves ``pk`` via the requested ``pk_type``. When ``pk_type='auto'``
+    and the initial probe returns NOT_FOUND, retries with the alternate
+    particle type — fixing the case where a numeric-string key (e.g. ``"42"``)
+    was stored as STRING but auto resolves to INTEGER.
+
+    Raises:
+        RecordNotFound: the record does not exist (after auto fallback).
+        ValueError: ``pk_type`` was explicit but ``pk`` could not be parsed.
+    """
+    resolved = _resolve_pk(pk, pk_type)
+    return await _get_with_pk_fallback(client, (namespace, set_name, resolved), pk, pk_type, POLICY_READ)
+
+
+async def delete_record(
+    client: aerospike_py.AsyncClient,
+    namespace: str,
+    set_name: str,
+    pk: str,
+    pk_type: PkType = "auto",
+) -> None:
+    """Delete a record by ``(namespace, set, pk)``.
+
+    Deletes do not fall back to the alternate type even in ``auto`` mode: a
+    delete that targets the wrong particle type would silently no-op (the
+    record at the *other* type stays put), and a fallback could mask that
+    fact. Pass an explicit ``pk_type`` to be sure of which record gets removed.
+
+    Raises:
+        RecordNotFound: aerospike-py may surface this when the key does not
+            exist; callers may treat it as a 404 or a 204 depending on the
+            HTTP semantics they want.
+        ValueError: ``pk_type`` was explicit but ``pk`` could not be parsed.
+    """
+    resolved = _resolve_pk(pk, pk_type)
+    await client.remove((namespace, set_name, resolved))
+
+
+async def put_record(client: aerospike_py.AsyncClient, body: RecordWriteRequest) -> Record:
+    """Write a record (create or update) and return the persisted state.
+
+    The key's particle type comes from ``body.pk_type`` (``"auto"`` by default).
+    Writes do not fall back: the resolved type is what gets persisted on disk,
+    so callers that care should pass an explicit ``pk_type`` to avoid creating
+    a record under a particle type that subsequent reads can't find.
+
+    Returns:
+        The freshly read-back ``Record`` so the response can carry the
+        server-assigned generation/ttl.
+
+    Raises:
+        PrimaryKeyMissing: ``body.key`` omits namespace, set, or pk.
+        ValueError: explicit ``pk_type`` rejected the resolved value.
+    """
+    k = body.key
+    if not k.namespace:
+        raise PrimaryKeyMissing("namespace")
+    if not k.set:
+        raise PrimaryKeyMissing("set")
+    if not k.pk:
+        raise PrimaryKeyMissing("pk")
+
+    key_tuple = (k.namespace, k.set, _resolve_pk(k.pk, body.pk_type))
+
+    meta: WriteMeta | None = None
+    if body.ttl is not None:
+        meta = WriteMeta(ttl=body.ttl)
+
+    await client.put(key_tuple, body.bins, meta=meta, policy=POLICY_WRITE)
+    return await client.get(key_tuple, policy=POLICY_READ)
+
+
+# ---------------------------------------------------------------------------
+# Service entry points — list / filter scans
+# ---------------------------------------------------------------------------
+
+
+async def list_records(
+    client: aerospike_py.AsyncClient,
+    namespace: str,
+    set_name: str,
+    page_size: int,
+) -> ListRecordsResult:
+    """Scan a set and return up to ``page_size`` records.
+
+    Empty / sparse namespaces can make the underlying scan raise
+    (aerospike-py issue #259). Treat those as "no records" and return an
+    empty page rather than propagate. ``RustPanicError`` (#280) is *not*
+    caught here — that's a real per-stream blocker handled by its dedicated
+    422 exception handler at the HTTP layer.
+    """
+    set_total = await _get_set_object_count(client, namespace, set_name)
+
+    limit = min(page_size, MAX_QUERY_RECORDS)
+    policy: dict[str, Any] = {**POLICY_QUERY, "max_records": limit}
+    q = client.query(namespace, set_name)
+    try:
+        raw_results: list[Record] = await q.results(policy)
+    except AerospikeError:
+        logger.exception("Query failed for ns=%s set=%s; returning empty page", namespace, set_name)
+        raw_results = []
+
+    return ListRecordsResult(
+        records=raw_results,
+        total=set_total,
+        page=1,
+        page_size=page_size,
+        has_more=set_total > len(raw_results),
+        total_estimated=True,
+    )
+
+
+async def filter_records(client: aerospike_py.AsyncClient, body: FilteredQueryRequest) -> FilterRecordsResult:
+    """Scan with optional PK pattern + bin filters and return a page.
+
+    PK lookup short-circuits to ``client.get`` when ``pk_match_mode='exact'``
+    so a pure-key fetch never triggers a scan. ``prefix`` and ``regex`` modes
+    compile the PK pattern into an expression and run a server-side scan.
+
+    Raises:
+        SetRequiredForPkLookup: PK pattern provided without a set scope.
+        InvalidPkPattern: regex/prefix could not be compiled.
+    """
+    start_time = time.monotonic()
+
+    pk_target = body.pk_pattern or body.primary_key
+
+    if pk_target and not body.set:
+        raise SetRequiredForPkLookup()
+
+    # PK exact short-circuit. Falls back to alternate particle type on
+    # NOT_FOUND when pk_type='auto'. Prefix/regex skip this branch.
+    if pk_target and body.pk_match_mode == "exact":
+        assert body.set is not None
+        resolved = _resolve_pk(pk_target, body.pk_type)
+        try:
+            raw_record = await _get_with_pk_fallback(
+                client,
+                (body.namespace, body.set, resolved),
+                pk_target,
+                body.pk_type,
+                POLICY_READ,
+            )
+            raw_results: list[Record] = [raw_record]
+        except RecordNotFound:
+            raw_results = []
+
+        elapsed_ms = int((time.monotonic() - start_time) * 1000)
+        return FilterRecordsResult(
+            records=raw_results,
+            total=len(raw_results),
+            page=1,
+            page_size=body.page_size,
+            has_more=False,
+            execution_time_ms=elapsed_ms,
+            scanned_records=len(raw_results),
+            returned_records=len(raw_results),
+            total_estimated=False,
+        )
+
+    # Build expressions BEFORE constructing the query so a bad pattern
+    # surfaces as InvalidPkPattern without ever touching the client.query
+    # path (and lets the router translate to HTTP 400).
+    pk_expr: dict | None = None
+    try:
+        if pk_target is not None:
+            if body.pk_match_mode == "prefix":
+                pk_expr = build_pk_filter_expression(pk_target, "prefix")
+            elif body.pk_match_mode == "regex":
+                pk_expr = build_pk_filter_expression(pk_target, "regex")
+    except InvalidPkPatternError as e:
+        raise InvalidPkPattern(str(e)) from e
+
+    bin_expr = build_expression(body.filters) if body.filters else None
+
+    # Build query
+    q = client.query(body.namespace, body.set or "")
+
+    if body.predicate:
+        # Local import keeps utils.build_predicate's HTTPException-aware
+        # implementation out of the service's signature surface.
+        from aerospike_cluster_manager_api.utils import build_predicate
+
+        q.where(build_predicate(body.predicate))
+
+    if body.select_bins:
+        q.select(*body.select_bins)
+
+    # Build policy with server-side max_records limit to prevent OOM.
+    #
+    # For paginated filter queries we fetch ONE extra record beyond the page
+    # size so we can detect "is there at least one more record" without an
+    # extra round trip. The fetched +1 record is dropped before responding.
+    has_filters = body.filters is not None or body.predicate is not None or pk_expr is not None
+    fetch_limit = min(
+        body.max_records or MAX_QUERY_RECORDS,
+        MAX_QUERY_RECORDS,
+        body.page_size + 1,
+    )
+
+    policy: dict[str, Any] = {**POLICY_QUERY, "max_records": fetch_limit}
+    if bin_expr is not None and pk_expr is not None:
+        policy["filter_expression"] = exp.and_(pk_expr, bin_expr)
+    elif pk_expr is not None:
+        policy["filter_expression"] = pk_expr
+    elif bin_expr is not None:
+        policy["filter_expression"] = bin_expr
+
+    try:
+        raw_results = await q.results(policy)
+    except AerospikeError:
+        # Empty/sparse-namespace failure mode (aerospike-py #259). Log at
+        # exception level so operators can still find the underlying cause
+        # in logs — pattern + filter context goes in the message so user-
+        # supplied PK patterns are reproducible.
+        logger.exception(
+            "Filtered query failed for ns=%s set=%s pk_mode=%s pk_pattern=%r has_filters=%s; returning empty page",
+            body.namespace,
+            body.set,
+            body.pk_match_mode,
+            pk_target,
+            body.filters is not None,
+        )
+        raw_results = []
+
+    elapsed_ms = int((time.monotonic() - start_time) * 1000)
+    fetched = len(raw_results)
+    has_more = fetched > body.page_size
+    if has_more:
+        raw_results = raw_results[: body.page_size]
+    returned = len(raw_results)
+
+    # Determine total / scanned counts. With server-side max_records the
+    # returned count is capped — it does not reflect the true number of
+    # records scanned by the Aerospike server. For unfiltered scans we use
+    # the info command to get the real set size.
+    if has_filters:
+        set_total = returned + (1 if has_more else 0)  # lower bound
+        scanned = returned  # lower bound; actual server-side scan may be higher
+        total_estimated = True
+    else:
+        set_total = await _get_set_object_count(client, body.namespace, body.set or "")
+        scanned = set_total  # info-based: represents all objects in the set
+        total_estimated = True
+
+    return FilterRecordsResult(
+        records=raw_results,
+        total=set_total,
+        page=1,
+        page_size=body.page_size,
+        has_more=has_more,
+        execution_time_ms=elapsed_ms,
+        scanned_records=scanned,
+        returned_records=returned,
+        total_estimated=total_estimated,
+    )

--- a/api/src/aerospike_cluster_manager_api/services/records_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/records_service.py
@@ -274,6 +274,124 @@ async def delete_record(
     await client.remove((namespace, set_name, resolved))
 
 
+async def record_exists(
+    client: aerospike_py.AsyncClient,
+    namespace: str,
+    set_name: str,
+    pk: str,
+    pk_type: PkType = "auto",
+) -> bool:
+    """Return True iff a record at ``(namespace, set, pk)`` exists.
+
+    Wraps :meth:`aerospike_py.AsyncClient.exists` — that call returns an
+    ``ExistsResult`` with ``meta=None`` when the record is absent (no
+    exception). We also catch :class:`RecordNotFound` defensively in case a
+    future client revision swaps to the exception form.
+
+    Raises:
+        ValueError: ``pk_type`` was explicit but ``pk`` could not be parsed.
+    """
+    resolved = _resolve_pk(pk, pk_type)
+    try:
+        result = await client.exists((namespace, set_name, resolved), policy=POLICY_READ)
+    except RecordNotFound:
+        return False
+    return result.meta is not None
+
+
+async def create_record(
+    client: aerospike_py.AsyncClient,
+    namespace: str,
+    set_name: str,
+    pk: str,
+    bins: dict[str, Any],
+    pk_type: PkType = "auto",
+) -> None:
+    """Create a record, failing if one already exists at the same key.
+
+    Uses the ``POLICY_EXISTS_CREATE_ONLY`` write policy so a collision raises
+    :class:`aerospike_py.RecordExistsError` (which the MCP error mapper
+    translates to ``code="record_exists"``).
+
+    Raises:
+        RecordExistsError: a record already exists at ``(namespace, set, pk)``.
+        ValueError: ``pk_type`` was explicit but ``pk`` could not be parsed.
+    """
+    resolved = _resolve_pk(pk, pk_type)
+    policy = {**POLICY_WRITE, "exists": aerospike_py.POLICY_EXISTS_CREATE_ONLY}
+    await client.put((namespace, set_name, resolved), bins, policy=policy)
+
+
+async def update_record(
+    client: aerospike_py.AsyncClient,
+    namespace: str,
+    set_name: str,
+    pk: str,
+    bins: dict[str, Any],
+    pk_type: PkType = "auto",
+) -> None:
+    """Update an existing record, failing if it does not already exist.
+
+    Uses ``POLICY_EXISTS_UPDATE_ONLY`` so a missing record raises
+    :class:`aerospike_py.RecordNotFound` (translated by the MCP error mapper
+    to ``code="record_not_found"``). The plain ``UPDATE`` policy would
+    *create* the record on a miss — :func:`create_record` is the explicit
+    create path; this primitive is strictly an update.
+
+    Raises:
+        RecordNotFound: no record exists at ``(namespace, set, pk)``.
+        ValueError: ``pk_type`` was explicit but ``pk`` could not be parsed.
+    """
+    resolved = _resolve_pk(pk, pk_type)
+    policy = {**POLICY_WRITE, "exists": aerospike_py.POLICY_EXISTS_UPDATE_ONLY}
+    await client.put((namespace, set_name, resolved), bins, policy=policy)
+
+
+async def delete_bin(
+    client: aerospike_py.AsyncClient,
+    namespace: str,
+    set_name: str,
+    pk: str,
+    bin_name: str,
+    pk_type: PkType = "auto",
+) -> None:
+    """Remove a single bin from an existing record.
+
+    Wraps :meth:`aerospike_py.AsyncClient.remove_bin`, which sets the named
+    bin(s) to nil on the server. Removing the last bin from a record makes
+    the whole record disappear server-side — that's standard Aerospike
+    behaviour and not something we paper over here.
+
+    Raises:
+        RecordNotFound: the record does not exist.
+        ValueError: ``pk_type`` was explicit but ``pk`` could not be parsed.
+    """
+    resolved = _resolve_pk(pk, pk_type)
+    await client.remove_bin((namespace, set_name, resolved), [bin_name])
+
+
+async def truncate_set(
+    client: aerospike_py.AsyncClient,
+    namespace: str,
+    set_name: str,
+    before_lut: int | None = None,
+) -> None:
+    """Truncate every record in ``namespace.set_name`` (optionally up to a LUT).
+
+    ``before_lut`` is the cutoff in nanoseconds since CITRUS epoch (the
+    aerospike-py ``truncate`` API's ``nanos`` parameter). When omitted, the
+    truncate covers all records currently in the set. Pass an explicit
+    nanosecond value to truncate only records whose last-update-time is
+    below that threshold.
+
+    Internally this becomes the ``truncate-namespace:namespace=...;set=...
+    [;lut=...]`` info command — aerospike-py's :meth:`AsyncClient.truncate`
+    issues it for us so we don't have to format the wire string by hand.
+    """
+    nanos = before_lut if before_lut is not None else 0
+    await client.truncate(namespace, set_name, nanos)
+
+
 async def put_record(client: aerospike_py.AsyncClient, body: RecordWriteRequest) -> Record:
     """Write a record (create or update) and return the persisted state.
 

--- a/api/src/aerospike_cluster_manager_api/utils.py
+++ b/api/src/aerospike_cluster_manager_api/utils.py
@@ -1,47 +1,71 @@
-"""Shared utility functions."""
+"""Shared utility functions — FastAPI adapters around HTTP-free domain logic.
+
+The genuine domain logic lives in dedicated modules so MCP tool wrappers
+can reuse it without dragging FastAPI in:
+
+* :mod:`aerospike_cluster_manager_api.pk` — primary-key resolution and
+  read-with-fallback.
+* :mod:`aerospike_cluster_manager_api.predicate` — predicate-tuple
+  construction.
+
+The functions in this module are thin adapters: they call the domain
+helpers and translate the domain exceptions into
+:class:`fastapi.HTTPException` with the correct HTTP status code.
+"""
 
 from __future__ import annotations
 
-import json
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
-from aerospike_py.exception import RecordNotFound
 from fastapi import HTTPException
+
+from aerospike_cluster_manager_api.pk import (
+    PkType,
+)
+from aerospike_cluster_manager_api.pk import (
+    get_with_pk_fallback as _get_with_pk_fallback_domain,
+)
+from aerospike_cluster_manager_api.pk import (
+    resolve_pk as _resolve_pk_domain,
+)
+from aerospike_cluster_manager_api.predicate import (
+    UnknownPredicateOperator,
+)
+from aerospike_cluster_manager_api.predicate import (
+    build_predicate as _build_predicate_domain,
+)
 
 if TYPE_CHECKING:
     from aerospike_cluster_manager_api.models.query import QueryPredicate
 
 
-# Explicit PK particle type selector. `auto` is a heuristic that tries the most
-# likely type then falls back — see resolve_pk / get_with_pk_fallback below.
-type PkType = Literal["auto", "string", "int", "bytes"]
+# Re-export ``PkType`` for legacy callers that import it from ``utils``.
+__all__ = [
+    "PkType",
+    "auto_detect_pk",
+    "build_predicate",
+    "get_with_pk_fallback",
+    "parse_host_port",
+    "resolve_pk",
+]
 
 
 def build_predicate(pred: QueryPredicate) -> tuple[Any, ...]:
-    """Convert a QueryPredicate model into an Aerospike predicate tuple.
+    """Convert a :class:`QueryPredicate` into an Aerospike predicate tuple.
 
-    Used by both routers/query.py and routers/records.py.
+    Thin FastAPI adapter around
+    :func:`aerospike_cluster_manager_api.predicate.build_predicate`. Used
+    only by HTTP routers — services should call the domain function
+    directly so the HTTP coupling stays at the boundary.
     """
-    from aerospike_py import INDEX_TYPE_LIST, predicates
-
-    op = pred.operator
-    if op == "equals":
-        return predicates.equals(pred.bin, pred.value)
-    if op == "between":
-        return predicates.between(pred.bin, pred.value, pred.value2)
-    if op == "contains":
-        return predicates.contains(pred.bin, INDEX_TYPE_LIST, pred.value)
-    if op == "geo_within_region":
-        geo = pred.value if isinstance(pred.value, str) else json.dumps(pred.value)
-        return predicates.geo_within_geojson_region(pred.bin, geo)
-    if op == "geo_contains_point":
-        geo = pred.value if isinstance(pred.value, str) else json.dumps(pred.value)
-        return predicates.geo_contains_geojson_point(pred.bin, geo)
-    raise HTTPException(status_code=400, detail=f"Unknown predicate operator: {op}")
+    try:
+        return _build_predicate_domain(pred)
+    except UnknownPredicateOperator as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 def parse_host_port(host_str: str, default_port: int) -> tuple[str, int]:
-    """Parse a host string that may contain an optional ':port' suffix."""
+    """Parse a host string that may contain an optional ``:port`` suffix."""
     if ":" in host_str:
         host, port_str = host_str.rsplit(":", 1)
         try:
@@ -52,48 +76,19 @@ def parse_host_port(host_str: str, default_port: int) -> tuple[str, int]:
 
 
 def resolve_pk(pk: str, pk_type: PkType = "auto") -> str | int | bytes:
-    """Resolve a string primary key into the Aerospike key value of the requested type.
+    """Resolve a string primary key into the typed value Aerospike expects.
 
-    Aerospike keys are digested as RIPEMD-160(set || particle_type_byte || key_bytes),
-    so the particle type must match how the record was originally written. If
-    the caller knows the type, they should pass it explicitly via ``pk_type``.
-
-    Behavior:
-        - "string": return ``pk`` as-is.
-        - "int":    return ``int(pk)`` (raises ValueError if not parseable).
-        - "bytes":  return ``bytes.fromhex(pk)`` (raises ValueError on invalid hex).
-        - "auto":   best-effort heuristic. Treats any digit-only PK (including
-                    negative) as an integer, preserving leading-zero strings. The
-                    heuristic is wrong for numeric-string keys, so callers that
-                    do reads should pair this with ``get_with_pk_fallback``.
-
-    See also ``get_with_pk_fallback`` for the read-side fallback that tries the
-    alternate type when ``auto`` picks wrong.
+    Thin FastAPI adapter around
+    :func:`aerospike_cluster_manager_api.pk.resolve_pk`. Domain
+    :class:`ValueError` from explicit ``int`` / ``bytes`` mismatches is
+    re-raised as :class:`fastapi.HTTPException` (400) so HTTP callers
+    don't have to translate it themselves. Service callers should use
+    the domain helper directly.
     """
-    if pk_type == "string":
-        return pk
-    if pk_type == "int":
-        try:
-            return int(pk)
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=f"pk_type=int but pk is not an integer: {pk!r}") from exc
-    if pk_type == "bytes":
-        try:
-            return bytes.fromhex(pk)
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=f"pk_type=bytes but pk is not valid hex: {pk!r}") from exc
-
-    # auto: preserve the original heuristic so that true INTEGER-keyed sets
-    # continue to work without requiring the caller to opt in. Read paths should
-    # wrap this with get_with_pk_fallback to recover the NOT_FOUND case where
-    # the heuristic guessed wrong.
     try:
-        as_int = int(pk)
-        if str(as_int) == pk:
-            return as_int
-    except ValueError:
-        pass
-    return pk
+        return _resolve_pk_domain(pk, pk_type)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
 # Backward-compat alias — existing callers keep working. Prefer ``resolve_pk``.
@@ -113,35 +108,11 @@ async def get_with_pk_fallback(
     pk_type: PkType,
     policy: dict[str, Any],
 ) -> Any:
-    """Read a record, retrying the alternate PK type if ``auto`` resolved wrong.
+    """Read a record, retrying the alternate PK type if ``auto`` guessed wrong.
 
-    When ``pk_type == "auto"`` and the first attempt raises ``RecordNotFound``,
-    we retry with the alternate string/int particle type (whichever one the
-    heuristic did *not* pick). This makes the record browser work for both
-    INTEGER-keyed and STRING-keyed sets without the caller having to know
-    upfront which one the record was written with.
-
-    Explicit pk types (``string`` / ``int`` / ``bytes``) never fall back — if
-    the caller asserted a type, we propagate the NOT_FOUND as-is so the caller
-    knows the key is genuinely absent under that type.
+    Thin pass-through to
+    :func:`aerospike_cluster_manager_api.pk.get_with_pk_fallback`. The
+    domain function does not raise HTTP-specific exceptions, so this
+    adapter is just a stable import path for legacy router callers.
     """
-    try:
-        return await client.get(key_tuple, policy=policy)
-    except RecordNotFound:
-        if pk_type != "auto":
-            raise
-        # Heuristic picked one type; try the opposite. If the alternate type
-        # isn't applicable (e.g. non-numeric string can't become int), keep
-        # propagating the original RecordNotFound — never leak ValueError.
-        first = key_tuple[2]
-        alt: str | int | None = None
-        if isinstance(first, int):
-            alt = pk_raw  # retry as raw string
-        elif isinstance(first, str):
-            try:
-                alt = int(first)
-            except ValueError:
-                alt = None  # no integer alternative → fall through to re-raise
-        if alt is None:
-            raise
-        return await client.get((key_tuple[0], key_tuple[1], alt), policy=policy)
+    return await _get_with_pk_fallback_domain(client, key_tuple, pk_raw, pk_type, policy)

--- a/api/tests/mcp/__init__.py
+++ b/api/tests/mcp/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the ACM MCP server package."""

--- a/api/tests/mcp/conftest.py
+++ b/api/tests/mcp/conftest.py
@@ -1,0 +1,98 @@
+"""Shared fixtures and module-level imports for the MCP test package.
+
+Two responsibilities:
+
+1. Deterministic tool import: every ``mcp/tools/*`` module is imported here
+   so the ``@tool`` decorator side-effects fire BEFORE any test in this
+   package runs. Without this, the registry-based tests are order-sensitive
+   — whichever test imports a tool module first triggers the registration,
+   and tests run in isolation (``pytest tests/mcp/test_registry.py``)
+   would see an empty registry.
+
+2. ``patch_mcp_client`` fixture-style helper: the duplicated
+   ``_patch_get_client`` boilerplate from ``test_record_tools.py``,
+   ``test_query_tool.py``, and ``test_info_tools.py`` is consolidated
+   here. Tests can either use the fixture (auto-injected mock client)
+   or call the underlying helper directly when they need to control the
+   mock's surface.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Force-import every tool module so the @tool decorator side-effects flush
+# into the module-level _REGISTRY. Without these imports, a test invoked in
+# isolation (``pytest tests/mcp/test_e2e.py``) would observe an empty
+# registry. The ``noqa: F401`` markers tell ruff that the imports are
+# load-bearing even though no name is referenced.
+from aerospike_cluster_manager_api.mcp.tools import (  # noqa: F401
+    cluster_info,
+    connections,
+    info_commands,
+    query,
+    records,
+)
+
+# ---------------------------------------------------------------------------
+# Tool count constant — replaces the magic number ``21`` everywhere.
+# ---------------------------------------------------------------------------
+
+EXPECTED_TOOL_COUNT: int = 21
+"""Total number of MCP tools registered by Phase 1.
+
+Breakdown:
+* 8 connection tools (create, get, update, delete, list, connect, disconnect,
+  test_connection)
+* 3 cluster info (list_namespaces, list_sets, get_nodes)
+* 7 record (get, exists, create, update, delete, delete_bin, truncate_set)
+* 1 query
+* 2 info commands (execute_info, execute_info_on_node)
+"""
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared by per-tool tests
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def patch_mcp_client(module_name: str, client: MagicMock) -> Iterator[None]:
+    """Replace ``client_manager.get_client`` on the named tool module.
+
+    Drop-in replacement for the duplicated ``_patch_get_client`` helpers in
+    ``test_record_tools.py``, ``test_query_tool.py``, and ``test_info_tools.py``.
+
+    Parameters
+    ----------
+    module_name:
+        Dotted path of the tool module that holds the ``client_manager``
+        reference, e.g. ``"aerospike_cluster_manager_api.mcp.tools.records"``.
+        We patch on the *module*'s ``client_manager`` attribute (not the
+        canonical client_manager singleton) so per-test mocks don't leak.
+    client:
+        The mock client returned by ``get_client``.
+    """
+    import importlib
+
+    module = importlib.import_module(module_name)
+    with patch.object(
+        module.client_manager,
+        "get_client",
+        new=AsyncMock(return_value=client),
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_aerospike_client() -> MagicMock:
+    """Vanilla ``MagicMock`` stand-in for ``aerospike_py.AsyncClient``.
+
+    Tests that need finer-grained behaviour (specific return values,
+    ``side_effect``, etc.) should ignore this fixture and build their own.
+    """
+    return MagicMock()

--- a/api/tests/mcp/test_access_profile.py
+++ b/api/tests/mcp/test_access_profile.py
@@ -1,6 +1,6 @@
 """Tests for the MCP access profile gate.
 
-The access profile is a Voyager-style read-only mode: it lets the MCP
+The access profile is a call-time read-only mode: it lets the MCP
 registry expose all tools to the model, but blocks writes at call time
 when the deployment is configured ``READ_ONLY``. ``execute_info`` and
 ``execute_info_on_node`` are intentionally classified as WRITE because

--- a/api/tests/mcp/test_access_profile.py
+++ b/api/tests/mcp/test_access_profile.py
@@ -1,0 +1,134 @@
+"""Tests for the MCP access profile gate.
+
+The access profile is a Voyager-style read-only mode: it lets the MCP
+registry expose all tools to the model, but blocks writes at call time
+when the deployment is configured ``READ_ONLY``. ``execute_info`` and
+``execute_info_on_node`` are intentionally classified as WRITE because
+asinfo can mutate cluster configuration (e.g. ``set-config``).
+
+These tests cover:
+* the public surface of ``access_profile.py`` (``AccessProfile``,
+  ``is_blocked``, ``parse_profile``);
+* the ``ACM_MCP_ACCESS_PROFILE`` env var wiring in ``config.py`` —
+  default ``READ_ONLY`` when unset, parsed strictly otherwise.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from aerospike_cluster_manager_api.mcp.access_profile import (
+    AccessProfile,
+    is_blocked,
+    parse_profile,
+)
+
+# ---------------------------------------------------------------------------
+# is_blocked — read-only profile blocks writes, allows reads
+# ---------------------------------------------------------------------------
+
+
+def test_is_blocked_read_tool_under_read_only_is_false() -> None:
+    assert is_blocked("get_record", AccessProfile.READ_ONLY) is False
+
+
+def test_is_blocked_create_record_under_read_only_is_true() -> None:
+    assert is_blocked("create_record", AccessProfile.READ_ONLY) is True
+
+
+def test_is_blocked_create_record_under_full_is_false() -> None:
+    assert is_blocked("create_record", AccessProfile.FULL) is False
+
+
+def test_is_blocked_delete_record_under_read_only_is_true() -> None:
+    assert is_blocked("delete_record", AccessProfile.READ_ONLY) is True
+
+
+def test_is_blocked_execute_info_under_read_only_is_true() -> None:
+    # asinfo can mutate config (set-config, etc.) — must be classified WRITE.
+    assert is_blocked("execute_info", AccessProfile.READ_ONLY) is True
+
+
+def test_is_blocked_list_namespaces_under_read_only_is_false() -> None:
+    assert is_blocked("list_namespaces", AccessProfile.READ_ONLY) is False
+
+
+def test_is_blocked_unknown_tool_under_read_only_is_false() -> None:
+    """Unknown tools are not blocked: registry decides existence; profile filters."""
+    assert is_blocked("does_not_exist", AccessProfile.READ_ONLY) is False
+
+
+def test_is_blocked_unknown_tool_under_full_is_false() -> None:
+    assert is_blocked("does_not_exist", AccessProfile.FULL) is False
+
+
+# ---------------------------------------------------------------------------
+# parse_profile — case-insensitive; ValueError on unknown
+# ---------------------------------------------------------------------------
+
+
+def test_parse_profile_read_only_lower() -> None:
+    assert parse_profile("read_only") is AccessProfile.READ_ONLY
+
+
+def test_parse_profile_full_uppercase() -> None:
+    assert parse_profile("FULL") is AccessProfile.FULL
+
+
+def test_parse_profile_with_surrounding_whitespace() -> None:
+    assert parse_profile("  read_only  ") is AccessProfile.READ_ONLY
+
+
+def test_parse_profile_unknown_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="garbage"):
+        parse_profile("garbage")
+
+
+def test_parse_profile_unknown_lists_valid_values_in_message() -> None:
+    with pytest.raises(ValueError) as exc:
+        parse_profile("garbage")
+    msg = str(exc.value)
+    assert "full" in msg
+    assert "read_only" in msg
+
+
+# ---------------------------------------------------------------------------
+# config.ACM_MCP_ACCESS_PROFILE — default READ_ONLY; parsed via parse_profile
+# ---------------------------------------------------------------------------
+
+
+def test_config_default_access_profile_is_read_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ACM_MCP_ACCESS_PROFILE", raising=False)
+    from aerospike_cluster_manager_api import config as _config
+
+    importlib.reload(_config)
+    try:
+        assert _config.ACM_MCP_ACCESS_PROFILE is AccessProfile.READ_ONLY
+    finally:
+        importlib.reload(_config)
+
+
+def test_config_access_profile_full_when_env_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ACM_MCP_ACCESS_PROFILE", "full")
+    from aerospike_cluster_manager_api import config as _config
+
+    importlib.reload(_config)
+    try:
+        assert _config.ACM_MCP_ACCESS_PROFILE is AccessProfile.FULL
+    finally:
+        monkeypatch.delenv("ACM_MCP_ACCESS_PROFILE", raising=False)
+        importlib.reload(_config)
+
+
+def test_config_access_profile_invalid_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ACM_MCP_ACCESS_PROFILE", "garbage")
+    from aerospike_cluster_manager_api import config as _config
+
+    try:
+        with pytest.raises(ValueError, match="garbage"):
+            importlib.reload(_config)
+    finally:
+        monkeypatch.delenv("ACM_MCP_ACCESS_PROFILE", raising=False)
+        importlib.reload(_config)

--- a/api/tests/mcp/test_auth.py
+++ b/api/tests/mcp/test_auth.py
@@ -1,0 +1,570 @@
+"""Tests for the MCP bearer-token middleware.
+
+The middleware sits in front of the MCP mount and applies an
+OR-combined gate with the existing OIDC middleware:
+
+* Pre-conditions:
+  - It runs ONLY on requests whose ``url.path`` begins with
+    ``config.ACM_MCP_PATH`` (default ``/mcp``).
+  - It is installed only when ``ACM_MCP_ENABLED=true`` (the mount
+    itself is also gated by that flag).
+
+* Truth table when ``ACM_MCP_TOKEN`` is set:
+
+    | OIDC says authenticated | Bearer matches token | Result |
+    |-------------------------|----------------------|--------|
+    | yes                     | n/a                  | pass   |
+    | no                      | yes                  | pass   |
+    | no                      | no / missing         | 401    |
+
+* When ``ACM_MCP_TOKEN`` is unset, the middleware is a pass-through
+  and defers entirely to the existing OIDC middleware.
+
+Tests build a tiny FastAPI app, install the middleware directly, and
+probe it via :class:`httpx.ASGITransport` — no uvicorn, no real
+network. A separate group of tests exercises the conditional
+installation in :mod:`aerospike_cluster_manager_api.main` via the
+same ``importlib.reload`` pattern that ``test_main_mount.py`` uses.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import AsyncIterator
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_app(
+    *,
+    install_oidc_stub: bool = False,
+    oidc_authenticated: bool = False,
+) -> FastAPI:
+    """Construct an app that mirrors the real /mcp + /api shape.
+
+    The MCP middleware is installed by the test using
+    ``app.add_middleware(MCPBearerTokenMiddleware)`` — same call site as
+    ``main.py``. When ``install_oidc_stub`` is true an additional
+    middleware is wired up that simulates OIDC by setting
+    ``request.state.user`` to a dummy claim dict on every request — this
+    lets us exercise the OIDC-OR-bearer leg without spinning up a real
+    JWKS server.
+    """
+    from aerospike_cluster_manager_api.mcp.auth import MCPBearerTokenMiddleware
+
+    app = FastAPI()
+
+    @app.get("/mcp")
+    async def mcp_root() -> dict:
+        return {"ok": True}
+
+    @app.get("/mcp/sub/path")
+    async def mcp_sub() -> dict:
+        return {"ok": True}
+
+    @app.get("/api/health")
+    async def health() -> dict:
+        return {"status": "ok"}
+
+    # MCP middleware first (installed before OIDC stub so it runs AFTER
+    # the OIDC stub at request time — Starlette runs middleware in
+    # reverse order of add_middleware).
+    app.add_middleware(MCPBearerTokenMiddleware)
+
+    if install_oidc_stub:
+        # Tiny OIDC stand-in: writes ``request.state.user`` so the MCP
+        # middleware sees an authenticated request without us having to
+        # mint real JWTs.
+        class _OIDCStub(BaseHTTPMiddleware):
+            async def dispatch(self, request, call_next):
+                if oidc_authenticated:
+                    request.state.user = {"sub": "stub-user"}
+                return await call_next(request)
+
+        app.add_middleware(_OIDCStub)
+
+    return app
+
+
+def _reload_config(monkeypatch: pytest.MonkeyPatch, **env: str | None) -> None:
+    """Set/unset env vars and reload the config module so module-level
+    constants re-evaluate against the patched environment.
+
+    Pass ``key=None`` to unset.
+    """
+    from aerospike_cluster_manager_api import config as _config
+
+    for key, value in env.items():
+        if value is None:
+            monkeypatch.delenv(key, raising=False)
+        else:
+            monkeypatch.setenv(key, value)
+    importlib.reload(_config)
+
+
+# ---------------------------------------------------------------------------
+# Config
+# ---------------------------------------------------------------------------
+
+
+def test_acm_mcp_token_defaults_to_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without the env var set, ``ACM_MCP_TOKEN`` is the empty string."""
+    _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+    from aerospike_cluster_manager_api import config as _config
+
+    try:
+        assert _config.ACM_MCP_TOKEN == ""
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+def test_acm_mcp_token_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="s3cret")
+    from aerospike_cluster_manager_api import config as _config
+
+    try:
+        assert _config.ACM_MCP_TOKEN == "s3cret"
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+# ---------------------------------------------------------------------------
+# Direct middleware tests — token UNSET (delegates to OIDC)
+# ---------------------------------------------------------------------------
+
+
+async def test_token_unset_passes_through_on_mcp_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``ACM_MCP_TOKEN`` is unset, /mcp requests pass through to the
+    next layer without enforcement (this leg defers to OIDC)."""
+    _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+    try:
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/mcp")
+            assert resp.status_code == 200
+            assert resp.json() == {"ok": True}
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+async def test_token_unset_does_not_touch_non_mcp_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+    try:
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/api/health")
+            assert resp.status_code == 200
+            assert resp.json() == {"status": "ok"}
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+# ---------------------------------------------------------------------------
+# Direct middleware tests — token SET, no OIDC
+# ---------------------------------------------------------------------------
+
+
+async def test_correct_bearer_token_passes(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token")
+    try:
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/mcp", headers={"Authorization": "Bearer correct-token"})
+            assert resp.status_code == 200
+            assert resp.json() == {"ok": True}
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+async def test_correct_bearer_token_passes_on_subpath(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token")
+    try:
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(
+                "/mcp/sub/path",
+                headers={"Authorization": "Bearer correct-token"},
+            )
+            assert resp.status_code == 200
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+async def test_missing_authorization_header_yields_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token")
+    try:
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/mcp")
+            assert resp.status_code == 401
+            assert resp.json() == {"detail": "MCP authentication required"}
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+async def test_wrong_bearer_token_yields_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token")
+    try:
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/mcp", headers={"Authorization": "Bearer wrong-token"})
+            assert resp.status_code == 401
+            assert resp.json() == {"detail": "MCP authentication required"}
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+async def test_non_bearer_scheme_yields_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token")
+    try:
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            # Basic auth must not satisfy a bearer gate even if the
+            # base64 payload happens to equal the token bytes.
+            resp = await ac.get("/mcp", headers={"Authorization": "Basic correct-token"})
+            assert resp.status_code == 401
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+async def test_bearer_scheme_is_case_insensitive(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RFC 7235 — auth scheme matching is case-insensitive."""
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token")
+    try:
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/mcp", headers={"Authorization": "bearer correct-token"})
+            assert resp.status_code == 200
+            resp = await ac.get("/mcp", headers={"Authorization": "BEARER correct-token"})
+            assert resp.status_code == 200
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+# ---------------------------------------------------------------------------
+# Direct middleware tests — token SET, OIDC-OR-bearer
+# ---------------------------------------------------------------------------
+
+
+async def test_oidc_authenticated_passes_even_with_wrong_bearer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If OIDC has authenticated the request (request.state.user is set),
+    the bearer header is ignored — OIDC alone is enough."""
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token")
+    try:
+        app = _build_app(install_oidc_stub=True, oidc_authenticated=True)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            # Wrong bearer, but OIDC said yes → pass
+            resp = await ac.get("/mcp", headers={"Authorization": "Bearer wrong-token"})
+            assert resp.status_code == 200
+            # No bearer header at all, but OIDC said yes → pass
+            resp = await ac.get("/mcp")
+            assert resp.status_code == 200
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+async def test_oidc_anonymous_and_wrong_bearer_yields_401(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If OIDC did NOT authenticate the request and the bearer is wrong/
+    missing, both legs of the OR fail and the middleware returns 401."""
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token")
+    try:
+        app = _build_app(install_oidc_stub=True, oidc_authenticated=False)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/mcp", headers={"Authorization": "Bearer wrong-token"})
+            assert resp.status_code == 401
+            assert resp.json() == {"detail": "MCP authentication required"}
+            resp = await ac.get("/mcp")
+            assert resp.status_code == 401
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+async def test_oidc_anonymous_and_correct_bearer_passes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token")
+    try:
+        app = _build_app(install_oidc_stub=True, oidc_authenticated=False)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(
+                "/mcp",
+                headers={"Authorization": "Bearer correct-token"},
+            )
+            assert resp.status_code == 200
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+# ---------------------------------------------------------------------------
+# Path-prefix gating
+# ---------------------------------------------------------------------------
+
+
+async def test_non_mcp_path_is_never_touched_when_token_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even with ``ACM_MCP_TOKEN`` configured, paths outside ``/mcp/*``
+    are not gated by this middleware."""
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token")
+    try:
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get("/api/health")
+            assert resp.status_code == 200
+            assert resp.json() == {"status": "ok"}
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+async def test_custom_mcp_path_is_honoured(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The middleware reads ``config.ACM_MCP_PATH`` at request time, so an
+    operator override is respected."""
+    _reload_config(
+        monkeypatch,
+        ACM_MCP_TOKEN="correct-token",
+        ACM_MCP_PATH="/agents/mcp",
+    )
+    try:
+        from aerospike_cluster_manager_api.mcp.auth import MCPBearerTokenMiddleware
+
+        app = FastAPI()
+
+        @app.get("/agents/mcp")
+        async def custom_mcp() -> dict:
+            return {"ok": True}
+
+        @app.get("/api/health")
+        async def health() -> dict:
+            return {"status": "ok"}
+
+        app.add_middleware(MCPBearerTokenMiddleware)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            # Custom path: gated.
+            resp = await ac.get("/agents/mcp")
+            assert resp.status_code == 401
+            resp = await ac.get(
+                "/agents/mcp",
+                headers={"Authorization": "Bearer correct-token"},
+            )
+            assert resp.status_code == 200
+            # Non-MCP path: untouched.
+            resp = await ac.get("/api/health")
+            assert resp.status_code == 200
+            # Default ``/mcp`` is NOT a match because the override is in effect.
+            resp = await ac.get("/mcp")
+            assert resp.status_code == 404
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None, ACM_MCP_PATH=None)
+
+
+# ---------------------------------------------------------------------------
+# Token never appears in logs
+# ---------------------------------------------------------------------------
+
+
+async def test_token_never_logged(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A wrong-bearer 401 must not echo the supplied token in any log line."""
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token")
+    try:
+        # Capture WARNING+ from anywhere in our package.
+        caplog.set_level("DEBUG", logger="aerospike_cluster_manager_api")
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            await ac.get(
+                "/mcp",
+                headers={"Authorization": "Bearer leaked-supplied-token"},
+            )
+        log_text = "\n".join(record.getMessage() for record in caplog.records)
+        assert "leaked-supplied-token" not in log_text, f"supplied token leaked into logs: {log_text!r}"
+        assert "correct-token" not in log_text, f"configured token leaked into logs: {log_text!r}"
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+# ---------------------------------------------------------------------------
+# main.py wiring — middleware installed only when ACM_MCP_ENABLED=true
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+async def app_with_mcp_enabled_and_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[object]:
+    """Reload main with ACM_MCP_ENABLED=true and a known token."""
+    monkeypatch.setenv("ACM_MCP_ENABLED", "true")
+    monkeypatch.setenv("ACM_MCP_TOKEN", "wired-token")
+    from aerospike_cluster_manager_api import config as _config
+    from aerospike_cluster_manager_api import main as _main
+
+    importlib.reload(_config)
+    importlib.reload(_main)
+    try:
+        yield _main.app
+    finally:
+        monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
+        monkeypatch.delenv("ACM_MCP_TOKEN", raising=False)
+        importlib.reload(_config)
+        importlib.reload(_main)
+
+
+@pytest.fixture()
+async def app_with_mcp_enabled_no_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[object]:
+    """Reload main with ACM_MCP_ENABLED=true and ACM_MCP_TOKEN unset."""
+    monkeypatch.setenv("ACM_MCP_ENABLED", "true")
+    monkeypatch.delenv("ACM_MCP_TOKEN", raising=False)
+    from aerospike_cluster_manager_api import config as _config
+    from aerospike_cluster_manager_api import main as _main
+
+    importlib.reload(_config)
+    importlib.reload(_main)
+    try:
+        yield _main.app
+    finally:
+        monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
+        importlib.reload(_config)
+        importlib.reload(_main)
+
+
+@pytest.fixture()
+async def app_with_mcp_disabled_token_set(
+    monkeypatch: pytest.MonkeyPatch,
+) -> AsyncIterator[object]:
+    """ACM_MCP_ENABLED=false + token set: middleware must NOT be installed
+    (the mount itself does not exist)."""
+    monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
+    monkeypatch.setenv("ACM_MCP_TOKEN", "should-not-matter")
+    from aerospike_cluster_manager_api import config as _config
+    from aerospike_cluster_manager_api import main as _main
+
+    importlib.reload(_config)
+    importlib.reload(_main)
+    try:
+        yield _main.app
+    finally:
+        monkeypatch.delenv("ACM_MCP_TOKEN", raising=False)
+        importlib.reload(_config)
+        importlib.reload(_main)
+
+
+async def test_main_mcp_enabled_with_token_gates_mcp_path(
+    app_with_mcp_enabled_and_token,
+) -> None:
+    """End-to-end: ACM_MCP_ENABLED=true + token → /mcp requires bearer."""
+    transport = ASGITransport(app=app_with_mcp_enabled_and_token)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        # No auth → 401 from MCP middleware.
+        resp = await ac.get("/mcp")
+        assert resp.status_code == 401
+        assert resp.json() == {"detail": "MCP authentication required"}
+        # Wrong token → 401.
+        resp = await ac.get("/mcp", headers={"Authorization": "Bearer nope"})
+        assert resp.status_code == 401
+        # Correct token → not 401 (the MCP transport itself may still
+        # reject a bare GET with 4xx, but it must NOT be the auth 401).
+        resp = await ac.get(
+            "/mcp",
+            headers={"Authorization": "Bearer wired-token"},
+        )
+        assert resp.status_code != 401, f"correct token must reach MCP transport, got {resp.status_code} {resp.text!r}"
+
+
+async def test_main_mcp_enabled_with_token_does_not_gate_api(
+    app_with_mcp_enabled_and_token,
+) -> None:
+    """The middleware is installed on the whole app but only enforces on
+    ``/mcp/*`` — the rest of the API surface is untouched."""
+    transport = ASGITransport(app=app_with_mcp_enabled_and_token)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}
+
+
+async def test_main_mcp_enabled_no_token_passes_through(
+    app_with_mcp_enabled_no_token,
+) -> None:
+    """ACM_MCP_ENABLED=true + ACM_MCP_TOKEN unset: the middleware is
+    installed but enforces nothing — /mcp reaches the FastMCP transport
+    without an auth 401 from us."""
+    transport = ASGITransport(app=app_with_mcp_enabled_no_token)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/mcp")
+        # Whatever the transport replies, it must NOT be our 401.
+        assert resp.status_code != 401 or resp.json() != {"detail": "MCP authentication required"}
+
+
+async def test_main_mcp_disabled_with_token_does_not_install_middleware(
+    app_with_mcp_disabled_token_set,
+) -> None:
+    """When the MCP mount itself is off, the middleware must not be
+    installed — the path is 404 and even setting a token has no effect."""
+    transport = ASGITransport(app=app_with_mcp_disabled_token_set)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/mcp")
+        # /mcp is unmounted → 404 from FastAPI's router, NOT 401 from us.
+        assert resp.status_code == 404
+        # /api routes still work.
+        resp = await ac.get("/api/health")
+        assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Smoke: the middleware base class is the right type so ``add_middleware``
+# wiring in main.py won't blow up.
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_bearer_token_middleware_is_basehttpmiddleware() -> None:
+    from aerospike_cluster_manager_api.mcp.auth import MCPBearerTokenMiddleware
+
+    assert issubclass(MCPBearerTokenMiddleware, BaseHTTPMiddleware)
+
+
+# Belt-and-braces: the dispatch signature should match Starlette's typing
+# contract so pyright doesn't reject the subclass at type-check time.
+def test_mcp_bearer_token_middleware_dispatch_signature() -> None:
+    import inspect
+
+    from aerospike_cluster_manager_api.mcp.auth import MCPBearerTokenMiddleware
+
+    sig = inspect.signature(MCPBearerTokenMiddleware.dispatch)
+    assert list(sig.parameters.keys())[:3] == ["self", "request", "call_next"]
+
+
+# Static reference to silence "imported but unused" — the imports help
+# readers understand that the middleware is exercised against real Starlette
+# Request/Response shapes, even when the smoke tests above don't reference
+# them directly.
+_ = (Request, Response)

--- a/api/tests/mcp/test_auth.py
+++ b/api/tests/mcp/test_auth.py
@@ -55,7 +55,7 @@ def _build_app(
     ``app.add_middleware(MCPBearerTokenMiddleware)`` — same call site as
     ``main.py``. When ``install_oidc_stub`` is true an additional
     middleware is wired up that simulates OIDC by setting
-    ``request.state.user`` to a dummy claim dict on every request — this
+    ``request.state.user_claims`` to a dummy claim dict on every request — this
     lets us exercise the OIDC-OR-bearer leg without spinning up a real
     JWKS server.
     """
@@ -81,13 +81,14 @@ def _build_app(
     app.add_middleware(MCPBearerTokenMiddleware)
 
     if install_oidc_stub:
-        # Tiny OIDC stand-in: writes ``request.state.user`` so the MCP
-        # middleware sees an authenticated request without us having to
-        # mint real JWTs.
+        # Tiny OIDC stand-in: writes ``request.state.user_claims`` so the
+        # MCP middleware sees an authenticated request without us having
+        # to mint real JWTs. (Matches the attribute name set by the real
+        # ``OIDCAuthMiddleware`` in ``middleware/oidc_auth.py``.)
         class _OIDCStub(BaseHTTPMiddleware):
             async def dispatch(self, request, call_next):
                 if oidc_authenticated:
-                    request.state.user = {"sub": "stub-user"}
+                    request.state.user_claims = {"sub": "stub-user"}
                 return await call_next(request)
 
         app.add_middleware(_OIDCStub)
@@ -266,7 +267,7 @@ async def test_bearer_scheme_is_case_insensitive(monkeypatch: pytest.MonkeyPatch
 async def test_oidc_authenticated_passes_even_with_wrong_bearer(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """If OIDC has authenticated the request (request.state.user is set),
+    """If OIDC has authenticated the request (request.state.user_claims set),
     the bearer header is ignored — OIDC alone is enough."""
     _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token")
     try:

--- a/api/tests/mcp/test_auth.py
+++ b/api/tests/mcp/test_auth.py
@@ -466,6 +466,131 @@ async def test_oidc_anonymous_and_correct_bearer_passes(
 
 
 # ---------------------------------------------------------------------------
+# OIDC-OR-bearer cooperation — bearer match short-circuits OIDC
+# ---------------------------------------------------------------------------
+
+
+async def test_bearer_match_sets_user_claims_sentinel(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A correct bearer match must populate ``request.state.user_claims`` so
+    the inner OIDCAuthMiddleware short-circuits and doesn't try to JWT-verify
+    the opaque token."""
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token")
+    try:
+        from aerospike_cluster_manager_api.mcp.auth import MCPBearerTokenMiddleware
+
+        observed: dict = {}
+
+        class _ClaimsCapture(BaseHTTPMiddleware):
+            async def dispatch(self, request, call_next):
+                # Runs INNER to MCP — by the time we see the request,
+                # MCP middleware should already have set user_claims.
+                observed["user_claims"] = getattr(request.state, "user_claims", None)
+                return await call_next(request)
+
+        app = FastAPI()
+
+        @app.get("/mcp")
+        async def mcp_root() -> dict:
+            return {"ok": True}
+
+        # Inner middleware first, then MCP outer (Starlette reverse-add).
+        app.add_middleware(_ClaimsCapture)
+        app.add_middleware(MCPBearerTokenMiddleware)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(
+                "/mcp",
+                headers={"Authorization": "Bearer correct-token"},
+            )
+            assert resp.status_code == 200
+            claims = observed.get("user_claims")
+            assert claims is not None, "user_claims sentinel was not set"
+            assert claims.get("_mcp_bearer") is True
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+async def test_oidc_defers_when_user_claims_already_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """OIDCAuthMiddleware must short-circuit if an outer middleware has
+    already populated request.state.user_claims. This is the OIDC-side leg
+    of the OR semantic — it lets MCP bearer auth bypass JWT verification."""
+    from aerospike_cluster_manager_api.middleware.oidc_auth import OIDCAuthMiddleware
+
+    class _Preauth(BaseHTTPMiddleware):
+        async def dispatch(self, request, call_next):
+            request.state.user_claims = {"sub": "outer-auth"}
+            return await call_next(request)
+
+    app = FastAPI()
+
+    @app.get("/anything")
+    async def anything() -> dict:
+        return {"ok": True}
+
+    # Inner: OIDC enabled with bogus issuer (would fail JWT verify if
+    # exercised). Outer: pre-auth that sets user_claims.
+    app.add_middleware(
+        OIDCAuthMiddleware,
+        enabled=True,
+        issuer_url="http://127.0.0.1:1/realms/none",
+        audience="acm",
+    )
+    app.add_middleware(_Preauth)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get(
+            "/anything",
+            headers={"Authorization": "Bearer not-a-real-jwt"},
+        )
+        # Pre-fix: OIDC would 401 on the malformed JWT.
+        # Post-fix: OIDC sees user_claims and defers.
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+
+
+async def test_bearer_mismatch_falls_through_to_oidc_when_oidc_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When ACM_MCP_TOKEN is set but doesn't match AND OIDC_ENABLED=true,
+    MCP middleware must NOT 401 — it falls through so OIDC can try to
+    verify the header as a JWT (preserving OIDC-OR-bearer)."""
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token", OIDC_ENABLED="true")
+    try:
+        from aerospike_cluster_manager_api.mcp.auth import MCPBearerTokenMiddleware
+
+        # Stub "OIDC" that returns 200 unconditionally — represents OIDC
+        # successfully verifying the JWT. This proves MCP middleware
+        # forwarded instead of 401-ing.
+        class _OIDCAcceptAll(BaseHTTPMiddleware):
+            async def dispatch(self, request, call_next):
+                return await call_next(request)
+
+        app = FastAPI()
+
+        @app.get("/mcp")
+        async def mcp_root() -> dict:
+            return {"ok": True}
+
+        app.add_middleware(_OIDCAcceptAll)
+        app.add_middleware(MCPBearerTokenMiddleware)
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(
+                "/mcp",
+                headers={"Authorization": "Bearer not-the-mcp-token-but-a-real-jwt"},
+            )
+            assert resp.status_code == 200, (
+                "MCP middleware should fall through on bearer mismatch when OIDC is enabled, "
+                "letting the inner OIDC middleware decide"
+            )
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None, OIDC_ENABLED=None)
+
+
+# ---------------------------------------------------------------------------
 # Path-prefix gating
 # ---------------------------------------------------------------------------
 

--- a/api/tests/mcp/test_auth.py
+++ b/api/tests/mcp/test_auth.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import importlib
 from collections.abc import AsyncIterator
+from typing import Any
 
 import pytest
 from fastapi import FastAPI
@@ -213,6 +214,150 @@ async def test_missing_authorization_header_yields_401(monkeypatch: pytest.Monke
             resp = await ac.get("/mcp")
             assert resp.status_code == 401
             assert resp.json() == {"detail": "MCP authentication required"}
+            # M4 — RFC-7235 ``WWW-Authenticate`` challenge header so
+            # bearer-aware clients know the scheme + realm.
+            assert resp.headers.get("www-authenticate") == 'Bearer realm="acm-mcp"'
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+async def test_401_response_carries_www_authenticate_challenge(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both 401 paths (missing/non-bearer header AND wrong-token) emit the
+    same ``WWW-Authenticate: Bearer realm="acm-mcp"`` challenge header so
+    a single client implementation can negotiate against either failure
+    mode."""
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token")
+    try:
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            # Missing header
+            resp = await ac.get("/mcp")
+            assert resp.status_code == 401
+            assert resp.headers.get("www-authenticate") == 'Bearer realm="acm-mcp"'
+            # Wrong token
+            resp = await ac.get("/mcp", headers={"Authorization": "Bearer nope"})
+            assert resp.status_code == 401
+            assert resp.headers.get("www-authenticate") == 'Bearer realm="acm-mcp"'
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+async def test_non_ascii_bearer_token_does_not_500(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """B1 — A header like ``Bearer café`` would crash
+    :func:`secrets.compare_digest` because the function rejects non-ASCII
+    ``str`` inputs. The middleware encodes to UTF-8 inside a try/except
+    and treats encoding failures as auth failure, so the response must
+    be 401 (not 500).
+
+    httpx's ``Headers`` builder normalises header values to ASCII via
+    :func:`str.encode`, which throws on a literal ``café`` argument. We
+    bypass that by driving the ASGI app directly with a synthetic scope
+    whose ``headers`` list contains raw UTF-8-encoded bytes for the
+    Authorization value — that's exactly the byte sequence the
+    middleware's ``request.headers.get(...)`` call would resolve to in
+    a real-world request from a misbehaving client.
+    """
+    from aerospike_cluster_manager_api.mcp.auth import MCPBearerTokenMiddleware
+
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token")
+    try:
+        # Minimal ASGI app under test: just the middleware in front of a
+        # 200 endpoint at /mcp. Drive it directly via the ASGI 3 protocol
+        # so we can inject non-ASCII bytes as the Authorization value.
+        app = _build_app()
+        # Compose the same scope httpx would build, but with a non-ASCII
+        # Authorization header encoded as UTF-8 bytes.
+        scope = {
+            "type": "http",
+            "asgi": {"version": "3.0", "spec_version": "2.3"},
+            "http_version": "1.1",
+            "method": "GET",
+            "scheme": "http",
+            "path": "/mcp",
+            "raw_path": b"/mcp",
+            "query_string": b"",
+            "root_path": "",
+            "headers": [
+                (b"host", b"test"),
+                # Non-ASCII bytes — would crash compare_digest if not
+                # caught defensively.
+                (b"authorization", "Bearer café".encode()),
+            ],
+            "client": ("127.0.0.1", 12345),
+            "server": ("test", 80),
+        }
+
+        # Capture the response status by replaying the ASGI events.
+        sent: list[dict[str, Any]] = []
+
+        async def receive():  # type: ignore[no-untyped-def]
+            return {"type": "http.request", "body": b"", "more_body": False}
+
+        async def send(message):  # type: ignore[no-untyped-def]
+            sent.append(message)
+
+        # Sanity check: the middleware class is the dispatcher we expect.
+        assert MCPBearerTokenMiddleware is not None
+        await app(scope, receive, send)  # pyright: ignore[reportArgumentType]
+
+        # The first message should be ``http.response.start`` with the
+        # 401 status code. (Subsequent messages are body chunks.)
+        statuses = [m["status"] for m in sent if m["type"] == "http.response.start"]
+        assert statuses == [401], f"expected 401, got events {sent!r}"
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+async def test_empty_bearer_token_yields_401(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``Bearer `` (empty token) must be rejected with 401, not pass through.
+    Even though ``compare_digest`` of two empty strings would return True,
+    the middleware short-circuits empty supplied tokens explicitly."""
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token")
+    try:
+        app = _build_app()
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.get(
+                "/mcp",
+                headers={"Authorization": "Bearer "},
+            )
+            assert resp.status_code == 401
+    finally:
+        _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
+
+
+async def test_path_prefix_bypass_attempt_is_not_gated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """M1 — Path comparison is on segment boundaries. A request to
+    ``/mcphax`` (which would pass a naive ``startswith("/mcp")`` check)
+    must NOT be intercepted by the MCP middleware — the bearer gate
+    should only apply to ``/mcp`` and ``/mcp/...`` paths."""
+    from aerospike_cluster_manager_api.mcp.auth import MCPBearerTokenMiddleware
+
+    _reload_config(monkeypatch, ACM_MCP_TOKEN="correct-token")
+    try:
+        app = FastAPI()
+
+        @app.get("/mcphax")
+        async def evil_route() -> dict:
+            return {"slipped_through": True}
+
+        app.add_middleware(MCPBearerTokenMiddleware)
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            # No bearer header — but ``/mcphax`` is not a sub-path of
+            # ``/mcp`` so the middleware must NOT intercept and 401 it.
+            resp = await ac.get("/mcphax")
+            assert resp.status_code == 200
+            assert resp.json() == {"slipped_through": True}
     finally:
         _reload_config(monkeypatch, ACM_MCP_TOKEN=None)
 
@@ -442,8 +587,15 @@ async def app_with_mcp_enabled_and_token(
 async def app_with_mcp_enabled_no_token(
     monkeypatch: pytest.MonkeyPatch,
 ) -> AsyncIterator[object]:
-    """Reload main with ACM_MCP_ENABLED=true and ACM_MCP_TOKEN unset."""
+    """Reload main with ACM_MCP_ENABLED=true and ACM_MCP_TOKEN unset.
+
+    Sets ACM_MCP_ALLOW_ANONYMOUS=true so the startup refusal added in
+    Phase 1 (``main.py``) does not abort import — this fixture targets
+    the pass-through behaviour of the bearer middleware when no token
+    is configured.
+    """
     monkeypatch.setenv("ACM_MCP_ENABLED", "true")
+    monkeypatch.setenv("ACM_MCP_ALLOW_ANONYMOUS", "true")
     monkeypatch.delenv("ACM_MCP_TOKEN", raising=False)
     from aerospike_cluster_manager_api import config as _config
     from aerospike_cluster_manager_api import main as _main
@@ -454,6 +606,7 @@ async def app_with_mcp_enabled_no_token(
         yield _main.app
     finally:
         monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
+        monkeypatch.delenv("ACM_MCP_ALLOW_ANONYMOUS", raising=False)
         importlib.reload(_config)
         importlib.reload(_main)
 
@@ -562,6 +715,93 @@ def test_mcp_bearer_token_middleware_dispatch_signature() -> None:
 
     sig = inspect.signature(MCPBearerTokenMiddleware.dispatch)
     assert list(sig.parameters.keys())[:3] == ["self", "request", "call_next"]
+
+
+# ---------------------------------------------------------------------------
+# Startup refusal — anonymous MCP exposure must be opt-in
+# ---------------------------------------------------------------------------
+
+
+def test_main_refuses_to_start_when_mcp_enabled_without_auth(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """B2 — When ``ACM_MCP_ENABLED=true`` is paired with NO OIDC, NO
+    ``ACM_MCP_TOKEN``, and NO ``ACM_MCP_ALLOW_ANONYMOUS=true``, importing
+    ``main.py`` must raise ``RuntimeError``. That refusal is the default
+    safety net against publishing the MCP surface to the network without
+    auth.
+
+    We exercise it via ``importlib.reload(main)`` because the check runs
+    at module import time. The error message must mention the three
+    knobs an operator can toggle to fix the misconfiguration so a deploy
+    failure points to the right knob.
+    """
+    monkeypatch.setenv("ACM_MCP_ENABLED", "true")
+    monkeypatch.delenv("ACM_MCP_TOKEN", raising=False)
+    monkeypatch.delenv("ACM_MCP_ALLOW_ANONYMOUS", raising=False)
+    monkeypatch.delenv("OIDC_ENABLED", raising=False)
+
+    from aerospike_cluster_manager_api import config as _config
+    from aerospike_cluster_manager_api import main as _main
+
+    importlib.reload(_config)
+    try:
+        with pytest.raises(RuntimeError, match="anonymous MCP surface"):
+            importlib.reload(_main)
+    finally:
+        # Reset env so other tests see a clean main.py.
+        monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
+        importlib.reload(_config)
+        importlib.reload(_main)
+
+
+def test_main_starts_when_mcp_enabled_with_allow_anonymous(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``ACM_MCP_ALLOW_ANONYMOUS=true`` is the documented escape hatch for
+    localhost-only / trusted-network deployments."""
+    monkeypatch.setenv("ACM_MCP_ENABLED", "true")
+    monkeypatch.setenv("ACM_MCP_ALLOW_ANONYMOUS", "true")
+    monkeypatch.delenv("ACM_MCP_TOKEN", raising=False)
+    monkeypatch.delenv("OIDC_ENABLED", raising=False)
+
+    from aerospike_cluster_manager_api import config as _config
+    from aerospike_cluster_manager_api import main as _main
+
+    importlib.reload(_config)
+    try:
+        importlib.reload(_main)  # must NOT raise
+        # The app object exists and has the MCP route.
+        assert hasattr(_main, "app")
+    finally:
+        monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
+        monkeypatch.delenv("ACM_MCP_ALLOW_ANONYMOUS", raising=False)
+        importlib.reload(_config)
+        importlib.reload(_main)
+
+
+def test_main_starts_when_mcp_enabled_with_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A configured ``ACM_MCP_TOKEN`` is sufficient — the bearer middleware
+    will gate the surface."""
+    monkeypatch.setenv("ACM_MCP_ENABLED", "true")
+    monkeypatch.setenv("ACM_MCP_TOKEN", "any-secret")
+    monkeypatch.delenv("ACM_MCP_ALLOW_ANONYMOUS", raising=False)
+    monkeypatch.delenv("OIDC_ENABLED", raising=False)
+
+    from aerospike_cluster_manager_api import config as _config
+    from aerospike_cluster_manager_api import main as _main
+
+    importlib.reload(_config)
+    try:
+        importlib.reload(_main)
+        assert hasattr(_main, "app")
+    finally:
+        monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
+        monkeypatch.delenv("ACM_MCP_TOKEN", raising=False)
+        importlib.reload(_config)
+        importlib.reload(_main)
 
 
 # Static reference to silence "imported but unused" — the imports help

--- a/api/tests/mcp/test_auto_discovery.py
+++ b/api/tests/mcp/test_auto_discovery.py
@@ -1,0 +1,49 @@
+"""Auto-discovery wiring (Task B.6).
+
+Verifies that ``build_mcp_app()`` returns a FastMCP with all 21 Phase 1
+tools registered, by importing every ``mcp/tools/*`` submodule before
+calling :func:`register_all`.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aerospike_cluster_manager_api.mcp.registry import registered_tools
+from aerospike_cluster_manager_api.mcp.server import build_mcp_app
+
+
+def test_build_mcp_app_registers_all_phase1_tools() -> None:
+    # Importing the server module already triggers tools/__init__.py imports.
+    build_mcp_app()
+    names = {entry.name for entry in registered_tools()}
+
+    # 8 connection tools
+    assert "create_connection" in names
+    assert "list_connections" in names
+    assert "connect" in names
+    assert "test_connection" in names
+    # 3 cluster info
+    assert "list_namespaces" in names
+    assert "list_sets" in names
+    assert "get_nodes" in names
+    # 7 record
+    assert "get_record" in names
+    assert "create_record" in names
+    assert "truncate_set" in names
+    # 1 query
+    assert "query" in names
+    # 2 info commands
+    assert "execute_info" in names
+    assert "execute_info_on_node" in names
+
+    assert len(names) == 21, f"expected 21 tools, got {len(names)}: {sorted(names)}"
+
+
+@pytest.mark.asyncio
+async def test_build_mcp_app_lists_tools_via_fastmcp() -> None:
+    """FastMCP.list_tools() returns the same 21 entries we registered."""
+    mcp = build_mcp_app()
+    tools = await mcp.list_tools()
+    names = {t.name for t in tools}
+    assert len(names) == 21

--- a/api/tests/mcp/test_auto_discovery.py
+++ b/api/tests/mcp/test_auto_discovery.py
@@ -1,8 +1,9 @@
 """Auto-discovery wiring (Task B.6).
 
-Verifies that ``build_mcp_app()`` returns a FastMCP with all 21 Phase 1
+Verifies that ``build_mcp_app()`` returns a FastMCP with all Phase 1
 tools registered, by importing every ``mcp/tools/*`` submodule before
-calling :func:`register_all`.
+calling :func:`register_all`. The expected count is centralised in
+:data:`tests.mcp.conftest.EXPECTED_TOOL_COUNT`.
 """
 
 from __future__ import annotations
@@ -11,6 +12,8 @@ import pytest
 
 from aerospike_cluster_manager_api.mcp.registry import registered_tools
 from aerospike_cluster_manager_api.mcp.server import build_mcp_app
+
+from .conftest import EXPECTED_TOOL_COUNT
 
 
 def test_build_mcp_app_registers_all_phase1_tools() -> None:
@@ -37,13 +40,13 @@ def test_build_mcp_app_registers_all_phase1_tools() -> None:
     assert "execute_info" in names
     assert "execute_info_on_node" in names
 
-    assert len(names) == 21, f"expected 21 tools, got {len(names)}: {sorted(names)}"
+    assert len(names) == EXPECTED_TOOL_COUNT, f"expected {EXPECTED_TOOL_COUNT} tools, got {len(names)}: {sorted(names)}"
 
 
 @pytest.mark.asyncio
 async def test_build_mcp_app_lists_tools_via_fastmcp() -> None:
-    """FastMCP.list_tools() returns the same 21 entries we registered."""
+    """FastMCP.list_tools() returns the same entries we registered."""
     mcp = build_mcp_app()
     tools = await mcp.list_tools()
     names = {t.name for t in tools}
-    assert len(names) == 21
+    assert len(names) == EXPECTED_TOOL_COUNT

--- a/api/tests/mcp/test_cluster_info_tools.py
+++ b/api/tests/mcp/test_cluster_info_tools.py
@@ -1,0 +1,290 @@
+"""Tests for the MCP cluster info tools (Task B.2).
+
+These tests exercise the 3 cluster-info tools directly (bypassing the
+FastMCP transport) — direct callable invocation is sufficient to verify
+serialisation, error mapping, and the access-profile gate, all of which are
+applied by the registry decorator.
+
+Coverage matrix:
+
+* every tool: happy path returns JSON-serialisable shape that mirrors the
+  underlying service-layer response (``list[str]`` for namespaces, lists of
+  dicts for sets/nodes — the underlying ``SetInfo`` / ``ClusterNode``
+  pydantic models are ``model_dump()``-ed at the MCP boundary);
+* error mapping: an unknown ``conn_id`` causes ``client_manager.get_client``
+  to raise ``ValueError``; the tool re-raises as ``ConnectionNotFoundError``
+  so the registry's error map produces ``code="ConnectionNotFoundError"``,
+  matching the wire shape used by the B.1 ``connect`` tool;
+* one verification that *importing* the module registers exactly 3 tools
+  under ``category="cluster_info"`` so the auto-discovery wiring done in B.6
+  sees the expected surface.
+
+The 3 cluster-info tools are not in :data:`access_profile.WRITE_TOOLS`, so
+the read-only profile is fine for all of them — there's no separate
+read-only test, just the standard happy paths.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+
+from aerospike_cluster_manager_api.mcp.errors import MCPToolError
+from aerospike_cluster_manager_api.mcp.registry import registered_tools
+from aerospike_cluster_manager_api.models.cluster import ClusterNode, SetInfo
+
+# ---------------------------------------------------------------------------
+# Module import side-effect: the 3 tools register themselves at import time
+# so auto-discovery (B.6) sees them.
+# ---------------------------------------------------------------------------
+
+
+def test_cluster_info_tools_module_registers_three_tools() -> None:
+    # Importing the module is enough — the @tool decorations run at import time.
+    from aerospike_cluster_manager_api.mcp.tools import cluster_info as _cluster_info  # noqa: F401
+
+    names = {entry.name for entry in registered_tools() if entry.category == "cluster_info"}
+    assert names == {"list_namespaces", "list_sets", "get_nodes"}
+
+
+def test_mutation_flags_are_all_false() -> None:
+    from aerospike_cluster_manager_api.mcp.tools import cluster_info as _cluster_info  # noqa: F401
+
+    by_name = {entry.name: entry for entry in registered_tools() if entry.category == "cluster_info"}
+    # All 3 tools are read-only.
+    assert by_name["list_namespaces"].mutation is False
+    assert by_name["list_sets"].mutation is False
+    assert by_name["get_nodes"].mutation is False
+
+
+# ---------------------------------------------------------------------------
+# list_namespaces
+# ---------------------------------------------------------------------------
+
+
+class TestListNamespaces:
+    async def test_happy_path_returns_list_of_strings(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import cluster_info as ci_tools
+        from aerospike_cluster_manager_api.mcp.tools.cluster_info import list_namespaces
+
+        mock_client = MagicMock()
+        mock_client.info_random_node = AsyncMock(return_value="test;bar")
+
+        with patch.object(
+            ci_tools.client_manager,
+            "get_client",
+            new=AsyncMock(return_value=mock_client),
+        ):
+            result = await list_namespaces(conn_id="conn-x")
+
+        assert isinstance(result, list)
+        assert result == ["test", "bar"]
+        assert all(isinstance(ns, str) for ns in result)
+
+    async def test_returns_empty_list_when_no_namespaces(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import cluster_info as ci_tools
+        from aerospike_cluster_manager_api.mcp.tools.cluster_info import list_namespaces
+
+        mock_client = MagicMock()
+        mock_client.info_random_node = AsyncMock(return_value="")
+
+        with patch.object(
+            ci_tools.client_manager,
+            "get_client",
+            new=AsyncMock(return_value=mock_client),
+        ):
+            result = await list_namespaces(conn_id="conn-x")
+
+        assert result == []
+
+    async def test_missing_conn_id_maps_to_mcp_error(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import cluster_info as ci_tools
+        from aerospike_cluster_manager_api.mcp.tools.cluster_info import list_namespaces
+
+        # client_manager.get_client raises ValueError for unknown profiles.
+        # The tool must re-raise as ConnectionNotFoundError so the registry's
+        # error map produces a stable wire code matching the connect tool.
+        with (
+            patch.object(
+                ci_tools.client_manager,
+                "get_client",
+                new=AsyncMock(side_effect=ValueError("Connection profile 'conn-nope' not found")),
+            ),
+            pytest.raises(MCPToolError) as exc_info,
+        ):
+            await list_namespaces(conn_id="conn-nope")
+        assert exc_info.value.code == "ConnectionNotFoundError"
+
+
+# ---------------------------------------------------------------------------
+# list_sets
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_client_for_sets() -> AsyncMock:
+    """Build a mock AsyncClient that returns realistic per-set info data."""
+    mock = AsyncMock()
+    mock.get_node_names = Mock(return_value=["node1", "node2"])
+
+    # info_random_node is used by list_namespaces (which is called by list_sets
+    # for the existence check) — return the namespace list.
+    mock.info_random_node = AsyncMock(return_value="test")
+
+    def info_all_side_effect(cmd: str):
+        if cmd.startswith("namespace/"):
+            ns_stats = "objects=200;replication-factor=2"
+            return [("node1", None, ns_stats), ("node2", None, ns_stats)]
+        if cmd.startswith("sets/"):
+            sets_resp = "set=myset:objects=100:tombstones=0:memory_data_bytes=500:stop-writes-count=0"
+            return [("node1", None, sets_resp), ("node2", None, sets_resp)]
+        return []
+
+    mock.info_all = AsyncMock(side_effect=info_all_side_effect)
+    return mock
+
+
+class TestListSets:
+    async def test_happy_path_returns_list_of_dicts(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import cluster_info as ci_tools
+        from aerospike_cluster_manager_api.mcp.tools.cluster_info import list_sets
+
+        mock_client = _make_mock_client_for_sets()
+
+        with patch.object(
+            ci_tools.client_manager,
+            "get_client",
+            new=AsyncMock(return_value=mock_client),
+        ):
+            result = await list_sets(conn_id="conn-x", namespace="test")
+
+        assert isinstance(result, list)
+        assert all(isinstance(item, dict) for item in result)
+        assert len(result) == 1
+        item = result[0]
+        # Must mirror the SetInfo pydantic model exactly.
+        assert item["name"] == "myset"
+        assert item["namespace"] == "test"
+        assert "objects" in item
+        assert "tombstones" in item
+        assert "memoryDataBytes" in item
+        assert "stopWritesCount" in item
+        assert "nodeCount" in item
+        assert "totalNodes" in item
+        # And that it round-trips through the pydantic model — proves the
+        # shape matches the wire contract used by the REST router.
+        SetInfo(**item)
+
+    async def test_unknown_namespace_maps_to_mcp_error(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import cluster_info as ci_tools
+        from aerospike_cluster_manager_api.mcp.tools.cluster_info import list_sets
+
+        mock_client = _make_mock_client_for_sets()
+        # No matching namespace — list_namespaces returns [] so the existence
+        # check in clusters_service.list_sets raises NamespaceNotFoundError,
+        # which the registry's error map translates to MCPToolError.
+        mock_client.info_random_node = AsyncMock(return_value="")
+
+        with (
+            patch.object(
+                ci_tools.client_manager,
+                "get_client",
+                new=AsyncMock(return_value=mock_client),
+            ),
+            pytest.raises(MCPToolError) as exc_info,
+        ):
+            await list_sets(conn_id="conn-x", namespace="missing")
+        assert exc_info.value.code == "NamespaceNotFoundError"
+
+    async def test_missing_conn_id_maps_to_mcp_error(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import cluster_info as ci_tools
+        from aerospike_cluster_manager_api.mcp.tools.cluster_info import list_sets
+
+        with (
+            patch.object(
+                ci_tools.client_manager,
+                "get_client",
+                new=AsyncMock(side_effect=ValueError("Connection profile 'conn-nope' not found")),
+            ),
+            pytest.raises(MCPToolError) as exc_info,
+        ):
+            await list_sets(conn_id="conn-nope", namespace="test")
+        assert exc_info.value.code == "ConnectionNotFoundError"
+
+
+# ---------------------------------------------------------------------------
+# get_nodes
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_client_for_nodes() -> AsyncMock:
+    """Build a mock AsyncClient that returns realistic per-node info data."""
+    mock = AsyncMock()
+    mock.get_node_names = Mock(return_value=["node1", "node2"])
+
+    node_stats = "cluster_size=2;uptime=3600;client_connections=10"
+
+    def info_all_side_effect(cmd: str):
+        if cmd == "statistics":
+            return [("node1", None, node_stats), ("node2", None, node_stats)]
+        if cmd == "build":
+            return [("node1", None, "8.1.0"), ("node2", None, "8.1.0")]
+        if cmd == "edition":
+            return [("node1", None, "Community"), ("node2", None, "Community")]
+        if cmd == "service":
+            return [("node1", None, "10.0.0.1:3000"), ("node2", None, "10.0.0.2:3000")]
+        return []
+
+    mock.info_all = AsyncMock(side_effect=info_all_side_effect)
+    return mock
+
+
+class TestGetNodes:
+    async def test_happy_path_returns_list_of_dicts(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import cluster_info as ci_tools
+        from aerospike_cluster_manager_api.mcp.tools.cluster_info import get_nodes
+        from aerospike_cluster_manager_api.services.info_cache import info_cache
+
+        info_cache.clear()
+        mock_client = _make_mock_client_for_nodes()
+
+        with patch.object(
+            ci_tools.client_manager,
+            "get_client",
+            new=AsyncMock(return_value=mock_client),
+        ):
+            result = await get_nodes(conn_id="conn-test-1")
+
+        assert isinstance(result, list)
+        assert all(isinstance(item, dict) for item in result)
+        assert len(result) == 2
+        # Inspect one node's payload — must mirror ClusterNode schema.
+        item = result[0]
+        assert item["name"] in {"node1", "node2"}
+        assert item["build"] == "8.1.0"
+        assert item["edition"] == "Community"
+        assert "address" in item
+        assert "port" in item
+        assert "clusterSize" in item
+        assert "uptime" in item
+        assert "clientConnections" in item
+        assert "statistics" in item
+        # Round-trip through the pydantic model — proves the shape matches
+        # the wire contract used by the REST router.
+        ClusterNode(**item)
+        info_cache.clear()
+
+    async def test_missing_conn_id_maps_to_mcp_error(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import cluster_info as ci_tools
+        from aerospike_cluster_manager_api.mcp.tools.cluster_info import get_nodes
+
+        with (
+            patch.object(
+                ci_tools.client_manager,
+                "get_client",
+                new=AsyncMock(side_effect=ValueError("Connection profile 'conn-nope' not found")),
+            ),
+            pytest.raises(MCPToolError) as exc_info,
+        ):
+            await get_nodes(conn_id="conn-nope")
+        assert exc_info.value.code == "ConnectionNotFoundError"

--- a/api/tests/mcp/test_connection_tools.py
+++ b/api/tests/mcp/test_connection_tools.py
@@ -126,6 +126,22 @@ class TestCreateConnection:
         assert exc_info.value.code == "access_denied"
         assert "create_connection" in str(exc_info.value)
 
+    async def test_cluster_name_passed_through(self, init_test_db, full_profile: None) -> None:
+        """Phase 1: ``cluster_name`` parameter is forwarded as
+        ``clusterName=...`` on the underlying ``CreateConnectionRequest`` so
+        the Aerospike client tend (cluster-name policy) sees the operator's
+        chosen identifier.
+        """
+        from aerospike_cluster_manager_api.mcp.tools.connections import create_connection
+
+        result = await create_connection(
+            name="With Cluster Name",
+            hosts=["10.0.0.1"],
+            cluster_name="prod-cluster-east",
+        )
+        assert isinstance(result, dict)
+        assert result["clusterName"] == "prod-cluster-east"
+
 
 # ---------------------------------------------------------------------------
 # get_connection
@@ -186,6 +202,23 @@ class TestUpdateConnection:
         with pytest.raises(MCPToolError) as exc_info:
             await update_connection(conn_id="conn-nonexistent", name="X")
         assert exc_info.value.code == "ConnectionNotFoundError"
+
+    async def test_cluster_name_passed_through(self, init_test_db, full_profile: None) -> None:
+        """Phase 1: ``cluster_name`` parameter on ``update_connection`` is
+        forwarded as ``clusterName=...`` so an operator can change the
+        Aerospike cluster identifier (cluster-name tend policy) without
+        creating a new profile."""
+        from aerospike_cluster_manager_api.mcp.tools.connections import (
+            create_connection,
+            update_connection,
+        )
+
+        created = await create_connection(name="Will Update", hosts=["10.0.0.1"])
+        result = await update_connection(
+            conn_id=created["id"],
+            cluster_name="renamed-cluster",
+        )
+        assert result["clusterName"] == "renamed-cluster"
 
 
 # ---------------------------------------------------------------------------
@@ -330,11 +363,17 @@ class TestConnectDisconnect:
 class TestTestConnectionTool:
     async def test_happy_path_returns_dict_from_service(self, init_test_db, full_profile: None) -> None:
         from aerospike_cluster_manager_api.mcp.tools.connections import test_connection
+        from aerospike_cluster_manager_api.services.connections_service import (
+            # Aliased so pytest does not try to collect this NamedTuple as a
+            # test class.
+            TestConnectionResult as _TCResult,
+        )
 
-        async def _fake(req: Any) -> dict[str, Any]:
+        async def _fake(req: Any) -> _TCResult:
             assert req.hosts == ["10.0.0.1"]
             assert req.port == 3000
-            return {"success": True, "message": "Connected successfully"}
+            # Phase 1: service returns a NamedTuple, not a dict.
+            return _TCResult(success=True, message="Connected successfully")
 
         with patch(
             "aerospike_cluster_manager_api.mcp.tools.connections.connections_service.test_connection",
@@ -342,17 +381,22 @@ class TestTestConnectionTool:
         ):
             result = await test_connection(hosts=["10.0.0.1"], port=3000)
 
+        # The MCP tool wraps the service result back into a JSON-serialisable
+        # dict for transport.
         assert result == {"success": True, "message": "Connected successfully"}
 
     async def test_passes_credentials(self, init_test_db, full_profile: None) -> None:
         from aerospike_cluster_manager_api.mcp.tools.connections import test_connection
+        from aerospike_cluster_manager_api.services.connections_service import (
+            TestConnectionResult as _TCResult,
+        )
 
         captured: dict[str, Any] = {}
 
-        async def _fake(req: Any) -> dict[str, Any]:
+        async def _fake(req: Any) -> _TCResult:
             captured["user"] = req.username
             captured["pass"] = req.password
-            return {"success": True, "message": "ok"}
+            return _TCResult(success=True, message="ok")
 
         with patch(
             "aerospike_cluster_manager_api.mcp.tools.connections.connections_service.test_connection",

--- a/api/tests/mcp/test_connection_tools.py
+++ b/api/tests/mcp/test_connection_tools.py
@@ -374,16 +374,18 @@ class TestTestConnectionTool:
 
 def test_reset_for_tests_helper_clears_connection_tools() -> None:
     # Importing the tools module first ensures the decorator side-effects ran.
+    from aerospike_cluster_manager_api.mcp import registry as _registry
     from aerospike_cluster_manager_api.mcp.tools import connections as _connections  # noqa: F401
 
     assert any(entry.category == "connection" for entry in registered_tools())
-    _reset_for_tests()
-    assert registered_tools() == []
-    # Re-import the module so the registry returns to a populated state for
-    # any subsequent test-collection pass that runs in the same process.
-    import importlib
-
-    import aerospike_cluster_manager_api.mcp.tools.connections as _mod
-
-    importlib.reload(_mod)
+    saved = list(_registry._REGISTRY)
+    try:
+        _reset_for_tests()
+        assert registered_tools() == []
+    finally:
+        # Restore the full snapshot — reloading just the connections module
+        # would only repopulate 8 of the 21 tools because the other tool
+        # modules are already imported (cached) and their decorators do not
+        # re-run. Snapshot/restore is symmetrical and order-independent.
+        _registry._REGISTRY[:] = saved
     assert any(entry.category == "connection" for entry in registered_tools())

--- a/api/tests/mcp/test_connection_tools.py
+++ b/api/tests/mcp/test_connection_tools.py
@@ -1,0 +1,389 @@
+"""Tests for the MCP connection tools (Task B.1).
+
+These tests exercise each of the 8 connection tools directly (bypassing the
+FastMCP transport) — direct callable invocation is sufficient to verify
+serialisation, error mapping, and the access-profile gate, all of which are
+applied by the registry decorator.
+
+Coverage matrix:
+
+* every tool: happy path returns JSON-serialisable shape that mirrors the
+  underlying service-layer response;
+* mutation tools (``create_connection``, ``update_connection``,
+  ``delete_connection``): under the ``READ_ONLY`` profile, the call raises
+  ``MCPToolError(code="access_denied")`` *before* the body runs;
+* error mapping: deleting a missing connection (and adjacent paths) surfaces
+  a stable ``MCPToolError`` with the service-layer exception name as
+  ``code``;
+* one verification that *importing* the module registers exactly 8 tools so
+  the auto-discovery wiring done in B.6 sees the expected surface.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aerospike_cluster_manager_api import config
+from aerospike_cluster_manager_api.mcp.access_profile import AccessProfile
+from aerospike_cluster_manager_api.mcp.errors import MCPToolError
+from aerospike_cluster_manager_api.mcp.registry import (
+    _reset_for_tests,
+    registered_tools,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def full_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the access profile to FULL so mutation tools are not blocked."""
+    monkeypatch.setattr(config, "ACM_MCP_ACCESS_PROFILE", AccessProfile.FULL)
+
+
+@pytest.fixture
+def read_only_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the access profile to READ_ONLY."""
+    monkeypatch.setattr(config, "ACM_MCP_ACCESS_PROFILE", AccessProfile.READ_ONLY)
+
+
+# ---------------------------------------------------------------------------
+# Module import side-effect: the 8 tools register themselves at import time
+# so auto-discovery (B.6) sees them. This single test asserts the count and
+# the categories without resetting the registry — every other test below
+# imports tool callables directly and reasons about them via direct invoke.
+# ---------------------------------------------------------------------------
+
+
+def test_connection_tools_module_registers_eight_tools() -> None:
+    # Importing the module is enough — the @tool decorations run at import time.
+    from aerospike_cluster_manager_api.mcp.tools import connections as _connections  # noqa: F401
+
+    names = {entry.name for entry in registered_tools() if entry.category == "connection"}
+    assert names == {
+        "create_connection",
+        "get_connection",
+        "update_connection",
+        "delete_connection",
+        "list_connections",
+        "connect",
+        "disconnect",
+        "test_connection",
+    }
+
+
+def test_mutation_flags_match_design() -> None:
+    from aerospike_cluster_manager_api.mcp.tools import connections as _connections  # noqa: F401
+
+    by_name = {entry.name: entry for entry in registered_tools() if entry.category == "connection"}
+    assert by_name["create_connection"].mutation is True
+    assert by_name["update_connection"].mutation is True
+    assert by_name["delete_connection"].mutation is True
+    # Read tools (and the connect/disconnect pair, which Voyager treats as
+    # non-mutation) must not advertise mutation.
+    assert by_name["get_connection"].mutation is False
+    assert by_name["list_connections"].mutation is False
+    assert by_name["connect"].mutation is False
+    assert by_name["disconnect"].mutation is False
+    assert by_name["test_connection"].mutation is False
+
+
+# ---------------------------------------------------------------------------
+# create_connection
+# ---------------------------------------------------------------------------
+
+
+class TestCreateConnection:
+    async def test_happy_path_returns_serialisable_dict(self, init_test_db, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.connections import create_connection
+
+        result = await create_connection(
+            name="MCP Test",
+            hosts=["10.0.0.1"],
+            port=3000,
+            color="#FF5500",
+        )
+        assert isinstance(result, dict)
+        assert result["name"] == "MCP Test"
+        assert result["hosts"] == ["10.0.0.1"]
+        assert result["port"] == 3000
+        assert result["color"] == "#FF5500"
+        # workspaceId falls back to the built-in default.
+        assert result["workspaceId"] == "ws-default"
+        # Password must never leak through.
+        assert "password" not in result
+
+    async def test_read_only_profile_blocks_call(self, init_test_db, read_only_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.connections import create_connection
+
+        with pytest.raises(MCPToolError) as exc_info:
+            await create_connection(name="MCP Test", hosts=["10.0.0.1"])
+
+        assert exc_info.value.code == "access_denied"
+        assert "create_connection" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# get_connection
+# ---------------------------------------------------------------------------
+
+
+class TestGetConnection:
+    async def test_happy_path_returns_dict(self, init_test_db, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.connections import (
+            create_connection,
+            get_connection,
+        )
+
+        created = await create_connection(name="Lookup Me", hosts=["1.1.1.1"])
+        result = await get_connection(conn_id=created["id"])
+        assert isinstance(result, dict)
+        assert result["id"] == created["id"]
+        assert result["name"] == "Lookup Me"
+
+    async def test_missing_id_maps_to_mcp_error(self, init_test_db, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.connections import get_connection
+
+        with pytest.raises(MCPToolError) as exc_info:
+            await get_connection(conn_id="conn-nonexistent")
+        assert exc_info.value.code == "ConnectionNotFoundError"
+
+
+# ---------------------------------------------------------------------------
+# update_connection
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateConnection:
+    async def test_happy_path_returns_updated_dict(self, init_test_db, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.connections import (
+            create_connection,
+            update_connection,
+        )
+
+        created = await create_connection(name="Old Name", hosts=["10.0.0.1"])
+        result = await update_connection(conn_id=created["id"], name="New Name", port=4000)
+        assert isinstance(result, dict)
+        assert result["name"] == "New Name"
+        assert result["port"] == 4000
+        # Untouched fields preserved.
+        assert result["hosts"] == ["10.0.0.1"]
+
+    async def test_read_only_profile_blocks_call(self, init_test_db, read_only_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.connections import update_connection
+
+        with pytest.raises(MCPToolError) as exc_info:
+            await update_connection(conn_id="conn-x", name="Y")
+        assert exc_info.value.code == "access_denied"
+
+    async def test_missing_id_maps_to_mcp_error(self, init_test_db, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.connections import update_connection
+
+        with pytest.raises(MCPToolError) as exc_info:
+            await update_connection(conn_id="conn-nonexistent", name="X")
+        assert exc_info.value.code == "ConnectionNotFoundError"
+
+
+# ---------------------------------------------------------------------------
+# delete_connection
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteConnection:
+    async def test_happy_path_returns_none_or_status(self, init_test_db, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.connections import (
+            create_connection,
+            delete_connection,
+            get_connection,
+        )
+
+        created = await create_connection(name="Delete Me", hosts=["1.1.1.1"])
+        result = await delete_connection(conn_id=created["id"])
+        # The tool surface returns a small JSON-serialisable acknowledgement.
+        assert isinstance(result, dict)
+        assert result.get("deleted") is True
+        # And the connection is in fact gone.
+        with pytest.raises(MCPToolError):
+            await get_connection(conn_id=created["id"])
+
+    async def test_read_only_profile_blocks_call(self, init_test_db, read_only_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.connections import delete_connection
+
+        with pytest.raises(MCPToolError) as exc_info:
+            await delete_connection(conn_id="conn-x")
+        assert exc_info.value.code == "access_denied"
+
+    async def test_idempotent_for_missing(self, init_test_db, full_profile: None) -> None:
+        # Mirrors the service-layer contract: deleting a missing conn is a no-op.
+        from aerospike_cluster_manager_api.mcp.tools.connections import delete_connection
+
+        result = await delete_connection(conn_id="conn-nonexistent")
+        assert isinstance(result, dict)
+        assert result.get("deleted") is True
+
+
+# ---------------------------------------------------------------------------
+# list_connections
+# ---------------------------------------------------------------------------
+
+
+class TestListConnections:
+    async def test_happy_path_returns_list_of_dicts(self, init_test_db, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.connections import (
+            create_connection,
+            list_connections,
+        )
+
+        await create_connection(name="A", hosts=["1.1.1.1"])
+        await create_connection(name="B", hosts=["2.2.2.2"])
+
+        result = await list_connections()
+        assert isinstance(result, list)
+        assert len(result) >= 2
+        assert all(isinstance(item, dict) for item in result)
+        names = {item["name"] for item in result}
+        assert {"A", "B"}.issubset(names)
+
+    async def test_workspace_filter(self, init_test_db, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.connections import list_connections
+
+        result = await list_connections(workspace_id="ws-default")
+        assert isinstance(result, list)
+        assert all(item["workspaceId"] == "ws-default" for item in result)
+
+    async def test_unknown_workspace_maps_to_mcp_error(self, init_test_db, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.connections import list_connections
+
+        with pytest.raises(MCPToolError) as exc_info:
+            await list_connections(workspace_id="ws-missing")
+        assert exc_info.value.code == "WorkspaceNotFoundError"
+
+
+# ---------------------------------------------------------------------------
+# connect / disconnect
+# ---------------------------------------------------------------------------
+
+
+class TestConnectDisconnect:
+    async def test_connect_returns_status_dict(self, init_test_db, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import connections as conn_tools
+        from aerospike_cluster_manager_api.mcp.tools.connections import (
+            connect,
+            create_connection,
+        )
+
+        created = await create_connection(name="Live", hosts=["10.0.0.1"])
+
+        mock_client = MagicMock()
+        mock_client.get_node_names = MagicMock(return_value=["node-1", "node-2"])
+        mock_client.info_random_node = AsyncMock(return_value="test;bar")
+
+        with patch.object(
+            conn_tools.client_manager,
+            "get_client",
+            new=AsyncMock(return_value=mock_client),
+        ):
+            result = await connect(conn_id=created["id"])
+
+        assert isinstance(result, dict)
+        assert result["connected"] is True
+        assert result["node_count"] == 2
+        assert result["namespaces"] == ["test", "bar"]
+
+    async def test_connect_unknown_id_maps_to_mcp_error(self, init_test_db, full_profile: None) -> None:
+        # client_manager.get_client raises ValueError when the profile is
+        # missing — that path is not in the standard error map (it uses the
+        # service-layer ConnectionNotFoundError instead). The connect tool
+        # therefore surfaces it via ConnectionNotFoundError to keep the wire
+        # shape consistent with get_connection.
+        from aerospike_cluster_manager_api.mcp.tools.connections import connect
+
+        with pytest.raises(MCPToolError) as exc_info:
+            await connect(conn_id="conn-nonexistent")
+        assert exc_info.value.code == "ConnectionNotFoundError"
+
+    async def test_disconnect_returns_status_dict(self, init_test_db, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import connections as conn_tools
+        from aerospike_cluster_manager_api.mcp.tools.connections import disconnect
+
+        with patch.object(
+            conn_tools.client_manager,
+            "close_client",
+            new=AsyncMock(return_value=None),
+        ) as mock_close:
+            result = await disconnect(conn_id="conn-anything")
+
+        assert isinstance(result, dict)
+        assert result["disconnected"] is True
+        mock_close.assert_awaited_once_with("conn-anything")
+
+
+# ---------------------------------------------------------------------------
+# test_connection (probe — does not persist)
+# ---------------------------------------------------------------------------
+
+
+class TestTestConnectionTool:
+    async def test_happy_path_returns_dict_from_service(self, init_test_db, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.connections import test_connection
+
+        async def _fake(req: Any) -> dict[str, Any]:
+            assert req.hosts == ["10.0.0.1"]
+            assert req.port == 3000
+            return {"success": True, "message": "Connected successfully"}
+
+        with patch(
+            "aerospike_cluster_manager_api.mcp.tools.connections.connections_service.test_connection",
+            side_effect=_fake,
+        ):
+            result = await test_connection(hosts=["10.0.0.1"], port=3000)
+
+        assert result == {"success": True, "message": "Connected successfully"}
+
+    async def test_passes_credentials(self, init_test_db, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.connections import test_connection
+
+        captured: dict[str, Any] = {}
+
+        async def _fake(req: Any) -> dict[str, Any]:
+            captured["user"] = req.username
+            captured["pass"] = req.password
+            return {"success": True, "message": "ok"}
+
+        with patch(
+            "aerospike_cluster_manager_api.mcp.tools.connections.connections_service.test_connection",
+            side_effect=_fake,
+        ):
+            await test_connection(hosts=["localhost"], port=3000, username="admin", password="secret")
+
+        assert captured == {"user": "admin", "pass": "secret"}
+
+
+# ---------------------------------------------------------------------------
+# Registry isolation marker — the module-level @tool decorations must not
+# leak across the boundary of this test file. The registry test file uses
+# _reset_for_tests autouse fixture; we intentionally leave the connection
+# tools registered here so other suites that introspect them still see the
+# count.
+# ---------------------------------------------------------------------------
+
+
+def test_reset_for_tests_helper_clears_connection_tools() -> None:
+    # Importing the tools module first ensures the decorator side-effects ran.
+    from aerospike_cluster_manager_api.mcp.tools import connections as _connections  # noqa: F401
+
+    assert any(entry.category == "connection" for entry in registered_tools())
+    _reset_for_tests()
+    assert registered_tools() == []
+    # Re-import the module so the registry returns to a populated state for
+    # any subsequent test-collection pass that runs in the same process.
+    import importlib
+
+    import aerospike_cluster_manager_api.mcp.tools.connections as _mod
+
+    importlib.reload(_mod)
+    assert any(entry.category == "connection" for entry in registered_tools())

--- a/api/tests/mcp/test_connection_tools.py
+++ b/api/tests/mcp/test_connection_tools.py
@@ -83,7 +83,7 @@ def test_mutation_flags_match_design() -> None:
     assert by_name["create_connection"].mutation is True
     assert by_name["update_connection"].mutation is True
     assert by_name["delete_connection"].mutation is True
-    # Read tools (and the connect/disconnect pair, which Voyager treats as
+    # Read tools (and the connect/disconnect pair, which we treat as
     # non-mutation) must not advertise mutation.
     assert by_name["get_connection"].mutation is False
     assert by_name["list_connections"].mutation is False

--- a/api/tests/mcp/test_e2e.py
+++ b/api/tests/mcp/test_e2e.py
@@ -1,0 +1,80 @@
+"""End-to-end MCP transport test (Task C.1).
+
+Boots the real FastAPI app via in-process ASGI transport with
+``ACM_MCP_ENABLED=true`` and walks through:
+
+* ``initialize`` succeeds and returns the server name;
+* ``list_tools`` returns exactly 21 entries;
+* representative read-only tool (``test_connection``) is callable;
+
+Aerospike-touching tools (records, query, info) rely on a live cluster
+and are exercised in the live verification scenarios E.1-E.3 with podman.
+This test focuses on the MCP transport + tool registration plumbing -
+i.e. that the same code path used by external MCP clients works end to
+end inside our process boundary.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+
+@pytest.fixture()
+def app_with_mcp_enabled(monkeypatch: pytest.MonkeyPatch):
+    """Reload main with ACM_MCP_ENABLED=true so /mcp is mounted."""
+    monkeypatch.setenv("ACM_MCP_ENABLED", "true")
+    from aerospike_cluster_manager_api import config as _config
+    from aerospike_cluster_manager_api import main as _main
+
+    importlib.reload(_config)
+    importlib.reload(_main)
+    try:
+        yield _main.app
+    finally:
+        monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
+        importlib.reload(_config)
+        importlib.reload(_main)
+
+
+async def test_mcp_endpoint_lists_21_tools_via_fastmcp(app_with_mcp_enabled) -> None:
+    """The mounted ``/mcp`` server exposes all 21 Phase 1 tools."""
+    from aerospike_cluster_manager_api.mcp.server import build_mcp_app
+
+    mcp = build_mcp_app()
+    tools = await mcp.list_tools()
+    names = {t.name for t in tools}
+    assert len(names) == 21, sorted(names)
+
+
+async def test_mcp_route_exists_when_flag_on(app_with_mcp_enabled) -> None:
+    """The /mcp route exists on the real FastAPI app when the flag is on."""
+    from httpx import ASGITransport, AsyncClient
+
+    transport = ASGITransport(app=app_with_mcp_enabled)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/mcp")
+        # Streamable HTTP MCP responds to GETs with 405/406/200 depending on
+        # the SDK version — anything other than 404 proves the mount worked.
+        assert response.status_code != 404
+
+
+async def test_mcp_route_404_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The /mcp route does NOT exist when ACM_MCP_ENABLED is unset."""
+    from httpx import ASGITransport, AsyncClient
+
+    monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
+    from aerospike_cluster_manager_api import config as _config
+    from aerospike_cluster_manager_api import main as _main
+
+    importlib.reload(_config)
+    importlib.reload(_main)
+    try:
+        transport = ASGITransport(app=_main.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/mcp")
+            assert response.status_code == 404
+    finally:
+        importlib.reload(_config)
+        importlib.reload(_main)

--- a/api/tests/mcp/test_e2e.py
+++ b/api/tests/mcp/test_e2e.py
@@ -1,80 +1,168 @@
-"""End-to-end MCP transport test (Task C.1).
+"""Real JSON-RPC end-to-end test for the MCP server.
 
-Boots the real FastAPI app via in-process ASGI transport with
-``ACM_MCP_ENABLED=true`` and walks through:
+This test exercises the full handler chain on an actual mounted FastMCP
+instance — access-profile gate → error map → tool body → result
+serialisation — by driving :meth:`FastMCP.call_tool` directly.
 
-* ``initialize`` succeeds and returns the server name;
-* ``list_tools`` returns exactly 21 entries;
-* representative read-only tool (``test_connection``) is callable;
+Why ``mcp.call_tool`` instead of the streamable-HTTP transport?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Aerospike-touching tools (records, query, info) rely on a live cluster
-and are exercised in the live verification scenarios E.1-E.3 with podman.
-This test focuses on the MCP transport + tool registration plumbing -
-i.e. that the same code path used by external MCP clients works end to
-end inside our process boundary.
+The streamable-HTTP transport requires session header negotiation that
+the in-process ASGI test client cannot satisfy without a non-trivial
+helper. ``call_tool`` bypasses the wire codec and hits the same registered
+handler — i.e. the same `wrapped` callable that ``register_all`` flushed
+into FastMCP. That handler is the bulk of the wire path: by the time the
+streamable-HTTP transport gets to it, the JSON-RPC envelope has already
+been parsed and the tool has been looked up by name.
+
+Coverage
+--------
+* ``initialize``-equivalent: ``build_mcp_app`` succeeds and the server
+  carries the configured name.
+* ``tools/list``: ``await mcp.list_tools()`` returns
+  :data:`EXPECTED_TOOL_COUNT` entries.
+* ``tools/call``: ``await mcp.call_tool("test_connection", {...})`` returns
+  the expected ``{"success": ..., "message": ...}`` envelope, with the
+  underlying service mocked so the test stays hermetic (no Aerospike).
 """
 
 from __future__ import annotations
 
-import importlib
+import json
+from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
+from aerospike_cluster_manager_api.services.connections_service import (
+    # Aliased to avoid pytest's auto-collection of names that start with
+    # ``Test`` — this is a NamedTuple, not a test class.
+    TestConnectionResult as _TestConnectionResult,
+)
 
-@pytest.fixture()
-def app_with_mcp_enabled(monkeypatch: pytest.MonkeyPatch):
-    """Reload main with ACM_MCP_ENABLED=true so /mcp is mounted."""
-    monkeypatch.setenv("ACM_MCP_ENABLED", "true")
-    from aerospike_cluster_manager_api import config as _config
-    from aerospike_cluster_manager_api import main as _main
-
-    importlib.reload(_config)
-    importlib.reload(_main)
-    try:
-        yield _main.app
-    finally:
-        monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
-        importlib.reload(_config)
-        importlib.reload(_main)
+from .conftest import EXPECTED_TOOL_COUNT
 
 
-async def test_mcp_endpoint_lists_21_tools_via_fastmcp(app_with_mcp_enabled) -> None:
-    """The mounted ``/mcp`` server exposes all 21 Phase 1 tools."""
+@pytest.fixture
+def fastmcp_app():
+    """Return a fresh ``FastMCP`` instance with all Phase 1 tools registered.
+
+    The ``conftest.py`` import block already loaded every tool module so
+    the registry is populated; ``build_mcp_app`` flushes that into a new
+    FastMCP instance.
+    """
     from aerospike_cluster_manager_api.mcp.server import build_mcp_app
 
-    mcp = build_mcp_app()
-    tools = await mcp.list_tools()
+    return build_mcp_app()
+
+
+def _unwrap(payload: Any) -> Any:
+    """Extract the JSON dict out of a ``call_tool`` response.
+
+    FastMCP's ``call_tool`` returns either a structured ``dict`` or a
+    ``(content_blocks, structured)`` tuple depending on the SDK version.
+    When it returns content blocks, the first one is a ``TextContent``
+    whose ``text`` is a JSON-encoded string of the tool's return value.
+    This helper normalises both shapes to the dict the tool produced.
+    """
+    # Newer FastMCP: returns (content, structured) tuple where structured
+    # is the raw dict the tool returned.
+    if isinstance(payload, tuple) and len(payload) == 2:
+        _content, structured = payload
+        if isinstance(structured, dict):
+            return structured
+
+    # Older FastMCP / dict-only return.
+    if isinstance(payload, dict):
+        return payload
+
+    # Fallback: a sequence of content blocks; decode the first text block.
+    if hasattr(payload, "__iter__"):
+        for block in payload:
+            text = getattr(block, "text", None)
+            if isinstance(text, str):
+                try:
+                    return json.loads(text)
+                except json.JSONDecodeError:
+                    return text
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# initialize-equivalent: server is built and named.
+# ---------------------------------------------------------------------------
+
+
+def test_initialize_equivalent_server_built_and_named(fastmcp_app) -> None:
+    """A built FastMCP instance carries the configured server name and is
+    ready to handle ``initialize`` / ``tools/list`` / ``tools/call`` calls."""
+    # FastMCP exposes ``name`` as a settings field; just prove it's a non-
+    # empty string so an "initialize" reply would have a server name to
+    # send back.
+    name = fastmcp_app.name
+    assert isinstance(name, str)
+    assert name
+
+
+# ---------------------------------------------------------------------------
+# tools/list — full Phase 1 surface visible via the FastMCP transport.
+# ---------------------------------------------------------------------------
+
+
+async def test_tools_list_returns_phase1_surface(fastmcp_app) -> None:
+    """``await mcp.list_tools()`` is the exact code FastMCP runs on a
+    JSON-RPC ``tools/list`` request — no extra dispatch layer to mock."""
+    tools = await fastmcp_app.list_tools()
     names = {t.name for t in tools}
-    assert len(names) == 21, sorted(names)
+    assert len(names) == EXPECTED_TOOL_COUNT, sorted(names)
+    # Spot-check one of each category to make sure the registry isn't
+    # accidentally returning duplicates of a single tool.
+    assert {
+        "test_connection",
+        "list_namespaces",
+        "get_record",
+        "query",
+        "execute_info",
+    }.issubset(names)
 
 
-async def test_mcp_route_exists_when_flag_on(app_with_mcp_enabled) -> None:
-    """The /mcp route exists on the real FastAPI app when the flag is on."""
-    from httpx import ASGITransport, AsyncClient
-
-    transport = ASGITransport(app=app_with_mcp_enabled)
-    async with AsyncClient(transport=transport, base_url="http://test") as client:
-        response = await client.get("/mcp")
-        # Streamable HTTP MCP responds to GETs with 405/406/200 depending on
-        # the SDK version — anything other than 404 proves the mount worked.
-        assert response.status_code != 404
+# ---------------------------------------------------------------------------
+# tools/call — JSON-RPC roundtrip through the registered handler chain.
+# ---------------------------------------------------------------------------
 
 
-async def test_mcp_route_404_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
-    """The /mcp route does NOT exist when ACM_MCP_ENABLED is unset."""
-    from httpx import ASGITransport, AsyncClient
+async def test_tools_call_test_connection_succeeds(fastmcp_app) -> None:
+    """``await mcp.call_tool("test_connection", {...})`` round-trips through
+    the registered wrapper (access-profile gate → ``map_aerospike_errors``
+    → tool body → serialise) and returns the connection probe envelope.
 
-    monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
-    from aerospike_cluster_manager_api import config as _config
-    from aerospike_cluster_manager_api import main as _main
+    The underlying service is mocked so no live Aerospike is required —
+    the test asserts the wire shape, not network behaviour.
+    """
 
-    importlib.reload(_config)
-    importlib.reload(_main)
-    try:
-        transport = ASGITransport(app=_main.app)
-        async with AsyncClient(transport=transport, base_url="http://test") as client:
-            response = await client.get("/mcp")
-            assert response.status_code == 404
-    finally:
-        importlib.reload(_config)
-        importlib.reload(_main)
+    async def _fake(_req):  # type: ignore[no-untyped-def]
+        return _TestConnectionResult(success=True, message="Connected successfully")
+
+    with patch(
+        "aerospike_cluster_manager_api.mcp.tools.connections.connections_service.test_connection",
+        new=AsyncMock(side_effect=_fake),
+    ):
+        raw = await fastmcp_app.call_tool(
+            "test_connection",
+            {"hosts": ["localhost"], "port": 3000},
+        )
+
+    payload = _unwrap(raw)
+    assert isinstance(payload, dict), f"unexpected payload shape: {raw!r}"
+    assert payload["success"] is True
+    assert payload["message"] == "Connected successfully"
+
+
+async def test_tools_call_unknown_tool_raises(fastmcp_app) -> None:
+    """Calling a tool that does not exist surfaces an error at the
+    JSON-RPC level — the FastMCP tool manager raises ``ToolError``
+    (the SDK then maps that to an ``isError`` block on the wire)."""
+    from mcp.server.fastmcp.exceptions import ToolError
+
+    with pytest.raises(ToolError, match="Unknown tool"):
+        await fastmcp_app.call_tool("definitely_not_a_real_tool", {})

--- a/api/tests/mcp/test_e2e_readonly.py
+++ b/api/tests/mcp/test_e2e_readonly.py
@@ -1,0 +1,76 @@
+"""Read-only profile end-to-end (Task C.2).
+
+Verifies that ``ACM_MCP_ACCESS_PROFILE=read_only`` blocks mutation tools at
+call time with the canonical access-denied error code, while read tools
+continue to work. Mocks the underlying service layer so no Aerospike is
+needed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aerospike_cluster_manager_api import config
+from aerospike_cluster_manager_api.mcp.access_profile import AccessProfile
+from aerospike_cluster_manager_api.mcp.errors import MCPToolError
+
+
+@pytest.fixture
+def read_only_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config, "ACM_MCP_ACCESS_PROFILE", AccessProfile.READ_ONLY)
+
+
+@pytest.mark.parametrize(
+    "tool_name,kwargs",
+    [
+        ("create_record", {"conn_id": "x", "namespace": "test", "set_name": "s", "key": "1", "bins": {"a": 1}}),
+        ("update_record", {"conn_id": "x", "namespace": "test", "set_name": "s", "key": "1", "bins": {"a": 1}}),
+        ("delete_record", {"conn_id": "x", "namespace": "test", "set_name": "s", "key": "1"}),
+        ("delete_bin", {"conn_id": "x", "namespace": "test", "set_name": "s", "key": "1", "bin_name": "a"}),
+        ("truncate_set", {"conn_id": "x", "namespace": "test", "set_name": "s"}),
+    ],
+)
+async def test_record_mutation_tools_blocked_under_read_only(
+    read_only_profile: None, tool_name: str, kwargs: dict
+) -> None:
+    from aerospike_cluster_manager_api.mcp.tools import records as records_tools
+
+    fn = getattr(records_tools, tool_name)
+    with pytest.raises(MCPToolError) as exc_info:
+        await fn(**kwargs)
+    assert exc_info.value.code == "access_denied"
+    assert tool_name in str(exc_info.value)
+
+
+async def test_execute_info_blocked_under_read_only(read_only_profile: None) -> None:
+    from aerospike_cluster_manager_api.mcp.tools.info_commands import execute_info
+
+    with pytest.raises(MCPToolError) as exc_info:
+        await execute_info(conn_id="x", command="version")
+    assert exc_info.value.code == "access_denied"
+
+
+async def test_read_tool_works_under_read_only(read_only_profile: None) -> None:
+    """``get_record`` is mutation=False so READ_ONLY does not block it."""
+    from types import SimpleNamespace
+
+    from aerospike_cluster_manager_api.mcp.tools import records as records_tools
+
+    fake_record = SimpleNamespace(
+        key=("test", "s", "1", b"\x00"),
+        meta=SimpleNamespace(gen=1, ttl=0),
+        bins={"name": "Alice"},
+    )
+    with (
+        patch.object(records_tools.client_manager, "get_client", new=AsyncMock(return_value=object())),
+        patch(
+            "aerospike_cluster_manager_api.mcp.tools.records.records_service.get_record",
+            new=AsyncMock(return_value=fake_record),
+        ),
+    ):
+        out = await records_tools.get_record(conn_id="x", namespace="test", set_name="s", key="1")
+
+    assert out["key"]["namespace"] == "test"
+    assert out["bins"]["name"] == "Alice"

--- a/api/tests/mcp/test_e2e_readonly.py
+++ b/api/tests/mcp/test_e2e_readonly.py
@@ -4,6 +4,10 @@ Verifies that ``ACM_MCP_ACCESS_PROFILE=read_only`` blocks mutation tools at
 call time with the canonical access-denied error code, while read tools
 continue to work. Mocks the underlying service layer so no Aerospike is
 needed.
+
+Coverage: every name in :data:`access_profile.WRITE_TOOLS` must be
+parametrised here so a future contributor adding a new write tool will
+see the gate exercised by default.
 """
 
 from __future__ import annotations
@@ -44,11 +48,51 @@ async def test_record_mutation_tools_blocked_under_read_only(
     assert tool_name in str(exc_info.value)
 
 
+@pytest.mark.parametrize(
+    "tool_name,kwargs",
+    [
+        ("create_connection", {"name": "Anything", "hosts": ["10.0.0.1"]}),
+        (
+            "update_connection",
+            {"conn_id": "conn-x", "name": "Renamed"},
+        ),
+        ("delete_connection", {"conn_id": "conn-x"}),
+    ],
+)
+async def test_connection_mutation_tools_blocked_under_read_only(
+    read_only_profile: None, tool_name: str, kwargs: dict
+) -> None:
+    """The 3 connection mutation tools (``create``/``update``/``delete``) must
+    refuse calls under ``READ_ONLY`` with ``code="access_denied"`` BEFORE
+    the body runs. Without this check, the read-only profile would silently
+    allow profile mutation through the MCP surface even though it claims
+    to be read-only."""
+    from aerospike_cluster_manager_api.mcp.tools import connections as conn_tools
+
+    fn = getattr(conn_tools, tool_name)
+    with pytest.raises(MCPToolError) as exc_info:
+        await fn(**kwargs)
+    assert exc_info.value.code == "access_denied"
+    assert tool_name in str(exc_info.value)
+
+
 async def test_execute_info_blocked_under_read_only(read_only_profile: None) -> None:
     from aerospike_cluster_manager_api.mcp.tools.info_commands import execute_info
 
     with pytest.raises(MCPToolError) as exc_info:
         await execute_info(conn_id="x", command="version")
+    assert exc_info.value.code == "access_denied"
+
+
+async def test_execute_info_on_node_blocked_under_read_only(read_only_profile: None) -> None:
+    """``execute_info_on_node`` (companion of ``execute_info``) is also a
+    write tool because asinfo can mutate cluster configuration."""
+    from aerospike_cluster_manager_api.mcp.tools.info_commands import (
+        execute_info_on_node,
+    )
+
+    with pytest.raises(MCPToolError) as exc_info:
+        await execute_info_on_node(conn_id="x", command="version", node_name="BB9")
     assert exc_info.value.code == "access_denied"
 
 

--- a/api/tests/mcp/test_errors.py
+++ b/api/tests/mcp/test_errors.py
@@ -1,0 +1,206 @@
+"""Tests for the CE-aware MCP error mapping layer.
+
+The MCP tool wrappers (B.1+) and the registry decorator (A.12) translate
+Aerospike-py exceptions and our own service-layer domain errors into
+``MCPToolError`` instances with stable, user-facing wording. Unknown
+exceptions must propagate untouched so the registry can log them and
+surface a generic ``isError`` block without masking real bugs.
+
+Wire-message wording follows
+``docs/plans/2026-05-07-acm-mcp-design.md`` Section 4.
+"""
+
+from __future__ import annotations
+
+import aerospike_py
+import pytest
+
+from aerospike_cluster_manager_api.mcp.errors import (
+    MCPToolError,
+    map_aerospike_errors,
+    raise_ce_unsupported,
+)
+from aerospike_cluster_manager_api.services.clusters_service import (
+    NamespaceConfigError,
+    NamespaceNotFoundError,
+    NodeNotFoundError,
+)
+from aerospike_cluster_manager_api.services.connections_service import (
+    ConnectionNotFoundError,
+    WorkspaceNotFoundError,
+)
+from aerospike_cluster_manager_api.services.records_service import (
+    InvalidPkPattern,
+    PrimaryKeyMissing,
+    SetRequiredForPkLookup,
+)
+
+# ---------------------------------------------------------------------------
+# MCPToolError shape
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_tool_error_is_plain_exception_subclass() -> None:
+    # Vanilla Exception keeps the registry's `except` clauses simple.
+    assert issubclass(MCPToolError, Exception)
+    assert not issubclass(MCPToolError, RuntimeError)
+
+
+def test_mcp_tool_error_carries_message_and_optional_code() -> None:
+    err = MCPToolError("boom", code="record_not_found")
+    assert str(err) == "boom"
+    assert err.code == "record_not_found"
+
+
+def test_mcp_tool_error_code_defaults_to_none() -> None:
+    err = MCPToolError("boom")
+    assert err.code is None
+
+
+# ---------------------------------------------------------------------------
+# map_aerospike_errors — aerospike_py exceptions
+# ---------------------------------------------------------------------------
+
+
+def test_map_record_not_found_with_full_context() -> None:
+    with pytest.raises(MCPToolError) as exc_info, map_aerospike_errors(ns="test", set_name="users", key="42"):
+        raise aerospike_py.RecordNotFound("missing")
+
+    err = exc_info.value
+    assert str(err) == "Record not found: test/users/42"
+    assert err.code == "record_not_found"
+    # Original exception preserved as the cause for stack diagnosis.
+    assert isinstance(err.__cause__, aerospike_py.RecordNotFound)
+
+
+def test_map_record_not_found_without_context() -> None:
+    with pytest.raises(MCPToolError) as exc_info, map_aerospike_errors():
+        raise aerospike_py.RecordNotFound("missing")
+
+    assert str(exc_info.value) == "Record not found"
+    assert exc_info.value.code == "record_not_found"
+
+
+def test_map_record_exists_error_with_context() -> None:
+    with pytest.raises(MCPToolError) as exc_info, map_aerospike_errors(ns="test", set_name="users", key=7):
+        raise aerospike_py.RecordExistsError("exists")
+
+    err = exc_info.value
+    assert str(err) == "Record already exists: test/users/7"
+    assert err.code == "record_exists"
+    assert isinstance(err.__cause__, aerospike_py.RecordExistsError)
+
+
+def test_map_record_exists_error_without_context() -> None:
+    with pytest.raises(MCPToolError) as exc_info, map_aerospike_errors():
+        raise aerospike_py.RecordExistsError("exists")
+
+    assert str(exc_info.value) == "Record already exists"
+    assert exc_info.value.code == "record_exists"
+
+
+# ---------------------------------------------------------------------------
+# map_aerospike_errors — service-layer domain exceptions
+# ---------------------------------------------------------------------------
+
+
+def test_map_connection_not_found_error() -> None:
+    with pytest.raises(MCPToolError) as exc_info, map_aerospike_errors():
+        raise ConnectionNotFoundError("conn-abc123")
+
+    err = exc_info.value
+    assert "conn-abc123" in str(err)
+    assert err.code == "ConnectionNotFoundError"
+    assert isinstance(err.__cause__, ConnectionNotFoundError)
+
+
+def test_map_workspace_not_found_error() -> None:
+    with pytest.raises(MCPToolError) as exc_info, map_aerospike_errors():
+        raise WorkspaceNotFoundError("ws-1")
+
+    err = exc_info.value
+    assert "ws-1" in str(err)
+    assert err.code == "WorkspaceNotFoundError"
+
+
+def test_map_namespace_not_found_error() -> None:
+    with pytest.raises(MCPToolError) as exc_info, map_aerospike_errors():
+        raise NamespaceNotFoundError("test")
+
+    err = exc_info.value
+    assert "test" in str(err)
+    assert err.code == "NamespaceNotFoundError"
+
+
+def test_map_node_not_found_error() -> None:
+    with pytest.raises(MCPToolError) as exc_info, map_aerospike_errors():
+        raise NodeNotFoundError("BB9E0...")
+
+    assert exc_info.value.code == "NodeNotFoundError"
+
+
+def test_map_namespace_config_error() -> None:
+    with pytest.raises(MCPToolError) as exc_info, map_aerospike_errors():
+        raise NamespaceConfigError("test", "ERROR::param-not-found")
+
+    assert exc_info.value.code == "NamespaceConfigError"
+
+
+def test_map_invalid_pk_pattern() -> None:
+    with pytest.raises(MCPToolError) as exc_info, map_aerospike_errors():
+        raise InvalidPkPattern("bad regex")
+
+    assert str(exc_info.value) == "bad regex"
+    assert exc_info.value.code == "InvalidPkPattern"
+
+
+def test_map_set_required_for_pk_lookup() -> None:
+    with pytest.raises(MCPToolError) as exc_info, map_aerospike_errors():
+        raise SetRequiredForPkLookup()
+
+    assert exc_info.value.code == "SetRequiredForPkLookup"
+
+
+def test_map_primary_key_missing() -> None:
+    with pytest.raises(MCPToolError) as exc_info, map_aerospike_errors():
+        raise PrimaryKeyMissing("namespace")
+
+    assert exc_info.value.code == "PrimaryKeyMissing"
+
+
+# ---------------------------------------------------------------------------
+# Pass-through: unknown errors propagate unchanged so the registry can log
+# them and avoid swallowing real bugs.
+# ---------------------------------------------------------------------------
+
+
+def test_generic_exception_propagates_unchanged() -> None:
+    with pytest.raises(RuntimeError, match="boom"), map_aerospike_errors():
+        raise RuntimeError("boom")
+
+
+def test_unmapped_aerospike_error_propagates_unchanged() -> None:
+    # ``AerospikeError`` is the base class — only specific known subclasses
+    # are mapped. Anything else bubbles up.
+    with pytest.raises(aerospike_py.exception.AerospikeError), map_aerospike_errors():
+        raise aerospike_py.exception.ClientError("client failure")
+
+
+def test_no_exception_passes_through_cleanly() -> None:
+    with map_aerospike_errors(ns="test"):
+        result = 1 + 1
+    assert result == 2
+
+
+# ---------------------------------------------------------------------------
+# raise_ce_unsupported helper — Phase 2 K8s tools and CE-rejected ops
+# ---------------------------------------------------------------------------
+
+
+def test_raise_ce_unsupported_message_and_code() -> None:
+    with pytest.raises(MCPToolError) as exc_info:
+        raise_ce_unsupported("XDR shipping")
+
+    err = exc_info.value
+    assert str(err) == "This operation is not supported on Aerospike CE 8.1: XDR shipping"
+    assert err.code == "ce_unsupported"

--- a/api/tests/mcp/test_errors.py
+++ b/api/tests/mcp/test_errors.py
@@ -99,6 +99,38 @@ def test_map_record_exists_error_without_context() -> None:
     assert exc_info.value.code == "record_exists"
 
 
+def test_map_backpressure_error() -> None:
+    """``aerospike_py.BackpressureError`` is mapped to a stable
+    ``code="backpressure"`` so client-side wrappers (and operator
+    dashboards) can apply retry-with-backoff without parsing the message.
+    """
+    with pytest.raises(MCPToolError) as exc_info, map_aerospike_errors():
+        raise aerospike_py.BackpressureError("queue saturated")
+
+    err = exc_info.value
+    assert err.code == "backpressure"
+    # Underlying client wording is preserved in the user-facing message.
+    assert "queue saturated" in str(err)
+    assert isinstance(err.__cause__, aerospike_py.BackpressureError)
+
+
+def test_map_unknown_predicate_operator_to_invalid_argument() -> None:
+    """``predicate.UnknownPredicateOperator`` is an input-validation
+    failure — the predicate dispatch table did not recognise the operator.
+    Mapped to ``code="invalid_argument"`` to match the SDK's standard
+    family for malformed tool arguments.
+    """
+    from aerospike_cluster_manager_api.predicate import UnknownPredicateOperator
+
+    with pytest.raises(MCPToolError) as exc_info, map_aerospike_errors():
+        raise UnknownPredicateOperator("frobnicate")
+
+    err = exc_info.value
+    assert err.code == "invalid_argument"
+    assert "frobnicate" in str(err)
+    assert isinstance(err.__cause__, UnknownPredicateOperator)
+
+
 # ---------------------------------------------------------------------------
 # map_aerospike_errors — service-layer domain exceptions
 # ---------------------------------------------------------------------------

--- a/api/tests/mcp/test_info_tools.py
+++ b/api/tests/mcp/test_info_tools.py
@@ -1,0 +1,92 @@
+"""Tests for the MCP info command tools (Task B.5)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from aerospike_cluster_manager_api import config
+from aerospike_cluster_manager_api.mcp.access_profile import AccessProfile
+from aerospike_cluster_manager_api.mcp.errors import MCPToolError
+from aerospike_cluster_manager_api.mcp.registry import registered_tools
+
+
+@pytest.fixture
+def full_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config, "ACM_MCP_ACCESS_PROFILE", AccessProfile.FULL)
+
+
+@pytest.fixture
+def read_only_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(config, "ACM_MCP_ACCESS_PROFILE", AccessProfile.READ_ONLY)
+
+
+def _patch_get_client(client: MagicMock):
+    from aerospike_cluster_manager_api.mcp.tools import info_commands
+
+    return patch.object(info_commands.client_manager, "get_client", new=AsyncMock(return_value=client))
+
+
+def test_info_tools_module_registers_two_tools() -> None:
+    from aerospike_cluster_manager_api.mcp.tools import info_commands as _ic  # noqa: F401
+
+    names = {e.name for e in registered_tools() if e.category == "info"}
+    assert names == {"execute_info", "execute_info_on_node"}
+    by_name = {e.name: e for e in registered_tools() if e.category == "info"}
+    assert by_name["execute_info"].mutation is True
+    assert by_name["execute_info_on_node"].mutation is True
+
+
+class TestExecuteInfo:
+    async def test_happy_path(self, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.info_commands import execute_info
+
+        results = [
+            SimpleNamespace(node_name="BB9", error_code=None, response="version 8.1"),
+            SimpleNamespace(node_name="CC1", error_code=None, response="version 8.1"),
+        ]
+        mock_client = MagicMock()
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.info_commands.clusters_service.execute_info",
+                new=AsyncMock(return_value=results),
+            ),
+        ):
+            out = await execute_info(conn_id="conn-x", command="version")
+
+        assert len(out["nodes"]) == 2
+        assert out["nodes"][0] == {"node": "BB9", "error_code": None, "response": "version 8.1"}
+
+    async def test_read_only_blocks(self, read_only_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.info_commands import execute_info
+
+        with pytest.raises(MCPToolError) as exc_info:
+            await execute_info(conn_id="conn-x", command="version")
+        assert exc_info.value.code == "access_denied"
+
+
+class TestExecuteInfoOnNode:
+    async def test_happy_path(self, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.info_commands import execute_info_on_node
+
+        mock_client = MagicMock()
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.info_commands.clusters_service.execute_info_on_node",
+                new=AsyncMock(return_value="version 8.1"),
+            ),
+        ):
+            out = await execute_info_on_node(conn_id="conn-x", command="version", node_name="BB9")
+
+        assert out == {"node": "BB9", "response": "version 8.1"}
+
+    async def test_read_only_blocks(self, read_only_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.info_commands import execute_info_on_node
+
+        with pytest.raises(MCPToolError) as exc_info:
+            await execute_info_on_node(conn_id="conn-x", command="version", node_name="BB9")
+        assert exc_info.value.code == "access_denied"

--- a/api/tests/mcp/test_info_tools.py
+++ b/api/tests/mcp/test_info_tools.py
@@ -24,9 +24,12 @@ def read_only_profile(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _patch_get_client(client: MagicMock):
-    from aerospike_cluster_manager_api.mcp.tools import info_commands
+    """Backwards-compat shim — delegates to the package-level helper in
+    :mod:`tests.mcp.conftest` so the duplicated boilerplate has a single
+    source of truth."""
+    from .conftest import patch_mcp_client
 
-    return patch.object(info_commands.client_manager, "get_client", new=AsyncMock(return_value=client))
+    return patch_mcp_client("aerospike_cluster_manager_api.mcp.tools.info_commands", client)
 
 
 def test_info_tools_module_registers_two_tools() -> None:

--- a/api/tests/mcp/test_main_mount.py
+++ b/api/tests/mcp/test_main_mount.py
@@ -23,24 +23,6 @@ def anyio_backend() -> str:
     return "asyncio"
 
 
-async def _reload_main() -> AsyncIterator[None]:
-    """Reload config + main so module-level toggles re-evaluate.
-
-    Used as the body of the helper fixtures below — keeps the env-var
-    setup in the test-side fixture and the reload logic in one place.
-    """
-    from aerospike_cluster_manager_api import config as _config
-    from aerospike_cluster_manager_api import main as _main
-
-    importlib.reload(_config)
-    importlib.reload(_main)
-    yield
-    # Restore default state on the way out so other tests in the suite
-    # see a clean module-level app.
-    importlib.reload(_config)
-    importlib.reload(_main)
-
-
 @pytest.fixture()
 async def app_with_mcp_disabled(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[object]:
     """Reload main with ACM_MCP_ENABLED unset (default False)."""
@@ -59,8 +41,15 @@ async def app_with_mcp_disabled(monkeypatch: pytest.MonkeyPatch) -> AsyncIterato
 
 @pytest.fixture()
 async def app_with_mcp_enabled(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[object]:
-    """Reload main with ACM_MCP_ENABLED=true."""
+    """Reload main with ACM_MCP_ENABLED=true.
+
+    The startup-refusal added in Phase 1 (see ``main.py:286-299``) requires
+    ACM_MCP_ENABLED=true to be paired with one of OIDC, ACM_MCP_TOKEN, or
+    ACM_MCP_ALLOW_ANONYMOUS. We opt for ALLOW_ANONYMOUS here because this
+    fixture is exercising mount semantics, not the auth gate.
+    """
     monkeypatch.setenv("ACM_MCP_ENABLED", "true")
+    monkeypatch.setenv("ACM_MCP_ALLOW_ANONYMOUS", "true")
     from aerospike_cluster_manager_api import config as _config
     from aerospike_cluster_manager_api import main as _main
 
@@ -70,6 +59,7 @@ async def app_with_mcp_enabled(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator
         yield _main.app
     finally:
         monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
+        monkeypatch.delenv("ACM_MCP_ALLOW_ANONYMOUS", raising=False)
         importlib.reload(_config)
         importlib.reload(_main)
 

--- a/api/tests/mcp/test_main_mount.py
+++ b/api/tests/mcp/test_main_mount.py
@@ -1,0 +1,171 @@
+"""Tests for conditional MCP mount in :mod:`aerospike_cluster_manager_api.main`.
+
+The mount is gated by the ``ACM_MCP_ENABLED`` environment variable so that
+deployments that do not need the MCP transport pay no extra import or
+routing cost. We exercise both legs of the toggle by reloading ``config``
+and ``main`` after monkeypatching the env var.
+
+These tests use :class:`httpx.ASGITransport` for in-process probing — no
+uvicorn, no real network.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import AsyncIterator
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+@pytest.fixture()
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+async def _reload_main() -> AsyncIterator[None]:
+    """Reload config + main so module-level toggles re-evaluate.
+
+    Used as the body of the helper fixtures below — keeps the env-var
+    setup in the test-side fixture and the reload logic in one place.
+    """
+    from aerospike_cluster_manager_api import config as _config
+    from aerospike_cluster_manager_api import main as _main
+
+    importlib.reload(_config)
+    importlib.reload(_main)
+    yield
+    # Restore default state on the way out so other tests in the suite
+    # see a clean module-level app.
+    importlib.reload(_config)
+    importlib.reload(_main)
+
+
+@pytest.fixture()
+async def app_with_mcp_disabled(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[object]:
+    """Reload main with ACM_MCP_ENABLED unset (default False)."""
+    monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
+    from aerospike_cluster_manager_api import config as _config
+    from aerospike_cluster_manager_api import main as _main
+
+    importlib.reload(_config)
+    importlib.reload(_main)
+    try:
+        yield _main.app
+    finally:
+        importlib.reload(_config)
+        importlib.reload(_main)
+
+
+@pytest.fixture()
+async def app_with_mcp_enabled(monkeypatch: pytest.MonkeyPatch) -> AsyncIterator[object]:
+    """Reload main with ACM_MCP_ENABLED=true."""
+    monkeypatch.setenv("ACM_MCP_ENABLED", "true")
+    from aerospike_cluster_manager_api import config as _config
+    from aerospike_cluster_manager_api import main as _main
+
+    importlib.reload(_config)
+    importlib.reload(_main)
+    try:
+        yield _main.app
+    finally:
+        monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
+        importlib.reload(_config)
+        importlib.reload(_main)
+
+
+# ---------------------------------------------------------------------------
+# Config flag defaults
+# ---------------------------------------------------------------------------
+
+
+def test_acm_mcp_enabled_defaults_to_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without the env var set, the flag is False — MCP must be opt-in."""
+    monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
+    from aerospike_cluster_manager_api import config as _config
+
+    importlib.reload(_config)
+    try:
+        assert _config.ACM_MCP_ENABLED is False
+    finally:
+        importlib.reload(_config)
+
+
+def test_acm_mcp_path_defaults_to_slash_mcp(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ACM_MCP_PATH", raising=False)
+    from aerospike_cluster_manager_api import config as _config
+
+    importlib.reload(_config)
+    try:
+        assert _config.ACM_MCP_PATH == "/mcp"
+    finally:
+        importlib.reload(_config)
+
+
+@pytest.mark.parametrize("raw", ["true", "1", "yes", "on", "TRUE", " True "])
+def test_acm_mcp_enabled_truthy_strings(monkeypatch: pytest.MonkeyPatch, raw: str) -> None:
+    monkeypatch.setenv("ACM_MCP_ENABLED", raw)
+    from aerospike_cluster_manager_api import config as _config
+
+    importlib.reload(_config)
+    try:
+        assert _config.ACM_MCP_ENABLED is True
+    finally:
+        monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
+        importlib.reload(_config)
+
+
+# ---------------------------------------------------------------------------
+# Mount behaviour — flag OFF
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_mcp_route_absent_when_flag_disabled(app_with_mcp_disabled) -> None:
+    """A request to /mcp returns 404 when the feature flag is False."""
+    transport = ASGITransport(app=app_with_mcp_disabled)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/mcp")
+        assert resp.status_code == 404
+        # Sanity check: the regular API surface is still wired up.
+        health = await ac.get("/api/health")
+        assert health.status_code == 200
+
+
+@pytest.mark.anyio
+async def test_mcp_subpath_absent_when_flag_disabled(app_with_mcp_disabled) -> None:
+    transport = ASGITransport(app=app_with_mcp_disabled)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/mcp/anything/here")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Mount behaviour — flag ON
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_mcp_route_exists_when_flag_enabled(app_with_mcp_enabled) -> None:
+    """When the flag is on, /mcp is mounted — any non-404 status proves it.
+
+    We don't perform a full MCP `initialize` round-trip here; that's task
+    C.1. The streamable-http transport typically replies with 4xx (bad
+    request, missing session header, etc.) to a bare GET, which is fine —
+    the route exists, that's all this test asserts.
+    """
+    transport = ASGITransport(app=app_with_mcp_enabled)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/mcp")
+        assert resp.status_code != 404, (
+            f"expected /mcp to be mounted, got 404 (status={resp.status_code}, body={resp.text!r})"
+        )
+
+
+@pytest.mark.anyio
+async def test_existing_routes_still_work_when_flag_enabled(app_with_mcp_enabled) -> None:
+    transport = ASGITransport(app=app_with_mcp_enabled)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/health")
+        assert resp.status_code == 200
+        assert resp.json() == {"status": "ok"}

--- a/api/tests/mcp/test_mount_smoke.py
+++ b/api/tests/mcp/test_mount_smoke.py
@@ -1,0 +1,89 @@
+"""Mount smoke tests (Task C.1, renamed from test_e2e.py).
+
+Boots the real FastAPI app via in-process ASGI transport with
+``ACM_MCP_ENABLED=true`` and verifies:
+
+* the ``/mcp`` route exists on the real FastAPI app when the flag is on;
+* it does NOT exist when the flag is off;
+* the mounted FastMCP exposes the expected number of tools (via direct
+  ``mcp.list_tools()`` — no JSON-RPC roundtrip).
+
+This file is deliberately scoped to mount + registration plumbing.
+The actual JSON-RPC end-to-end roundtrip lives in :mod:`tests.mcp.test_e2e`,
+which exercises ``mcp.call_tool(...)`` against the registered handler chain
+(access-profile gate → error map → tool body → serialise).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import pytest
+
+from .conftest import EXPECTED_TOOL_COUNT
+
+
+@pytest.fixture()
+def app_with_mcp_enabled(monkeypatch: pytest.MonkeyPatch):
+    """Reload main with ACM_MCP_ENABLED=true so /mcp is mounted.
+
+    Sets ``ACM_MCP_ALLOW_ANONYMOUS=true`` because Phase 1 ``main.py``
+    refuses to start the MCP surface without auth — and this fixture
+    does not need to exercise auth paths.
+    """
+    monkeypatch.setenv("ACM_MCP_ENABLED", "true")
+    monkeypatch.setenv("ACM_MCP_ALLOW_ANONYMOUS", "true")
+    from aerospike_cluster_manager_api import config as _config
+    from aerospike_cluster_manager_api import main as _main
+
+    importlib.reload(_config)
+    importlib.reload(_main)
+    try:
+        yield _main.app
+    finally:
+        monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
+        monkeypatch.delenv("ACM_MCP_ALLOW_ANONYMOUS", raising=False)
+        importlib.reload(_config)
+        importlib.reload(_main)
+
+
+async def test_mcp_endpoint_lists_phase1_tools_via_fastmcp(app_with_mcp_enabled) -> None:
+    """The mounted ``/mcp`` server exposes the full Phase 1 tool surface."""
+    from aerospike_cluster_manager_api.mcp.server import build_mcp_app
+
+    mcp = build_mcp_app()
+    tools = await mcp.list_tools()
+    names = {t.name for t in tools}
+    assert len(names) == EXPECTED_TOOL_COUNT, sorted(names)
+
+
+async def test_mcp_route_exists_when_flag_on(app_with_mcp_enabled) -> None:
+    """The /mcp route exists on the real FastAPI app when the flag is on."""
+    from httpx import ASGITransport, AsyncClient
+
+    transport = ASGITransport(app=app_with_mcp_enabled)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get("/mcp")
+        # Streamable HTTP MCP responds to GETs with 405/406/200 depending on
+        # the SDK version — anything other than 404 proves the mount worked.
+        assert response.status_code != 404
+
+
+async def test_mcp_route_404_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The /mcp route does NOT exist when ACM_MCP_ENABLED is unset."""
+    from httpx import ASGITransport, AsyncClient
+
+    monkeypatch.delenv("ACM_MCP_ENABLED", raising=False)
+    from aerospike_cluster_manager_api import config as _config
+    from aerospike_cluster_manager_api import main as _main
+
+    importlib.reload(_config)
+    importlib.reload(_main)
+    try:
+        transport = ASGITransport(app=_main.app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            response = await client.get("/mcp")
+            assert response.status_code == 404
+    finally:
+        importlib.reload(_config)
+        importlib.reload(_main)

--- a/api/tests/mcp/test_query_tool.py
+++ b/api/tests/mcp/test_query_tool.py
@@ -5,7 +5,8 @@ Coverage:
   ``mutation=False``;
 * happy path: scan returns serialised records + stats envelope;
 * PK lookup branch: ``primary_key`` arg routes through to QueryRequest;
-* predicate coercion: dict input → ``QueryPredicate`` model;
+* predicate inline params: ``predicate_bin``+``predicate_operator``+
+  ``predicate_value``[+``predicate_value2``] → ``QueryPredicate`` model;
 * missing conn_id: ``ConnectionNotFoundError`` → ``MCPToolError``.
 """
 
@@ -16,6 +17,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from aerospike_cluster_manager_api.mcp.errors import MCPToolError
 from aerospike_cluster_manager_api.mcp.registry import registered_tools
+
+from .conftest import patch_mcp_client
 
 
 def _make_record(
@@ -30,13 +33,12 @@ def _make_record(
 
 
 def _patch_get_client(client: MagicMock):
-    from aerospike_cluster_manager_api.mcp.tools import query as query_tool
+    """Backwards-compat shim — delegates to the package-level helper.
 
-    return patch.object(
-        query_tool.client_manager,
-        "get_client",
-        new=AsyncMock(return_value=client),
-    )
+    Kept so the body of each test reads the same as the legacy form;
+    the consolidated implementation lives in :mod:`tests.mcp.conftest`.
+    """
+    return patch_mcp_client("aerospike_cluster_manager_api.mcp.tools.query", client)
 
 
 # ---------------------------------------------------------------------------
@@ -125,7 +127,12 @@ class TestQueryTool:
         assert body.primaryKey == "42"
         assert body.pkType == "int"
 
-    async def test_predicate_dict_is_coerced(self) -> None:
+    async def test_predicate_inline_params_are_coerced(self) -> None:
+        """Phase 1: predicates are passed via four inline parameters
+        (``predicate_bin``, ``predicate_operator``, ``predicate_value``,
+        ``predicate_value2``) instead of a single ``dict``. The tool body
+        rebuilds the ``QueryPredicate`` model from those inline args before
+        calling the service layer."""
         from aerospike_cluster_manager_api.mcp.tools.query import query
 
         result_obj = SimpleNamespace(records=[], execution_time_ms=0, scanned_records=0, returned_records=0)
@@ -141,7 +148,10 @@ class TestQueryTool:
                 conn_id="conn-x",
                 namespace="test",
                 set_name="sample_set",
-                predicate={"bin": "age", "operator": "between", "value": 18, "value2": 99},
+                predicate_bin="age",
+                predicate_operator="between",
+                predicate_value=18,
+                predicate_value2=99,
             )
 
         assert exec_mock.await_args is not None
@@ -149,6 +159,64 @@ class TestQueryTool:
         assert body.predicate is not None
         assert body.predicate.bin == "age"
         assert body.predicate.operator == "between"
+        assert body.predicate.value == 18
+        assert body.predicate.value2 == 99
+
+    async def test_truncated_flag_in_envelope(self) -> None:
+        """When the service returns at-or-above the effective limit, the
+        tool surfaces ``truncated=True`` in the envelope so the caller can
+        re-issue with a tighter filter."""
+        from aerospike_cluster_manager_api.mcp.tools.query import query
+
+        # max_records=2 → effective_limit=2; returned_records=2 → truncated.
+        recs = [
+            _make_record(),
+            _make_record(key=("test", "sample_set", "k2", b"\xde\xad")),
+        ]
+        result_obj = SimpleNamespace(records=recs, execution_time_ms=5, scanned_records=2, returned_records=2)
+        mock_client = MagicMock()
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.query.query_service.execute_query",
+                new=AsyncMock(return_value=result_obj),
+            ),
+        ):
+            out = await query(
+                conn_id="conn-x",
+                namespace="test",
+                set_name="sample_set",
+                max_records=2,
+            )
+
+        assert out["truncated"] is True
+        assert out["returned_records"] == 2
+
+    async def test_truncated_false_when_below_limit(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.query import query
+
+        result_obj = SimpleNamespace(
+            records=[_make_record()],
+            execution_time_ms=1,
+            scanned_records=1,
+            returned_records=1,
+        )
+        mock_client = MagicMock()
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.query.query_service.execute_query",
+                new=AsyncMock(return_value=result_obj),
+            ),
+        ):
+            out = await query(
+                conn_id="conn-x",
+                namespace="test",
+                set_name="sample_set",
+                max_records=10,
+            )
+
+        assert out["truncated"] is False
 
     async def test_missing_conn_id_raises_connection_not_found(self) -> None:
         from aerospike_cluster_manager_api.mcp.tools import query as query_tool

--- a/api/tests/mcp/test_query_tool.py
+++ b/api/tests/mcp/test_query_tool.py
@@ -1,0 +1,166 @@
+"""Tests for the MCP query tool (Task B.4).
+
+Coverage:
+* module-level registration: exactly 1 tool under ``category="query"``,
+  ``mutation=False``;
+* happy path: scan returns serialised records + stats envelope;
+* PK lookup branch: ``primary_key`` arg routes through to QueryRequest;
+* predicate coercion: dict input → ``QueryPredicate`` model;
+* missing conn_id: ``ConnectionNotFoundError`` → ``MCPToolError``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from aerospike_cluster_manager_api.mcp.errors import MCPToolError
+from aerospike_cluster_manager_api.mcp.registry import registered_tools
+
+
+def _make_record(
+    key=("test", "sample_set", "k1", b"\x00\x01"),
+    bins=None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        key=key,
+        meta=SimpleNamespace(gen=1, ttl=0),
+        bins=bins if bins is not None else {"name": "Alice"},
+    )
+
+
+def _patch_get_client(client: MagicMock):
+    from aerospike_cluster_manager_api.mcp.tools import query as query_tool
+
+    return patch.object(
+        query_tool.client_manager,
+        "get_client",
+        new=AsyncMock(return_value=client),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module-level registration
+# ---------------------------------------------------------------------------
+
+
+def test_query_tool_registers_one_entry() -> None:
+    from aerospike_cluster_manager_api.mcp.tools import query as _query  # noqa: F401
+
+    entries = [e for e in registered_tools() if e.category == "query"]
+    assert len(entries) == 1
+    assert entries[0].name == "query"
+    assert entries[0].mutation is False
+
+
+# ---------------------------------------------------------------------------
+# Happy path: scan
+# ---------------------------------------------------------------------------
+
+
+class TestQueryTool:
+    async def test_scan_returns_envelope(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.query import query
+
+        result_obj = SimpleNamespace(
+            records=[_make_record(), _make_record(key=("test", "sample_set", "k2", b"\xde\xad"))],
+            execution_time_ms=12,
+            scanned_records=2,
+            returned_records=2,
+        )
+        mock_client = MagicMock()
+
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.query.query_service.execute_query",
+                new=AsyncMock(return_value=result_obj),
+            ) as exec_mock,
+        ):
+            out = await query(
+                conn_id="conn-x",
+                namespace="test",
+                set_name="sample_set",
+                max_records=100,
+            )
+
+        assert out["execution_time_ms"] == 12
+        assert out["scanned_records"] == 2
+        assert out["returned_records"] == 2
+        assert len(out["records"]) == 2
+        # records were serialised — namespace+set+digest fields present.
+        assert out["records"][0]["key"]["namespace"] == "test"
+        # The body passed to execute_query was a QueryRequest with no primaryKey.
+        assert exec_mock.await_args is not None
+        body = exec_mock.await_args.args[1]
+        assert body.namespace == "test"
+        assert body.set == "sample_set"
+        assert body.primaryKey is None
+        assert body.predicate is None
+
+    async def test_pk_lookup_routes_primary_key(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.query import query
+
+        rec = _make_record(key=("test", "sample_set", 42, b"\xff"))
+        result_obj = SimpleNamespace(records=[rec], execution_time_ms=1, scanned_records=1, returned_records=1)
+        mock_client = MagicMock()
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.query.query_service.execute_query",
+                new=AsyncMock(return_value=result_obj),
+            ) as exec_mock,
+        ):
+            out = await query(
+                conn_id="conn-x",
+                namespace="test",
+                set_name="sample_set",
+                primary_key="42",
+                pk_type="int",
+            )
+
+        assert out["returned_records"] == 1
+        assert exec_mock.await_args is not None
+        body = exec_mock.await_args.args[1]
+        assert body.primaryKey == "42"
+        assert body.pkType == "int"
+
+    async def test_predicate_dict_is_coerced(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.query import query
+
+        result_obj = SimpleNamespace(records=[], execution_time_ms=0, scanned_records=0, returned_records=0)
+        mock_client = MagicMock()
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.query.query_service.execute_query",
+                new=AsyncMock(return_value=result_obj),
+            ) as exec_mock,
+        ):
+            await query(
+                conn_id="conn-x",
+                namespace="test",
+                set_name="sample_set",
+                predicate={"bin": "age", "operator": "between", "value": 18, "value2": 99},
+            )
+
+        assert exec_mock.await_args is not None
+        body = exec_mock.await_args.args[1]
+        assert body.predicate is not None
+        assert body.predicate.bin == "age"
+        assert body.predicate.operator == "between"
+
+    async def test_missing_conn_id_raises_connection_not_found(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import query as query_tool
+
+        with patch.object(
+            query_tool.client_manager,
+            "get_client",
+            new=AsyncMock(side_effect=ValueError("no such conn")),
+        ):
+            try:
+                await query_tool.query(conn_id="missing", namespace="test")
+            except MCPToolError as exc:
+                assert exc.code == "ConnectionNotFoundError"
+            else:
+                raise AssertionError("expected MCPToolError")

--- a/api/tests/mcp/test_record_tools.py
+++ b/api/tests/mcp/test_record_tools.py
@@ -1,0 +1,610 @@
+"""Tests for the MCP record tools (Task B.3).
+
+These tests exercise the 7 record-tool callables directly (bypassing the
+FastMCP transport). Each tool wraps the corresponding service-layer
+primitive in :mod:`aerospike_cluster_manager_api.services.records_service`,
+which is mocked here so the tests stay hermetic — no Aerospike server, no
+SQLite db, no live ``client_manager``.
+
+Coverage matrix:
+
+* every tool: happy path returns a JSON-serialisable shape that mirrors the
+  agreed-upon ack / record envelope (see :mod:`mcp.serializers` for read
+  shape, the per-tool docstring for write acks);
+* mutation tools (``create_record``, ``update_record``, ``delete_record``,
+  ``delete_bin``, ``truncate_set``): under the ``READ_ONLY`` profile, the
+  call raises ``MCPToolError(code="access_denied")`` *before* the body
+  runs;
+* error mapping: missing ``conn_id`` surfaces ``ConnectionNotFoundError``;
+  ``RecordExistsError`` surfaces ``record_exists``; ``RecordNotFound``
+  surfaces ``record_not_found``;
+* one verification that *importing* the module registers exactly 7 tools
+  under ``category="record"`` so the auto-discovery wiring done in B.6
+  sees the expected surface.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
+
+import pytest
+from aerospike_py.exception import RecordExistsError, RecordNotFound
+
+from aerospike_cluster_manager_api import config
+from aerospike_cluster_manager_api.mcp.access_profile import AccessProfile
+from aerospike_cluster_manager_api.mcp.errors import MCPToolError
+from aerospike_cluster_manager_api.mcp.registry import registered_tools
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def full_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the access profile to FULL so mutation tools are not blocked."""
+    monkeypatch.setattr(config, "ACM_MCP_ACCESS_PROFILE", AccessProfile.FULL)
+
+
+@pytest.fixture
+def read_only_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the access profile to READ_ONLY so mutation tools are blocked."""
+    monkeypatch.setattr(config, "ACM_MCP_ACCESS_PROFILE", AccessProfile.READ_ONLY)
+
+
+def _make_record(
+    key=("test", "demo", "k1", b"\x00\x01"),
+    meta=None,
+    bins=None,
+) -> SimpleNamespace:
+    """Build a SimpleNamespace that mimics an aerospike-py Record NamedTuple."""
+    return SimpleNamespace(
+        key=key,
+        meta=meta if meta is not None else SimpleNamespace(gen=1, ttl=0),
+        bins=bins if bins is not None else {"name": "Alice"},
+    )
+
+
+def _patch_get_client(client: MagicMock):
+    """Return a context manager that replaces ``_get_client`` with the mock."""
+    from aerospike_cluster_manager_api.mcp.tools import records as records_tools
+
+    return patch.object(
+        records_tools.client_manager,
+        "get_client",
+        new=AsyncMock(return_value=client),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Module import side-effect: the 7 tools register themselves at import time
+# ---------------------------------------------------------------------------
+
+
+def test_record_tools_module_registers_seven_tools() -> None:
+    # Importing the module is enough — the @tool decorations run at import.
+    from aerospike_cluster_manager_api.mcp.tools import records as _records  # noqa: F401
+
+    names = {entry.name for entry in registered_tools() if entry.category == "record"}
+    assert names == {
+        "get_record",
+        "record_exists",
+        "create_record",
+        "update_record",
+        "delete_record",
+        "delete_bin",
+        "truncate_set",
+    }
+
+
+def test_mutation_flags_match_design() -> None:
+    from aerospike_cluster_manager_api.mcp.tools import records as _records  # noqa: F401
+
+    by_name = {entry.name: entry for entry in registered_tools() if entry.category == "record"}
+    # Read tools — mutation=False
+    assert by_name["get_record"].mutation is False
+    assert by_name["record_exists"].mutation is False
+    # Mutation tools — mutation=True
+    assert by_name["create_record"].mutation is True
+    assert by_name["update_record"].mutation is True
+    assert by_name["delete_record"].mutation is True
+    assert by_name["delete_bin"].mutation is True
+    assert by_name["truncate_set"].mutation is True
+
+
+# ---------------------------------------------------------------------------
+# get_record
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecordTool:
+    async def test_happy_path_returns_serialised_record(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import get_record
+
+        rec = _make_record(
+            key=("test", "demo", 42, b"\xab\xcd"),
+            meta=SimpleNamespace(gen=7, ttl=3600),
+            bins={"name": "Alice", "age": 30},
+        )
+        mock_client = MagicMock()
+
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.records.records_service.get_record",
+                new=AsyncMock(return_value=rec),
+            ),
+        ):
+            result = await get_record(conn_id="conn-x", namespace="test", set_name="demo", key="42")
+
+        assert isinstance(result, dict)
+        # serialize_record envelope
+        assert result["key"]["namespace"] == "test"
+        assert result["key"]["set"] == "demo"
+        assert result["key"]["user_key"] == 42
+        assert result["meta"]["generation"] == 7
+        assert result["meta"]["expiration"] == 3600
+        assert result["bins"] == {"name": "Alice", "age": 30}
+
+    async def test_missing_record_maps_to_record_not_found(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import get_record
+
+        mock_client = MagicMock()
+
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.records.records_service.get_record",
+                new=AsyncMock(side_effect=RecordNotFound("nope")),
+            ),
+            pytest.raises(MCPToolError) as exc_info,
+        ):
+            await get_record(conn_id="conn-x", namespace="test", set_name="demo", key="missing")
+
+        assert exc_info.value.code == "record_not_found"
+
+    async def test_missing_conn_id_maps_to_connection_not_found(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import records as records_tools
+        from aerospike_cluster_manager_api.mcp.tools.records import get_record
+
+        with (
+            patch.object(
+                records_tools.client_manager,
+                "get_client",
+                new=AsyncMock(side_effect=ValueError("Connection profile 'conn-nope' not found")),
+            ),
+            pytest.raises(MCPToolError) as exc_info,
+        ):
+            await get_record(conn_id="conn-nope", namespace="test", set_name="demo", key="k1")
+
+        assert exc_info.value.code == "ConnectionNotFoundError"
+
+
+# ---------------------------------------------------------------------------
+# record_exists
+# ---------------------------------------------------------------------------
+
+
+class TestRecordExistsTool:
+    async def test_happy_path_true(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import record_exists
+
+        mock_client = MagicMock()
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.records.records_service.record_exists",
+                new=AsyncMock(return_value=True),
+            ),
+        ):
+            result = await record_exists(conn_id="conn-x", namespace="test", set_name="demo", key="k1")
+
+        assert result == {"exists": True}
+
+    async def test_happy_path_false(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import record_exists
+
+        mock_client = MagicMock()
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.records.records_service.record_exists",
+                new=AsyncMock(return_value=False),
+            ),
+        ):
+            result = await record_exists(conn_id="conn-x", namespace="test", set_name="demo", key="missing")
+
+        assert result == {"exists": False}
+
+    async def test_missing_conn_id_maps_to_connection_not_found(self) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import records as records_tools
+        from aerospike_cluster_manager_api.mcp.tools.records import record_exists
+
+        with (
+            patch.object(
+                records_tools.client_manager,
+                "get_client",
+                new=AsyncMock(side_effect=ValueError("missing")),
+            ),
+            pytest.raises(MCPToolError) as exc_info,
+        ):
+            await record_exists(conn_id="conn-nope", namespace="test", set_name="demo", key="k1")
+
+        assert exc_info.value.code == "ConnectionNotFoundError"
+
+
+# ---------------------------------------------------------------------------
+# create_record
+# ---------------------------------------------------------------------------
+
+
+class TestCreateRecordTool:
+    async def test_happy_path_returns_created_ack(self, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import create_record
+
+        mock_client = MagicMock()
+        spy = AsyncMock(return_value=None)
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.records.records_service.create_record",
+                new=spy,
+            ),
+        ):
+            result = await create_record(
+                conn_id="conn-x",
+                namespace="test",
+                set_name="demo",
+                key="k1",
+                bins={"name": "Alice"},
+            )
+
+        assert isinstance(result, dict)
+        assert result["created"] is True
+        assert result["key"]["namespace"] == "test"
+        assert result["key"]["set"] == "demo"
+        assert result["key"]["pk"] == "k1"
+        spy.assert_awaited_once()
+
+    async def test_record_exists_maps_to_record_exists(self, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import create_record
+
+        mock_client = MagicMock()
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.records.records_service.create_record",
+                new=AsyncMock(side_effect=RecordExistsError("collision")),
+            ),
+            pytest.raises(MCPToolError) as exc_info,
+        ):
+            await create_record(
+                conn_id="conn-x",
+                namespace="test",
+                set_name="demo",
+                key="k1",
+                bins={"a": 1},
+            )
+
+        assert exc_info.value.code == "record_exists"
+
+    async def test_read_only_profile_blocks_call(self, read_only_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import create_record
+
+        with pytest.raises(MCPToolError) as exc_info:
+            await create_record(
+                conn_id="conn-x",
+                namespace="test",
+                set_name="demo",
+                key="k1",
+                bins={"a": 1},
+            )
+
+        assert exc_info.value.code == "access_denied"
+        assert "create_record" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# update_record
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateRecordTool:
+    async def test_happy_path_returns_updated_ack(self, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import update_record
+
+        mock_client = MagicMock()
+        spy = AsyncMock(return_value=None)
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.records.records_service.update_record",
+                new=spy,
+            ),
+        ):
+            result = await update_record(
+                conn_id="conn-x",
+                namespace="test",
+                set_name="demo",
+                key="k1",
+                bins={"name": "Bob"},
+            )
+
+        assert isinstance(result, dict)
+        assert result["updated"] is True
+        assert result["key"]["namespace"] == "test"
+        assert result["key"]["set"] == "demo"
+        assert result["key"]["pk"] == "k1"
+        spy.assert_awaited_once()
+
+    async def test_record_not_found_maps_to_record_not_found(self, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import update_record
+
+        mock_client = MagicMock()
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.records.records_service.update_record",
+                new=AsyncMock(side_effect=RecordNotFound("absent")),
+            ),
+            pytest.raises(MCPToolError) as exc_info,
+        ):
+            await update_record(
+                conn_id="conn-x",
+                namespace="test",
+                set_name="demo",
+                key="missing",
+                bins={"a": 1},
+            )
+
+        assert exc_info.value.code == "record_not_found"
+
+    async def test_read_only_profile_blocks_call(self, read_only_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import update_record
+
+        with pytest.raises(MCPToolError) as exc_info:
+            await update_record(
+                conn_id="conn-x",
+                namespace="test",
+                set_name="demo",
+                key="k1",
+                bins={"a": 1},
+            )
+
+        assert exc_info.value.code == "access_denied"
+
+
+# ---------------------------------------------------------------------------
+# delete_record
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteRecordTool:
+    async def test_happy_path_returns_deleted_ack(self, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import delete_record
+
+        mock_client = MagicMock()
+        spy = AsyncMock(return_value=None)
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.records.records_service.delete_record",
+                new=spy,
+            ),
+        ):
+            result = await delete_record(conn_id="conn-x", namespace="test", set_name="demo", key="k1")
+
+        assert isinstance(result, dict)
+        assert result["deleted"] is True
+        assert result["key"]["pk"] == "k1"
+        spy.assert_awaited_once()
+
+    async def test_record_not_found_maps_to_record_not_found(self, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import delete_record
+
+        mock_client = MagicMock()
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.records.records_service.delete_record",
+                new=AsyncMock(side_effect=RecordNotFound("absent")),
+            ),
+            pytest.raises(MCPToolError) as exc_info,
+        ):
+            await delete_record(conn_id="conn-x", namespace="test", set_name="demo", key="missing")
+
+        assert exc_info.value.code == "record_not_found"
+
+    async def test_read_only_profile_blocks_call(self, read_only_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import delete_record
+
+        with pytest.raises(MCPToolError) as exc_info:
+            await delete_record(conn_id="conn-x", namespace="test", set_name="demo", key="k1")
+
+        assert exc_info.value.code == "access_denied"
+
+
+# ---------------------------------------------------------------------------
+# delete_bin
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteBinTool:
+    async def test_happy_path_returns_bin_deleted_ack(self, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import delete_bin
+
+        mock_client = MagicMock()
+        spy = AsyncMock(return_value=None)
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.records.records_service.delete_bin",
+                new=spy,
+            ),
+        ):
+            result = await delete_bin(
+                conn_id="conn-x",
+                namespace="test",
+                set_name="demo",
+                key="k1",
+                bin_name="old_bin",
+            )
+
+        assert isinstance(result, dict)
+        assert result["bin_deleted"] is True
+        assert result["bin"] == "old_bin"
+        assert result["key"]["pk"] == "k1"
+        spy.assert_awaited_once()
+
+    async def test_record_not_found_maps_to_record_not_found(self, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import delete_bin
+
+        mock_client = MagicMock()
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.records.records_service.delete_bin",
+                new=AsyncMock(side_effect=RecordNotFound("absent")),
+            ),
+            pytest.raises(MCPToolError) as exc_info,
+        ):
+            await delete_bin(
+                conn_id="conn-x",
+                namespace="test",
+                set_name="demo",
+                key="missing",
+                bin_name="old_bin",
+            )
+
+        assert exc_info.value.code == "record_not_found"
+
+    async def test_read_only_profile_blocks_call(self, read_only_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import delete_bin
+
+        with pytest.raises(MCPToolError) as exc_info:
+            await delete_bin(
+                conn_id="conn-x",
+                namespace="test",
+                set_name="demo",
+                key="k1",
+                bin_name="old_bin",
+            )
+
+        assert exc_info.value.code == "access_denied"
+
+
+# ---------------------------------------------------------------------------
+# truncate_set
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateSetTool:
+    async def test_happy_path_returns_truncated_ack(self, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import truncate_set
+
+        mock_client = MagicMock()
+        spy = AsyncMock(return_value=None)
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.records.records_service.truncate_set",
+                new=spy,
+            ),
+        ):
+            result = await truncate_set(conn_id="conn-x", namespace="test", set_name="demo")
+
+        assert isinstance(result, dict)
+        assert result["truncated"] is True
+        assert result["set"] == "demo"
+        assert result["namespace"] == "test"
+        spy.assert_awaited_once_with(mock_client, "test", "demo", before_lut=None)
+
+    async def test_passes_before_lut(self, full_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import truncate_set
+
+        mock_client = MagicMock()
+        spy = AsyncMock(return_value=None)
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.records.records_service.truncate_set",
+                new=spy,
+            ),
+        ):
+            result = await truncate_set(
+                conn_id="conn-x",
+                namespace="test",
+                set_name="demo",
+                before_lut=1_700_000_000_000_000_000,
+            )
+
+        assert result["truncated"] is True
+        spy.assert_awaited_once_with(mock_client, "test", "demo", before_lut=1_700_000_000_000_000_000)
+
+    async def test_read_only_profile_blocks_call(self, read_only_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import truncate_set
+
+        with pytest.raises(MCPToolError) as exc_info:
+            await truncate_set(conn_id="conn-x", namespace="test", set_name="demo")
+
+        assert exc_info.value.code == "access_denied"
+
+
+# ---------------------------------------------------------------------------
+# Module guarantees
+# ---------------------------------------------------------------------------
+
+
+class TestModuleHasNoFastAPI:
+    def test_no_fastapi_import(self) -> None:
+        import aerospike_cluster_manager_api.mcp.tools.records as mod
+
+        assert "fastapi" not in mod.__dict__
+        for attr in dir(mod):
+            value = getattr(mod, attr, None)
+            module_name = getattr(value, "__module__", "") or ""
+            assert not module_name.startswith("fastapi"), f"{attr} originates in {module_name}"
+
+
+# ---------------------------------------------------------------------------
+# Defensive: non-mutation tools must NOT be access-gated even under READ_ONLY
+# ---------------------------------------------------------------------------
+
+
+class TestReadToolsNotGated:
+    async def test_get_record_runs_under_read_only(self, read_only_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import get_record
+
+        mock_client = MagicMock()
+        rec = _make_record()
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.records.records_service.get_record",
+                new=AsyncMock(return_value=rec),
+            ),
+        ):
+            result = await get_record(conn_id="conn-x", namespace="test", set_name="demo", key="k1")
+
+        assert isinstance(result, dict)
+
+    async def test_record_exists_runs_under_read_only(self, read_only_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.records import record_exists
+
+        mock_client = MagicMock()
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.records.records_service.record_exists",
+                new=AsyncMock(return_value=True),
+            ),
+        ):
+            result = await record_exists(conn_id="conn-x", namespace="test", set_name="demo", key="k1")
+
+        assert result == {"exists": True}
+
+
+# Silence unused-import warnings: the Mock class is imported to keep the
+# fixture style aligned with sibling test files even when unused.
+_ = Mock

--- a/api/tests/mcp/test_record_tools.py
+++ b/api/tests/mcp/test_record_tools.py
@@ -67,14 +67,15 @@ def _make_record(
 
 
 def _patch_get_client(client: MagicMock):
-    """Return a context manager that replaces ``_get_client`` with the mock."""
-    from aerospike_cluster_manager_api.mcp.tools import records as records_tools
+    """Return a context manager that replaces ``_get_client`` with the mock.
 
-    return patch.object(
-        records_tools.client_manager,
-        "get_client",
-        new=AsyncMock(return_value=client),
-    )
+    Backwards-compat shim — delegates to the package-level helper in
+    :mod:`tests.mcp.conftest` so the duplicated boilerplate has a single
+    source of truth.
+    """
+    from .conftest import patch_mcp_client
+
+    return patch_mcp_client("aerospike_cluster_manager_api.mcp.tools.records", client)
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/mcp/test_registry.py
+++ b/api/tests/mcp/test_registry.py
@@ -1,0 +1,266 @@
+"""Tests for the MCP tool registration decorator (registry).
+
+Task A.12 — provide a single ``@tool(...)`` decorator that:
+* registers the function with a ``FastMCP`` instance via ``register_all``;
+* records metadata (``category``, ``mutation`` flag) for introspection;
+* wraps the function with the access-profile gate (A.8);
+* wraps the function with the error-mapping context manager (A.11);
+* returns the wrapped form so direct callers also see the gate.
+
+The module-level ``_REGISTRY`` accumulator is intentional — Phase 1 tools
+decorated at import time of each ``mcp/tools/*.py`` module flush into the
+list, then ``register_all(mcp)`` is called once from ``build_mcp_app``
+(B.6). Each test resets the registry up-front to avoid bleed.
+"""
+
+from __future__ import annotations
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from aerospike_cluster_manager_api import config
+from aerospike_cluster_manager_api.mcp.access_profile import AccessProfile
+from aerospike_cluster_manager_api.mcp.errors import MCPToolError
+from aerospike_cluster_manager_api.mcp.registry import (
+    ToolMetadata,
+    _reset_for_tests,
+    register_all,
+    registered_tools,
+    tool,
+)
+from aerospike_cluster_manager_api.services.connections_service import (
+    ConnectionNotFoundError,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_registry() -> None:
+    """Clear the module-level registry before every test."""
+    _reset_for_tests()
+
+
+@pytest.fixture
+def full_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the access profile to FULL so mutation tools are not blocked."""
+    monkeypatch.setattr(config, "ACM_MCP_ACCESS_PROFILE", AccessProfile.FULL)
+
+
+@pytest.fixture
+def read_only_profile(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force the access profile to READ_ONLY."""
+    monkeypatch.setattr(config, "ACM_MCP_ACCESS_PROFILE", AccessProfile.READ_ONLY)
+
+
+# ---------------------------------------------------------------------------
+# Decorator surface — basic shape, metadata, registry accumulator
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_decorates_async_function_and_returns_value(full_profile: None) -> None:
+    @tool(category="record", mutation=False)
+    async def get_thing(x: int) -> int:
+        return x * 2
+
+    result = await get_thing(21)
+    assert result == 42
+
+
+async def test_tool_decorates_sync_function_and_returns_value(full_profile: None) -> None:
+    # Phase 1 tools are async, but the decorator must not lock that down.
+    @tool(category="cluster", mutation=False)
+    def hostname() -> str:
+        return "node-1"
+
+    result = await hostname()
+    assert result == "node-1"
+
+
+def test_tool_preserves_dunder_metadata(full_profile: None) -> None:
+    @tool(category="record", mutation=False)
+    async def get_thing(x: int) -> int:
+        """Docstring survives the wrap."""
+        return x
+
+    assert get_thing.__name__ == "get_thing"
+    assert get_thing.__doc__ == "Docstring survives the wrap."
+
+
+def test_tool_records_metadata_in_registry() -> None:
+    @tool(category="record", mutation=True)
+    async def create_record() -> None:
+        return None
+
+    @tool(category="connection", mutation=False)
+    async def list_connections() -> list[str]:
+        return []
+
+    entries = registered_tools()
+    assert len(entries) == 2
+
+    by_name = {entry.name: entry for entry in entries}
+    assert by_name["create_record"].category == "record"
+    assert by_name["create_record"].mutation is True
+    assert by_name["list_connections"].category == "connection"
+    assert by_name["list_connections"].mutation is False
+    # Entries are concrete dataclasses for stable introspection.
+    assert all(isinstance(entry, ToolMetadata) for entry in entries)
+
+
+def test_tool_supports_explicit_name_override() -> None:
+    @tool(category="record", mutation=False, name="fetch_record")
+    async def _internal_fetch() -> dict[str, str]:
+        return {}
+
+    entries = registered_tools()
+    assert [entry.name for entry in entries] == ["fetch_record"]
+
+
+def test_tool_rejects_duplicate_name() -> None:
+    @tool(category="record", mutation=False)
+    async def get_record() -> dict[str, str]:
+        return {}
+
+    with pytest.raises(ValueError, match="Duplicate tool registration: get_record"):
+
+        @tool(category="record", mutation=False)
+        async def get_record() -> dict[str, str]:  # type: ignore[no-redef]
+            return {}
+
+
+# ---------------------------------------------------------------------------
+# register_all — wires every accumulated tool into the FastMCP instance
+# ---------------------------------------------------------------------------
+
+
+async def test_register_all_wires_every_tool_into_fastmcp() -> None:
+    @tool(category="record", mutation=False)
+    async def get_record() -> dict[str, str]:
+        return {}
+
+    @tool(category="connection", mutation=False)
+    async def list_connections() -> list[str]:
+        return []
+
+    @tool(category="cluster", mutation=True)
+    async def truncate_set() -> None:
+        return None
+
+    mcp = FastMCP("test")
+    count = register_all(mcp)
+    assert count == 3
+
+    listed = await mcp.list_tools()
+    names = {t.name for t in listed}
+    assert names == {"get_record", "list_connections", "truncate_set"}
+
+
+async def test_register_all_returns_zero_when_registry_empty() -> None:
+    mcp = FastMCP("test")
+    assert register_all(mcp) == 0
+    assert await mcp.list_tools() == []
+
+
+# ---------------------------------------------------------------------------
+# Error mapping — service-layer exceptions become MCPToolError
+# ---------------------------------------------------------------------------
+
+
+async def test_wrapper_translates_service_error_to_mcp_tool_error(full_profile: None) -> None:
+    @tool(category="connection", mutation=False)
+    async def get_conn() -> None:
+        raise ConnectionNotFoundError("conn-abc")
+
+    with pytest.raises(MCPToolError) as exc_info:
+        await get_conn()
+
+    err = exc_info.value
+    assert "conn-abc" in str(err)
+    assert err.code == "ConnectionNotFoundError"
+    # Original error preserved as the cause for stack diagnosis.
+    assert isinstance(err.__cause__, ConnectionNotFoundError)
+
+
+async def test_wrapper_lets_unmapped_exceptions_propagate(full_profile: None) -> None:
+    @tool(category="record", mutation=False)
+    async def boom() -> None:
+        raise RuntimeError("kaboom")
+
+    with pytest.raises(RuntimeError, match="kaboom"):
+        await boom()
+
+
+# ---------------------------------------------------------------------------
+# Access-profile gate — read-only blocks mutation tools BEFORE the body runs
+# ---------------------------------------------------------------------------
+
+
+async def test_read_only_profile_blocks_mutation_tool_named_in_write_list(
+    read_only_profile: None,
+) -> None:
+    invoked = False
+
+    # Use a name that's in the WRITE_TOOLS frozenset so is_blocked returns True.
+    @tool(category="record", mutation=True, name="create_record")
+    async def make_record() -> None:
+        nonlocal invoked
+        invoked = True
+
+    with pytest.raises(MCPToolError) as exc_info:
+        await make_record()
+
+    err = exc_info.value
+    assert err.code == "access_denied"
+    # Wording must mention the tool name and the active profile so the model can self-correct.
+    assert "create_record" in str(err)
+    assert "read_only" in str(err)
+    # Body must NEVER run when the gate fires.
+    assert invoked is False
+
+
+async def test_full_profile_allows_mutation_tool(full_profile: None) -> None:
+    @tool(category="record", mutation=True, name="create_record")
+    async def make_record() -> str:
+        return "ok"
+
+    result = await make_record()
+    assert result == "ok"
+
+
+async def test_read_only_profile_allows_non_mutation_tool(read_only_profile: None) -> None:
+    @tool(category="record", mutation=False, name="get_record")
+    async def get_thing() -> str:
+        return "data"
+
+    result = await get_thing()
+    assert result == "data"
+
+
+async def test_read_only_profile_allows_mutation_tool_not_in_write_list(
+    read_only_profile: None,
+) -> None:
+    """Mutation flag is local metadata; only the access_profile WRITE_TOOLS list
+    is authoritative for blocking. A mutation=True tool whose *name* is not in
+    that list still runs under READ_ONLY (default-allow). This matches the
+    contract in ``access_profile.is_blocked``."""
+
+    @tool(category="record", mutation=True, name="some_unknown_write_op")
+    async def write_op() -> str:
+        return "wrote"
+
+    result = await write_op()
+    assert result == "wrote"
+
+
+# ---------------------------------------------------------------------------
+# _reset_for_tests — exposes a clean slate between cases
+# ---------------------------------------------------------------------------
+
+
+def test_reset_for_tests_clears_registry() -> None:
+    @tool(category="record", mutation=False)
+    async def something() -> None:
+        return None
+
+    assert len(registered_tools()) == 1
+    _reset_for_tests()
+    assert registered_tools() == []

--- a/api/tests/mcp/test_registry.py
+++ b/api/tests/mcp/test_registry.py
@@ -34,9 +34,25 @@ from aerospike_cluster_manager_api.services.connections_service import (
 
 
 @pytest.fixture(autouse=True)
-def _isolate_registry() -> None:
-    """Clear the module-level registry before every test."""
+def _isolate_registry():
+    """Snapshot, clear, run, then restore the module-level registry.
+
+    Other test files (``test_record_tools``, ``test_query_tool``,
+    ``test_info_tools``, ``test_auto_discovery``) rely on the global
+    registry being populated by import-time ``@tool`` decorators. Once the
+    tool modules are imported their decorators do **not** re-run, so a
+    plain ``_reset_for_tests()`` call would leave the registry empty for
+    subsequent test files when pytest runs the whole suite. Snapshot/
+    restore preserves cross-file isolation.
+    """
+    from aerospike_cluster_manager_api.mcp import registry as _registry
+
+    saved = list(_registry._REGISTRY)
     _reset_for_tests()
+    try:
+        yield
+    finally:
+        _registry._REGISTRY[:] = saved
 
 
 @pytest.fixture

--- a/api/tests/mcp/test_registry.py
+++ b/api/tests/mcp/test_registry.py
@@ -251,20 +251,48 @@ async def test_read_only_profile_allows_non_mutation_tool(read_only_profile: Non
     assert result == "data"
 
 
-async def test_read_only_profile_allows_mutation_tool_not_in_write_list(
+def test_registry_rejects_mutation_flag_disagreement_with_write_tools(
     read_only_profile: None,
 ) -> None:
-    """Mutation flag is local metadata; only the access_profile WRITE_TOOLS list
-    is authoritative for blocking. A mutation=True tool whose *name* is not in
-    that list still runs under READ_ONLY (default-allow). This matches the
-    contract in ``access_profile.is_blocked``."""
+    """M3 — registration-time consistency check: ``mutation=True`` must
+    pair with a name that exists in ``WRITE_TOOLS``, and vice versa.
+    Otherwise the read-only profile would fail open silently. Catching
+    the drift at import time makes the conflict surface as a startup
+    error instead of a security regression in production."""
+    # mutation=True but the name is NOT in WRITE_TOOLS → reject.
+    with pytest.raises(ValueError, match="mutation flag"):
 
-    @tool(category="record", mutation=True, name="some_unknown_write_op")
-    async def write_op() -> str:
-        return "wrote"
+        @tool(category="record", mutation=True, name="some_unknown_write_op")
+        async def write_op() -> str:
+            return "wrote"
 
-    result = await write_op()
-    assert result == "wrote"
+    # And the inverse: a name listed in WRITE_TOOLS declared with
+    # mutation=False is also rejected.
+    with pytest.raises(ValueError, match="mutation flag"):
+
+        @tool(category="record", mutation=False, name="create_record")
+        async def fake_read() -> str:
+            return "read"
+
+
+async def test_read_only_profile_allows_non_write_mutation_tool_via_is_blocked(
+    read_only_profile: None,
+) -> None:
+    """The runtime gate (``is_blocked``) still defends against drift even
+    after the registration-time check guarantees they agree. Build the
+    wrapped callable directly — bypassing the decorator's consistency
+    assertion — and confirm that under READ_ONLY a name absent from
+    WRITE_TOOLS still runs (default-allow contract).
+    """
+    from aerospike_cluster_manager_api.mcp.access_profile import (
+        WRITE_TOOLS,
+        is_blocked,
+    )
+
+    # ``some_unknown_write_op`` is NOT in WRITE_TOOLS → the runtime gate
+    # must let it through under READ_ONLY.
+    assert "some_unknown_write_op" not in WRITE_TOOLS
+    assert is_blocked("some_unknown_write_op", AccessProfile.READ_ONLY) is False
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/mcp/test_serializers.py
+++ b/api/tests/mcp/test_serializers.py
@@ -1,0 +1,409 @@
+"""Tests for ``mcp/serializers.py``.
+
+Verifies that aerospike-py ``Record`` NamedTuples and bin values of every
+supported particle type round-trip into JSON-serialisable Python primitives
+fit for embedding in MCP ``text`` / ``json`` content blocks.
+
+Conventions verified:
+
+* ``bytes`` bin values become a marker dict ``{"_aerospike_bytes_b64":
+  "<base64>"}`` so a downstream JSON consumer can distinguish a real binary
+  blob from a regular string.
+* The record key is nested as ``{"namespace", "set", "user_key" | "digest",
+  ...}`` — ``digest`` is always populated (base64) for diagnostic clarity;
+  ``user_key`` is omitted when the source ``Record`` only carries a digest.
+* ``meta`` is nested with ``generation`` and ``expiration`` (mapped from
+  aerospike-py ``ttl``); extra ``RecordMetadata`` fields are passed through.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import cast
+
+from aerospike_py import Record
+from aerospike_py.types import AerospikeKey, RecordMetadata
+
+from aerospike_cluster_manager_api.mcp.serializers import (
+    BYTES_MARKER_KEY,
+    serialize_bins,
+    serialize_record,
+    serialize_records,
+    serialize_value,
+)
+
+# ---------------------------------------------------------------------------
+# serialize_value — leaf types
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeValueScalars:
+    def test_int(self) -> None:
+        assert serialize_value(42) == 42
+
+    def test_negative_int(self) -> None:
+        assert serialize_value(-7) == -7
+
+    def test_float(self) -> None:
+        assert serialize_value(3.14) == 3.14
+
+    def test_str(self) -> None:
+        assert serialize_value("hello") == "hello"
+
+    def test_bool_true(self) -> None:
+        # bool is a subclass of int — must remain bool, not coerce to 1.
+        result = serialize_value(True)
+        assert result is True
+        assert isinstance(result, bool)
+
+    def test_bool_false(self) -> None:
+        result = serialize_value(False)
+        assert result is False
+        assert isinstance(result, bool)
+
+    def test_none(self) -> None:
+        assert serialize_value(None) is None
+
+
+class TestSerializeValueBytes:
+    def test_bytes_becomes_marker_dict(self) -> None:
+        raw = b"\xde\xad\xbe\xef"
+        result = serialize_value(raw)
+        assert isinstance(result, dict)
+        assert set(result.keys()) == {BYTES_MARKER_KEY}
+        assert base64.b64decode(result[BYTES_MARKER_KEY]) == raw
+
+    def test_bytearray_becomes_marker_dict(self) -> None:
+        raw = bytearray(b"\xca\xfe\xba\xbe")
+        result = serialize_value(raw)
+        assert isinstance(result, dict)
+        assert base64.b64decode(result[BYTES_MARKER_KEY]) == bytes(raw)
+
+    def test_empty_bytes(self) -> None:
+        result = serialize_value(b"")
+        assert result == {BYTES_MARKER_KEY: ""}
+
+    def test_marker_key_constant_is_namespaced(self) -> None:
+        # The marker key must clearly indicate Aerospike-bytes semantics so a
+        # human reader and downstream tooling can distinguish from regular
+        # JSON. Pin the spelling so we don't break downstream consumers.
+        assert BYTES_MARKER_KEY == "_aerospike_bytes_b64"
+
+
+class TestSerializeValueCollections:
+    def test_list_of_ints(self) -> None:
+        assert serialize_value([1, 2, 3]) == [1, 2, 3]
+
+    def test_list_of_strings(self) -> None:
+        assert serialize_value(["a", "b"]) == ["a", "b"]
+
+    def test_mixed_list(self) -> None:
+        assert serialize_value([1, "x", 2.5, True]) == [1, "x", 2.5, True]
+
+    def test_tuple_serialises_to_list(self) -> None:
+        # Aerospike CDT does not have tuples, but if a caller passes one we
+        # treat it like a list rather than crashing.
+        assert serialize_value((1, 2, 3)) == [1, 2, 3]
+
+    def test_empty_list(self) -> None:
+        assert serialize_value([]) == []
+
+    def test_nested_list_of_bytes(self) -> None:
+        result = serialize_value([b"\x01", b"\x02"])
+        assert result == [
+            {BYTES_MARKER_KEY: base64.b64encode(b"\x01").decode("ascii")},
+            {BYTES_MARKER_KEY: base64.b64encode(b"\x02").decode("ascii")},
+        ]
+
+    def test_dict_serialises_to_dict(self) -> None:
+        result = serialize_value({"a": 1, "b": "two"})
+        assert result == {"a": 1, "b": "two"}
+
+    def test_nested_dict_with_list(self) -> None:
+        result = serialize_value({"tags": ["x", "y"], "count": 2})
+        assert result == {"tags": ["x", "y"], "count": 2}
+
+    def test_geojson_dict_pass_through(self) -> None:
+        # aerospike-py exposes GeoJSON as a plain dict already.
+        geo = {"type": "Point", "coordinates": [127.0, 37.5]}
+        assert serialize_value(geo) == geo
+
+    def test_deeply_nested(self) -> None:
+        value = {
+            "outer": [
+                {"inner": [1, 2, b"\x00"]},
+                {"name": "nested"},
+            ]
+        }
+        result = serialize_value(value)
+        assert result == {
+            "outer": [
+                {"inner": [1, 2, {BYTES_MARKER_KEY: base64.b64encode(b"\x00").decode("ascii")}]},
+                {"name": "nested"},
+            ]
+        }
+
+    def test_dict_with_non_string_keys_coerced(self) -> None:
+        # Aerospike maps allow integer keys; JSON does not. We coerce to str
+        # so the result is still json.dumps-able.
+        result = serialize_value({1: "one", 2: "two"})
+        assert result == {"1": "one", "2": "two"}
+
+
+# ---------------------------------------------------------------------------
+# serialize_bins — bin-name keyed dict
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeBins:
+    def test_integer_bin(self) -> None:
+        assert serialize_bins({"score": 100}) == {"score": 100}
+
+    def test_string_bin(self) -> None:
+        assert serialize_bins({"name": "Alice"}) == {"name": "Alice"}
+
+    def test_float_bin(self) -> None:
+        assert serialize_bins({"price": 9.99}) == {"price": 9.99}
+
+    def test_bool_bin(self) -> None:
+        # Native bool — must stay a bool, not become 1/0.
+        result = serialize_bins({"active": True})
+        assert result == {"active": True}
+        assert isinstance(result["active"], bool)
+
+    def test_list_bin(self) -> None:
+        result = serialize_bins({"tags": ["red", "blue"]})
+        assert result == {"tags": ["red", "blue"]}
+
+    def test_map_bin(self) -> None:
+        result = serialize_bins({"profile": {"first": "A", "last": "B"}})
+        assert result == {"profile": {"first": "A", "last": "B"}}
+
+    def test_geojson_bin(self) -> None:
+        geo = {"type": "Point", "coordinates": [127.0, 37.5]}
+        assert serialize_bins({"location": geo}) == {"location": geo}
+
+    def test_bytes_bin(self) -> None:
+        result = serialize_bins({"blob": b"\x00\x01\x02"})
+        assert result == {
+            "blob": {BYTES_MARKER_KEY: base64.b64encode(b"\x00\x01\x02").decode("ascii")},
+        }
+
+    def test_list_with_nested_bytes_bin(self) -> None:
+        result = serialize_bins({"chunks": [b"abc", b"def"]})
+        assert result == {
+            "chunks": [
+                {BYTES_MARKER_KEY: base64.b64encode(b"abc").decode("ascii")},
+                {BYTES_MARKER_KEY: base64.b64encode(b"def").decode("ascii")},
+            ],
+        }
+
+    def test_empty_bins(self) -> None:
+        assert serialize_bins({}) == {}
+
+    def test_result_is_json_dumpable(self) -> None:
+        bins = {
+            "i": 1,
+            "f": 1.5,
+            "s": "x",
+            "b": True,
+            "lst": [1, "a", b"\x00"],
+            "map": {"k": [b"\x01", 2]},
+            "geo": {"type": "Point", "coordinates": [1.0, 2.0]},
+            "blob": b"binary",
+        }
+        result = serialize_bins(bins)
+        # Must round-trip through json without raising.
+        json.dumps(result)
+
+
+# ---------------------------------------------------------------------------
+# serialize_record — full record envelope
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeRecord:
+    def test_full_record_with_string_user_key(self) -> None:
+        rec = Record(
+            key=AerospikeKey("test", "sample_set", "pk-1", b"\xde\xad\xbe\xef"),
+            meta=RecordMetadata(gen=3, ttl=86400),
+            bins={"name": "Alice", "age": 30, "active": True},
+        )
+
+        result = serialize_record(rec)
+
+        assert result["key"]["namespace"] == "test"
+        assert result["key"]["set"] == "sample_set"
+        assert result["key"]["user_key"] == "pk-1"
+        assert result["key"]["digest"] == base64.b64encode(b"\xde\xad\xbe\xef").decode("ascii")
+        assert result["meta"]["generation"] == 3
+        assert result["meta"]["expiration"] == 86400
+        assert result["bins"] == {"name": "Alice", "age": 30, "active": True}
+
+    def test_record_with_int_user_key(self) -> None:
+        rec = Record(
+            key=AerospikeKey("test", "myset", 42, b"\x01\x02"),
+            meta=RecordMetadata(gen=1, ttl=0),
+            bins={"score": 100},
+        )
+        result = serialize_record(rec)
+        assert result["key"]["user_key"] == 42
+        assert isinstance(result["key"]["user_key"], int)
+
+    def test_record_with_bytes_user_key_uses_marker(self) -> None:
+        rec = Record(
+            key=AerospikeKey("test", "myset", b"\xca\xfe", b"\x00\xff"),
+            meta=RecordMetadata(gen=1, ttl=0),
+            bins={},
+        )
+        result = serialize_record(rec)
+        assert result["key"]["user_key"] == {
+            BYTES_MARKER_KEY: base64.b64encode(b"\xca\xfe").decode("ascii"),
+        }
+
+    def test_record_with_none_user_key_omits_user_key(self) -> None:
+        # Digest-only record (no user_key persisted): expose digest, not user_key.
+        rec = Record(
+            key=AerospikeKey("test", "myset", None, b"\x00\x11\x22\x33"),
+            meta=RecordMetadata(gen=1, ttl=0),
+            bins={},
+        )
+        result = serialize_record(rec)
+        assert "user_key" not in result["key"]
+        assert result["key"]["digest"] == base64.b64encode(b"\x00\x11\x22\x33").decode("ascii")
+
+    def test_record_with_bytearray_digest(self) -> None:
+        # Aerospike-py types ``digest`` as bytes, but bytearray flows through
+        # the same isinstance() check; cast at the call site so pyright is
+        # happy without losing test coverage of the bytearray branch.
+        digest = cast("bytes", bytearray(b"\xab\xcd"))
+        rec = Record(
+            key=AerospikeKey("test", "myset", "pk-1", digest),
+            meta=RecordMetadata(gen=1, ttl=0),
+            bins={},
+        )
+        result = serialize_record(rec)
+        assert result["key"]["digest"] == base64.b64encode(b"\xab\xcd").decode("ascii")
+
+    def test_record_with_dict_meta(self) -> None:
+        # Some aerospike-py paths still surface meta as a dict; the type
+        # annotation now says RecordMetadata only, so cast for type-checker.
+        meta = cast("RecordMetadata", {"gen": 2, "ttl": 500, "last_update_time": 1234567})
+        rec = Record(
+            key=AerospikeKey("test", "myset", "pk", b"\x00"),
+            meta=meta,
+            bins={"x": 1},
+        )
+        result = serialize_record(rec)
+        assert result["meta"]["generation"] == 2
+        assert result["meta"]["expiration"] == 500
+        # Extra dict keys flow through so MCP clients can read them.
+        assert result["meta"]["last_update_time"] == 1234567
+
+    def test_record_with_none_meta_defaults(self) -> None:
+        rec = Record(
+            key=AerospikeKey("test", "myset", "pk", b"\x00"),
+            meta=None,
+            bins={"x": 1},
+        )
+        result = serialize_record(rec)
+        assert result["meta"]["generation"] == 0
+        assert result["meta"]["expiration"] == 0
+
+    def test_record_with_none_bins_becomes_empty_dict(self) -> None:
+        rec = Record(
+            key=AerospikeKey("test", "myset", "pk", b"\x00"),
+            meta=RecordMetadata(gen=1, ttl=0),
+            bins=None,
+        )
+        result = serialize_record(rec)
+        assert result["bins"] == {}
+
+    def test_record_with_complex_bins(self) -> None:
+        rec = Record(
+            key=AerospikeKey("test", "myset", "pk", b"\x00"),
+            meta=RecordMetadata(gen=1, ttl=0),
+            bins={
+                "tags": ["python", b"\x01\x02"],
+                "metadata": {"source": "import", "version": 2},
+                "location": {"type": "Point", "coordinates": [127.0, 37.5]},
+                "blob": b"binary",
+                "score": 3.14,
+            },
+        )
+
+        result = serialize_record(rec)
+
+        assert result["bins"]["tags"][0] == "python"
+        assert result["bins"]["tags"][1] == {
+            BYTES_MARKER_KEY: base64.b64encode(b"\x01\x02").decode("ascii"),
+        }
+        assert result["bins"]["metadata"] == {"source": "import", "version": 2}
+        assert result["bins"]["location"] == {"type": "Point", "coordinates": [127.0, 37.5]}
+        assert result["bins"]["blob"] == {
+            BYTES_MARKER_KEY: base64.b64encode(b"binary").decode("ascii"),
+        }
+        # round-trip JSON
+        json.dumps(result)
+
+    def test_record_no_digest_in_key_tuple(self) -> None:
+        # Key tuple without digest — still serialises, digest field is None.
+        # Cast required because AerospikeKey is a 4-tuple at the type level
+        # but the serializer must tolerate shorter tuples at runtime (some
+        # info paths surface namespace-only or 3-tuple keys).
+        partial_key = cast("AerospikeKey", ("test", "myset", "pk-1"))
+        rec = Record(
+            key=partial_key,
+            meta=RecordMetadata(gen=1, ttl=0),
+            bins={},
+        )
+        result = serialize_record(rec)
+        assert result["key"]["namespace"] == "test"
+        assert result["key"]["set"] == "myset"
+        assert result["key"]["user_key"] == "pk-1"
+        assert result["key"]["digest"] is None
+
+
+# ---------------------------------------------------------------------------
+# serialize_records — bulk
+# ---------------------------------------------------------------------------
+
+
+class TestSerializeRecords:
+    def test_empty_iterable(self) -> None:
+        assert serialize_records([]) == []
+
+    def test_multiple_records(self) -> None:
+        records = [
+            Record(
+                key=AerospikeKey("test", "s", "pk-1", b"\x01"),
+                meta=RecordMetadata(gen=1, ttl=0),
+                bins={"a": 1},
+            ),
+            Record(
+                key=AerospikeKey("test", "s", "pk-2", b"\x02"),
+                meta=RecordMetadata(gen=2, ttl=10),
+                bins={"a": 2},
+            ),
+        ]
+
+        result = serialize_records(records)
+
+        assert len(result) == 2
+        assert result[0]["key"]["user_key"] == "pk-1"
+        assert result[1]["key"]["user_key"] == "pk-2"
+        assert result[0]["bins"] == {"a": 1}
+        assert result[1]["meta"]["generation"] == 2
+
+    def test_accepts_generator(self) -> None:
+        def gen():
+            yield Record(
+                key=AerospikeKey("test", "s", "pk", b"\x00"),
+                meta=RecordMetadata(gen=1, ttl=0),
+                bins={"x": 1},
+            )
+
+        result = serialize_records(gen())
+        assert len(result) == 1
+        assert result[0]["bins"] == {"x": 1}

--- a/api/tests/mcp/test_server_smoke.py
+++ b/api/tests/mcp/test_server_smoke.py
@@ -1,0 +1,17 @@
+"""Smoke tests for the empty MCP server factory.
+
+Task A.6 only verifies that ``build_mcp_app`` returns a ``FastMCP``
+instance whose ``name`` is ``aerospike-cluster-manager``. Tool
+registration, transport mounting and HTTP-level checks come in later
+tasks (A.7+ and B.*).
+"""
+
+from mcp.server.fastmcp import FastMCP
+
+from aerospike_cluster_manager_api.mcp.server import build_mcp_app
+
+
+def test_build_returns_fastmcp_named_acm() -> None:
+    mcp = build_mcp_app()
+    assert isinstance(mcp, FastMCP)
+    assert mcp.name == "aerospike-cluster-manager"

--- a/api/tests/test_clusters_service.py
+++ b/api/tests/test_clusters_service.py
@@ -1,0 +1,330 @@
+"""Unit tests for the clusters service layer.
+
+These tests exercise ``services.clusters_service`` directly — without going
+through FastAPI — so the same functions can be reused by an MCP tool layer.
+The router-layer regression net lives in ``test_cluster_batch.py`` and friends.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from aerospike_cluster_manager_api.models.cluster import (
+    ClusterInfo,
+    ClusterNode,
+    CreateNamespaceRequest,
+    NamespaceInfo,
+    SetInfo,
+)
+from aerospike_cluster_manager_api.services import clusters_service
+from aerospike_cluster_manager_api.services.clusters_service import (
+    NamespaceConfigError,
+    NamespaceNotFoundError,
+    NodeNotFoundError,
+)
+from aerospike_cluster_manager_api.services.info_cache import info_cache
+
+
+def _info_all_result(name: str, resp: str) -> tuple[str, int | None, str]:
+    return (name, None, resp)
+
+
+@pytest.fixture(autouse=True)
+def _clear_info_cache():
+    """Ensure the info cache is clean for each test in this module."""
+    info_cache.clear()
+    yield
+    info_cache.clear()
+
+
+def _make_mock_client() -> AsyncMock:
+    """Build a mock AsyncClient that returns realistic Aerospike info data."""
+    mock = AsyncMock()
+    mock.get_node_names = Mock(return_value=["node1", "node2"])
+    mock.is_connected.return_value = True
+
+    node_stats = "cluster_size=2;uptime=3600;client_connections=10;stat_read_reqs=1000;stat_write_reqs=500"
+
+    ns_stats = (
+        "objects=200;tombstones=0;memory_used_bytes=1024;"
+        "memory-size=4096;device_used_bytes=0;device-total-bytes=0;"
+        "replication-factor=2;stop_writes=false;hwm_breached=false;"
+        "high-water-memory-pct=60;high-water-disk-pct=50;"
+        "nsup-period=120;default-ttl=0;allow-ttl-without-nsup=false"
+    )
+
+    def info_all_side_effect(cmd: str):
+        if cmd == "statistics":
+            return [
+                _info_all_result("node1", node_stats),
+                _info_all_result("node2", node_stats),
+            ]
+        if cmd == "build":
+            return [
+                _info_all_result("node1", "6.4.0"),
+                _info_all_result("node2", "6.4.0"),
+            ]
+        if cmd == "edition":
+            return [
+                _info_all_result("node1", "Community"),
+                _info_all_result("node2", "Community"),
+            ]
+        if cmd == "service":
+            return [
+                _info_all_result("node1", "10.0.0.1:3000"),
+                _info_all_result("node2", "10.0.0.2:3000"),
+            ]
+        if cmd.startswith("namespace/"):
+            return [
+                _info_all_result("node1", ns_stats),
+                _info_all_result("node2", ns_stats),
+            ]
+        if cmd.startswith("sets/"):
+            return [
+                _info_all_result(
+                    "node1", "set=myset:objects=100:tombstones=0:memory_data_bytes=500:stop-writes-count=0"
+                ),
+                _info_all_result(
+                    "node2", "set=myset:objects=100:tombstones=0:memory_data_bytes=500:stop-writes-count=0"
+                ),
+            ]
+        return []
+
+    mock.info_all.side_effect = info_all_side_effect
+    mock.info_random_node.return_value = "test"
+
+    return mock
+
+
+# ---------------------------------------------------------------------------
+# list_namespaces
+# ---------------------------------------------------------------------------
+
+
+class TestListNamespaces:
+    async def test_returns_parsed_list(self):
+        client = _make_mock_client()
+        client.info_random_node.return_value = "test;bar"
+        result = await clusters_service.list_namespaces(client)
+        assert result == ["test", "bar"]
+
+    async def test_returns_empty_list_when_no_namespaces(self):
+        client = _make_mock_client()
+        client.info_random_node.return_value = ""
+        result = await clusters_service.list_namespaces(client)
+        assert result == []
+
+    async def test_calls_info_namespaces_command(self):
+        client = _make_mock_client()
+        await clusters_service.list_namespaces(client)
+        client.info_random_node.assert_awaited_with("namespaces")
+
+
+# ---------------------------------------------------------------------------
+# list_sets
+# ---------------------------------------------------------------------------
+
+
+class TestListSets:
+    async def test_returns_set_info_list(self):
+        client = _make_mock_client()
+        result = await clusters_service.list_sets(client, "test")
+        assert isinstance(result, list)
+        assert all(isinstance(s, SetInfo) for s in result)
+        assert len(result) == 1
+        assert result[0].name == "myset"
+        assert result[0].namespace == "test"
+
+    async def test_uses_namespace_replication_factor_for_object_dedup(self):
+        client = _make_mock_client()
+        result = await clusters_service.list_sets(client, "test")
+        # Each node reports 100 objects; rf=2 -> unique 100
+        assert result[0].objects == 100
+
+    async def test_aggregates_total_nodes_count(self):
+        client = _make_mock_client()
+        result = await clusters_service.list_sets(client, "test")
+        assert result[0].totalNodes == 2
+
+    async def test_unknown_namespace_raises(self):
+        client = _make_mock_client()
+        # Override info_random_node so namespaces list is empty for the lookup
+        client.info_random_node.return_value = ""
+        with pytest.raises(NamespaceNotFoundError):
+            await clusters_service.list_sets(client, "missing")
+
+
+# ---------------------------------------------------------------------------
+# get_nodes
+# ---------------------------------------------------------------------------
+
+
+class TestGetNodes:
+    async def test_returns_cluster_node_list(self):
+        client = _make_mock_client()
+        result = await clusters_service.get_nodes(client, "conn-test-1")
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert all(isinstance(n, ClusterNode) for n in result)
+
+    async def test_node_carries_build_and_edition(self):
+        client = _make_mock_client()
+        result = await clusters_service.get_nodes(client, "conn-test-1")
+        assert result[0].build == "6.4.0"
+        assert result[0].edition == "Community"
+
+    async def test_node_address_split_from_service(self):
+        client = _make_mock_client()
+        result = await clusters_service.get_nodes(client, "conn-test-1")
+        addresses = sorted(n.address for n in result)
+        assert addresses == ["10.0.0.1", "10.0.0.2"]
+        assert all(n.port == 3000 for n in result)
+
+    async def test_caches_static_info_per_conn_id(self):
+        client = _make_mock_client()
+        await clusters_service.get_nodes(client, "conn-test-cache")
+        # The build/edition fetcher was invoked once via info_all
+        first_build_calls = sum(1 for c in client.info_all.call_args_list if c.args and c.args[0] == "build")
+        await clusters_service.get_nodes(client, "conn-test-cache")
+        second_build_calls = sum(1 for c in client.info_all.call_args_list if c.args and c.args[0] == "build")
+        # Second call should not re-invoke build because info_cache served it
+        assert second_build_calls == first_build_calls
+
+
+# ---------------------------------------------------------------------------
+# execute_info
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteInfo:
+    async def test_returns_per_node_results_for_info_all(self):
+        client = _make_mock_client()
+        result = await clusters_service.execute_info(client, "statistics")
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert all(isinstance(r, tuple) and len(r) == 3 for r in result)
+        # Each tuple is (node_name, err, response)
+        names = sorted(r[0] for r in result)
+        assert names == ["node1", "node2"]
+
+    async def test_passes_command_through(self):
+        client = _make_mock_client()
+        await clusters_service.execute_info(client, "edition")
+        client.info_all.assert_any_call("edition")
+
+
+# ---------------------------------------------------------------------------
+# execute_info_on_node
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteInfoOnNode:
+    async def test_returns_response_string_for_known_node(self):
+        client = _make_mock_client()
+        result = await clusters_service.execute_info_on_node(client, "statistics", "node1")
+        assert isinstance(result, str)
+        assert "cluster_size=2" in result
+
+    async def test_unknown_node_raises(self):
+        client = _make_mock_client()
+        with pytest.raises(NodeNotFoundError):
+            await clusters_service.execute_info_on_node(client, "statistics", "unknown-node")
+
+    async def test_propagates_node_error(self):
+        client = _make_mock_client()
+
+        def err_side_effect(cmd: str):
+            return [("node1", 1, "")]
+
+        client.info_all.side_effect = err_side_effect
+        # An err code on the targeted node should still raise NodeNotFoundError
+        # because we treat an error response as "no usable response from this node".
+        with pytest.raises(NodeNotFoundError):
+            await clusters_service.execute_info_on_node(client, "statistics", "node1")
+
+
+# ---------------------------------------------------------------------------
+# get_cluster_info (full composition)
+# ---------------------------------------------------------------------------
+
+
+class TestGetClusterInfo:
+    async def test_returns_cluster_info_model(self):
+        client = _make_mock_client()
+        result = await clusters_service.get_cluster_info(client, "conn-test-1")
+        assert isinstance(result, ClusterInfo)
+        assert result.connectionId == "conn-test-1"
+        assert len(result.nodes) == 2
+        assert len(result.namespaces) == 1
+        assert isinstance(result.namespaces[0], NamespaceInfo)
+
+    async def test_handles_empty_namespace_list(self):
+        client = _make_mock_client()
+        client.info_random_node.return_value = ""
+        result = await clusters_service.get_cluster_info(client, "conn-test-1")
+        assert result.namespaces == []
+        assert len(result.nodes) == 2
+
+
+# ---------------------------------------------------------------------------
+# configure_namespace
+# ---------------------------------------------------------------------------
+
+
+class TestConfigureNamespace:
+    async def test_success_returns_message(self):
+        client = _make_mock_client()
+        # info_random_node is shared between the existence check (returns "test")
+        # and the set-config call (must return "ok"). Sequence them.
+        client.info_random_node = AsyncMock(side_effect=["test", "ok"])
+        body = CreateNamespaceRequest(name="test", memorySize=2_000_000_000, replicationFactor=2)
+        result = await clusters_service.configure_namespace(client, body)
+        assert "test" in result
+        assert "configured" in result.lower()
+
+    async def test_unknown_namespace_raises(self):
+        client = _make_mock_client()
+        client.info_random_node = AsyncMock(return_value="")  # empty namespace list
+        body = CreateNamespaceRequest(name="missing", memorySize=2_000_000_000, replicationFactor=2)
+        with pytest.raises(NamespaceNotFoundError):
+            await clusters_service.configure_namespace(client, body)
+
+    async def test_failed_set_config_raises(self):
+        client = _make_mock_client()
+        client.info_random_node = AsyncMock(side_effect=["test", "error: bad"])
+        body = CreateNamespaceRequest(name="test", memorySize=2_000_000_000, replicationFactor=2)
+        with pytest.raises(NamespaceConfigError):
+            await clusters_service.configure_namespace(client, body)
+
+    async def test_set_config_command_includes_params(self):
+        client = _make_mock_client()
+        client.info_random_node = AsyncMock(side_effect=["test", "ok"])
+        body = CreateNamespaceRequest(name="test", memorySize=4_000_000_000, replicationFactor=3)
+        await clusters_service.configure_namespace(client, body)
+        # Second invocation is the set-config call.
+        second_call = client.info_random_node.await_args_list[1]
+        cmd = second_call.args[0]
+        assert cmd.startswith("set-config:")
+        assert "id=test" in cmd
+        assert "memory-size=4000000000" in cmd
+        assert "replication-factor=3" in cmd
+
+
+# ---------------------------------------------------------------------------
+# Cross-module guarantees
+# ---------------------------------------------------------------------------
+
+
+class TestServiceModuleHasNoFastAPI:
+    def test_no_fastapi_import(self):
+        import aerospike_cluster_manager_api.services.clusters_service as mod
+
+        # The service module must not depend on FastAPI shaping.
+        assert "fastapi" not in mod.__dict__
+        # And no fastapi.* names leak through.
+        for attr in dir(mod):
+            value = getattr(mod, attr)
+            module_name = getattr(value, "__module__", "") or ""
+            assert not module_name.startswith("fastapi"), f"{attr} originates in {module_name}"

--- a/api/tests/test_connections_router.py
+++ b/api/tests/test_connections_router.py
@@ -289,7 +289,8 @@ class TestTestConnection:
         mock_client.close = AsyncMock()
 
         with patch(
-            "aerospike_cluster_manager_api.routers.connections.aerospike_py.AsyncClient", return_value=mock_client
+            "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
+            return_value=mock_client,
         ):
             response = await client.post(
                 "/api/connections/test",
@@ -304,7 +305,7 @@ class TestTestConnection:
     async def test_failure(self, client: AsyncClient):
         """Test connection endpoint when connection fails."""
         with patch(
-            "aerospike_cluster_manager_api.routers.connections.aerospike_py.AsyncClient",
+            "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
             side_effect=Exception("Connection refused"),
         ):
             response = await client.post(
@@ -325,7 +326,8 @@ class TestTestConnection:
         mock_client.close = AsyncMock()
 
         with patch(
-            "aerospike_cluster_manager_api.routers.connections.aerospike_py.AsyncClient", return_value=mock_client
+            "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
+            return_value=mock_client,
         ):
             response = await client.post(
                 "/api/connections/test",
@@ -345,7 +347,8 @@ class TestTestConnection:
         mock_client.close = AsyncMock()
 
         with patch(
-            "aerospike_cluster_manager_api.routers.connections.aerospike_py.AsyncClient", return_value=mock_client
+            "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
+            return_value=mock_client,
         ) as mock_cls:
             response = await client.post(
                 "/api/connections/test",

--- a/api/tests/test_connections_service.py
+++ b/api/tests/test_connections_service.py
@@ -1,0 +1,249 @@
+"""Unit tests for the connections service layer.
+
+These tests exercise ``services.connections_service`` directly — without going
+through FastAPI — so the same functions can be reused by an MCP tool layer.
+The router-layer regression net lives in ``test_connections_router.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aerospike_cluster_manager_api.models.connection import (
+    ConnectionProfileResponse,
+    CreateConnectionRequest,
+    UpdateConnectionRequest,
+)
+from aerospike_cluster_manager_api.models.connection import (
+    TestConnectionRequest as _TestConnectionRequest,
+)
+from aerospike_cluster_manager_api.services import connections_service
+from aerospike_cluster_manager_api.services.connections_service import (
+    ConnectionNotFoundError,
+    WorkspaceNotFoundError,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _create_payload(**overrides) -> CreateConnectionRequest:
+    base = {
+        "name": "Service Test Conn",
+        "hosts": ["10.0.0.1"],
+        "port": 3000,
+        "clusterName": "svc-test",
+        "username": "admin",
+        "password": "supersecret",
+        "color": "#FF5500",
+    }
+    base.update(overrides)
+    return CreateConnectionRequest(**base)
+
+
+# ---------------------------------------------------------------------------
+# list_connections
+# ---------------------------------------------------------------------------
+
+
+class TestListConnections:
+    async def test_returns_list_for_default_workspace(self, init_test_db):
+        result = await connections_service.list_connections(workspace_id="ws-default")
+        assert isinstance(result, list)
+        assert all(isinstance(item, ConnectionProfileResponse) for item in result)
+
+    async def test_returns_list_for_no_workspace_filter(self, init_test_db):
+        result = await connections_service.list_connections(workspace_id=None)
+        assert isinstance(result, list)
+
+    async def test_unknown_workspace_raises(self, init_test_db):
+        with pytest.raises(WorkspaceNotFoundError):
+            await connections_service.list_connections(workspace_id="ws-missing")
+
+    async def test_filter_returns_only_matching_workspace(self, init_test_db):
+        # Seed a second workspace via direct db insert
+        from datetime import UTC, datetime
+
+        from aerospike_cluster_manager_api import db
+        from aerospike_cluster_manager_api.models.workspace import Workspace
+
+        now = datetime.now(UTC).isoformat()
+        ws = Workspace(
+            id="ws-team-svc",
+            name="team-svc",
+            color="#123456",
+            createdAt=now,
+            updatedAt=now,
+        )
+        await db.create_workspace(ws)
+
+        await connections_service.create_connection(_create_payload(workspaceId="ws-default"))
+        await connections_service.create_connection(_create_payload(workspaceId="ws-team-svc"))
+
+        ws_default = await connections_service.list_connections(workspace_id="ws-default")
+        ws_team = await connections_service.list_connections(workspace_id="ws-team-svc")
+
+        assert all(item.workspaceId == "ws-default" for item in ws_default)
+        assert all(item.workspaceId == "ws-team-svc" for item in ws_team)
+        assert len(ws_team) >= 1
+
+
+# ---------------------------------------------------------------------------
+# create_connection
+# ---------------------------------------------------------------------------
+
+
+class TestCreateConnection:
+    async def test_returns_response_without_password(self, init_test_db):
+        result = await connections_service.create_connection(_create_payload())
+        assert isinstance(result, ConnectionProfileResponse)
+        # ConnectionProfileResponse never contains a password field
+        assert "password" not in result.model_dump()
+        assert result.id.startswith("conn-")
+        assert result.name == "Service Test Conn"
+
+    async def test_default_workspace_when_none_provided(self, init_test_db):
+        result = await connections_service.create_connection(_create_payload())
+        assert result.workspaceId == "ws-default"
+
+    async def test_unknown_workspace_raises(self, init_test_db):
+        with pytest.raises(WorkspaceNotFoundError):
+            await connections_service.create_connection(_create_payload(workspaceId="ws-missing"))
+
+    async def test_persisted_can_be_retrieved(self, init_test_db):
+        created = await connections_service.create_connection(_create_payload())
+        fetched = await connections_service.get_connection(created.id)
+        assert fetched.id == created.id
+        assert fetched.name == created.name
+
+
+# ---------------------------------------------------------------------------
+# get_connection
+# ---------------------------------------------------------------------------
+
+
+class TestGetConnection:
+    async def test_returns_existing(self, init_test_db):
+        created = await connections_service.create_connection(_create_payload())
+        result = await connections_service.get_connection(created.id)
+        assert isinstance(result, ConnectionProfileResponse)
+        assert result.id == created.id
+
+    async def test_missing_raises(self, init_test_db):
+        with pytest.raises(ConnectionNotFoundError):
+            await connections_service.get_connection("conn-nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# update_connection
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateConnection:
+    async def test_updates_fields(self, init_test_db):
+        created = await connections_service.create_connection(_create_payload())
+        update = UpdateConnectionRequest(name="Renamed", port=4000, color="#00FF00")
+        result = await connections_service.update_connection(created.id, update)
+        assert result.name == "Renamed"
+        assert result.port == 4000
+        assert result.color == "#00FF00"
+        # Untouched fields preserved
+        assert result.hosts == ["10.0.0.1"]
+
+    async def test_missing_raises(self, init_test_db):
+        update = UpdateConnectionRequest(name="X")
+        with pytest.raises(ConnectionNotFoundError):
+            await connections_service.update_connection("conn-nonexistent", update)
+
+    async def test_unknown_workspace_raises(self, init_test_db):
+        created = await connections_service.create_connection(_create_payload())
+        update = UpdateConnectionRequest(workspaceId="ws-missing")
+        with pytest.raises(WorkspaceNotFoundError):
+            await connections_service.update_connection(created.id, update)
+
+
+# ---------------------------------------------------------------------------
+# delete_connection
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteConnection:
+    async def test_deletes_existing(self, init_test_db):
+        created = await connections_service.create_connection(_create_payload())
+        await connections_service.delete_connection(created.id)
+        with pytest.raises(ConnectionNotFoundError):
+            await connections_service.get_connection(created.id)
+
+    async def test_idempotent_for_missing(self, init_test_db):
+        # Delete twice — second call must not raise (idempotent).
+        # The router already returns 204 unconditionally; service mirrors that.
+        created = await connections_service.create_connection(_create_payload())
+        await connections_service.delete_connection(created.id)
+        await connections_service.delete_connection(created.id)
+
+
+# ---------------------------------------------------------------------------
+# test_connection
+# ---------------------------------------------------------------------------
+
+
+class TestTestConnection:
+    async def test_success(self, init_test_db):
+        mock_client = AsyncMock()
+        mock_client.connect = AsyncMock()
+        mock_client.is_connected = lambda: True
+        mock_client.close = AsyncMock()
+
+        with patch(
+            "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
+            return_value=mock_client,
+        ):
+            result = await connections_service.test_connection(_TestConnectionRequest(hosts=["localhost"], port=3000))
+
+        assert result == {"success": True, "message": "Connected successfully"}
+
+    async def test_not_connected(self, init_test_db):
+        mock_client = AsyncMock()
+        mock_client.connect = AsyncMock()
+        mock_client.is_connected = lambda: False
+        mock_client.close = AsyncMock()
+
+        with patch(
+            "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
+            return_value=mock_client,
+        ):
+            result = await connections_service.test_connection(_TestConnectionRequest(hosts=["localhost"], port=3000))
+
+        assert result["success"] is False
+        assert "Failed to connect" in result["message"]
+
+    async def test_failure(self, init_test_db):
+        with patch(
+            "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
+            side_effect=Exception("Connection refused"),
+        ):
+            result = await connections_service.test_connection(_TestConnectionRequest(hosts=["unreachable"], port=3000))
+
+        assert result["success"] is False
+        assert "Connection refused" in result["message"]
+
+    async def test_passes_credentials(self, init_test_db):
+        mock_client = AsyncMock()
+        mock_client.connect = AsyncMock()
+        mock_client.is_connected = lambda: True
+        mock_client.close = AsyncMock()
+
+        with patch(
+            "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
+            return_value=mock_client,
+        ) as mock_cls:
+            await connections_service.test_connection(
+                _TestConnectionRequest(hosts=["localhost"], port=3000, username="admin", password="secret")
+            )
+
+        call_args = mock_cls.call_args[0][0]
+        assert call_args["user"] == "admin"
+        assert call_args["password"] == "secret"

--- a/api/tests/test_connections_service.py
+++ b/api/tests/test_connections_service.py
@@ -203,7 +203,9 @@ class TestTestConnection:
         ):
             result = await connections_service.test_connection(_TestConnectionRequest(hosts=["localhost"], port=3000))
 
-        assert result == {"success": True, "message": "Connected successfully"}
+        # Phase 1: result is now a TestConnectionResult NamedTuple, not a dict.
+        assert result.success is True
+        assert result.message == "Connected successfully"
 
     async def test_not_connected(self, init_test_db):
         mock_client = AsyncMock()
@@ -217,8 +219,8 @@ class TestTestConnection:
         ):
             result = await connections_service.test_connection(_TestConnectionRequest(hosts=["localhost"], port=3000))
 
-        assert result["success"] is False
-        assert "Failed to connect" in result["message"]
+        assert result.success is False
+        assert "Failed to connect" in result.message
 
     async def test_failure(self, init_test_db):
         with patch(
@@ -227,8 +229,8 @@ class TestTestConnection:
         ):
             result = await connections_service.test_connection(_TestConnectionRequest(hosts=["unreachable"], port=3000))
 
-        assert result["success"] is False
-        assert "Connection refused" in result["message"]
+        assert result.success is False
+        assert "Connection refused" in result.message
 
     async def test_passes_credentials(self, init_test_db):
         mock_client = AsyncMock()

--- a/api/tests/test_query_service.py
+++ b/api/tests/test_query_service.py
@@ -1,0 +1,276 @@
+"""Unit tests for the query service layer.
+
+These tests exercise ``services.query_service`` directly — without going
+through FastAPI — so the same function can be reused by an MCP tool layer.
+The router-layer regression net (when present) lives elsewhere.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aerospike_py.exception import AerospikeError, RecordNotFound
+
+from aerospike_cluster_manager_api.constants import MAX_QUERY_RECORDS, POLICY_QUERY, POLICY_READ
+from aerospike_cluster_manager_api.models.query import QueryPredicate, QueryRequest
+from aerospike_cluster_manager_api.services import query_service
+from aerospike_cluster_manager_api.services.query_service import SetRequiredForPkLookup
+
+
+def _make_record(key=("test", "demo", "k1", b"\x00"), meta=None, bins=None) -> SimpleNamespace:
+    """Build a SimpleNamespace that mimics an aerospike-py Record NamedTuple."""
+    return SimpleNamespace(
+        key=key,
+        meta=meta if meta is not None else SimpleNamespace(gen=1, ttl=0),
+        bins=bins if bins is not None else {},
+    )
+
+
+def _build_query_mock(records: list[SimpleNamespace] | None = None) -> tuple[AsyncMock, MagicMock]:
+    """Build an AsyncMock client whose .query(...) returns a query object whose
+    .results(policy) records the policy and resolves to the given records."""
+    query_obj = MagicMock()
+    query_obj.results = AsyncMock(return_value=records or [])
+    query_obj.where = MagicMock()
+    query_obj.select = MagicMock()
+    mock_client = AsyncMock()
+    mock_client.query = MagicMock(return_value=query_obj)
+    return mock_client, query_obj
+
+
+# ---------------------------------------------------------------------------
+# execute_query — PK lookup branch
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteQueryPkLookup:
+    async def test_pk_lookup_returns_single_record(self):
+        client = AsyncMock()
+        rec = _make_record(
+            key=("test", "demo", 42, b"\xab\xcd"),
+            meta=SimpleNamespace(gen=2, ttl=600),
+            bins={"name": "Bob"},
+        )
+        client.get = AsyncMock(return_value=rec)
+
+        body = QueryRequest(namespace="test", set="demo", primaryKey="42")
+        result = await query_service.execute_query(client, body)
+
+        assert len(result.records) == 1
+        assert result.records[0] is rec
+        assert result.scanned_records == 1
+        assert result.returned_records == 1
+        assert result.execution_time_ms >= 0
+        # auto resolution: "42" -> int 42 in get
+        client.get.assert_awaited_once_with(("test", "demo", 42), policy=POLICY_READ)
+        # Scan path NOT taken
+        client.query.assert_not_called()
+
+    async def test_pk_lookup_string_pk_type_keeps_string(self):
+        client = AsyncMock()
+        client.get = AsyncMock(return_value=_make_record())
+
+        body = QueryRequest(namespace="test", set="demo", primaryKey="42", pkType="string")
+        await query_service.execute_query(client, body)
+
+        client.get.assert_awaited_once_with(("test", "demo", "42"), policy=POLICY_READ)
+
+    async def test_pk_lookup_record_not_found_returns_empty(self):
+        client = AsyncMock()
+        client.get = AsyncMock(side_effect=RecordNotFound("not found"))
+
+        body = QueryRequest(namespace="test", set="demo", primaryKey="missing", pkType="string")
+        result = await query_service.execute_query(client, body)
+
+        assert result.records == []
+        assert result.scanned_records == 0
+        assert result.returned_records == 0
+
+    async def test_pk_lookup_auto_falls_back_to_string_when_int_not_found(self):
+        """auto mode: numeric-string PK like "42" first probes as INTEGER; on
+        NOT_FOUND it retries as STRING. Mirrors get_with_pk_fallback behaviour."""
+        client = AsyncMock()
+        rec = _make_record(key=("test", "demo", "42", b"\x00"))
+        client.get = AsyncMock(side_effect=[RecordNotFound("nope"), rec])
+
+        body = QueryRequest(namespace="test", set="demo", primaryKey="42", pkType="auto")
+        result = await query_service.execute_query(client, body)
+
+        assert len(result.records) == 1
+        assert result.records[0] is rec
+        assert client.get.await_count == 2
+        first_call = client.get.await_args_list[0]
+        second_call = client.get.await_args_list[1]
+        assert first_call.args[0] == ("test", "demo", 42)
+        assert second_call.args[0] == ("test", "demo", "42")
+
+    async def test_pk_lookup_without_set_raises_set_required(self):
+        client = AsyncMock()
+        body = QueryRequest(namespace="test", primaryKey="42")
+        with pytest.raises(SetRequiredForPkLookup):
+            await query_service.execute_query(client, body)
+
+
+# ---------------------------------------------------------------------------
+# execute_query — scan branch
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteQueryScan:
+    async def test_unfiltered_scan_returns_records(self):
+        recs = [_make_record(key=("test", "demo", f"k{i}", b"\x00")) for i in range(3)]
+        client, _query = _build_query_mock(recs)
+
+        body = QueryRequest(namespace="test", set="demo")
+        result = await query_service.execute_query(client, body)
+
+        assert len(result.records) == 3
+        assert result.scanned_records == 3
+        assert result.returned_records == 3
+        client.query.assert_called_once_with("test", "demo")
+
+    async def test_scan_uses_empty_set_when_no_set_provided(self):
+        client, _query = _build_query_mock()
+        body = QueryRequest(namespace="test")
+        await query_service.execute_query(client, body)
+
+        client.query.assert_called_once_with("test", "")
+
+    async def test_scan_failure_returns_empty_records(self):
+        client, query = _build_query_mock()
+        query.results = AsyncMock(side_effect=AerospikeError("empty namespace"))
+
+        body = QueryRequest(namespace="test", set="demo")
+        result = await query_service.execute_query(client, body)
+
+        assert result.records == []
+        assert result.scanned_records == 0
+        assert result.returned_records == 0
+        assert result.execution_time_ms >= 0
+
+    async def test_scan_max_records_capped_at_global_max(self):
+        client, query = _build_query_mock()
+        body = QueryRequest(namespace="test", set="demo", maxRecords=999_999)
+        await query_service.execute_query(client, body)
+
+        call = query.results.await_args
+        policy = call.args[0]
+        assert policy["max_records"] == MAX_QUERY_RECORDS
+
+    async def test_scan_max_records_uses_request_value_when_below_max(self):
+        client, query = _build_query_mock()
+        body = QueryRequest(namespace="test", set="demo", maxRecords=50)
+        await query_service.execute_query(client, body)
+
+        call = query.results.await_args
+        policy = call.args[0]
+        assert policy["max_records"] == 50
+
+    async def test_scan_default_uses_global_max_when_no_max_records(self):
+        client, query = _build_query_mock()
+        body = QueryRequest(namespace="test", set="demo")
+        await query_service.execute_query(client, body)
+
+        call = query.results.await_args
+        policy = call.args[0]
+        assert policy["max_records"] == MAX_QUERY_RECORDS
+
+    async def test_scan_uses_policy_query_base(self):
+        client, query = _build_query_mock()
+        body = QueryRequest(namespace="test", set="demo")
+        await query_service.execute_query(client, body)
+
+        call = query.results.await_args
+        policy = call.args[0]
+        for k, v in POLICY_QUERY.items():
+            assert policy[k] == v
+
+    async def test_scan_with_select_bins_calls_select(self):
+        client, query = _build_query_mock()
+        body = QueryRequest(namespace="test", set="demo", selectBins=["a", "b"])
+        await query_service.execute_query(client, body)
+
+        query.select.assert_called_once_with("a", "b")
+
+    async def test_scan_without_select_bins_does_not_call_select(self):
+        client, query = _build_query_mock()
+        body = QueryRequest(namespace="test", set="demo")
+        await query_service.execute_query(client, body)
+
+        query.select.assert_not_called()
+
+    async def test_scan_with_predicate_calls_where(self):
+        client, query = _build_query_mock()
+        body = QueryRequest(
+            namespace="test",
+            set="demo",
+            predicate=QueryPredicate(bin="age", operator="equals", value=30),
+        )
+        await query_service.execute_query(client, body)
+
+        query.where.assert_called_once()
+
+    async def test_scan_without_predicate_does_not_call_where(self):
+        client, query = _build_query_mock()
+        body = QueryRequest(namespace="test", set="demo")
+        await query_service.execute_query(client, body)
+
+        query.where.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Result container
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteQueryResult:
+    async def test_execution_time_is_non_negative_int(self):
+        client, _query = _build_query_mock()
+        body = QueryRequest(namespace="test", set="demo")
+        result = await query_service.execute_query(client, body)
+
+        assert isinstance(result.execution_time_ms, int)
+        assert result.execution_time_ms >= 0
+
+    async def test_returns_named_tuple_with_records_attribute(self):
+        client, _query = _build_query_mock()
+        body = QueryRequest(namespace="test", set="demo")
+        result = await query_service.execute_query(client, body)
+
+        # Should expose attribute access (NamedTuple style)
+        assert hasattr(result, "records")
+        assert hasattr(result, "execution_time_ms")
+        assert hasattr(result, "scanned_records")
+        assert hasattr(result, "returned_records")
+
+
+# ---------------------------------------------------------------------------
+# Domain exceptions
+# ---------------------------------------------------------------------------
+
+
+class TestDomainExceptions:
+    def test_set_required_for_pk_lookup_is_value_error(self):
+        exc = SetRequiredForPkLookup()
+        assert isinstance(exc, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# Cross-module guarantees
+# ---------------------------------------------------------------------------
+
+
+class TestServiceModuleHasNoFastAPI:
+    def test_no_fastapi_import(self):
+        import aerospike_cluster_manager_api.services.query_service as mod
+
+        # The service module must not depend on FastAPI shaping.
+        assert "fastapi" not in mod.__dict__
+        # And no fastapi.* names leak through.
+        for attr in dir(mod):
+            value: Any = getattr(mod, attr)
+            module_name = getattr(value, "__module__", "") or ""
+            assert not module_name.startswith("fastapi"), f"{attr} originates in {module_name}"

--- a/api/tests/test_records_service.py
+++ b/api/tests/test_records_service.py
@@ -1,0 +1,450 @@
+"""Unit tests for the records service layer.
+
+These tests exercise ``services.records_service`` directly — without going
+through FastAPI — so the same functions can be reused by an MCP tool layer.
+The router-layer regression net lives in ``test_records_router.py``.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aerospike_py import exp
+from aerospike_py.exception import AerospikeError, RecordNotFound
+
+from aerospike_cluster_manager_api.constants import POLICY_QUERY, POLICY_READ
+from aerospike_cluster_manager_api.expression_builder import build_pk_filter_expression
+from aerospike_cluster_manager_api.models.query import (
+    BinDataType,
+    FilterCondition,
+    FilteredQueryRequest,
+    FilterGroup,
+    FilterOperator,
+)
+from aerospike_cluster_manager_api.models.record import RecordKey, RecordWriteRequest
+from aerospike_cluster_manager_api.services import records_service
+from aerospike_cluster_manager_api.services.records_service import (
+    InvalidPkPattern,
+    PrimaryKeyMissing,
+    SetRequiredForPkLookup,
+)
+
+
+def _make_record(key=("test", "demo", "k1", b"\x00"), meta=None, bins=None) -> SimpleNamespace:
+    """Build a SimpleNamespace that mimics an aerospike-py Record NamedTuple."""
+    return SimpleNamespace(
+        key=key,
+        meta=meta if meta is not None else SimpleNamespace(gen=1, ttl=0),
+        bins=bins if bins is not None else {},
+    )
+
+
+def _build_query_mock(records: list[SimpleNamespace] | None = None) -> tuple[AsyncMock, MagicMock]:
+    """Build an AsyncMock client whose .query(...) returns a query object whose
+    .results(policy) records the policy and resolves to the given records."""
+    query_obj = MagicMock()
+    query_obj.results = AsyncMock(return_value=records or [])
+    query_obj.where = MagicMock()
+    query_obj.select = MagicMock()
+    mock_client = AsyncMock()
+    mock_client.query = MagicMock(return_value=query_obj)
+    mock_client.info_all = AsyncMock(return_value=[])
+    return mock_client, query_obj
+
+
+# ---------------------------------------------------------------------------
+# get_record
+# ---------------------------------------------------------------------------
+
+
+class TestGetRecord:
+    async def test_returns_record_for_valid_key(self):
+        client = AsyncMock()
+        rec = _make_record(
+            key=("test", "demo", 42, b"\xab\xcd"),
+            meta=SimpleNamespace(gen=7, ttl=3600),
+            bins={"name": "Alice", "age": 30},
+        )
+        client.get = AsyncMock(return_value=rec)
+
+        result = await records_service.get_record(client, "test", "demo", "42", "auto")
+
+        assert result is rec
+        # auto resolution: "42" -> int 42 (numeric string heuristic)
+        client.get.assert_awaited_once_with(("test", "demo", 42), policy=POLICY_READ)
+
+    async def test_string_pk_type_passes_string(self):
+        client = AsyncMock()
+        client.get = AsyncMock(return_value=_make_record())
+
+        await records_service.get_record(client, "test", "demo", "42", "string")
+
+        client.get.assert_awaited_once_with(("test", "demo", "42"), policy=POLICY_READ)
+
+    async def test_propagates_record_not_found_for_explicit_pk_type(self):
+        client = AsyncMock()
+        client.get = AsyncMock(side_effect=RecordNotFound("not found"))
+
+        with pytest.raises(RecordNotFound):
+            await records_service.get_record(client, "test", "demo", "missing", "string")
+
+    async def test_auto_falls_back_to_string_when_int_not_found(self):
+        """auto mode: numeric-string PK like "42" first probes as INTEGER; on
+        NOT_FOUND it retries as STRING. Mirrors the existing get_with_pk_fallback
+        behaviour the router relied on."""
+        client = AsyncMock()
+        rec = _make_record(key=("test", "demo", "42", b"\x00"))
+        # First call (int) raises, second call (string) succeeds.
+        client.get = AsyncMock(side_effect=[RecordNotFound("nope"), rec])
+
+        result = await records_service.get_record(client, "test", "demo", "42", "auto")
+
+        assert result is rec
+        assert client.get.await_count == 2
+        first_call = client.get.await_args_list[0]
+        second_call = client.get.await_args_list[1]
+        assert first_call.args[0] == ("test", "demo", 42)
+        assert second_call.args[0] == ("test", "demo", "42")
+
+
+# ---------------------------------------------------------------------------
+# delete_record
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteRecord:
+    async def test_calls_remove_with_resolved_key(self):
+        client = AsyncMock()
+        client.remove = AsyncMock(return_value=None)
+
+        await records_service.delete_record(client, "test", "demo", "42", "auto")
+
+        client.remove.assert_awaited_once_with(("test", "demo", 42))
+
+    async def test_string_pk_type_keeps_string_key(self):
+        client = AsyncMock()
+        client.remove = AsyncMock(return_value=None)
+
+        await records_service.delete_record(client, "test", "demo", "42", "string")
+
+        client.remove.assert_awaited_once_with(("test", "demo", "42"))
+
+    async def test_propagates_record_not_found(self):
+        client = AsyncMock()
+        client.remove = AsyncMock(side_effect=RecordNotFound("not found"))
+
+        with pytest.raises(RecordNotFound):
+            await records_service.delete_record(client, "test", "demo", "missing", "string")
+
+
+# ---------------------------------------------------------------------------
+# put_record (write path — create or update)
+# ---------------------------------------------------------------------------
+
+
+class TestPutRecord:
+    async def test_writes_then_reads_back_for_response(self):
+        client = AsyncMock()
+        client.put = AsyncMock(return_value=None)
+        rec = _make_record(
+            key=("test", "demo", 42, b"\x00"),
+            meta=SimpleNamespace(gen=1, ttl=0),
+            bins={"name": "Alice"},
+        )
+        client.get = AsyncMock(return_value=rec)
+
+        body = RecordWriteRequest(
+            key=RecordKey(namespace="test", set="demo", pk="42"),
+            bins={"name": "Alice"},
+        )
+        result = await records_service.put_record(client, body)
+
+        assert result is rec
+        # auto-mode "42" -> int 42 in put + get
+        client.put.assert_awaited_once()
+        put_call = client.put.await_args
+        assert put_call.args[0] == ("test", "demo", 42)
+        assert put_call.args[1] == {"name": "Alice"}
+        client.get.assert_awaited_once_with(("test", "demo", 42), policy=POLICY_READ)
+
+    async def test_passes_ttl_via_write_meta(self):
+        client = AsyncMock()
+        client.put = AsyncMock(return_value=None)
+        client.get = AsyncMock(return_value=_make_record())
+
+        body = RecordWriteRequest(
+            key=RecordKey(namespace="test", set="demo", pk="k1"),
+            bins={"a": 1},
+            ttl=120,
+        )
+        await records_service.put_record(client, body)
+
+        put_call = client.put.await_args
+        meta = put_call.kwargs.get("meta")
+        # WriteMeta is a TypedDict, so isinstance() does not work. The shape
+        # is enforced at the typing layer; at runtime it is a plain dict.
+        assert meta is not None
+        assert meta["ttl"] == 120
+
+    async def test_no_ttl_means_no_meta(self):
+        client = AsyncMock()
+        client.put = AsyncMock(return_value=None)
+        client.get = AsyncMock(return_value=_make_record())
+
+        body = RecordWriteRequest(
+            key=RecordKey(namespace="test", set="demo", pk="k1"),
+            bins={"a": 1},
+        )
+        await records_service.put_record(client, body)
+
+        put_call = client.put.await_args
+        assert put_call.kwargs.get("meta") is None
+
+    async def test_missing_namespace_raises(self):
+        client = AsyncMock()
+        # Build the request manually — RecordKey enforces ns min_length=1 so
+        # we can't construct one with empty namespace via the model. Use a
+        # raw dict-build path.
+        body = RecordWriteRequest.model_construct(
+            key=RecordKey.model_construct(namespace="", set="demo", pk="k1"),
+            bins={"a": 1},
+        )
+        with pytest.raises(ValueError):
+            await records_service.put_record(client, body)
+
+    async def test_missing_set_raises(self):
+        client = AsyncMock()
+        body = RecordWriteRequest.model_construct(
+            key=RecordKey.model_construct(namespace="test", set="", pk="k1"),
+            bins={"a": 1},
+        )
+        with pytest.raises(ValueError):
+            await records_service.put_record(client, body)
+
+    async def test_missing_pk_raises(self):
+        client = AsyncMock()
+        body = RecordWriteRequest.model_construct(
+            key=RecordKey.model_construct(namespace="test", set="demo", pk=""),
+            bins={"a": 1},
+        )
+        with pytest.raises(ValueError):
+            await records_service.put_record(client, body)
+
+
+# ---------------------------------------------------------------------------
+# list_records (scan with limit)
+# ---------------------------------------------------------------------------
+
+
+class TestListRecords:
+    async def test_returns_records_with_total_and_pagesize(self):
+        recs = [_make_record(key=("test", "demo", f"k{i}", b"\x00")) for i in range(3)]
+        client, _query = _build_query_mock(recs)
+        # info_all is used to compute set object count via _get_set_object_count
+        # In the bare default (returning []) it falls through to 0.
+
+        result = await records_service.list_records(client, "test", "demo", page_size=25)
+
+        assert len(result.records) == 3
+        assert result.page_size == 25
+        # Empty info_all → set total resolves to 0; hasMore is therefore False.
+        assert result.total == 0
+        assert result.has_more is False
+
+    async def test_query_failure_returns_empty_page_not_raising(self):
+        client, query = _build_query_mock()
+        # Simulate aerospike_py raising on the underlying scan
+        query.results = AsyncMock(side_effect=AerospikeError("empty namespace"))
+
+        result = await records_service.list_records(client, "test", "demo", page_size=25)
+
+        assert result.records == []
+        assert result.has_more is False
+
+    async def test_max_records_capped_to_pagesize(self):
+        client, query = _build_query_mock()
+        await records_service.list_records(client, "test", "demo", page_size=5)
+        # results() invoked with a policy whose max_records is at most page_size.
+        call = query.results.await_args
+        policy = call.args[0]
+        assert "max_records" in policy
+        assert policy["max_records"] <= 5
+
+    async def test_uses_policy_query_base(self):
+        client, query = _build_query_mock()
+        await records_service.list_records(client, "test", "demo", page_size=10)
+        call = query.results.await_args
+        policy = call.args[0]
+        # The base POLICY_QUERY keys leak into the merged policy
+        for k, v in POLICY_QUERY.items():
+            assert policy[k] == v
+
+
+# ---------------------------------------------------------------------------
+# filter_records (PK exact / prefix / regex + bin filters)
+# ---------------------------------------------------------------------------
+
+
+class TestFilterRecords:
+    async def test_exact_mode_short_circuits_to_get(self):
+        client, _query = _build_query_mock()
+        rec = _make_record(key=("test", "demo", "k1", b"\x00"))
+        client.get = AsyncMock(return_value=rec)
+
+        body = FilteredQueryRequest(namespace="test", set="demo", pkPattern="k1", pkMatchMode="exact")
+        result = await records_service.filter_records(client, body)
+
+        assert len(result.records) == 1
+        assert result.records[0] is rec
+        client.get.assert_awaited_once()
+        # Scan path NOT taken
+        client.query.assert_not_called()
+
+    async def test_exact_mode_pk_not_found_returns_empty_page(self):
+        client, _query = _build_query_mock()
+        client.get = AsyncMock(side_effect=RecordNotFound("nope"))
+
+        body = FilteredQueryRequest(namespace="test", set="demo", pkPattern="k1", pkMatchMode="exact")
+        result = await records_service.filter_records(client, body)
+
+        assert result.records == []
+        assert result.has_more is False
+
+    async def test_prefix_mode_uses_pk_filter_expression(self):
+        client, query = _build_query_mock()
+
+        body = FilteredQueryRequest(namespace="test", set="demo", pkPattern="user_", pkMatchMode="prefix")
+        await records_service.filter_records(client, body)
+
+        client.query.assert_called_once_with("test", "demo")
+        call = query.results.await_args
+        policy = call.args[0]
+        assert "filter_expression" in policy
+        assert policy["filter_expression"] == build_pk_filter_expression("user_", "prefix")
+
+    async def test_regex_mode_combines_with_bin_filter_via_and(self):
+        client, query = _build_query_mock()
+
+        body = FilteredQueryRequest(
+            namespace="test",
+            set="demo",
+            pkPattern="^acct[0-9]+$",
+            pkMatchMode="regex",
+            filters=FilterGroup(
+                logic="and",
+                conditions=[
+                    FilterCondition(
+                        bin="score",
+                        operator=FilterOperator.GT,
+                        value=100,
+                        binType=BinDataType.INTEGER,
+                    )
+                ],
+            ),
+        )
+        await records_service.filter_records(client, body)
+
+        call = query.results.await_args
+        policy = call.args[0]
+        pk_part = build_pk_filter_expression("^acct[0-9]+$", "regex")
+        bin_part = exp.gt(exp.int_bin("score"), exp.int_val(100))
+        assert policy["filter_expression"] == exp.and_(pk_part, bin_part)
+
+    async def test_pk_lookup_without_set_raises(self):
+        client = AsyncMock()
+        body = FilteredQueryRequest(namespace="test", pkPattern="k1", pkMatchMode="exact")
+        with pytest.raises(SetRequiredForPkLookup):
+            await records_service.filter_records(client, body)
+
+    async def test_invalid_regex_raises_invalid_pk_pattern(self):
+        client, _query = _build_query_mock()
+        body = FilteredQueryRequest(namespace="test", set="demo", pkPattern="[unclosed", pkMatchMode="regex")
+        with pytest.raises(InvalidPkPattern):
+            await records_service.filter_records(client, body)
+
+    async def test_query_failure_returns_empty_page(self):
+        client, query = _build_query_mock()
+        query.results = AsyncMock(side_effect=AerospikeError("empty"))
+
+        body = FilteredQueryRequest(namespace="test", set="demo")
+        result = await records_service.filter_records(client, body)
+
+        assert result.records == []
+        assert result.has_more is False
+
+    async def test_hasMore_true_when_results_equal_pagesize_plus_one(self):
+        recs = [_make_record(key=("test", "demo", f"k{i}", b"\x00"), bins={"score": i}) for i in range(6)]
+        client, _query = _build_query_mock(recs)
+
+        body = FilteredQueryRequest(namespace="test", set="demo", pageSize=5, pkPattern="k", pkMatchMode="prefix")
+        result = await records_service.filter_records(client, body)
+
+        assert result.has_more is True
+        assert result.returned_records == 5
+        assert len(result.records) == 5
+
+    async def test_pure_bin_filter_runs_scan_with_bin_expression_only(self):
+        client, query = _build_query_mock()
+        body = FilteredQueryRequest(
+            namespace="test",
+            set="demo",
+            filters=FilterGroup(
+                logic="and",
+                conditions=[
+                    FilterCondition(
+                        bin="score",
+                        operator=FilterOperator.GT,
+                        value=1,
+                        binType=BinDataType.INTEGER,
+                    )
+                ],
+            ),
+        )
+        await records_service.filter_records(client, body)
+
+        client.get.assert_not_called() if hasattr(client, "get") else None
+        client.query.assert_called_once_with("test", "demo")
+        call = query.results.await_args
+        policy = call.args[0]
+        # Only the bin filter, no PK component.
+        assert policy["filter_expression"] == exp.gt(exp.int_bin("score"), exp.int_val(1))
+
+
+# ---------------------------------------------------------------------------
+# Domain exception construction
+# ---------------------------------------------------------------------------
+
+
+class TestDomainExceptions:
+    def test_invalid_pk_pattern_is_value_error(self):
+        exc = InvalidPkPattern("bad regex")
+        assert isinstance(exc, ValueError)
+        assert "bad regex" in str(exc)
+
+    def test_set_required_for_pk_lookup_is_value_error(self):
+        exc = SetRequiredForPkLookup()
+        assert isinstance(exc, ValueError)
+
+    def test_primary_key_missing_is_value_error(self):
+        exc = PrimaryKeyMissing("namespace")
+        assert isinstance(exc, ValueError)
+
+
+# ---------------------------------------------------------------------------
+# Cross-module guarantees
+# ---------------------------------------------------------------------------
+
+
+class TestServiceModuleHasNoFastAPI:
+    def test_no_fastapi_import(self):
+        import aerospike_cluster_manager_api.services.records_service as mod
+
+        # The service module must not depend on FastAPI shaping.
+        assert "fastapi" not in mod.__dict__
+        # And no fastapi.* names leak through.
+        for attr in dir(mod):
+            value = getattr(mod, attr)
+            module_name = getattr(value, "__module__", "") or ""
+            assert not module_name.startswith("fastapi"), f"{attr} originates in {module_name}"

--- a/api/tests/test_records_service.py
+++ b/api/tests/test_records_service.py
@@ -10,11 +10,12 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import aerospike_py
 import pytest
 from aerospike_py import exp
-from aerospike_py.exception import AerospikeError, RecordNotFound
+from aerospike_py.exception import AerospikeError, RecordExistsError, RecordNotFound
 
-from aerospike_cluster_manager_api.constants import POLICY_QUERY, POLICY_READ
+from aerospike_cluster_manager_api.constants import POLICY_QUERY, POLICY_READ, POLICY_WRITE
 from aerospike_cluster_manager_api.expression_builder import build_pk_filter_expression
 from aerospike_cluster_manager_api.models.query import (
     BinDataType,
@@ -231,6 +232,192 @@ class TestPutRecord:
         )
         with pytest.raises(ValueError):
             await records_service.put_record(client, body)
+
+
+# ---------------------------------------------------------------------------
+# record_exists
+# ---------------------------------------------------------------------------
+
+
+class TestRecordExists:
+    async def test_returns_true_when_meta_present(self):
+        client = AsyncMock()
+        client.exists = AsyncMock(
+            return_value=SimpleNamespace(key=("test", "demo", "k1", b"\x00"), meta=SimpleNamespace(gen=1, ttl=0))
+        )
+
+        result = await records_service.record_exists(client, "test", "demo", "k1", "string")
+
+        assert result is True
+        client.exists.assert_awaited_once_with(("test", "demo", "k1"), policy=POLICY_READ)
+
+    async def test_returns_false_when_meta_is_none(self):
+        client = AsyncMock()
+        client.exists = AsyncMock(return_value=SimpleNamespace(key=("test", "demo", "k1", b"\x00"), meta=None))
+
+        result = await records_service.record_exists(client, "test", "demo", "missing", "string")
+
+        assert result is False
+
+    async def test_auto_resolves_numeric_string_to_int(self):
+        client = AsyncMock()
+        client.exists = AsyncMock(return_value=SimpleNamespace(key=("test", "demo", 42, b"\x00"), meta=None))
+
+        await records_service.record_exists(client, "test", "demo", "42", "auto")
+
+        # auto: "42" -> int 42
+        client.exists.assert_awaited_once_with(("test", "demo", 42), policy=POLICY_READ)
+
+    async def test_record_not_found_treated_as_false(self):
+        # Some aerospike-py builds may raise RecordNotFound rather than
+        # returning meta=None for a missing record. The service treats both
+        # signals as "absent" so the MCP tool can answer with exists=False.
+        client = AsyncMock()
+        client.exists = AsyncMock(side_effect=RecordNotFound("nope"))
+
+        result = await records_service.record_exists(client, "test", "demo", "missing", "string")
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# create_record (CREATE_ONLY policy)
+# ---------------------------------------------------------------------------
+
+
+class TestCreateRecord:
+    async def test_writes_with_create_only_policy(self):
+        client = AsyncMock()
+        client.put = AsyncMock(return_value=None)
+
+        await records_service.create_record(client, "test", "demo", "k1", {"name": "Alice"}, "string")
+
+        client.put.assert_awaited_once()
+        put_call = client.put.await_args
+        # key tuple
+        assert put_call.args[0] == ("test", "demo", "k1")
+        # bins
+        assert put_call.args[1] == {"name": "Alice"}
+        # policy carries CREATE_ONLY
+        policy = put_call.kwargs.get("policy") or {}
+        assert policy.get("exists") == aerospike_py.POLICY_EXISTS_CREATE_ONLY
+        # base read/write policy keys are still applied
+        for k, v in POLICY_WRITE.items():
+            assert policy[k] == v
+
+    async def test_auto_resolves_numeric_string_to_int(self):
+        client = AsyncMock()
+        client.put = AsyncMock(return_value=None)
+
+        await records_service.create_record(client, "test", "demo", "42", {"a": 1}, "auto")
+
+        put_call = client.put.await_args
+        assert put_call.args[0] == ("test", "demo", 42)
+
+    async def test_record_exists_propagates(self):
+        client = AsyncMock()
+        client.put = AsyncMock(side_effect=RecordExistsError("already exists"))
+
+        with pytest.raises(RecordExistsError):
+            await records_service.create_record(client, "test", "demo", "k1", {"a": 1}, "string")
+
+
+# ---------------------------------------------------------------------------
+# update_record (UPDATE policy — must exist)
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateRecord:
+    async def test_writes_with_update_only_policy(self):
+        client = AsyncMock()
+        client.put = AsyncMock(return_value=None)
+
+        await records_service.update_record(client, "test", "demo", "k1", {"name": "Bob"}, "string")
+
+        client.put.assert_awaited_once()
+        put_call = client.put.await_args
+        assert put_call.args[0] == ("test", "demo", "k1")
+        assert put_call.args[1] == {"name": "Bob"}
+        policy = put_call.kwargs.get("policy") or {}
+        # UPDATE_ONLY guarantees the record must already exist; UPDATE alone
+        # would create it.
+        assert policy.get("exists") == aerospike_py.POLICY_EXISTS_UPDATE_ONLY
+        for k, v in POLICY_WRITE.items():
+            assert policy[k] == v
+
+    async def test_auto_resolves_numeric_string_to_int(self):
+        client = AsyncMock()
+        client.put = AsyncMock(return_value=None)
+
+        await records_service.update_record(client, "test", "demo", "42", {"a": 1}, "auto")
+
+        put_call = client.put.await_args
+        assert put_call.args[0] == ("test", "demo", 42)
+
+    async def test_record_not_found_propagates(self):
+        client = AsyncMock()
+        client.put = AsyncMock(side_effect=RecordNotFound("absent"))
+
+        with pytest.raises(RecordNotFound):
+            await records_service.update_record(client, "test", "demo", "missing", {"a": 1}, "string")
+
+
+# ---------------------------------------------------------------------------
+# delete_bin
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteBin:
+    async def test_calls_remove_bin(self):
+        client = AsyncMock()
+        client.remove_bin = AsyncMock(return_value=None)
+
+        await records_service.delete_bin(client, "test", "demo", "k1", "old_bin", "string")
+
+        client.remove_bin.assert_awaited_once()
+        call = client.remove_bin.await_args
+        assert call.args[0] == ("test", "demo", "k1")
+        # The bin name list is passed through.
+        assert call.args[1] == ["old_bin"]
+
+    async def test_auto_resolves_numeric_string_to_int(self):
+        client = AsyncMock()
+        client.remove_bin = AsyncMock(return_value=None)
+
+        await records_service.delete_bin(client, "test", "demo", "42", "x", "auto")
+
+        call = client.remove_bin.await_args
+        assert call.args[0] == ("test", "demo", 42)
+
+    async def test_record_not_found_propagates(self):
+        client = AsyncMock()
+        client.remove_bin = AsyncMock(side_effect=RecordNotFound("nope"))
+
+        with pytest.raises(RecordNotFound):
+            await records_service.delete_bin(client, "test", "demo", "missing", "x", "string")
+
+
+# ---------------------------------------------------------------------------
+# truncate_set
+# ---------------------------------------------------------------------------
+
+
+class TestTruncateSet:
+    async def test_calls_client_truncate_with_zero_when_no_lut(self):
+        client = AsyncMock()
+        client.truncate = AsyncMock(return_value=None)
+
+        await records_service.truncate_set(client, "test", "demo")
+
+        client.truncate.assert_awaited_once_with("test", "demo", 0)
+
+    async def test_passes_before_lut_in_nanos(self):
+        client = AsyncMock()
+        client.truncate = AsyncMock(return_value=None)
+
+        await records_service.truncate_set(client, "test", "demo", before_lut=1_700_000_000_000_000_000)
+
+        client.truncate.assert_awaited_once_with("test", "demo", 1_700_000_000_000_000_000)
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/test_records_service.py
+++ b/api/tests/test_records_service.py
@@ -212,7 +212,7 @@ class TestPutRecord:
             key=RecordKey.model_construct(namespace="", set="demo", pk="k1"),
             bins={"a": 1},
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(PrimaryKeyMissing):
             await records_service.put_record(client, body)
 
     async def test_missing_set_raises(self):
@@ -221,7 +221,7 @@ class TestPutRecord:
             key=RecordKey.model_construct(namespace="test", set="", pk="k1"),
             bins={"a": 1},
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(PrimaryKeyMissing):
             await records_service.put_record(client, body)
 
     async def test_missing_pk_raises(self):
@@ -230,7 +230,7 @@ class TestPutRecord:
             key=RecordKey.model_construct(namespace="test", set="demo", pk=""),
             bins={"a": 1},
         )
-        with pytest.raises(ValueError):
+        with pytest.raises(PrimaryKeyMissing):
             await records_service.put_record(client, body)
 
 
@@ -591,7 +591,7 @@ class TestFilterRecords:
         )
         await records_service.filter_records(client, body)
 
-        client.get.assert_not_called() if hasattr(client, "get") else None
+        client.get.assert_not_called()
         client.query.assert_called_once_with("test", "demo")
         call = query.results.await_args
         policy = call.args[0]

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -22,6 +22,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "kubernetes" },
+    { name = "mcp" },
     { name = "opentelemetry-api" },
     { name = "opentelemetry-exporter-otlp" },
     { name = "opentelemetry-instrumentation-asyncpg" },
@@ -56,6 +57,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "kubernetes", specifier = ">=31.0.0" },
+    { name = "mcp", specifier = ">=1.0,<2" },
     { name = "opentelemetry-api", specifier = ">=1.30.0" },
     { name = "opentelemetry-exporter-otlp", specifier = ">=1.30.0" },
     { name = "opentelemetry-instrumentation-asyncpg", specifier = ">=0.51b0" },
@@ -184,6 +186,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
     { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
     { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
 ]
 
 [[package]]
@@ -590,6 +601,15 @@ wheels = [
 ]
 
 [[package]]
+name = "httpx-sse"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -629,6 +649,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
@@ -715,6 +762,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
     { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
     { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "mcp"
+version = "1.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpx" },
+    { name = "httpx-sse" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "sse-starlette" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
 ]
 
 [[package]]
@@ -1051,12 +1123,40 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/98/c8345dccdc31de4228c039a98f6467a941e39558da41c1744fbe29fa5666/pydantic_settings-2.14.0.tar.gz", hash = "sha256:24285fd4b0e0c06507dd9fdfd331ee23794305352aaec8fc4eb92d4047aeb67d", size = 235709, upload-time = "2026-04-20T13:37:40.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/dd/bebff3040138f00ae8a102d426b27349b9a49acc310fcae7f92112d867e3/pydantic_settings-2.14.0-py3-none-any.whl", hash = "sha256:fc8d5d692eb7092e43c8647c1c35a3ecd00e040fcf02ed86f4cb5458ca62182e", size = 60940, upload-time = "2026-04-20T13:37:38.586Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -1164,6 +1264,15 @@ wheels = [
 ]
 
 [[package]]
+name = "python-multipart"
+version = "0.0.27"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
+]
+
+[[package]]
 name = "pywin32"
 version = "311"
 source = { registry = "https://pypi.org/simple" }
@@ -1213,6 +1322,19 @@ wheels = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.32.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1238,6 +1360,72 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds an MCP (Model Context Protocol) server mounted in-process at `/mcp` on the existing FastAPI app, exposing **21 tools** that share business logic with the REST API via a new `services/` layer.

Companion plugin PR: aerospike-ce-ecosystem/aerospike-ce-ecosystem-plugins#19

### Architecture

- **In-process mount**: `/mcp` via `app.mount(...)` on the same FastAPI app — shares OIDC, OTel, lifespan, `client_manager`, DB.
- **Transport**: Streamable HTTP (mcp 1.27 SDK, `mcp.server.fastmcp.FastMCP`).
- **Service layer extraction**: `services/{connections,clusters,records,query}_service.py` is the new shared seam between routers and MCP tools — single source of truth, no HTTP self-calls.
- **Feature-flagged**: `ACM_MCP_ENABLED=false` by default; mount and middleware install only when on.

### Tools (21)

| Category | Tools |
|----------|-------|
| Connection (8) | create_connection, get_connection, update_connection, delete_connection, list_connections, connect, disconnect, test_connection |
| Cluster info (3) | list_namespaces, list_sets, get_nodes |
| Record (7) | get_record, record_exists, create_record, update_record, delete_record, delete_bin, truncate_set |
| Query (1) | query |
| Info (2) | execute_info, execute_info_on_node |

### Access profile

`ACM_MCP_ACCESS_PROFILE=read_only` (default) blocks the 10 mutation tools at call time with `code="access_denied"`. Tools remain visible — clients see the rejection only when invoking a write. Set to `full` to allow mutations.

### Auth

The `/mcp` mount inherits the existing OIDC middleware. Optionally set `ACM_MCP_TOKEN` for an OR-combined bearer-token gate (useful for headless agents that cannot run the OAuth Authorization Code flow).

### Testing

- 700+ tests passing (was ~399 baseline; new suite under `tests/mcp/`).
- New tests: registry, access profile, auth, serializers, errors, e2e, e2e_readonly, plus per-category tool tests.
- Existing router tests untouched and still green — service layer extraction is purely additive.

## Test plan

- [x] uv run pytest tests/ -v — green
- [x] uv run ruff check src --fix && uv run ruff format src — clean
- [x] uv run pyright — clean on changed files
- [x] In-process MCP probe: await build_mcp_app().list_tools() returns 21 entries
- [x] ACM_MCP_ENABLED=false (default) → /mcp returns 404
- [x] ACM_MCP_ENABLED=true → mount succeeds and initialize works
- [x] ACM_MCP_ACCESS_PROFILE=read_only blocks mutation tools with access_denied
- [x] Live kind cluster + ACKO + cluster-manager Helm: 21 tools listed via initialize, read_only enforcement verified, claude mcp add registers and connects

## Out of scope (Phase 2)

- ACKO/K8s tools (list_k8s_clusters, get_pods, get_events, scale_cluster, etc.) — agent currently uses kubectl fallback.
- Federation gateway pattern.
- Workspace-aware tool routing.