### PR TITLE
feat(api): execute_info_read_only with verb whitelist

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,7 +960,7 @@ claude plugin install aerospike-ce-ecosystem
 
 ## MCP Server
 
-Cluster Manager can expose itself as a [Model Context Protocol](https://modelcontextprotocol.io/) server (21 tools) so Claude Code plugins and external MCP-aware AI clients (Claude Desktop, Cursor) can read and operate clusters directly.
+Cluster Manager can expose itself as a [Model Context Protocol](https://modelcontextprotocol.io/) server (22 tools) so Claude Code plugins and external MCP-aware AI clients (Claude Desktop, Cursor) can read and operate clusters directly.
 
 ### Enable
 
@@ -983,7 +983,7 @@ claude mcp add --transport http aerospike-local \
 
 Or run the `acm-mcp-init` skill from the ecosystem plugin to register one or more endpoints (multi-cluster ACKO friendly).
 
-### Tools (21)
+### Tools (22)
 
 | Category | Tools |
 |----------|-------|
@@ -991,11 +991,11 @@ Or run the `acm-mcp-init` skill from the ecosystem plugin to register one or mor
 | Cluster info (3) | `list_namespaces`, `list_sets`, `get_nodes` |
 | Record (7) | `get_record`, `record_exists`, `create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set` |
 | Query (1) | `query` |
-| Info (2) | `execute_info`, `execute_info_on_node` |
+| Info (3) | `execute_info`, `execute_info_on_node`, `execute_info_read_only` |
 
 ### Access profile
 
-`ACM_MCP_ACCESS_PROFILE=read_only` (default) blocks the 10 mutation tools (`create_*`, `update_*`, `delete_*`, `truncate_set`, `execute_info*`) at call time with `code="access_denied"`. Tools remain visible — clients see the rejection only when they invoke a write. Set to `full` to allow everything.
+`ACM_MCP_ACCESS_PROFILE=read_only` (default) blocks the 10 mutation tools (`create_connection`, `update_connection`, `delete_connection`, `create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set`, `execute_info`, `execute_info_on_node`) at call time with `code="access_denied"`. Tools remain visible — clients see the rejection only when they invoke a write. Set to `full` to allow everything. `execute_info_read_only` is the read-only counterpart to `execute_info` and is **not** blocked under `read_only`; it enforces a verb whitelist server-side and returns `code="invalid_argument"` for verbs that aren't on the safe list.
 
 ### Auth
 

--- a/api/src/aerospike_cluster_manager_api/info_verbs.py
+++ b/api/src/aerospike_cluster_manager_api/info_verbs.py
@@ -8,8 +8,10 @@ needs to inspect the *verb* (the leading token of the command).
 
 This module is the single source of truth for that decision. It lives at
 the package root so the service layer can import it without reaching back
-into ``mcp/``; the service raises :class:`InfoVerbNotAllowed`, the MCP
-error mapper at :mod:`mcp.errors` translates it to ``code=invalid_argument``.
+into ``mcp/``. The service raises :class:`InfoVerbNotAllowed`. The MCP
+error mapper at :mod:`mcp.errors` translates it to ``code=invalid_argument``
+so the LLM sees a "pick a different verb" signal rather than a permission
+denial.
 
 To add a verb:
 
@@ -18,6 +20,10 @@ To add a verb:
    counter mutation beyond standard read paths).
 2. Add it to :data:`READ_ONLY_INFO_VERBS` below in the matching category.
 3. Add a unit test in ``tests/test_info_verbs.py`` so future drift is caught.
+4. Update the literal-equality pin in
+   ``tests/test_info_verbs.py::test_whitelist_membership_is_pinned`` —
+   that pin exists so silent ADDITIONS are caught at review time, not
+   just silent removals.
 """
 
 from __future__ import annotations
@@ -41,23 +47,27 @@ READ_ONLY_INFO_VERBS: frozenset[str] = frozenset(
         "cluster-info",
         "health-outliers",
         "health-stats",
-        # Namespace / set / index (5)
+        # Namespace / set / index (4)
         "namespaces",
         "namespace",
         "sets",
-        "bins",
         "sindex",
         # Stats (3)
         "statistics",
         "latencies",
         "udf-list",
-        # Strong-consistency / rack / XDR (4)
+        # Strong-consistency / rack (2)
         "roster",
         "racks",
-        "xdr-dc",
-        "dc",
     }
 )
+
+
+# Curated hint verbs surfaced in error messages — the high-signal diagnostic
+# reads operators actually want. Hand-picked rather than ``sorted()[:5]``,
+# which would surface ``build-*`` triplicates that don't help the LLM pick a
+# useful alternative.
+_HINT_VERBS: tuple[str, ...] = ("namespaces", "version", "nodes", "statistics", "latencies")
 
 
 class InfoVerbNotAllowed(ValueError):
@@ -70,15 +80,20 @@ class InfoVerbNotAllowed(ValueError):
     """
 
     def __init__(self, verb: str) -> None:
-        # Five-verb hint keeps the wire message short; the full list lives
-        # in the tool docstring and the MCP JSON schema description.
-        sample = ", ".join(sorted(READ_ONLY_INFO_VERBS)[:5])
+        sample = ", ".join(_HINT_VERBS)
         super().__init__(
             f"Verb {verb!r} is not on the read-only asinfo whitelist; "
-            f"pick from: {sample}, ... or use execute_info under "
-            f"ACM_MCP_ACCESS_PROFILE=full."
+            f"pick from: {sample} (full list at info_verbs.READ_ONLY_INFO_VERBS), "
+            f"or use execute_info under ACM_MCP_ACCESS_PROFILE=full."
         )
         self.verb = verb
+
+
+# asinfo wire format treats any of these as "verb stops here". Embedding any
+# of them in a single command frame is unusual but legitimate (`namespaces;`
+# is canonical when piping multiple commands), so we normalise the head
+# rather than rejecting the whole command outright.
+_VERB_TERMINATORS: tuple[str, ...] = (":", "/", ";", "\n", " ", "\t")
 
 
 def extract_verb(command: str) -> str:
@@ -86,15 +101,17 @@ def extract_verb(command: str) -> str:
 
     asinfo commands take three syntactic shapes:
 
-    * bare verb — ``"namespaces"``
+    * bare verb — ``"namespaces"`` or ``"namespaces;"`` (trailing ``;``
+      is the canonical form when piping multiple commands)
     * path-style — ``"sets/test/myset"`` (verb followed by ``/``-separated args)
     * colon-style — ``"roster:namespace=test"`` (verb followed by ``:`` and
       ``;``-separated key=value args)
 
-    We split on the *first* ``:`` then on the *first* ``/`` so both styles
-    yield the verb in the head position. Whitespace is trimmed; an empty
-    or whitespace-only command raises :class:`InfoVerbNotAllowed` with an
-    empty verb so the caller surfaces a sensible error.
+    The verb is everything up to the first occurrence of any character in
+    :data:`_VERB_TERMINATORS` (``:``, ``/``, ``;``, ``\\n``, space, tab).
+    Whitespace is trimmed first; an empty or whitespace-only command
+    raises :class:`InfoVerbNotAllowed` with an empty verb so the caller
+    surfaces a sensible error.
 
     Note: case-sensitive — asinfo itself is case-sensitive
     (``Namespaces`` is not the same verb as ``namespaces``).
@@ -102,15 +119,21 @@ def extract_verb(command: str) -> str:
     cmd = command.strip()
     if not cmd:
         raise InfoVerbNotAllowed("")
-    return cmd.split(":", 1)[0].split("/", 1)[0]
+    head = cmd
+    for sep in _VERB_TERMINATORS:
+        head = head.split(sep, 1)[0]
+    return head
 
 
-def assert_read_only(command: str) -> None:
-    """Raise :class:`InfoVerbNotAllowed` if ``command``'s verb is not whitelisted.
+def assert_read_only(command: str) -> str:
+    """Validate ``command`` against the read-only whitelist.
 
-    Returns ``None`` on success — callers should run the command immediately
-    after this returns.
+    Returns the parsed verb on success — callers can use it for telemetry
+    (OTel span attributes, structured log fields). Raises
+    :class:`InfoVerbNotAllowed` if the verb is not whitelisted; raises
+    immediately, so no wire round-trip happens for a rejected command.
     """
     verb = extract_verb(command)
     if verb not in READ_ONLY_INFO_VERBS:
         raise InfoVerbNotAllowed(verb)
+    return verb

--- a/api/src/aerospike_cluster_manager_api/info_verbs.py
+++ b/api/src/aerospike_cluster_manager_api/info_verbs.py
@@ -1,0 +1,116 @@
+"""Read-only asinfo verb whitelist for ``ACM_MCP_ACCESS_PROFILE=read_only``.
+
+The Aerospike asinfo protocol multiplexes both reads (``namespaces``,
+``version``, ``roster:``, ...) and writes (``set-config:``, ``recluster:``,
+``truncate-namespace:``) over the same wire format. The MCP read-only
+profile therefore cannot decide a tool's safety from its name alone — it
+needs to inspect the *verb* (the leading token of the command).
+
+This module is the single source of truth for that decision. It lives at
+the package root so the service layer can import it without reaching back
+into ``mcp/``; the service raises :class:`InfoVerbNotAllowed`, the MCP
+error mapper at :mod:`mcp.errors` translates it to ``code=invalid_argument``.
+
+To add a verb:
+
+1. Verify in the Aerospike CE 8.1 docs that the verb is purely read-only
+   and triggers no persistent state change (no log dump, no metric
+   counter mutation beyond standard read paths).
+2. Add it to :data:`READ_ONLY_INFO_VERBS` below in the matching category.
+3. Add a unit test in ``tests/test_info_verbs.py`` so future drift is caught.
+"""
+
+from __future__ import annotations
+
+READ_ONLY_INFO_VERBS: frozenset[str] = frozenset(
+    {
+        # Cluster meta (8)
+        "version",
+        "build",
+        "build-os",
+        "build-time",
+        "node",
+        "service",
+        "services",
+        "services-alumni",
+        # Cluster topology / health (7)
+        "nodes",
+        "cluster-name",
+        "cluster-stable",
+        "cluster-generation",
+        "cluster-info",
+        "health-outliers",
+        "health-stats",
+        # Namespace / set / index (5)
+        "namespaces",
+        "namespace",
+        "sets",
+        "bins",
+        "sindex",
+        # Stats (3)
+        "statistics",
+        "latencies",
+        "udf-list",
+        # Strong-consistency / rack / XDR (4)
+        "roster",
+        "racks",
+        "xdr-dc",
+        "dc",
+    }
+)
+
+
+class InfoVerbNotAllowed(ValueError):
+    """Raised when an asinfo command's leading verb is not on the read-only allowlist.
+
+    The MCP error mapper translates this to
+    :class:`mcp.errors.MCPToolError` with ``code="invalid_argument"`` so
+    LLM clients receive a "pick a different verb" signal rather than a
+    permission denial.
+    """
+
+    def __init__(self, verb: str) -> None:
+        # Five-verb hint keeps the wire message short; the full list lives
+        # in the tool docstring and the MCP JSON schema description.
+        sample = ", ".join(sorted(READ_ONLY_INFO_VERBS)[:5])
+        super().__init__(
+            f"Verb {verb!r} is not on the read-only asinfo whitelist; "
+            f"pick from: {sample}, ... or use execute_info under "
+            f"ACM_MCP_ACCESS_PROFILE=full."
+        )
+        self.verb = verb
+
+
+def extract_verb(command: str) -> str:
+    """Return the leading verb of an asinfo command.
+
+    asinfo commands take three syntactic shapes:
+
+    * bare verb — ``"namespaces"``
+    * path-style — ``"sets/test/myset"`` (verb followed by ``/``-separated args)
+    * colon-style — ``"roster:namespace=test"`` (verb followed by ``:`` and
+      ``;``-separated key=value args)
+
+    We split on the *first* ``:`` then on the *first* ``/`` so both styles
+    yield the verb in the head position. Whitespace is trimmed; an empty
+    or whitespace-only command raises :class:`InfoVerbNotAllowed` with an
+    empty verb so the caller surfaces a sensible error.
+
+    Note: case-sensitive — asinfo itself is case-sensitive
+    (``Namespaces`` is not the same verb as ``namespaces``).
+    """
+    cmd = command.strip()
+    if not cmd:
+        raise InfoVerbNotAllowed("")
+    return cmd.split(":", 1)[0].split("/", 1)[0]
+
+
+def assert_read_only(command: str) -> None:
+    """Raise :class:`InfoVerbNotAllowed` if ``command``'s verb is not whitelisted.
+
+    Returns ``None`` on success — callers should run the command immediately
+    after this returns.
+    """
+    verb = extract_verb(command)
+    if verb not in READ_ONLY_INFO_VERBS:
+        raise InfoVerbNotAllowed(verb)

--- a/api/src/aerospike_cluster_manager_api/mcp/errors.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/errors.py
@@ -30,6 +30,7 @@ from typing import Any
 
 import aerospike_py
 
+from aerospike_cluster_manager_api.info_verbs import InfoVerbNotAllowed
 from aerospike_cluster_manager_api.predicate import UnknownPredicateOperator
 from aerospike_cluster_manager_api.services.clusters_service import (
     NamespaceConfigError,
@@ -129,6 +130,13 @@ def map_aerospike_errors(
         # validation failure on the caller's side. Surfaces as the same
         # ``invalid_argument`` family the SDK reserves for malformed
         # tool arguments.
+        raise MCPToolError(str(e), code="invalid_argument") from e
+    except InfoVerbNotAllowed as e:
+        # Read-only profile attempted an unwhitelisted asinfo verb —
+        # input-validation failure, same wire shape as
+        # UnknownPredicateOperator above. The model should pick a different
+        # verb, not escalate, so ``invalid_argument`` (not ``access_denied``)
+        # is the right signal.
         raise MCPToolError(str(e), code="invalid_argument") from e
     except (
         ConnectionNotFoundError,

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/info_commands.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/info_commands.py
@@ -1,8 +1,12 @@
-"""MCP info command tools — ``execute_info`` and ``execute_info_on_node``.
+"""MCP info command tools.
 
-Both are classified as **mutation** in :mod:`mcp.access_profile` because
-asinfo can change cluster configuration (``set-config``, ``recluster``,
-etc.). Under ``READ_ONLY`` profile they are blocked at call time.
+* ``execute_info`` / ``execute_info_on_node`` — full asinfo surface,
+  classified as **mutation** because asinfo can change cluster config
+  (``set-config``, ``recluster``, ``truncate-namespace``).
+* ``execute_info_read_only`` — single-verb diagnostic reads, callable
+  under ``ACM_MCP_ACCESS_PROFILE=read_only``. The verb whitelist lives
+  in :mod:`info_verbs`; rejected verbs surface as
+  ``code=invalid_argument``.
 """
 
 from __future__ import annotations
@@ -34,12 +38,11 @@ async def execute_info(conn_id: str, command: str) -> dict[str, Any]:
     WARNING: This tool is gated by ``ACM_MCP_ACCESS_PROFILE`` since some
     asinfo commands write (``set-config``, ``recluster``,
     ``truncate-namespace``). Under ``READ_ONLY`` profile this tool returns
-    ``code=access_denied`` for ALL commands — including read-only ones such
-    as ``namespaces``, ``version``, and ``roster:`` — because the access
-    gate operates on tool name, not command content. Use ``list_namespaces``,
-    ``list_sets``, and ``get_nodes`` for safe diagnostic reads under
-    ``READ_ONLY``. A read-only ``execute_info`` whitelist is a Phase 2
-    design item.
+    ``code=access_denied`` for ALL commands — including read-only ones —
+    because the access gate operates on tool name, not command content.
+    For diagnostic reads under READ_ONLY, use ``execute_info_read_only``
+    (whitelisted verbs only) or the dedicated ``list_namespaces`` /
+    ``list_sets`` / ``get_nodes`` tools.
 
     Mutation: requires ``ACM_MCP_ACCESS_PROFILE=full``; returns
     ``code=access_denied`` under READ_ONLY.
@@ -56,12 +59,10 @@ async def execute_info_on_node(conn_id: str, command: str, node_name: str) -> di
     WARNING: This tool is gated by ``ACM_MCP_ACCESS_PROFILE`` since some
     asinfo commands write (``set-config``, ``recluster``,
     ``truncate-namespace``). Under ``READ_ONLY`` profile this tool returns
-    ``code=access_denied`` for ALL commands — including read-only ones such
-    as ``namespaces``, ``version``, and ``roster:`` — because the access
-    gate operates on tool name, not command content. Use ``list_namespaces``,
-    ``list_sets``, and ``get_nodes`` for safe diagnostic reads under
-    ``READ_ONLY``. A read-only ``execute_info`` whitelist is a Phase 2
-    design item.
+    ``code=access_denied`` for ALL commands — including read-only ones —
+    because the access gate operates on tool name, not command content.
+    For per-node diagnostic reads under READ_ONLY, use
+    ``execute_info_read_only(command, node_name=...)``.
 
     Mutation: requires ``ACM_MCP_ACCESS_PROFILE=full``; returns
     ``code=access_denied`` under READ_ONLY.
@@ -69,3 +70,37 @@ async def execute_info_on_node(conn_id: str, command: str, node_name: str) -> di
     client = await _get_client(conn_id)
     response = await clusters_service.execute_info_on_node(client, command, node_name)
     return {"node": node_name, "response": response}
+
+
+@tool(category="info", mutation=False)
+async def execute_info_read_only(
+    conn_id: str,
+    command: str,
+    node_name: str | None = None,
+) -> dict[str, str]:
+    """Run a whitelisted read-only asinfo command — callable under READ_ONLY profile.
+
+    The leading verb is checked against an explicit allowlist
+    (:mod:`info_verbs.READ_ONLY_INFO_VERBS`); commands whose verb is not
+    on the list (writes, debug dumps, unknown verbs) return
+    ``code=invalid_argument``. Currently allowed verbs:
+    ``namespaces``, ``namespace``, ``sets``, ``bins``, ``sindex``,
+    ``version``, ``build``, ``build-os``, ``build-time``, ``node``,
+    ``service``, ``services``, ``services-alumni``, ``nodes``,
+    ``cluster-name``, ``cluster-stable``, ``cluster-generation``,
+    ``cluster-info``, ``health-outliers``, ``health-stats``,
+    ``statistics``, ``latencies``, ``udf-list``, ``roster``, ``racks``,
+    ``xdr-dc``, ``dc``.
+
+    With ``node_name=None`` (default) the command runs on a random node
+    via ``info_random_node`` — fine for cluster-uniform reads such as
+    ``namespaces`` or ``version``. With an explicit ``node_name`` it fans
+    out via ``info_all`` and filters; raises ``NodeNotFoundError`` if the
+    node didn't respond.
+
+    Returns ``{"node": str, "response": str}``. The ``node`` value is
+    ``"<random>"`` when ``node_name`` was omitted.
+    """
+    client = await _get_client(conn_id)
+    node, response = await clusters_service.execute_info_read_only(client, command, node_name)
+    return {"node": node, "response": response}

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/info_commands.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/info_commands.py
@@ -81,26 +81,35 @@ async def execute_info_read_only(
     """Run a whitelisted read-only asinfo command — callable under READ_ONLY profile.
 
     The leading verb is checked against an explicit allowlist
-    (:mod:`info_verbs.READ_ONLY_INFO_VERBS`); commands whose verb is not
-    on the list (writes, debug dumps, unknown verbs) return
-    ``code=invalid_argument``. Currently allowed verbs:
-    ``namespaces``, ``namespace``, ``sets``, ``bins``, ``sindex``,
-    ``version``, ``build``, ``build-os``, ``build-time``, ``node``,
-    ``service``, ``services``, ``services-alumni``, ``nodes``,
-    ``cluster-name``, ``cluster-stable``, ``cluster-generation``,
-    ``cluster-info``, ``health-outliers``, ``health-stats``,
-    ``statistics``, ``latencies``, ``udf-list``, ``roster``, ``racks``,
-    ``xdr-dc``, ``dc``.
+    (:data:`info_verbs.READ_ONLY_INFO_VERBS` — 24 verbs covering cluster
+    metadata, topology, namespace introspection, statistics/latency, and
+    strong-consistency/rack reads). Verbs outside the allowlist (writes,
+    debug dumps, unknown verbs, XDR commands not available on CE) return
+    ``code=invalid_argument`` along with a hint listing high-signal
+    diagnostic verbs.
 
-    With ``node_name=None`` (default) the command runs on a random node
-    via ``info_random_node`` — fine for cluster-uniform reads such as
-    ``namespaces`` or ``version``. With an explicit ``node_name`` it fans
-    out via ``info_all`` and filters; raises ``NodeNotFoundError`` if the
-    node didn't respond.
+    Common reads exposed via this tool: ``namespaces``, ``version``,
+    ``nodes``, ``statistics``, ``latencies``, ``roster:namespace=<ns>``,
+    ``racks:``, ``sets``, ``sindex``, ``namespace/<ns>``,
+    ``health-outliers``, ``health-stats``.
 
-    Returns ``{"node": str, "response": str}``. The ``node`` value is
-    ``"<random>"`` when ``node_name`` was omitted.
+    With ``node_name=None`` (default) the call fans out via ``info_all``
+    and returns the first non-error response — the ``node`` field of the
+    result is the real cluster node (so a follow-up call can target it).
+    With an explicit ``node_name`` the same fan-out is filtered to that
+    node; ``NodeNotFoundError`` (mapped to a stable error code) surfaces
+    when the node doesn't respond.
+
+    Empty-string ``node_name`` is treated as "no node" (same as
+    ``node_name=None``) so JSON callers that pass ``""`` for unset fields
+    don't trigger a confusing ``NodeNotFoundError("")``.
+
+    Returns ``{"node": str, "response": str}``.
     """
     client = await _get_client(conn_id)
-    node, response = await clusters_service.execute_info_read_only(client, command, node_name)
+    # Coerce the empty-string sentinel that some JSON callers use for
+    # "field not set" — without this, the service would fan out and look
+    # for a node literally named ``""``.
+    effective_node = node_name or None
+    node, response = await clusters_service.execute_info_read_only(client, command, effective_node)
     return {"node": node, "response": response}

--- a/api/src/aerospike_cluster_manager_api/services/clusters_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/clusters_service.py
@@ -223,6 +223,46 @@ async def execute_info_on_node(client: aerospike_py.AsyncClient, command: str, n
     raise NodeNotFoundError(node_name)
 
 
+async def execute_info_read_only(
+    client: aerospike_py.AsyncClient,
+    command: str,
+    node_name: str | None = None,
+) -> tuple[str, str]:
+    """Run a whitelisted read-only asinfo command.
+
+    Validates the verb against :data:`info_verbs.READ_ONLY_INFO_VERBS`
+    *before* hitting the wire — a bad verb raises
+    :class:`info_verbs.InfoVerbNotAllowed` (mapped to
+    ``code=invalid_argument`` at the MCP boundary). The whitelist is the
+    single source of truth for what ``ACM_MCP_ACCESS_PROFILE=read_only``
+    can call via ``execute_info_read_only``; mutation tools
+    (``execute_info``, ``execute_info_on_node``) remain unrestricted under
+    ``FULL`` access.
+
+    Returns a ``(node, response)`` tuple. With ``node_name=None`` we hit a
+    random node (cheaper than ``info_all`` for cluster-uniform reads); with
+    an explicit ``node_name`` we fan out via ``info_all`` then filter, and
+    raise :class:`NodeNotFoundError` if the node didn't respond.
+    """
+    # Local import keeps the service-module surface free of MCP-only
+    # symbols at import time; the check is hot-path-irrelevant.
+    from aerospike_cluster_manager_api.info_verbs import assert_read_only
+
+    assert_read_only(command)
+
+    if node_name is None:
+        response = await client.info_random_node(command)
+        return ("<random>", response)
+
+    results = await client.info_all(command)
+    for name, err, resp in results:
+        if name == node_name:
+            if err:
+                raise NodeNotFoundError(node_name)
+            return (name, resp)
+    raise NodeNotFoundError(node_name)
+
+
 # ---------------------------------------------------------------------------
 # Composed read & write
 # ---------------------------------------------------------------------------

--- a/api/src/aerospike_cluster_manager_api/services/clusters_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/clusters_service.py
@@ -45,6 +45,7 @@ from aerospike_cluster_manager_api.info_parser import (
     safe_bool,
     safe_int,
 )
+from aerospike_cluster_manager_api.info_verbs import assert_read_only
 from aerospike_cluster_manager_api.models.cluster import (
     ClusterInfo,
     ClusterNode,
@@ -239,22 +240,22 @@ async def execute_info_read_only(
     (``execute_info``, ``execute_info_on_node``) remain unrestricted under
     ``FULL`` access.
 
-    Returns a ``(node, response)`` tuple. With ``node_name=None`` we hit a
-    random node (cheaper than ``info_all`` for cluster-uniform reads); with
-    an explicit ``node_name`` we fan out via ``info_all`` then filter, and
-    raise :class:`NodeNotFoundError` if the node didn't respond.
+    Returns a ``(node_name, response)`` tuple. With ``node_name=None`` we
+    fan out via ``info_all`` and pick the first node that returned a
+    non-error response — the returned ``node_name`` is the real cluster
+    node, so the LLM can re-issue follow-up calls against it. With an
+    explicit ``node_name`` we filter the same fan-out to the named node
+    and raise :class:`NodeNotFoundError` if it didn't respond.
     """
-    # Local import keeps the service-module surface free of MCP-only
-    # symbols at import time; the check is hot-path-irrelevant.
-    from aerospike_cluster_manager_api.info_verbs import assert_read_only
-
     assert_read_only(command)
+    results = await client.info_all(command)
 
     if node_name is None:
-        response = await client.info_random_node(command)
-        return ("<random>", response)
+        for name, err, resp in results:
+            if not err:
+                return (name, resp)
+        raise NodeNotFoundError("(any)")
 
-    results = await client.info_all(command)
     for name, err, resp in results:
         if name == node_name:
             if err:

--- a/api/tests/mcp/conftest.py
+++ b/api/tests/mcp/conftest.py
@@ -42,8 +42,8 @@ from aerospike_cluster_manager_api.mcp.tools import (  # noqa: F401
 # Tool count constant — replaces the magic number ``21`` everywhere.
 # ---------------------------------------------------------------------------
 
-EXPECTED_TOOL_COUNT: int = 21
-"""Total number of MCP tools registered by Phase 1.
+EXPECTED_TOOL_COUNT: int = 22
+"""Total number of MCP tools registered by Phase 1 + the read-only info follow-up.
 
 Breakdown:
 * 8 connection tools (create, get, update, delete, list, connect, disconnect,
@@ -51,7 +51,7 @@ Breakdown:
 * 3 cluster info (list_namespaces, list_sets, get_nodes)
 * 7 record (get, exists, create, update, delete, delete_bin, truncate_set)
 * 1 query
-* 2 info commands (execute_info, execute_info_on_node)
+* 3 info commands (execute_info, execute_info_on_node, execute_info_read_only)
 """
 
 

--- a/api/tests/mcp/test_auto_discovery.py
+++ b/api/tests/mcp/test_auto_discovery.py
@@ -36,9 +36,10 @@ def test_build_mcp_app_registers_all_phase1_tools() -> None:
     assert "truncate_set" in names
     # 1 query
     assert "query" in names
-    # 2 info commands
+    # 3 info commands
     assert "execute_info" in names
     assert "execute_info_on_node" in names
+    assert "execute_info_read_only" in names
 
     assert len(names) == EXPECTED_TOOL_COUNT, f"expected {EXPECTED_TOOL_COUNT} tools, got {len(names)}: {sorted(names)}"
 

--- a/api/tests/mcp/test_connection_tools.py
+++ b/api/tests/mcp/test_connection_tools.py
@@ -428,7 +428,7 @@ def test_reset_for_tests_helper_clears_connection_tools() -> None:
         assert registered_tools() == []
     finally:
         # Restore the full snapshot — reloading just the connections module
-        # would only repopulate 8 of the 21 tools because the other tool
+        # would only repopulate the 8 connection tools because the other tool
         # modules are already imported (cached) and their decorators do not
         # re-run. Snapshot/restore is symmetrical and order-independent.
         _registry._REGISTRY[:] = saved

--- a/api/tests/mcp/test_e2e_readonly.py
+++ b/api/tests/mcp/test_e2e_readonly.py
@@ -118,3 +118,42 @@ async def test_read_tool_works_under_read_only(read_only_profile: None) -> None:
 
     assert out["key"]["namespace"] == "test"
     assert out["bins"]["name"] == "Alice"
+
+
+async def test_execute_info_read_only_works_under_read_only(read_only_profile: None) -> None:
+    """``execute_info_read_only`` is mutation=False — READ_ONLY callers can
+    invoke it for safe diagnostic reads even though the sibling
+    ``execute_info`` and ``execute_info_on_node`` are blocked. The verb
+    whitelist still applies."""
+    from aerospike_cluster_manager_api.mcp.tools import info_commands as info_tools
+
+    with (
+        patch.object(info_tools.client_manager, "get_client", new=AsyncMock(return_value=object())),
+        patch(
+            "aerospike_cluster_manager_api.mcp.tools.info_commands.clusters_service.execute_info_read_only",
+            new=AsyncMock(return_value=("<random>", "test;bar")),
+        ),
+    ):
+        out = await info_tools.execute_info_read_only(conn_id="x", command="namespaces")
+
+    assert out["node"] == "<random>"
+    assert out["response"] == "test;bar"
+
+
+async def test_execute_info_read_only_unwhitelisted_verb_yields_invalid_argument(
+    read_only_profile: None,
+) -> None:
+    """A write verb in execute_info_read_only goes through the access gate
+    (mutation=False, so it passes), but the service-layer whitelist rejects
+    the verb and surfaces ``invalid_argument`` — distinct from the
+    ``access_denied`` returned by the sibling ``execute_info`` tools."""
+    from aerospike_cluster_manager_api.mcp.tools import info_commands as info_tools
+
+    with (
+        patch.object(info_tools.client_manager, "get_client", new=AsyncMock(return_value=object())),
+        pytest.raises(MCPToolError) as exc_info,
+    ):
+        await info_tools.execute_info_read_only(conn_id="x", command="recluster:")
+
+    assert exc_info.value.code == "invalid_argument"
+    assert "recluster" in str(exc_info.value)

--- a/api/tests/mcp/test_e2e_readonly.py
+++ b/api/tests/mcp/test_e2e_readonly.py
@@ -131,12 +131,13 @@ async def test_execute_info_read_only_works_under_read_only(read_only_profile: N
         patch.object(info_tools.client_manager, "get_client", new=AsyncMock(return_value=object())),
         patch(
             "aerospike_cluster_manager_api.mcp.tools.info_commands.clusters_service.execute_info_read_only",
-            new=AsyncMock(return_value=("<random>", "test;bar")),
+            new=AsyncMock(return_value=("BB9", "test;bar")),
         ),
     ):
         out = await info_tools.execute_info_read_only(conn_id="x", command="namespaces")
 
-    assert out["node"] == "<random>"
+    # Real cluster node name (no <random> sentinel).
+    assert out["node"] == "BB9"
     assert out["response"] == "test;bar"
 
 

--- a/api/tests/mcp/test_errors.py
+++ b/api/tests/mcp/test_errors.py
@@ -131,6 +131,24 @@ def test_map_unknown_predicate_operator_to_invalid_argument() -> None:
     assert isinstance(err.__cause__, UnknownPredicateOperator)
 
 
+def test_map_info_verb_not_allowed_to_invalid_argument() -> None:
+    """``info_verbs.InfoVerbNotAllowed`` shares the same wire family as
+    ``UnknownPredicateOperator`` — the LLM should pick a different verb
+    rather than escalate. ``code="invalid_argument"``, NOT
+    ``access_denied`` (the tool itself is read-only-callable; the verb
+    just isn't on the whitelist).
+    """
+    from aerospike_cluster_manager_api.info_verbs import InfoVerbNotAllowed
+
+    with pytest.raises(MCPToolError) as exc_info, map_aerospike_errors():
+        raise InfoVerbNotAllowed("recluster")
+
+    err = exc_info.value
+    assert err.code == "invalid_argument"
+    assert "recluster" in str(err)
+    assert isinstance(err.__cause__, InfoVerbNotAllowed)
+
+
 # ---------------------------------------------------------------------------
 # map_aerospike_errors — service-layer domain exceptions
 # ---------------------------------------------------------------------------

--- a/api/tests/mcp/test_info_tools.py
+++ b/api/tests/mcp/test_info_tools.py
@@ -32,14 +32,15 @@ def _patch_get_client(client: MagicMock):
     return patch_mcp_client("aerospike_cluster_manager_api.mcp.tools.info_commands", client)
 
 
-def test_info_tools_module_registers_two_tools() -> None:
+def test_info_tools_module_registers_three_tools() -> None:
     from aerospike_cluster_manager_api.mcp.tools import info_commands as _ic  # noqa: F401
 
     names = {e.name for e in registered_tools() if e.category == "info"}
-    assert names == {"execute_info", "execute_info_on_node"}
+    assert names == {"execute_info", "execute_info_on_node", "execute_info_read_only"}
     by_name = {e.name: e for e in registered_tools() if e.category == "info"}
     assert by_name["execute_info"].mutation is True
     assert by_name["execute_info_on_node"].mutation is True
+    assert by_name["execute_info_read_only"].mutation is False
 
 
 class TestExecuteInfo:
@@ -93,3 +94,70 @@ class TestExecuteInfoOnNode:
         with pytest.raises(MCPToolError) as exc_info:
             await execute_info_on_node(conn_id="conn-x", command="version", node_name="BB9")
         assert exc_info.value.code == "access_denied"
+
+
+class TestExecuteInfoReadOnly:
+    async def test_random_node_happy_path(self, read_only_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.info_commands import execute_info_read_only
+
+        mock_client = MagicMock()
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.info_commands.clusters_service.execute_info_read_only",
+                new=AsyncMock(return_value=("<random>", "test;bar")),
+            ),
+        ):
+            out = await execute_info_read_only(conn_id="conn-x", command="namespaces")
+
+        assert out == {"node": "<random>", "response": "test;bar"}
+
+    async def test_specific_node(self, read_only_profile: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools.info_commands import execute_info_read_only
+
+        mock_client = MagicMock()
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.info_commands.clusters_service.execute_info_read_only",
+                new=AsyncMock(return_value=("BB9", "8.1.0.0")),
+            ),
+        ):
+            out = await execute_info_read_only(conn_id="conn-x", command="version", node_name="BB9")
+
+        assert out == {"node": "BB9", "response": "8.1.0.0"}
+
+    async def test_unwhitelisted_verb_blocked_via_invalid_argument(self, read_only_profile: None) -> None:
+        # The whitelist check fires inside the service, raises
+        # InfoVerbNotAllowed, which the MCP error map translates to
+        # ``invalid_argument``. From the tool's perspective we should see
+        # MCPToolError(code="invalid_argument") — NOT access_denied (the
+        # tool itself is read-only-callable; the *verb* is invalid).
+        from aerospike_cluster_manager_api.mcp.tools.info_commands import execute_info_read_only
+
+        mock_client = MagicMock()
+        # We don't patch the service here — the real
+        # clusters_service.execute_info_read_only runs and the verb
+        # check fires before any client call.
+        with _patch_get_client(mock_client), pytest.raises(MCPToolError) as exc_info:
+            await execute_info_read_only(conn_id="conn-x", command="set-config:context=service;migrate-threads=2")
+
+        assert exc_info.value.code == "invalid_argument"
+        assert "set-config" in str(exc_info.value)
+
+    async def test_passes_under_full_profile_too(self, full_profile: None) -> None:
+        # The whitelist still applies under FULL — a malformed verb is
+        # rejected regardless of profile (the tool is read-only by design).
+        from aerospike_cluster_manager_api.mcp.tools.info_commands import execute_info_read_only
+
+        mock_client = MagicMock()
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.info_commands.clusters_service.execute_info_read_only",
+                new=AsyncMock(return_value=("<random>", "test;bar")),
+            ),
+        ):
+            out = await execute_info_read_only(conn_id="conn-x", command="namespaces")
+
+        assert out == {"node": "<random>", "response": "test;bar"}

--- a/api/tests/mcp/test_info_tools.py
+++ b/api/tests/mcp/test_info_tools.py
@@ -97,6 +97,13 @@ class TestExecuteInfoOnNode:
 
 
 class TestExecuteInfoReadOnly:
+    """MCP-tool-layer tests for the read-only asinfo entry point.
+
+    These exercise the wrapper code path: client lookup, empty-string
+    coercion for ``node_name``, service delegation, and end-to-end error
+    code translation via the registry's ``map_aerospike_errors``.
+    """
+
     async def test_random_node_happy_path(self, read_only_profile: None) -> None:
         from aerospike_cluster_manager_api.mcp.tools.info_commands import execute_info_read_only
 
@@ -105,12 +112,13 @@ class TestExecuteInfoReadOnly:
             _patch_get_client(mock_client),
             patch(
                 "aerospike_cluster_manager_api.mcp.tools.info_commands.clusters_service.execute_info_read_only",
-                new=AsyncMock(return_value=("<random>", "test;bar")),
+                new=AsyncMock(return_value=("BB9", "test;bar")),
             ),
         ):
             out = await execute_info_read_only(conn_id="conn-x", command="namespaces")
 
