### PR TITLE
docs(api): Phase 0 contracts for MCP Phase 2 work

### DIFF
--- a/docs/plans/2026-05-07-k8s-mcp-tools-contract.md
+++ b/docs/plans/2026-05-07-k8s-mcp-tools-contract.md
@@ -1,0 +1,163 @@
+# K8s MCP tools contract (Phase 0c for #305)
+
+**Date**: 2026-05-07
+**Branch**: `feature/mcp-phase2-contracts`
+**Used by**: #305 (5 K8s MCP tools).
+
+## Problem
+
+#305 adds five MCP tools that wrap the existing `services/k8s_service.py` + `k8s_client.py` surface. Without a contract, ad-hoc decisions in the implementation PR risk:
+
+* tool names colliding with Aerospike-side tools (`list_clusters` is ambiguous — connection profile or AerospikeCluster CR?);
+* the wrong access-profile classification for `scale_cluster` (it patches `spec.size`, so it's a write);
+* the workspace gate (Phase 0a) misfiring on tools that have no `conn_id`;
+* response shapes diverging from the existing `K8sCluster*` Pydantic models.
+
+This ADR pins the surface so #305 implementation is mechanical.
+
+## Tool surface
+
+All 5 tools live in `mcp/tools/k8s.py` (NEW). Names use the `k8s_` prefix to disambiguate from Aerospike-side tools (`list_namespaces` is Aerospike namespaces; `list_k8s_clusters` is K8s AerospikeCluster CRs).
+
+| Tool | Signature | Mutation | Returns |
+|---|---|:---:|---|
+| `list_k8s_clusters` | `(workspace_id: str \| None = None)` | ✗ | `list[K8sClusterSummary]` |
+| `get_k8s_pods` | `(cluster_id: str, workspace_id: str \| None = None)` | ✗ | `list[K8sPodStatus]` |
+| `get_k8s_events` | `(cluster_id: str, workspace_id: str \| None = None, since_minutes: int = 30)` | ✗ | `list[K8sClusterEvent]` |
+| `scale_k8s_cluster` | `(cluster_id: str, size: int, workspace_id: str \| None = None)` | **✓** | `{"clusterId": str, "previousSize": int, "newSize": int}` |
+| `get_k8s_logs` | `(cluster_id: str, pod_name: str, workspace_id: str \| None = None, since_seconds: int = 300, tail_lines: int = 200)` | ✗ | `{"podName": str, "lines": list[str], "truncated": bool}` |
+
+`cluster_id` is the AerospikeCluster CR's `<namespace>/<name>` (the existing convention used by `K8sClusterSummary.id`).
+
+### Param decisions
+
+* **`workspace_id` is optional in every tool.** Defaults to `ws-default`. The Phase 0a workspace gate fires if and only if it is supplied; bearer-token sessions skip the gate. With `None`, the tool resolves CRs across all namespaces the caller can see (per K8s RBAC), filtered to those whose `metadata.labels["acm.aerospike.com/workspace"]` matches `ws-default` or matches one of the caller's owned workspaces.
+* **No `conn_id`.** K8s tools do not touch Aerospike. The Phase 0a registry gate special-cases `workspace_id` so the workspace check still runs.
+* **`since_minutes` / `since_seconds` / `tail_lines` are bounded** (`since_minutes ≤ 1440`, `since_seconds ≤ 3600`, `tail_lines ≤ 1000`) at the tool wrapper. Out-of-range values raise `MCPToolError(code="invalid_argument")`.
+
+### Response shapes
+
+The tool returns the existing Pydantic models serialized via `mcp/serializers.py`. No new model types — the schema you see in the OpenAPI doc for `GET /api/k8s/clusters` is what the LLM gets.
+
+For `scale_k8s_cluster` we return a small dict instead of the full `K8sClusterDetail` because the tool's purpose is "did the patch succeed and what is the new size" — not a 50-field cluster snapshot the LLM would have to re-prompt for.
+
+## Access profile
+
+```python
+# mcp/access_profile.py — append
+
+WRITE_TOOLS: frozenset[str] = frozenset(
+    {
+        # ... existing 10 tools
+        "scale_k8s_cluster",   # K8s — patches spec.size
+    }
+)
+```
+
+The other four K8s tools are reads. `READ_ONLY` profile blocks `scale_k8s_cluster` only. No new profile category — these are deployment-level capabilities, same gate as the Aerospike side.
+
+## Categorization
+
+`@tool(category="k8s", mutation=...)`. The `"k8s"` category is new (Phase 1 had `"connection"`, `"cluster"`, `"record"`, `"query"`, `"info"`). Used for introspection / docs grouping; no behavior change.
+
+## Workspace gate interaction (per Phase 0a)
+
+The registry decorator's workspace check fires for any tool whose param signature contains `conn_id` or `workspace_id`. K8s tools take the latter, so:
+
+* Bearer-token sessions skip the gate entirely.
+* OIDC sessions: caller must own the supplied `workspace_id`, OR the workspace must be `ws-default` (`ownerId='system'`).
+* `workspace_id=None` (default) lets the tool see the default workspace + everything the caller owns.
+
+The K8s tool body itself does NOT re-check ownership — the registry gate is authoritative.
+
+## CR labeling for workspace association
+
+Existing convention from PR #297 already labels AerospikeCluster CRs with `acm.aerospike.com/workspace=<workspace_id>` on creation. This ADR does **not** change the labeling — `list_k8s_clusters(workspace_id="X")` filters by label selector (`metadata.labels.acm.aerospike.com/workspace=X`), which is exactly what `services/k8s_service.py` already does for the REST API.
+
+If a CR predates the labeling (PR #297 + earlier), it is missing the label and visible only when `workspace_id=None`. Existing behavior preserved.
+
+## Tool body shape
+
+Every tool follows this template:
+
+```python
+@tool(category="k8s", mutation=False)
+async def get_k8s_pods(
+    cluster_id: str,
+    workspace_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return pod status for an AerospikeCluster CR.
+
+    cluster_id is "<namespace>/<name>" as returned by list_k8s_clusters.
+    workspace_id None falls back to ws-default; cross-workspace access is
+    rejected with code=workspace_mismatch by the registry gate.
+    """
+    namespace, name = _parse_cluster_id(cluster_id)
+    pods = await k8s_service.list_cluster_pods(namespace, name)
+    return [serializers.k8s_pod(p) for p in pods]
+```
+
+* No direct `client_manager` calls (K8s client is global, no per-connection state).
+* No try/except around `K8sApiError` — `mcp/errors.map_aerospike_errors` is extended to handle `K8sApiError` → `MCPToolError(code="k8s_api_error", status=...)`.
+* No re-implementation of business logic — every tool is a thin wrapper over `services/k8s_service` (which already exists for the REST routers).
+
+## Errors
+
+`mcp/errors.py` extends `map_aerospike_errors` (the name stays generic; the function maps every domain exception, not just Aerospike's) to translate:
+
+| Source exception | MCP error code |
+|---|---|
+| `K8sApiError(status=404)` | `not_found` |
+| `K8sApiError(status=403)` | `access_denied` (rare — caller's K8s RBAC, not workspace gate) |
+| `K8sApiError(status=409)` | `conflict` |
+| `K8sApiError(status=4xx)` | `invalid_argument` |
+| `K8sApiError(status=5xx)` | `internal_error` (re-raised, OTel records) |
+| `K8S_MANAGEMENT_ENABLED=false` and any K8s tool called | `unavailable` with hint to enable the feature flag |
+
+The last row is the new contract: when K8s management is disabled at config time the registry must NOT raise `ImportError` or hand a half-initialized client to the tool body. It returns `MCPToolError(code="unavailable")` immediately.
+
+## Tool count
+
+```
+EXPECTED_TOOL_COUNT: int = 22  # Phase 1 + execute_info_read_only
+                  → 27          # + 5 K8s tools
+```
+
+`tests/mcp/conftest.py` and the README breakdown both update.
+
+## File map
+
+| File | Change |
+|---|---|
+| `api/src/aerospike_cluster_manager_api/mcp/tools/k8s.py` | NEW — 5 tool wrappers |
+| `api/src/aerospike_cluster_manager_api/mcp/tools/__init__.py` | import the new module so registration fires |
+| `api/src/aerospike_cluster_manager_api/mcp/access_profile.py` | add `scale_k8s_cluster` to `WRITE_TOOLS` |
+| `api/src/aerospike_cluster_manager_api/mcp/errors.py` | map `K8sApiError` per the table above; `unavailable` mapping for disabled flag |
+| `api/src/aerospike_cluster_manager_api/mcp/serializers.py` | `k8s_cluster_summary`, `k8s_pod`, `k8s_event` helpers |
+| `api/tests/mcp/conftest.py` | `EXPECTED_TOOL_COUNT 22 → 27` |
+| `api/tests/mcp/test_k8s_tools.py` | NEW — happy path + each error mapping |
+| `api/tests/mcp/test_e2e_readonly.py` | extend — `scale_k8s_cluster` blocked under READ_ONLY |
+| `api/tests/mcp/test_auto_discovery.py` | add 5 tool names to the named-presence assertion |
+| `README.md` | tool count `22 → 27`, add "K8s (5)" line |
+
+## Test contract
+
+* **Happy path per tool** with `K8sClient` fully mocked (no live cluster required).
+* **`K8S_MANAGEMENT_ENABLED=false`** path: every K8s tool returns `unavailable`. No K8s client is initialized.
+* **`scale_k8s_cluster` under READ_ONLY** returns `access_denied` before the K8s client is touched.
+* **Workspace gate** is exercised by the Phase 0a / #307 test suite; this PR only asserts the workspace param is accepted and forwarded.
+
+## Out of scope
+
+* **Cluster create / delete via MCP.** Creating an AerospikeCluster CR is a high-blast-radius action that needs the full `CreateK8sClusterRequest` body. The REST API already covers it; the MCP surface intentionally stays diagnostic-and-scale only.
+* **Streaming logs.** `get_k8s_logs` returns a bounded snapshot. A future tool can stream via the streamable-HTTP transport.
+* **Watching events.** Same — snapshot only; the stream API is a Phase 3 candidate.
+* **Custom label selectors.** Workspace label is the only filter. Generic selector support would let an LLM read pods it shouldn't.
+
+## References
+
+* Phase 0a — `2026-05-07-mcp-context-contract.md` (this PR).
+* Phase 0b — `2026-05-07-workspace-ownership-schema.md` (this PR).
+* Issue — #305.
+* K8s service surface — `services/k8s_service.py`, `k8s_client.py`.
+* AerospikeCluster CR labeling — PR #297.

--- a/docs/plans/2026-05-07-mcp-context-contract.md
+++ b/docs/plans/2026-05-07-mcp-context-contract.md
@@ -1,0 +1,121 @@
+# MCP Phase 2 — registry decorator Context contract
+
+**Date**: 2026-05-07
+**Branch**: `feature/mcp-phase2-contracts`
+**Used by**: #303 (per-session client cache), #305 (K8s tools), #307 (workspace-aware routing)
+
+## Problem
+
+Phase 2 work introduces three concerns the Phase 1 registry decorator does not currently handle:
+
+1. **Session-scoped client cache** (#303). The connect / disconnect tools must scope cached `AsyncClient`s to the calling MCP session so one caller's `disconnect("X")` cannot evict another caller's in-flight client. The session ID is per-call data only the transport (FastMCP) knows.
+2. **Workspace authorization** (#307). When a tool argument names a `conn_id` (or a `workspace_id`), the registry must assert the caller owns the referenced object. The caller identity is OIDC `sub` claim on `request.state.user_claims`, populated upstream of the MCP mount.
+3. **K8s tools workspace gate** (#305). K8s tools have no `conn_id` but operate on AerospikeCluster CRs which carry a workspace label. The same gate must fire for `workspace_id` params.
+
+If individual tool wrappers each plumb their own `ctx`, three things break:
+
+* Tool function signatures are no longer pure data (`ctx` becomes a leaky abstraction).
+* The 22 Phase 1 tools each need editing, plus every future tool.
+* The access-profile gate, the session lookup, and the workspace gate fan out into per-tool boilerplate that drifts.
+
+## Decision
+
+The registry decorator is the single chokepoint for all per-call MCP context. Tool functions stay pure (no `ctx` parameter). The wrapper extracts everything from FastMCP's `Context` parameter and applies gates before delegating.
+
+```python
+# mcp/registry.py — wrapped (Phase 2 form)
+
+@functools.wraps(func)
+async def wrapped(*args: Any, ctx: Context, **kwargs: Any) -> Any:
+    # 1. Profile gate (Phase 1, unchanged) — purely deployment-level
+    profile: AccessProfile = config.ACM_MCP_ACCESS_PROFILE
+    if mutation and is_blocked(tool_name, profile):
+        raise MCPToolError(..., code="access_denied")
+
+    # 2. Workspace gate (Phase 2, #307). Fires only for tools whose param
+    #    signature names ``conn_id`` or ``workspace_id``. Bearer-token
+    #    sessions (single-tenant deployments) bypass the gate.
+    if not _is_bearer_session(ctx):
+        await _assert_workspace_owns_arg(ctx, tool_name, kwargs)
+
+    # 3. Session-scoped client lookup (Phase 2, #303). The decorator does
+    #    NOT call client_manager itself — it stashes session_id on a
+    #    contextvar so client_manager.get_client(conn_id) reads it
+    #    transparently. Tool bodies remain "client_manager.get_client(conn_id)"
+    #    with no signature change.
+    _SESSION_CTXVAR.set(ctx.session_id)
+
+    # 4. Body
+    with map_aerospike_errors():
+        return await func(*args, **kwargs)
+```
+
+`ctx` is **always** the LAST keyword argument FastMCP injects when a tool's signature declares a `Context` parameter. Phase 2 declares it on `wrapped`, NOT on the user-facing tool body — FastMCP introspects `wrapped`'s signature, which is what `register_all` flushes into the FastMCP instance.
+
+## What lives where
+
+| Concern | Lives in | Why |
+|---|---|---|
+| Profile gate | `mcp/access_profile.is_blocked` | unchanged from Phase 1 |
+| Workspace gate | `mcp/registry._assert_workspace_owns_arg` | needs the FULL kwargs dict to inspect by-param-name |
+| Session lookup | `client_manager` via `_SESSION_CTXVAR` | tool bodies stay 1-arg `get_client(conn_id)` |
+| Bearer bypass | `mcp/registry._is_bearer_session` | reads `ctx.user_claims.get("_mcp_bearer")` set by `mcp/auth.py` (Phase 1) |
+
+## Workspace gate rules
+
+The gate fires when a tool's parameter list contains EITHER `conn_id` OR `workspace_id`. It never fires for tools that take neither (e.g. `test_connection`, which probes by hostname before any persistence).
+
+| Tool param | Resolution | Failure |
+|---|---|---|
+| `conn_id` | `db.get_connection(conn_id).workspaceId == caller.workspace_id` | `MCPToolError(code="workspace_mismatch")` |
+| `workspace_id` | `caller.workspace_id == workspace_id` | same |
+
+`caller.workspace_id` is computed from OIDC `sub` claim by reading `db.get_workspaces_owned_by(sub)` once per call and cached on `ctx`. For deployments where Workspace.ownerId is unset (legacy default workspace) the gate treats it as accessible — see Phase 0b for the ownership semantics.
+
+## Bearer-token bypass
+
+`mcp/auth.py` (Phase 1) sets `request.state.user_claims = {"sub": "mcp-bearer", "_mcp_bearer": True}` when the caller authenticates with the configured static bearer. Single-tenant deployments use this path; the workspace gate is meaningless because there is no per-user workspace concept. The decorator detects the sentinel and skips the gate. The session-scoping logic still applies — bearer mode is single-tenant, not single-session.
+
+## Tool body invariant
+
+Tool authors **never** add `ctx` to their function signature. They keep writing:
+
+```python
+@tool(category="connection", mutation=False)
+async def connect(conn_id: str) -> dict[str, Any]:
+    client = await client_manager.get_client(conn_id)   # session-scoped via ctxvar
+    return {...}
+```
+
+The 22 Phase 1 tool bodies require zero edits. New tools (#305 K8s) follow the same shape.
+
+The only place that reads `ctx` directly is the registry decorator. If a future tool genuinely needs the session ID in its body (it shouldn't), it imports `mcp.registry.current_session_id()` rather than threading `ctx` through.
+
+## Test contract
+
+* `tests/mcp/test_registry.py::test_wrapped_does_not_leak_ctx_into_body` — assert the user-facing tool body never sees `ctx`.
+* `tests/mcp/test_workspace_isolation.py` (NEW with #307) — cross-workspace `conn_id` rejection.
+* `tests/mcp/test_session_isolation.py` (NEW with #303) — two sessions, same `conn_id`, disconnect-from-A leaves-B-intact.
+* `tests/mcp/test_bearer_bypass.py` (NEW with #307) — bearer sentinel bypasses workspace gate.
+
+## Implementation order
+
+The contract is implementation-neutral on order. Recommended:
+
+1. #303 lands first because the contextvar plumbing is small and exercises the "decorator extracts ctx, body unchanged" claim end-to-end.
+2. #305 lands next — adds K8s tools with `workspace_id` parameter; gate stays a no-op until #307.
+3. #307 lands last — populates the gate body; #303 + #305 tests start exercising it.
+
+Each PR is independently mergeable. The registry decorator grows in three commits, each behind tests.
+
+## Out of scope
+
+* Multi-workspace-per-user (Phase 0b chose the 1:1 ownership model).
+* Per-tool capability tokens / scope claims (deferred to a hypothetical Phase 3).
+* Streaming-aware Context (current FastMCP API is request/response).
+
+## References
+
+* Phase 0b — `2026-05-07-workspace-ownership-schema.md` (this PR).
+* Phase 0c — `2026-05-07-k8s-mcp-tools-contract.md` (this PR).
+* Phase 1 design — `2026-05-07-execute-info-readonly-whitelist-design.md` (merged in #309).

--- a/docs/plans/2026-05-07-workspace-ownership-schema.md
+++ b/docs/plans/2026-05-07-workspace-ownership-schema.md
@@ -1,0 +1,144 @@
+# Workspace ownership schema (Phase 0b for #307)
+
+**Date**: 2026-05-07
+**Branch**: `feature/mcp-phase2-contracts`
+**Used by**: #307 (workspace-aware MCP tool routing). Required reading for #303 and #305 because they share the registry decorator that consumes ownership info.
+
+## Problem
+
+PR #297 introduced workspaces as a connection-grouping concept and PR #298 added Keycloak OIDC. The two have not been linked: a `Workspace` row has no notion of who owns it, and the OIDC `sub` claim is not persisted alongside any workspace. As long as the MCP surface is single-tenant, this is fine — the bearer-token sentinel grants global access.
+
+For #307 (workspace-aware tool routing) the registry decorator must answer "does the caller own the workspace this `conn_id` belongs to?" Without an ownership column the question is unanswerable. PR #302 left it explicitly out of scope.
+
+## Decision: 1:1 `Workspace.ownerId`
+
+Add a single non-nullable `ownerId: str` column to `Workspace`. One workspace has exactly one owner; one user owns 0..N workspaces. The shared-team / multi-member case is **not** supported in this phase — see *Out of scope*.
+
+```python
+# models/workspace.py (excerpt)
+
+class Workspace(BaseModel):
+    id: str
+    name: str
+    color: str
+    description: str | None = None
+    isDefault: bool = False
+    ownerId: str        # NEW. OIDC ``sub`` claim, or the sentinel ``"system"``.
+    createdAt: str
+    updatedAt: str
+```
+
+Why 1:1 and not a `WorkspaceMembership` table:
+
+* **Phase 1 single-user-per-tenant is the actual deployment shape today.** No customer asks for shared workspaces yet.
+* The MCP authorization story collapses to a string compare (`workspace.ownerId == caller.sub`). No join, no caching layer.
+* Future migration to many-to-many is a one-shot data migration: convert `ownerId` rows into a `(workspace_id, user_id, role='owner')` table. Rolling back is just dropping the table.
+
+## Migration
+
+### Schema
+
+```sql
+-- SQLite (db/_sqlite.py)
+ALTER TABLE workspaces ADD COLUMN owner_id TEXT NOT NULL DEFAULT 'system';
+
+-- PostgreSQL (db/_postgres.py)
+ALTER TABLE workspaces ADD COLUMN owner_id TEXT NOT NULL DEFAULT 'system';
+```
+
+`DEFAULT 'system'` is the migration-time backfill — every existing row (default workspace + any user-created workspaces from before this PR) becomes owned by the synthetic `"system"` user. After migration, code stops emitting the default; new rows must specify `ownerId` explicitly.
+
+### Default workspace
+
+The built-in `ws-default` (`isDefault=True`) is *intentionally* owned by `"system"`. The semantic is "any authenticated user can place connections here"; ownership is irrelevant for the default. The MCP gate special-cases `ownerId == "system"` to allow access regardless of caller.
+
+The default's row migrates from PR #297's schema (`ownerId` column simply did not exist) to `ownerId='system'` via the `DEFAULT 'system'` clause above. No data migration code required.
+
+## Authorization rules
+
+| Caller path | Gate result |
+|---|---|
+| Bearer-token sentinel (`_mcp_bearer=True`) | bypass — single-tenant deployment |
+| OIDC, `workspace.ownerId == 'system'` | allow — default workspace |
+| OIDC, `workspace.ownerId == caller.sub` | allow |
+| OIDC, otherwise | deny: `MCPToolError(code="workspace_mismatch")` |
+
+`caller.sub` is the OIDC `sub` claim already persisted on `request.state.user_claims` by `middleware/oidc_auth.py` (PR #298). The MCP registry decorator reads it (per Phase 0a contract) and threads it into the gate.
+
+## Workspace creation flow changes
+
+| API | Phase 1 behavior | Phase 2 behavior |
+|---|---|---|
+| `POST /api/workspaces` | persist with no owner | persist with `ownerId = caller.sub` (OIDC) or `"system"` (bearer) |
+| `GET /api/workspaces` | return all | return rows where `ownerId IN (caller.sub, 'system')` |
+| `GET /api/workspaces/{id}` | return any | 404 if `ownerId NOT IN (caller.sub, 'system')` to avoid leaking existence |
+| `PATCH /api/workspaces/{id}` | mutate any | reject (404) if not owner; `ownerId` itself is read-only — no transfers in Phase 2 |
+| `DELETE /api/workspaces/{id}` | delete any | same — owner-only |
+
+UI consequence: the workspace selector (PR #301) lists only the caller's workspaces plus `ws-default`. The `Workspace` model already has `isDefault` so the UI continues to surface the default with no API change.
+
+## Connection creation flow changes
+
+`POST /api/connections` already accepts `workspaceId` (PR #297). Phase 2 adds:
+
+* If `workspaceId` is omitted → fall back to `ws-default` (unchanged).
+* If `workspaceId` is provided → assert ownership before accepting. Reuse the workspace gate above.
+
+`GET /api/connections?workspaceId=X` enforces the same gate; passing a workspace not owned by the caller returns 404.
+
+## MCP tool consequence (deferred to #307)
+
+The registry decorator (per Phase 0a) calls a single helper:
+
+```python
+async def _assert_workspace_owns_conn(caller_sub: str, conn_id: str) -> None:
+    profile = await db.get_connection(conn_id)
+    if profile is None:
+        raise ConnectionNotFoundError(conn_id)
+    ws = await db.get_workspace(profile.workspaceId)
+    if ws is None or (ws.ownerId != caller_sub and ws.ownerId != "system"):
+        raise MCPToolError(code="workspace_mismatch", ...)
+```
+
+`mcp-bearer` callers skip the helper entirely (Phase 0a contract).
+
+## Tests
+
+| Suite | New cases |
+|---|---|
+| `tests/test_workspaces_router.py` | OIDC user A cannot read user B's workspace; default workspace visible to all; `ownerId` cannot be PATCHed |
+| `tests/test_workspaces_service.py` | `list_workspaces(caller_sub)` filters; `create_workspace` populates `ownerId` from claim; `delete_workspace` rejects non-owner |
+| `tests/test_connections_router.py` | `POST /api/connections` with cross-owner `workspaceId` rejected; `GET /api/connections?workspaceId=...` returns 404 for non-owner |
+| `tests/db/test_migration.py` (NEW) | post-ALTER, every row has `ownerId='system'` |
+
+## Rollout
+
+1. **Pre-deploy**: ship migration ALTER. `ownerId='system'` everywhere — no behavior change.
+2. **Deploy v(N)**: code starts populating `ownerId` from OIDC `sub` on new rows; existing rows still `'system'`.
+3. **Deploy v(N+1)** (this PR's E.3): MCP registry gate flips on. Existing `'system'`-owned workspaces remain accessible to all (correct — they predate ownership).
+4. **Optional cleanup**: separate manual migration converts pre-existing rows from `'system'` to a real owner once each is claimed by a user.
+
+Reversibility: dropping the column reverts to single-tenant behavior. The `'system'` sentinel means no production data is lost.
+
+## Out of scope
+
+* **Multi-member workspaces** (one workspace, multiple users with different roles). Future `WorkspaceMembership` table; not in Phase 2.
+* **Workspace transfer** (changing `ownerId`). Requires a separate confirmation flow + audit; defer.
+* **Cross-workspace operations** (e.g. an admin tool that lists everyone's workspaces). Out of scope for the read-only / full MCP profiles.
+* **OIDC group claim → workspace** (auto-create per-team workspaces from a group claim). A useful feature for Keycloak deployments but orthogonal to the ownership model — slot it in once 1:1 lands.
+
+## Migration risk
+
+| Risk | Mitigation |
+|---|---|
+| ALTER on a busy postgres locks the table | Add column is metadata-only on PG ≥ 11; safe |
+| SQLite ALTER is rebuild-on-disk (slow) | Workspaces table is small (≤ low hundreds of rows); negligible |
+| Existing API consumers passing `workspaceId` they don't own | Behavior change is a 404. Document in changelog. |
+| OIDC `sub` claim format unstable across IdPs | Spec-correct IdPs return stable `sub`. Add a config knob `ACM_OIDC_OWNER_CLAIM` (default `"sub"`) to switch to e.g. `preferred_username` for non-compliant IdPs |
+
+## References
+
+* Phase 0a — `2026-05-07-mcp-context-contract.md` (this PR).
+* Workspace introduction — PR #297.
+* OIDC introduction — PR #298.
+* Issue — #307.


### PR DESCRIPTION
## Summary

Phase 0 design pass for the remaining MCP issues (#303, #305, #307). Three ADRs land together because they cross-reference each other and any one of them affects how the registry decorator and tool authoring patterns evolve. No production code change — this PR is the contract that #303 / #305 / #307 will implement against.

## ADRs

| File | Subject | One-line decision |
|---|---|---|
| `docs/plans/2026-05-07-mcp-context-contract.md` | Registry decorator Context plumbing | Tool functions stay pure (no `ctx`). Decorator extracts session_id (via contextvar) + workspace_id (via OIDC `sub` claim) and applies the workspace gate when the tool's params name `conn_id` or `workspace_id`. Bearer-token sessions bypass. |
| `docs/plans/2026-05-07-workspace-ownership-schema.md` | Workspace ↔ user binding for #307 | 1:1 `Workspace.ownerId: str` (NOT a membership table). Migration backfills `'system'` so existing rows stay accessible. New workspaces own = OIDC `sub`. Default workspace stays `ownerId='system'` (open). |
| `docs/plans/2026-05-07-k8s-mcp-tools-contract.md` | K8s tool surface for #305 | 5 tools, `k8s_` name prefix, `category=\"k8s\"`, `scale_k8s_cluster` is the only mutation. No `conn_id` — workspace gate fires via `workspace_id` param instead. Tool count 22→27. `K8sApiError` mapping table; `K8S_MANAGEMENT_ENABLED=false` returns `code=unavailable`. |

## Why bundled

#303, #305, #307 all touch `mcp/registry.py`. Without the Phase 0a contract, parallel implementation would step on the decorator three different ways. Phase 0b (`Workspace.ownerId`) is a hard prereq for #307; bundling it keeps the design surface readable. Phase 0c is independent but small enough that splitting into a fourth PR is more churn than value.

## Implementation roadmap (from the ADRs)

```
After this PR merges:

  Stream A — #305 K8s tools          (independent, ~0.5d)
  Stream B — #303 per-session cache  (depends on 0a, ~4h)
  Stream C — #304 wire-level e2e     (independent, ~4h)
  Stream D — #306 federation ADR     (project-hub repo, ~2h)
  Stream E — #307 workspace gate     (depends on 0a + 0b, 3 PRs:
                                       E.1 schema migration
                                       E.2 OIDC claim plumbing
                                       E.3 registry gate body)

  Merge order: A/C/D parallel, B before E (registry conflict),
               E.1 → E.2 → E.3 sequential.
```

## Test plan

- [x] `pre-commit run --files docs/plans/2026-05-07-*.md` — clean (markdown only; pyright/ruff hooks skip docs)
- [x] No code change → no test suite to run
- [ ] Reviewers: cross-check the file map in 0c against the actual current `services/k8s_service.py` / `k8s_client.py` surface; flag any signatures the ADR got wrong before #305 starts implementing

## Out of scope

- Federation gateway (#306) — separate ADR in `project-hub` repo, no dependency on these three.
- Multi-member workspaces / shared teams — explicitly deferred in 0b.
- Cluster create / delete via MCP — explicitly out of scope per 0c.

Refs: #303 #305 #307. Federation #306 unaffected.