### PR TITLE
docs(api): audit dump-* asinfo verbs vs CE 8.1 (#308)

### DIFF
--- a/api/tests/test_info_verbs.py
+++ b/api/tests/test_info_verbs.py
@@ -154,8 +154,6 @@ class TestAssertReadOnly:
             "frobnicate",
             "Namespaces",  # case-sensitive — capital N is rejected
             "VERSION",
-            "dump-fabric:",  # debug dumps deliberately excluded
-            "dump-msgs:",
             "eviction",  # excluded conservatively
             "bins",  # deprecated since Aerospike 7.0, removal in 9.x
             "bins/test",
@@ -164,6 +162,8 @@ class TestAssertReadOnly:
         ],
     )
     def test_unknown_or_excluded_verb_blocked(self, command: str) -> None:
+        # dump-* verbs are covered by ``TestDumpVerbCatalog`` below — keep them
+        # out of this parametrize so the dump audit lives in one place.
         with pytest.raises(InfoVerbNotAllowed):
             assert_read_only(command)
 
@@ -185,3 +185,102 @@ class TestAssertReadOnly:
         msg = str(exc.value)
         assert "frobnicate" in msg
         assert "execute_info" in msg
+
+
+# ---------------------------------------------------------------------------
+# dump-* verb audit catalog (issue #308)
+# ---------------------------------------------------------------------------
+
+
+# Every ``dump-*`` verb known to CE 8.1 is enumerated here with its category.
+# Audit reproduced via ``aerospike/aerospike-server:8.1.2.1`` (see
+# ``docs/plans/2026-05-07-execute-info-readonly-whitelist-design.md`` Appendix A
+# for the full table including wire response and log-line delta).
+#
+# Categories:
+#   * ``log_only`` — verb is implemented; replies ``ok`` on the wire and
+#     dumps actual content to the server log file (cf_info / cf_warning).
+#     Excluded from the read-only whitelist because letting a READ_ONLY
+#     caller pile up server-log lines is a side-effect, even though the
+#     wire response is harmless.
+#   * ``not_in_ce_8_1`` — Aerospike rejects the verb with
+#     ``ERROR:4:unrecognized command``. Listed here so a future CE
+#     release that reintroduces one fails the catalog test until a
+#     deliberate include/exclude decision is made.
+#
+# When CE adds a verb that returns data on the wire (a hypothetical
+# ``pure_read`` category), update the audit, add the verb to
+# ``READ_ONLY_INFO_VERBS`` (and to ``test_whitelist_membership_is_pinned``),
+# and move the entry here. The test below requires every catalog member
+# to be rejected by the current whitelist — adding a ``pure_read`` entry
+# without whitelisting it would be a contradiction the test catches.
+DUMP_VERB_CATALOG: dict[str, str] = {
+    # --- implemented in CE 8.1.2.1, wire reply is "ok", content goes to log ---
+    "dump-cluster": "log_only",  # 12 log lines: paxos / exchange / cluster state
+    "dump-fabric": "log_only",  # 2 log lines: fabric node table
+    "dump-hb": "log_only",  # 10 log lines: heartbeat state
+    "dump-hlc": "log_only",  # 1 log line: HLC state
+    "dump-migrates": "log_only",  # 7 log lines: migration state
+    "dump-rw": "log_only",  # 1 log line: "rw_request_hash dump not yet implemented"
+    "dump-skew": "log_only",  # 1 log line: cluster-clock-skew
+    "dump-wb-summary": "log_only",  # requires :namespace=...;verbose=...; per docs dumps to log
+    # --- referenced in older docs / issue #308 body but absent from CE 8.1.2.1 ---
+    "dump-msgs": "not_in_ce_8_1",
+    "dump-namespace": "not_in_ce_8_1",
+    "dump-nsup": "not_in_ce_8_1",
+    "dump-paxos": "not_in_ce_8_1",
+    "dump-si": "not_in_ce_8_1",
+    "dump-smd": "not_in_ce_8_1",
+    "dump-stats": "not_in_ce_8_1",
+    "dump-tsvc": "not_in_ce_8_1",
+    "dump-wb": "not_in_ce_8_1",
+    "dump-wr": "not_in_ce_8_1",
+}
+
+
+class TestDumpVerbCatalog:
+    """Audit-driven catalog test — see #308 and the design doc Appendix A.
+
+    The catalog is the single source of truth for which dump-* verbs the
+    project has reasoned about. Every entry must be rejected by the
+    current whitelist; the per-verb category (``log_only`` vs
+    ``not_in_ce_8_1``) lives in the catalog as documentation and as a
+    forward-compat hook for future CE versions.
+    """
+
+    @pytest.mark.parametrize("verb,category", sorted(DUMP_VERB_CATALOG.items()))
+    def test_dump_verbs_are_excluded(self, verb: str, category: str) -> None:
+        # Catalog membership invariant: every dump-* verb the project has
+        # audited is currently excluded from the read-only whitelist,
+        # regardless of category. A future contributor who wants to
+        # whitelist a dump-* verb must (a) re-run the audit, (b) update
+        # the catalog category, AND (c) update READ_ONLY_INFO_VERBS plus
+        # the literal pin — this test will fail at step (c) skipped.
+        assert verb not in READ_ONLY_INFO_VERBS, (
+            f"{verb!r} is in READ_ONLY_INFO_VERBS but DUMP_VERB_CATALOG says "
+            f"category={category!r}; either remove it from the whitelist or "
+            f"change its catalog category and rerun the dump-* audit."
+        )
+        # Bare form
+        with pytest.raises(InfoVerbNotAllowed):
+            assert_read_only(verb)
+        # Colon-arg form (most dump-* verbs accept ``:`` even when no args)
+        with pytest.raises(InfoVerbNotAllowed):
+            assert_read_only(f"{verb}:")
+
+    def test_no_dump_verb_in_whitelist(self) -> None:
+        # Stronger global invariant — even a dump-* verb missed by the
+        # catalog (e.g. a typo by a future contributor) must not slip
+        # into the whitelist. Cheap belt-and-suspenders against the
+        # catalog drifting out of date.
+        leaked = {v for v in READ_ONLY_INFO_VERBS if v.startswith("dump-")}
+        assert leaked == set(), f"dump-* verbs leaked into the whitelist: {sorted(leaked)}"
+
+    @pytest.mark.parametrize("category", sorted({c for c in DUMP_VERB_CATALOG.values()}))
+    def test_catalog_categories_are_known(self, category: str) -> None:
+        # Defensive: if a future contributor adds a ``pure_read`` entry to
+        # the catalog without also adding it to the whitelist, the
+        # parametrized test above will fail loudly. This test enumerates
+        # the categories the audit currently produces so the set of
+        # legal categories stays explicit in code.
+        assert category in {"log_only", "not_in_ce_8_1"}