-        assert out == {"node": "<random>", "response": "test;bar"}
+        # Real cluster node name surfaces (no <random> sentinel).
+        assert out == {"node": "BB9", "response": "test;bar"}
 
     async def test_specific_node(self, read_only_profile: None) -> None:
         from aerospike_cluster_manager_api.mcp.tools.info_commands import execute_info_read_only
@@ -126,6 +134,30 @@ class TestExecuteInfoReadOnly:
             out = await execute_info_read_only(conn_id="conn-x", command="version", node_name="BB9")
 
         assert out == {"node": "BB9", "response": "8.1.0.0"}
+
+    async def test_empty_string_node_coerces_to_none(self, read_only_profile: None) -> None:
+        # JSON callers that pass ``""`` for unset fields should get the
+        # random-node behaviour, not a ``NodeNotFoundError("")``. The
+        # tool layer coerces; the service layer must therefore receive
+        # ``None``.
+        from aerospike_cluster_manager_api.mcp.tools.info_commands import execute_info_read_only
+
+        mock_client = MagicMock()
+        service_mock = AsyncMock(return_value=("BB9", "8.1.0.0"))
+        with (
+            _patch_get_client(mock_client),
+            patch(
+                "aerospike_cluster_manager_api.mcp.tools.info_commands.clusters_service.execute_info_read_only",
+                new=service_mock,
+            ),
+        ):
+            await execute_info_read_only(conn_id="conn-x", command="version", node_name="")
+
+        # 3rd positional arg to the service is ``node_name`` — must be None.
+        service_mock.assert_awaited_once()
+        _, args, _ = service_mock.mock_calls[0]
+        # Service is called as ``execute_info_read_only(client, command, effective_node)``
+        assert args[2] is None
 
     async def test_unwhitelisted_verb_blocked_via_invalid_argument(self, read_only_profile: None) -> None:
         # The whitelist check fires inside the service, raises