--- a/docs/plans/2026-05-07-execute-info-readonly-whitelist-design.md
+++ b/docs/plans/2026-05-07-execute-info-readonly-whitelist-design.md
@@ -62,7 +62,7 @@ READ_ONLY_INFO_VERBS: frozenset[str] = frozenset({
 |---|---|
 | `bins`, `bins/<ns>` | Deprecated in Aerospike 7.0 (when the bin-name limit was removed), warns since 7.1, scheduled for removal in 9.x. Use `sindex` for index introspection or `namespace/<ns>` for bin-count summary. |
 | `xdr-dc`, `dc`, `dcs`, `get-dc-config` | Not available in Aerospike CE — XDR is enterprise-only. Allowlisting them would let the LLM confidently recommend verbs that error confusingly on CE clusters. |
-| `dump-fabric:`, `dump-msgs:`, `dump-namespace:`, `dump-rw:`, `dump-cluster:` | Server-side log/file output side-effects. Phase 2.1 follow-up — needs server-impact audit. Tracked in #308. |
+| `dump-*` family | All verbs in this family — implemented and unrecognized — write to the server log file (or are not implemented at all in CE 8.1) and never return data over the network. Audited per-verb against `aerospike/aerospike-server:8.1.2.1`; results in [Appendix A](#appendix-a-dump--verb-audit-ce-812). Closed by #308. |
 | `latency:` (legacy) | Deprecated in CE 8.1. Use `latencies`. |
 | `quiesces`, `quiesce-undo` | Mutation. |
 | `set-config:`, `truncate-namespace:`, `recluster:`, `set-roster:`, `create-roster:`, `sindex-create:`, `sindex-delete:` | Mutation. |
@@ -118,8 +118,37 @@ Error message includes a curated 5-verb hint (`namespaces, version, nodes, stati
 
 ## Out of scope (Phase 2.1+)
 
-- `dump-*` debug verbs (need server-impact audit) — tracked in #308.
 - `release` and `edition` verb decisions (consolidation question) — defer to a later PR.
 - `eviction` and other lesser-used reads (add as use cases surface).
 - Per-Aerospike-version whitelist (CE 8.1 only for now).
 - Streaming `info_all` mode (current spec is single-node response per call).
+
+## Appendix A — `dump-*` verb audit (CE 8.1)
+
+**Image audited**: `docker.io/aerospike/aerospike-server:8.1.2.1` (single-node default config).
+**Method**: per-verb `asinfo -v <verb>` round-trip, observe (a) wire response length and content, (b) server log line delta over a 0.5s settle window. Reproduced by `tests/test_info_verbs.py::TestDumpVerbCatalog`.
+
+| Verb | Wire response | Log lines added | Category | Whitelist? |
+|---|---|---:|---|:---:|
+| `dump-cluster` | `ok` | 12 (CL paxos / exchange state) | log-only | ✗ |
+| `dump-fabric` | `ok` | 2 (fabric node table) | log-only | ✗ |
+| `dump-hb` | `ok` | 10 (heartbeat state) | log-only | ✗ |
+| `dump-hlc` | `ok` | 1 (HLC state) | log-only | ✗ |
+| `dump-migrates` | `ok` | 7 (migration state) | log-only | ✗ |
+| `dump-rw` | `ok` | 1 (`rw_request_hash dump not yet implemented`) | log-only / partial impl | ✗ |
+| `dump-skew` | `ok` | 1 (`cluster-clock-skew=0`) | log-only | ✗ |
+| `dump-wb-summary` | requires `namespace=...;verbose=...` | (multi-arg, log dump) | log-only | ✗ |
+| `dump-msgs` | `ERROR:4:unrecognized command` | — | not in CE 8.1 | ✗ |
+| `dump-namespace` | `ERROR:4:unrecognized command` | — | not in CE 8.1 | ✗ |
+| `dump-nsup` | `ERROR:4:unrecognized command` | — | not in CE 8.1 | ✗ |
+| `dump-paxos` | `ERROR:4:unrecognized command` | — | not in CE 8.1 | ✗ |
+| `dump-si` | `ERROR:4:unrecognized command` | — | not in CE 8.1 | ✗ |
+| `dump-smd` | `ERROR:4:unrecognized command` | — | not in CE 8.1 | ✗ |
+| `dump-stats` | `ERROR:4:unrecognized command` | — | not in CE 8.1 | ✗ |
+| `dump-tsvc` | `ERROR:4:unrecognized command` | — | not in CE 8.1 | ✗ |
+| `dump-wb` | `ERROR:4:unrecognized command` | — | not in CE 8.1 | ✗ |
+| `dump-wr` | `ERROR:4:unrecognized command` | — | not in CE 8.1 | ✗ |
+
+**Conclusion.** No `dump-*` verb returns data on the wire in CE 8.1.2.1 — every implemented verb dumps its output to the server log file and replies `ok`. Adding any to `READ_ONLY_INFO_VERBS` would let a `READ_ONLY` caller spam the server log (rotation pressure, audit-trail noise) for zero diagnostic data the LLM can read back. All `dump-*` verbs remain excluded.
+
+The catalog above is encoded in `tests/test_info_verbs.py::DUMP_VERB_CATALOG` and asserted against `assert_read_only`. If a future Aerospike release converts a `dump-*` verb from log-only to wire-returned, the audit must be re-run and the catalog updated; if a release reintroduces a `not_in_ce_8_1` verb, the test fails until a deliberate include/exclude decision is made.


### PR DESCRIPTION
## Summary

Phase 2.1 follow-up to [#309](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/309). The whitelist that landed with `execute_info_read_only` excluded the entire `dump-*` family pending a per-verb audit. This PR runs that audit against `aerospike/aerospike-server:8.1.2.1` and records the verdict in code + design doc.

**Conclusion: no production code change.** No `dump-*` verb in CE 8.1.2.1 returns data on the wire — the seven implemented verbs reply `\"ok\"` and dump their content to the server log file (`cf_info`). Adding any to `READ_ONLY_INFO_VERBS` would let a `READ_ONLY` caller pile up server-log lines for zero useful diagnostic data, so all remain excluded. The PR converts an open question into a recorded, reproducible decision and adds a regression catalog so future CE versions that change a verb's behavior trip the test.

## Audit results (CE 8.1.2.1)

| Verb | Wire response | Log lines added | Category |
|---|---|---:|---|
| `dump-cluster` | `ok` | 12 | log-only |
| `dump-fabric` | `ok` | 2 | log-only |
| `dump-hb` | `ok` | 10 | log-only |
| `dump-hlc` | `ok` | 1 | log-only |
| `dump-migrates` | `ok` | 7 | log-only |
| `dump-rw` | `ok` | 1 (\"not yet implemented\") | log-only |
| `dump-skew` | `ok` | 1 | log-only |
| `dump-wb-summary` | requires `:namespace=...;verbose=...` | (multi-arg) | log-only |
| `dump-msgs`, `dump-namespace`, `dump-nsup`, `dump-paxos`, `dump-si`, `dump-smd`, `dump-stats`, `dump-tsvc`, `dump-wb`, `dump-wr` | `ERROR:4:unrecognized command` | — | not in CE 8.1 |

Reproduction script + raw `podman logs` deltas are in the design doc Appendix A.

## Files

| File | Change |
|---|---|
| `docs/plans/2026-05-07-execute-info-readonly-whitelist-design.md` | Replace the Phase 2.1 placeholder row in \"Excluded with rationale\" with a permanent decision pointing at Appendix A. New Appendix A lists every audited verb with wire response and log-line delta. |
| `api/tests/test_info_verbs.py` | New `DUMP_VERB_CATALOG` (SSOT) + `TestDumpVerbCatalog` class. Three invariants: every catalog entry is rejected by `assert_read_only`, no `dump-*` verb leaks into `READ_ONLY_INFO_VERBS`, and only known categories appear in the catalog. Old `dump-fabric:` / `dump-msgs:` cases moved out of `test_unknown_or_excluded_verb_blocked` so the dump audit lives in one place. |
| `api/src/aerospike_cluster_manager_api/info_verbs.py` | unchanged — whitelist is the same. |

## Test plan

- [x] `uv run pytest tests/test_info_verbs.py` — 79 passed (was 47, +32 new fan-out cases from the catalog parametrization)
- [x] `uv run pytest tests/` — 821 passed (was 795)
- [x] `uv run ruff check src tests --fix` — clean
- [x] `uv run ruff format src tests` — no changes
- [x] `uv run pyright src/aerospike_cluster_manager_api/info_verbs.py tests/test_info_verbs.py` — 0 errors
- [x] `pre-commit run --files <changed>` — all hooks pass

## Out of scope

- Per-Aerospike-version whitelist (still CE 8.1 only).
- Re-running the audit when CE 8.2 ships — the catalog test fails loudly if a new verb's behavior changes, so the next CE bump will surface it naturally.

Closes #308.