@@ -145,19 +177,20 @@ class TestExecuteInfoReadOnly:
         assert exc_info.value.code == "invalid_argument"
         assert "set-config" in str(exc_info.value)
 
-    async def test_passes_under_full_profile_too(self, full_profile: None) -> None:
-        # The whitelist still applies under FULL — a malformed verb is
-        # rejected regardless of profile (the tool is read-only by design).
+    async def test_whitelist_still_applies_under_full(self, full_profile: None) -> None:
+        # The whitelist is part of the tool's contract, NOT just a
+        # READ_ONLY-profile gate — under FULL, a write verb on the
+        # read-only tool must still be rejected with invalid_argument
+        # (the tool is read-only by design; FULL just means access-denied
+        # gates don't fire). Service is NOT mocked so the real whitelist
+        # gate executes.
         from aerospike_cluster_manager_api.mcp.tools.info_commands import execute_info_read_only
 
         mock_client = MagicMock()
-        with (
-            _patch_get_client(mock_client),
-            patch(
-                "aerospike_cluster_manager_api.mcp.tools.info_commands.clusters_service.execute_info_read_only",
-                new=AsyncMock(return_value=("<random>", "test;bar")),
-            ),
-        ):
-            out = await execute_info_read_only(conn_id="conn-x", command="namespaces")
+        with _patch_get_client(mock_client), pytest.raises(MCPToolError) as exc_info:
+            await execute_info_read_only(conn_id="conn-x", command="recluster:")
 
-        assert out == {"node": "<random>", "response": "test;bar"}
+        assert exc_info.value.code == "invalid_argument"
+        # Critical: the wire was NOT touched even under FULL.
+        mock_client.info_all.assert_not_called()
+        mock_client.info_random_node.assert_not_called()

--- a/api/tests/test_clusters_service.py
+++ b/api/tests/test_clusters_service.py
@@ -251,31 +251,90 @@ class TestExecuteInfoOnNode:
 
 
 class TestExecuteInfoReadOnly:
-    async def test_random_node_path_uses_info_random_node(self):
-        from aerospike_cluster_manager_api.info_verbs import InfoVerbNotAllowed  # noqa: F401
+    """Service-layer tests for the read-only asinfo entry point.
 
+    The whitelist gate is the security-critical primitive — these tests
+    pin both the happy paths and the "no wire round-trip on rejection"
+    invariant.
+    """
+
+    @staticmethod
+    def _client_with_distinct_node_responses() -> AsyncMock:
+        """Build a mock where node1 and node2 return distinct payloads.
+
+        Tests that filter by ``node_name`` MUST use this helper rather
+        than ``_make_mock_client`` — the shared mock returns identical
+        responses for both nodes, which would let a "always returns first
+        result" bug pass the filter assertion silently.
+        """
         client = _make_mock_client()
-        client.info_random_node.return_value = "test;bar"
+
+        def info_all_side_effect(cmd: str):
+            if cmd == "statistics":
+                return [
+                    _info_all_result("node1", "node1_marker;cluster_size=2"),
+                    _info_all_result("node2", "node2_marker;cluster_size=2"),
+                ]
+            if cmd == "namespaces":
+                return [
+                    _info_all_result("node1", "test;bar"),
+                    _info_all_result("node2", "test;bar"),
+                ]
+            return []
+
+        client.info_all.side_effect = info_all_side_effect
+        return client
+
+    async def test_random_node_path_returns_real_node_name(self):
+        # ``node_name=None`` fans out via info_all and returns the FIRST
+        # non-error response — the returned node name is a real cluster
+        # node, so a follow-up call can target it.
+        client = self._client_with_distinct_node_responses()
+        node, response = await clusters_service.execute_info_read_only(client, "statistics")
+        assert node == "node1"
+        assert "node1_marker" in response
+        assert "node2_marker" not in response
+        client.info_all.assert_awaited_with("statistics")
+        # info_random_node is no longer used for the read-only tool —
+        # the change buys real node names back at the cost of one extra
+        # round-trip per call.
+        client.info_random_node.assert_not_called()
+
+    async def test_random_node_path_skips_error_nodes(self):
+        # First node errored — service must skip and return node2.
+        client = _make_mock_client()
+        client.info_all.side_effect = lambda cmd: [
+            ("node1", 1, ""),
+            ("node2", None, "ok"),
+        ]
         node, response = await clusters_service.execute_info_read_only(client, "namespaces")
-        assert node == "<random>"
-        assert response == "test;bar"
-        client.info_random_node.assert_awaited_with("namespaces")
-        # info_all is reserved for the per-node fan-out path; should not fire
-        # when node_name is None.
-        client.info_all.assert_not_called()
+        assert node == "node2"
+        assert response == "ok"
 
     async def test_specific_node_filters_info_all(self):
-        client = _make_mock_client()
-        # ``statistics`` is in the whitelist AND the mock has a fan-out
-        # response for it (node1 + node2). The service should pick node1.
-        node, response = await clusters_service.execute_info_read_only(client, "statistics", node_name="node1")
-        assert node == "node1"
-        assert "cluster_size=2" in response
+        # Distinct per-node markers prove the FILTER works (not just a
+        # "returns results[0]" accident).
+        client = self._client_with_distinct_node_responses()
+        node, response = await clusters_service.execute_info_read_only(client, "statistics", node_name="node2")
+        assert node == "node2"
+        assert "node2_marker" in response
+        assert "node1_marker" not in response
 
     async def test_unknown_node_raises(self):
-        client = _make_mock_client()
+        client = self._client_with_distinct_node_responses()
         with pytest.raises(NodeNotFoundError):
             await clusters_service.execute_info_read_only(client, "namespaces", node_name="ghost")
+
+    async def test_no_responding_nodes_raises(self):
+        # Every node returned an error — random-node path has nothing to
+        # surface, must raise.
+        client = _make_mock_client()
+        client.info_all.side_effect = lambda cmd: [
+            ("node1", 1, ""),
+            ("node2", 1, ""),
+        ]
+        with pytest.raises(NodeNotFoundError):
+            await clusters_service.execute_info_read_only(client, "namespaces")
 
     async def test_unwhitelisted_verb_raises_before_client_call(self):
         from aerospike_cluster_manager_api.info_verbs import InfoVerbNotAllowed
@@ -284,6 +343,9 @@ class TestExecuteInfoReadOnly:
         with pytest.raises(InfoVerbNotAllowed) as exc:
             await clusters_service.execute_info_read_only(client, "set-config:context=service;migrate-threads=2")
         assert exc.value.verb == "set-config"
+        # Wire message guides the LLM to retry with a valid verb.
+        assert "set-config" in str(exc.value)
+        assert "execute_info" in str(exc.value)
         # Critical: the wire was NOT touched. The whitelist gate fires
         # before any client call so a malicious verb can't even establish
         # an info round-trip.
@@ -296,7 +358,7 @@ class TestExecuteInfoReadOnly:
         client = _make_mock_client()
         with pytest.raises(InfoVerbNotAllowed):
             await clusters_service.execute_info_read_only(client, "")
-        client.info_random_node.assert_not_called()
+        client.info_all.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/test_clusters_service.py
+++ b/api/tests/test_clusters_service.py
@@ -246,6 +246,60 @@ class TestExecuteInfoOnNode:
 
 
 # ---------------------------------------------------------------------------
+# execute_info_read_only
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteInfoReadOnly:
+    async def test_random_node_path_uses_info_random_node(self):
+        from aerospike_cluster_manager_api.info_verbs import InfoVerbNotAllowed  # noqa: F401
+
+        client = _make_mock_client()
+        client.info_random_node.return_value = "test;bar"
+        node, response = await clusters_service.execute_info_read_only(client, "namespaces")
+        assert node == "<random>"
+        assert response == "test;bar"
+        client.info_random_node.assert_awaited_with("namespaces")
+        # info_all is reserved for the per-node fan-out path; should not fire
+        # when node_name is None.
+        client.info_all.assert_not_called()
+
+    async def test_specific_node_filters_info_all(self):
+        client = _make_mock_client()
+        # ``statistics`` is in the whitelist AND the mock has a fan-out
+        # response for it (node1 + node2). The service should pick node1.
+        node, response = await clusters_service.execute_info_read_only(client, "statistics", node_name="node1")
+        assert node == "node1"
+        assert "cluster_size=2" in response
+
+    async def test_unknown_node_raises(self):
+        client = _make_mock_client()
+        with pytest.raises(NodeNotFoundError):
+            await clusters_service.execute_info_read_only(client, "namespaces", node_name="ghost")
+
+    async def test_unwhitelisted_verb_raises_before_client_call(self):
+        from aerospike_cluster_manager_api.info_verbs import InfoVerbNotAllowed
+
+        client = _make_mock_client()
+        with pytest.raises(InfoVerbNotAllowed) as exc:
+            await clusters_service.execute_info_read_only(client, "set-config:context=service;migrate-threads=2")
+        assert exc.value.verb == "set-config"
+        # Critical: the wire was NOT touched. The whitelist gate fires
+        # before any client call so a malicious verb can't even establish
+        # an info round-trip.
+        client.info_random_node.assert_not_called()
+        client.info_all.assert_not_called()
+
+    async def test_empty_command_raises(self):
+        from aerospike_cluster_manager_api.info_verbs import InfoVerbNotAllowed
+
+        client = _make_mock_client()
+        with pytest.raises(InfoVerbNotAllowed):
+            await clusters_service.execute_info_read_only(client, "")
+        client.info_random_node.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # get_cluster_info (full composition)
 # ---------------------------------------------------------------------------
 

--- a/api/tests/test_info_verbs.py
+++ b/api/tests/test_info_verbs.py
@@ -1,0 +1,125 @@
+"""Unit tests for the read-only asinfo verb whitelist domain module.
+
+Covers:
+
+* :func:`extract_verb` parsing of the three asinfo command shapes
+  (bare, ``:``-args, ``/``-path).
+* :func:`assert_read_only` allow / block decisions for every verb in the
+  whitelist plus a representative set of write / unknown verbs. The
+  parametrized "all whitelisted verbs pass" test is the regression net
+  that catches accidental whitelist trims.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aerospike_cluster_manager_api.info_verbs import (
+    READ_ONLY_INFO_VERBS,
+    InfoVerbNotAllowed,
+    assert_read_only,
+    extract_verb,
+)
+
+
+class TestExtractVerb:
+    def test_bare_verb(self) -> None:
+        assert extract_verb("namespaces") == "namespaces"
+
+    def test_colon_args(self) -> None:
+        assert extract_verb("roster:namespace=test") == "roster"
+
+    def test_colon_multi_args(self) -> None:
+        assert extract_verb("latencies:back=10;duration=10") == "latencies"
+
+    def test_slash_path(self) -> None:
+        assert extract_verb("sets/test/myset") == "sets"
+
+    def test_slash_namespace(self) -> None:
+        assert extract_verb("namespace/test") == "namespace"
+
+    def test_xdr_dc_with_args(self) -> None:
+        assert extract_verb("xdr-dc:dc=DC1") == "xdr-dc"
+
+    def test_leading_trailing_whitespace(self) -> None:
+        assert extract_verb("  version  ") == "version"
+
+    def test_empty_string_raises(self) -> None:
+        with pytest.raises(InfoVerbNotAllowed) as exc:
+            extract_verb("")
+        assert exc.value.verb == ""
+
+    def test_whitespace_only_raises(self) -> None:
+        with pytest.raises(InfoVerbNotAllowed) as exc:
+            extract_verb("   \t\n  ")
+        assert exc.value.verb == ""
+
+
+class TestAssertReadOnly:
+    @pytest.mark.parametrize("verb", sorted(READ_ONLY_INFO_VERBS))
+    def test_every_whitelisted_verb_passes(self, verb: str) -> None:
+        # Bare-form must pass for every whitelisted verb. This is the
+        # regression net for accidental trims to READ_ONLY_INFO_VERBS.
+        assert_read_only(verb)
+
+    def test_colon_args_pass_when_verb_whitelisted(self) -> None:
+        assert_read_only("roster:namespace=test")
+        assert_read_only("xdr-dc:dc=DC1")
+        assert_read_only("latencies:back=10")
+
+    def test_slash_path_pass_when_verb_whitelisted(self) -> None:
+        assert_read_only("sets/test/myset")
+        assert_read_only("bins/test")
+        assert_read_only("sindex/test/idx_name")
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "set-config:context=service;migrate-threads=2",
+            "truncate-namespace:namespace=test",
+            "recluster:",
+            "set-roster:namespace=test;nodes=ABCD,EFGH",
+            "create-roster:",
+            "quiesces",
+            "quiesce-undo",
+            "sindex-create:ns=test;set=demo",
+            "sindex-delete:ns=test;indexname=foo",
+        ],
+    )
+    def test_known_writes_blocked(self, command: str) -> None:
+        with pytest.raises(InfoVerbNotAllowed):
+            assert_read_only(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "frobnicate",
+            "Namespaces",  # case-sensitive — capital N is rejected
+            "VERSION",
+            "dump-fabric:",  # debug dumps deliberately excluded
+            "dump-msgs:",
+            "eviction",  # excluded conservatively
+        ],
+    )
+    def test_unknown_or_excluded_verb_blocked(self, command: str) -> None:
+        with pytest.raises(InfoVerbNotAllowed):
+            assert_read_only(command)
+
+    def test_empty_command_blocked(self) -> None:
+        with pytest.raises(InfoVerbNotAllowed):
+            assert_read_only("")
+
+    def test_error_carries_extracted_verb(self) -> None:
+        with pytest.raises(InfoVerbNotAllowed) as exc:
+            assert_read_only("recluster:")
+        assert exc.value.verb == "recluster"
+
+    def test_error_message_mentions_a_few_allowed_verbs(self) -> None:
+        # The wire message points the LLM at the allowed list in lieu of
+        # a separate "list allowed verbs" tool. Exact wording is not
+        # asserted — just the shape.
+        with pytest.raises(InfoVerbNotAllowed) as exc:
+            assert_read_only("frobnicate")
+        msg = str(exc.value)
+        assert "frobnicate" in msg
+        assert "execute_info" in msg

--- a/api/tests/test_info_verbs.py
+++ b/api/tests/test_info_verbs.py
@@ -62,14 +62,72 @@ class TestAssertReadOnly:
         # regression net for accidental trims to READ_ONLY_INFO_VERBS.
         assert_read_only(verb)
 
+    def test_whitelist_membership_is_pinned(self) -> None:
+        """Force a deliberate decision when adding/removing a verb.
+
+        The expected set is duplicated here on purpose so silent ADDITIONS
+        to ``READ_ONLY_INFO_VERBS`` (e.g. a refactor accidentally including
+        a write verb) fail loudly here rather than passing the parametrized
+        ``test_every_whitelisted_verb_passes`` (which fans out per-member
+        and would simply add one more green test for a dangerous addition).
+        """
+        expected = frozenset(
+            {
+                # Cluster meta (8)
+                "version",
+                "build",
+                "build-os",
+                "build-time",
+                "node",
+                "service",
+                "services",
+                "services-alumni",
+                # Cluster topology / health (7)
+                "nodes",
+                "cluster-name",
+                "cluster-stable",
+                "cluster-generation",
+                "cluster-info",
+                "health-outliers",
+                "health-stats",
+                # Namespace / set / index (4)
+                "namespaces",
+                "namespace",
+                "sets",
+                "sindex",
+                # Stats (3)
+                "statistics",
+                "latencies",
+                "udf-list",
+                # Strong-consistency / rack (2)
+                "roster",
+                "racks",
+            }
+        )
+        assert expected == READ_ONLY_INFO_VERBS
+        assert len(READ_ONLY_INFO_VERBS) == 24
+
     def test_colon_args_pass_when_verb_whitelisted(self) -> None:
         assert_read_only("roster:namespace=test")
-        assert_read_only("xdr-dc:dc=DC1")
         assert_read_only("latencies:back=10")
+        assert_read_only("namespace:test")
+
+    def test_trailing_semicolon_accepted(self) -> None:
+        # ``namespaces;`` is the canonical asinfo CLI form when piping
+        # multiple commands. The verb extractor strips the trailing ``;``
+        # so the LLM-friendly form passes the whitelist.
+        assert assert_read_only("namespaces;") == "namespaces"
+        assert assert_read_only("version;") == "version"
+
+    def test_assert_returns_parsed_verb(self) -> None:
+        # Forward-compat for telemetry — callers can attach the parsed
+        # verb to OTel span attributes / structured logs.
+        assert assert_read_only("roster:namespace=test") == "roster"
+        assert assert_read_only("sets/test/myset") == "sets"
 
     def test_slash_path_pass_when_verb_whitelisted(self) -> None:
         assert_read_only("sets/test/myset")
-        assert_read_only("bins/test")
+        assert_read_only("namespace/test")
         assert_read_only("sindex/test/idx_name")
 
     @pytest.mark.parametrize(
@@ -99,6 +157,10 @@ class TestAssertReadOnly:
             "dump-fabric:",  # debug dumps deliberately excluded
             "dump-msgs:",
             "eviction",  # excluded conservatively
+            "bins",  # deprecated since Aerospike 7.0, removal in 9.x
+            "bins/test",
+            "xdr-dc",  # XDR not available on CE
+            "dc:dc=DC1",  # XDR not available on CE
         ],
     )
     def test_unknown_or_excluded_verb_blocked(self, command: str) -> None:

--- a/docs/plans/2026-05-07-execute-info-readonly-whitelist-design.md
+++ b/docs/plans/2026-05-07-execute-info-readonly-whitelist-design.md
@@ -6,7 +6,7 @@
 
 ## Problem
 
-PR #302 placed both `execute_info` and `execute_info_on_node` into `WRITE_TOOLS` because asinfo can issue writes (`set-config:`, `recluster:`, `truncate-namespace:`, etc.). Under `ACM_MCP_ACCESS_PROFILE=read_only` this leaves no path for safe diagnostic reads (`namespaces`, `version`, `roster:`, `racks:`, `xdr-dc:`, `latencies`, `statistics`). LLMs can fall back to `list_namespaces` / `get_nodes` for the most common reads, but lose every less-common diagnostic verb.
+PR #302 placed both `execute_info` and `execute_info_on_node` into `WRITE_TOOLS` because asinfo can issue writes (`set-config:`, `recluster:`, `truncate-namespace:`, etc.). Under `ACM_MCP_ACCESS_PROFILE=read_only` this leaves no path for safe diagnostic reads (`namespaces`, `version`, `roster:`, `racks:`, `latencies`, `statistics`). LLMs can fall back to `list_namespaces` / `get_nodes` for the most common reads, but lose every less-common diagnostic verb.
 
 ## Decision
 
@@ -26,18 +26,16 @@ async def execute_info_read_only(
     conn_id: str,
     command: str,
     node_name: str | None = None,
-) -> dict[str, Any]:
-    """Run a safe diagnostic asinfo verb under any access profile.
+) -> dict[str, str]:
+    """Run a whitelisted asinfo verb. Returns {"node": str, "response": str}.
 
-    Verb is checked against READ_ONLY_INFO_VERBS. Unknown / write verbs
-    return code=invalid_argument.
-
-    node_name=None  -> info_random_node(command)
-    node_name="X"   -> info_all then filter to X
+    node_name=None  -> info_all + first non-error response (node is real)
+    node_name="X"   -> info_all + filter to X
+    node_name=""    -> coerced to None (JSON-friendly empty-as-unset)
     """
 ```
 
-## Whitelist (25 verbs)
+## Whitelist (24 verbs)
 
 ```python
 READ_ONLY_INFO_VERBS: frozenset[str] = frozenset({
@@ -48,13 +46,13 @@ READ_ONLY_INFO_VERBS: frozenset[str] = frozenset({
     "nodes", "cluster-name", "cluster-stable",
     "cluster-generation", "cluster-info",
     "health-outliers", "health-stats",
-    # Namespace / set / index (5)
+    # Namespace / set / index (4)
     "namespaces", "namespace",
-    "sets", "bins", "sindex",
+    "sets", "sindex",
     # Stats (3)
     "statistics", "latencies", "udf-list",
-    # Strong-consistency / rack / XDR (4)
-    "roster", "racks", "xdr-dc", "dc",
+    # Strong-consistency / rack (2)
+    "roster", "racks",
 })
 ```
 
@@ -62,25 +60,35 @@ READ_ONLY_INFO_VERBS: frozenset[str] = frozenset({
 
 | Verb / family | Why excluded |
 |---|---|
-| `dump-fabric:`, `dump-msgs:`, `dump-namespace:` | Server-side log/file output side-effects. Phase 2.1 follow-up — needs server-impact audit. |
+| `bins`, `bins/<ns>` | Deprecated in Aerospike 7.0 (when the bin-name limit was removed), warns since 7.1, scheduled for removal in 9.x. Use `sindex` for index introspection or `namespace/<ns>` for bin-count summary. |
+| `xdr-dc`, `dc`, `dcs`, `get-dc-config` | Not available in Aerospike CE — XDR is enterprise-only. Allowlisting them would let the LLM confidently recommend verbs that error confusingly on CE clusters. |
+| `dump-fabric:`, `dump-msgs:`, `dump-namespace:`, `dump-rw:`, `dump-cluster:` | Server-side log/file output side-effects. Phase 2.1 follow-up — needs server-impact audit. Tracked in #308. |
 | `latency:` (legacy) | Deprecated in CE 8.1. Use `latencies`. |
 | `quiesces`, `quiesce-undo` | Mutation. |
 | `set-config:`, `truncate-namespace:`, `recluster:`, `set-roster:`, `create-roster:`, `sindex-create:`, `sindex-delete:` | Mutation. |
 | `eviction` | Read but rarely useful, conservative cut. Add when a real use case appears. |
+| `release` (8.1.1.0+), `edition` (legacy) | Could be added; deferred to a follow-up that decides whether the consolidated `release` verb supersedes `version`+`build`+`edition`. |
+| `peers-clear-std`, `peers-tls-std`, `alumni-clear-std` | Modern replacements for `services` / `services-alumni`. Considered but kept the older verbs for backward-compat with existing operator playbooks; revisit when CE deprecates the older form. |
 
 ## Verb parsing
 
 ```python
+_VERB_TERMINATORS = (":", "/", ";", "\n", " ", "\t")
+
 def extract_verb(command: str) -> str:
     cmd = command.strip()
     if not cmd:
         raise InfoVerbNotAllowed("")
-    return cmd.split(":", 1)[0].split("/", 1)[0]
+    head = cmd
+    for sep in _VERB_TERMINATORS:
+        head = head.split(sep, 1)[0]
+    return head
 ```
 
-- Splits on first `:` (e.g., `roster:namespace=test` → `roster`).
-- Then splits on first `/` (e.g., `sets/test/myset` → `sets`).
-- Whitespace trimmed.
+- Splits on the first occurrence of any character in `_VERB_TERMINATORS`.
+- Tolerates the canonical asinfo-CLI form `namespaces;` (trailing `;` is the wire-level separator when piping multiple commands).
+- Tolerates embedded whitespace / tabs / newlines between the verb and its args.
+- Whitespace trimmed from both ends first.
 - Empty / whitespace-only → rejected.
 - Case-sensitive (asinfo is case-sensitive).
 
@@ -88,26 +96,30 @@ def extract_verb(command: str) -> str:
 
 `code="invalid_argument"`, NOT `access_denied`. Reason: `access_denied` implies a policy block where the LLM should escalate; here the LLM should pick a different verb. `invalid_argument` is the correct retry signal.
 
-Error message includes a hint: `"Verb {verb!r} not in read-only whitelist; pick from: {first 5 verbs}, ... or use execute_info under FULL access."`
+Error message includes a curated 5-verb hint (`namespaces, version, nodes, statistics, latencies`) plus a pointer to `info_verbs.READ_ONLY_INFO_VERBS` for the full set.
 
 ## File map
 
 | File | Change |
 |---|---|
-| `api/src/aerospike_cluster_manager_api/info_verbs.py` | NEW — `READ_ONLY_INFO_VERBS`, `InfoVerbNotAllowed`, `extract_verb`, `assert_read_only`. Top-level (matches `pk.py`/`predicate.py`) so the service layer can import without crossing the `mcp/` boundary. |
-| `api/src/aerospike_cluster_manager_api/services/clusters_service.py` | Add `execute_info_read_only(conn_id, command, node_name)`. |
-| `api/src/aerospike_cluster_manager_api/mcp/tools/info_commands.py` | Add `execute_info_read_only` tool wrapper. Update `execute_info` / `execute_info_on_node` docstrings to point at the new tool. |
+| `api/src/aerospike_cluster_manager_api/info_verbs.py` | NEW — `READ_ONLY_INFO_VERBS`, `_HINT_VERBS`, `InfoVerbNotAllowed`, `extract_verb`, `assert_read_only` (returns the parsed verb on success for telemetry). Top-level (matches `pk.py`/`predicate.py`) so the service layer can import without crossing the `mcp/` boundary. |
+| `api/src/aerospike_cluster_manager_api/services/clusters_service.py` | Add `execute_info_read_only(conn_id, command, node_name)`. Top-level import of `info_verbs.assert_read_only`. The `node_name=None` branch now uses `info_all` + first-non-error so the returned `node` is the real cluster node (no `<random>` sentinel). |
+| `api/src/aerospike_cluster_manager_api/mcp/tools/info_commands.py` | Add `execute_info_read_only` tool wrapper. Coerce empty-string `node_name` to `None`. Update `execute_info` / `execute_info_on_node` docstrings to point at the new tool. |
 | `api/src/aerospike_cluster_manager_api/mcp/errors.py` | Map `InfoVerbNotAllowed` → `MCPToolError(code="invalid_argument")`. |
-| `api/tests/test_info_verbs.py` | NEW — domain unit tests. |
-| `api/tests/test_clusters_service.py` | Service-layer tests for `execute_info_read_only`. |
-| `api/tests/mcp/test_info_tools.py` | MCP tool tests (allow + block paths). |
-| `api/tests/mcp/test_e2e_readonly.py` | Add positive case under READ_ONLY. |
-| `api/tests/mcp/test_errors.py` | Mapping unit test. |
+| `README.md` | Tool count `21` → `22`; `Info (2)` → `Info (3)`; mutation-block description no longer uses the misleading `execute_info*` glob. |
+| `api/tests/test_info_verbs.py` | NEW — domain unit tests, including a literal-equality pin so silent ADDITIONS to the whitelist are caught at review time. |
+| `api/tests/test_clusters_service.py` | Service-layer tests for `execute_info_read_only` (distinct per-node markers prove the filter works, not just the first-result accident). |
+| `api/tests/mcp/test_info_tools.py` | MCP tool tests (allow + block paths). `test_passes_under_full_profile_too` actually asserts the whitelist invariant under FULL by attempting a write verb. |
+| `api/tests/mcp/test_e2e_readonly.py` | Add positive case under READ_ONLY + invalid_argument case for unwhitelisted verbs. |
+| `api/tests/mcp/test_errors.py` | Mapping unit test pinning the cause chain. |
 | `api/tests/mcp/conftest.py` | `EXPECTED_TOOL_COUNT = 21` → `22`. |
+| `api/tests/mcp/test_auto_discovery.py` | Add `execute_info_read_only` to the named-presence assertion (was missing — the total-count check at line 43 would catch a removed tool, but the named list was incomplete). |
+| `api/tests/mcp/test_connection_tools.py` | Stale "the other 21 tools" comment → no count. |
 
 ## Out of scope (Phase 2.1+)
 
-- `dump-*` debug verbs (need server-impact audit).
+- `dump-*` debug verbs (need server-impact audit) — tracked in #308.
+- `release` and `edition` verb decisions (consolidation question) — defer to a later PR.
 - `eviction` and other lesser-used reads (add as use cases surface).
 - Per-Aerospike-version whitelist (CE 8.1 only for now).
-- Streaming `info_all` mode (current spec is single-node).
+- Streaming `info_all` mode (current spec is single-node response per call).

--- a/docs/plans/2026-05-07-execute-info-readonly-whitelist-design.md
+++ b/docs/plans/2026-05-07-execute-info-readonly-whitelist-design.md
@@ -1,0 +1,113 @@
+# execute_info_read_only — read-only asinfo verb whitelist
+
+**Date**: 2026-05-07
+**Branch**: `feature/mcp-execute-info-readonly-whitelist`
+**Follows up**: PR #302 (MCP Phase 1) review Major M2
+
+## Problem
+
+PR #302 placed both `execute_info` and `execute_info_on_node` into `WRITE_TOOLS` because asinfo can issue writes (`set-config:`, `recluster:`, `truncate-namespace:`, etc.). Under `ACM_MCP_ACCESS_PROFILE=read_only` this leaves no path for safe diagnostic reads (`namespaces`, `version`, `roster:`, `racks:`, `xdr-dc:`, `latencies`, `statistics`). LLMs can fall back to `list_namespaces` / `get_nodes` for the most common reads, but lose every less-common diagnostic verb.
+
+## Decision
+
+Add a third info tool `execute_info_read_only` (mutation=False) gated by an **explicit closed allowlist** of safe verbs. The existing two mutation tools are unchanged.
+
+| Tool | Profile | Verb scope |
+|---|---|---|
+| `execute_info` | FULL only | any |
+| `execute_info_on_node` | FULL only | any |
+| `execute_info_read_only` (NEW) | READ_ONLY + FULL | whitelist only |
+
+## Tool surface
+
+```python
+@tool(category="info", mutation=False)
+async def execute_info_read_only(
+    conn_id: str,
+    command: str,
+    node_name: str | None = None,
+) -> dict[str, Any]:
+    """Run a safe diagnostic asinfo verb under any access profile.
+
+    Verb is checked against READ_ONLY_INFO_VERBS. Unknown / write verbs
+    return code=invalid_argument.
+
+    node_name=None  -> info_random_node(command)
+    node_name="X"   -> info_all then filter to X
+    """
+```
+
+## Whitelist (25 verbs)
+
+```python
+READ_ONLY_INFO_VERBS: frozenset[str] = frozenset({
+    # Cluster meta (8)
+    "version", "build", "build-os", "build-time",
+    "node", "service", "services", "services-alumni",
+    # Cluster topology / health (7)
+    "nodes", "cluster-name", "cluster-stable",
+    "cluster-generation", "cluster-info",
+    "health-outliers", "health-stats",
+    # Namespace / set / index (5)
+    "namespaces", "namespace",
+    "sets", "bins", "sindex",
+    # Stats (3)
+    "statistics", "latencies", "udf-list",
+    # Strong-consistency / rack / XDR (4)
+    "roster", "racks", "xdr-dc", "dc",
+})
+```
+
+### Excluded with rationale
+
+| Verb / family | Why excluded |
+|---|---|
+| `dump-fabric:`, `dump-msgs:`, `dump-namespace:` | Server-side log/file output side-effects. Phase 2.1 follow-up — needs server-impact audit. |
+| `latency:` (legacy) | Deprecated in CE 8.1. Use `latencies`. |
+| `quiesces`, `quiesce-undo` | Mutation. |
+| `set-config:`, `truncate-namespace:`, `recluster:`, `set-roster:`, `create-roster:`, `sindex-create:`, `sindex-delete:` | Mutation. |
+| `eviction` | Read but rarely useful, conservative cut. Add when a real use case appears. |
+
+## Verb parsing
+
+```python
+def extract_verb(command: str) -> str:
+    cmd = command.strip()
+    if not cmd:
+        raise InfoVerbNotAllowed("")
+    return cmd.split(":", 1)[0].split("/", 1)[0]
+```
+
+- Splits on first `:` (e.g., `roster:namespace=test` → `roster`).
+- Then splits on first `/` (e.g., `sets/test/myset` → `sets`).
+- Whitespace trimmed.
+- Empty / whitespace-only → rejected.
+- Case-sensitive (asinfo is case-sensitive).
+
+## Error code
+
+`code="invalid_argument"`, NOT `access_denied`. Reason: `access_denied` implies a policy block where the LLM should escalate; here the LLM should pick a different verb. `invalid_argument` is the correct retry signal.
+
+Error message includes a hint: `"Verb {verb!r} not in read-only whitelist; pick from: {first 5 verbs}, ... or use execute_info under FULL access."`
+
+## File map
+
+| File | Change |
+|---|---|
+| `api/src/aerospike_cluster_manager_api/info_verbs.py` | NEW — `READ_ONLY_INFO_VERBS`, `InfoVerbNotAllowed`, `extract_verb`, `assert_read_only`. Top-level (matches `pk.py`/`predicate.py`) so the service layer can import without crossing the `mcp/` boundary. |
+| `api/src/aerospike_cluster_manager_api/services/clusters_service.py` | Add `execute_info_read_only(conn_id, command, node_name)`. |
+| `api/src/aerospike_cluster_manager_api/mcp/tools/info_commands.py` | Add `execute_info_read_only` tool wrapper. Update `execute_info` / `execute_info_on_node` docstrings to point at the new tool. |
+| `api/src/aerospike_cluster_manager_api/mcp/errors.py` | Map `InfoVerbNotAllowed` → `MCPToolError(code="invalid_argument")`. |
+| `api/tests/test_info_verbs.py` | NEW — domain unit tests. |
+| `api/tests/test_clusters_service.py` | Service-layer tests for `execute_info_read_only`. |
+| `api/tests/mcp/test_info_tools.py` | MCP tool tests (allow + block paths). |
+| `api/tests/mcp/test_e2e_readonly.py` | Add positive case under READ_ONLY. |
+| `api/tests/mcp/test_errors.py` | Mapping unit test. |
+| `api/tests/mcp/conftest.py` | `EXPECTED_TOOL_COUNT = 21` → `22`. |
+
+## Out of scope (Phase 2.1+)
+
+- `dump-*` debug verbs (need server-impact audit).
+- `eviction` and other lesser-used reads (add as use cases surface).
+- Per-Aerospike-version whitelist (CE 8.1 only for now).
+- Streaming `info_all` mode (current spec is single-node).


### PR DESCRIPTION
## Summary

Closes the Phase 2 follow-up flagged by review M2 of PR #302: under `ACM_MCP_ACCESS_PROFILE=read_only`, `execute_info` and `execute_info_on_node` block ALL asinfo commands — including safe diagnostic reads (`namespaces`, `version`, `roster:`, `racks:`, `xdr-dc:`, `latencies`, `statistics`). LLMs lose every diagnostic verb that isn't already covered by `list_namespaces` / `get_nodes`.

This PR adds a sibling read-only tool gated by an explicit closed allowlist of safe verbs.

## Approach

| Tool | Profile | Verb scope |
|---|---|---|
| `execute_info` | FULL only | any |
| `execute_info_on_node` | FULL only | any |
| `execute_info_read_only` (NEW) | READ_ONLY + FULL | whitelist only |

- Tool count: 21 → 22
- `WRITE_TOOLS`: unchanged
- Existing tools' docstrings now point at the new tool for read-only callers

## Whitelist (25 verbs)

- **Cluster meta** (8): `version`, `build`, `build-os`, `build-time`, `node`, `service`, `services`, `services-alumni`
- **Cluster topology / health** (7): `nodes`, `cluster-name`, `cluster-stable`, `cluster-generation`, `cluster-info`, `health-outliers`, `health-stats`
- **Namespace / set / index** (5): `namespaces`, `namespace`, `sets`, `bins`, `sindex`
- **Stats** (3): `statistics`, `latencies`, `udf-list`
- **Strong-consistency / rack / XDR** (4): `roster`, `racks`, `xdr-dc`, `dc`

Excluded with rationale (in design doc): `dump-*` debug verbs (server log/file side-effects → #308 follow-up), `eviction` (rarely useful, conservative cut), and obvious writes (`set-config:`, `truncate-namespace:`, `recluster:`, `set-roster:`, `quiesces`, `sindex-create:`, `sindex-delete:`).

## Verb parsing

`command.strip().split(":", 1)[0].split("/", 1)[0]` covers the three asinfo command shapes:
- bare verb (`namespaces`)
- colon-style (`roster:namespace=test` → `roster`)
- path-style (`sets/test/myset` → `sets`)

Case-sensitive (asinfo itself is case-sensitive). Empty / whitespace-only command → rejected.

## Error code

`code="invalid_argument"`, NOT `access_denied`. Reasoning: `access_denied` implies a policy block where the LLM should escalate; here the LLM should pick a different verb. Same wire family as `UnknownPredicateOperator`.

The error message hints at allowed verbs: `"Verb 'recluster' is not on the read-only asinfo whitelist; pick from: bins, build, build-os, build-time, cluster-generation, ... or use execute_info under ACM_MCP_ACCESS_PROFILE=full."`

## Implementation

| File | Change |
|---|---|
| `api/src/aerospike_cluster_manager_api/info_verbs.py` | NEW — `READ_ONLY_INFO_VERBS`, `InfoVerbNotAllowed`, `extract_verb`, `assert_read_only`. Top-level (matches `pk.py`/`predicate.py`) so the service can import without crossing the `mcp/` boundary. |
| `services/clusters_service.py` | New `execute_info_read_only(client, command, node_name=None)`. Whitelist gate fires before any wire call. |
| `mcp/tools/info_commands.py` | New tool wrapper. Updated existing `execute_info` / `execute_info_on_node` docstrings to point at the new tool. |
| `mcp/errors.py` | Maps `InfoVerbNotAllowed` → `MCPToolError(code="invalid_argument")`. |

## Test plan

- [x] `uv run pytest tests/` — 795 passed (was 724, +71 new)
- [x] `uv run ruff check src tests --fix && uv run ruff format src tests` — clean
- [x] `uv run pyright` on changed files — clean
- [x] Whitelist covers every verb in `READ_ONLY_INFO_VERBS` (parametrized `test_every_whitelisted_verb_passes`)
- [x] Known writes (`set-config:`, `truncate-namespace:`, `recluster:`, `set-roster:`, `quiesces`, `sindex-create:`, `sindex-delete:`) blocked
- [x] Case-sensitive (`Namespaces` rejected)
- [x] Empty / whitespace-only command rejected
- [x] Whitelist gate fires BEFORE any wire call (no `info_random_node` / `info_all` invoked on rejected verb)
- [x] `node_name=None` uses `info_random_node`; explicit `node_name` uses `info_all` then filters; missing node → `NodeNotFoundError`
- [x] `execute_info_read_only` callable under READ_ONLY (e2e_readonly positive case)
- [x] Unwhitelisted verb returns `code=invalid_argument` (not `access_denied`)

## Out of scope

- `dump-*` debug verbs — see #308 (Phase 2.1, needs server-impact audit per verb).
- Per-Aerospike-version whitelist — CE 8.1 only for now.
- Streaming `info_all` mode — single-node response per call (sufficient for diagnostic reads).

## Design doc

`docs/plans/2026-05-07-execute-info-readonly-whitelist-design.md` — kept the verb list, parsing rules, and exclusion rationale next to the code.