### PR TITLE
feat(api): K8s MCP tools — list/get/scale/logs/events

### DIFF
--- a/README.md
+++ b/README.md
@@ -960,7 +960,7 @@ claude plugin install aerospike-ce-ecosystem
 
 ## MCP Server
 
-Cluster Manager can expose itself as a [Model Context Protocol](https://modelcontextprotocol.io/) server (22 tools) so Claude Code plugins and external MCP-aware AI clients (Claude Desktop, Cursor) can read and operate clusters directly.
+Cluster Manager can expose itself as a [Model Context Protocol](https://modelcontextprotocol.io/) server (27 tools) so Claude Code plugins and external MCP-aware AI clients (Claude Desktop, Cursor) can read and operate clusters directly.
 
 ### Enable
 
@@ -983,7 +983,7 @@ claude mcp add --transport http aerospike-local \
 
 Or run the `acm-mcp-init` skill from the ecosystem plugin to register one or more endpoints (multi-cluster ACKO friendly).
 
-### Tools (22)
+### Tools (27)
 
 | Category | Tools |
 |----------|-------|
@@ -992,10 +992,11 @@ Or run the `acm-mcp-init` skill from the ecosystem plugin to register one or mor
 | Record (7) | `get_record`, `record_exists`, `create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set` |
 | Query (1) | `query` |
 | Info (3) | `execute_info`, `execute_info_on_node`, `execute_info_read_only` |
+| K8s (5) | `list_k8s_clusters`, `get_k8s_pods`, `get_k8s_events`, `scale_k8s_cluster`, `get_k8s_logs` |
 
 ### Access profile
 
-`ACM_MCP_ACCESS_PROFILE=read_only` (default) blocks the 10 mutation tools (`create_connection`, `update_connection`, `delete_connection`, `create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set`, `execute_info`, `execute_info_on_node`) at call time with `code="access_denied"`. Tools remain visible — clients see the rejection only when they invoke a write. Set to `full` to allow everything. `execute_info_read_only` is the read-only counterpart to `execute_info` and is **not** blocked under `read_only`; it enforces a verb whitelist server-side and returns `code="invalid_argument"` for verbs that aren't on the safe list.
+`ACM_MCP_ACCESS_PROFILE=read_only` (default) blocks the 11 mutation tools (`create_connection`, `update_connection`, `delete_connection`, `create_record`, `update_record`, `delete_record`, `delete_bin`, `truncate_set`, `execute_info`, `execute_info_on_node`, `scale_k8s_cluster`) at call time with `code="access_denied"`. Tools remain visible — clients see the rejection only when they invoke a write. Set to `full` to allow everything. `execute_info_read_only` is the read-only counterpart to `execute_info` and is **not** blocked under `read_only`; it enforces a verb whitelist server-side and returns `code="invalid_argument"` for verbs that aren't on the safe list.
 
 ### Auth
 

--- a/api/src/aerospike_cluster_manager_api/mcp/access_profile.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/access_profile.py
@@ -47,6 +47,8 @@ WRITE_TOOLS: frozenset[str] = frozenset(
         "truncate_set",
         "execute_info",
         "execute_info_on_node",
+        # K8s — patches AerospikeCluster CR ``spec.size``; gated under READ_ONLY.
+        "scale_k8s_cluster",
     }
 )
 

--- a/api/src/aerospike_cluster_manager_api/mcp/errors.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/errors.py
@@ -31,6 +31,7 @@ from typing import Any
 import aerospike_py
 
 from aerospike_cluster_manager_api.info_verbs import InfoVerbNotAllowed
+from aerospike_cluster_manager_api.k8s_client import K8sApiError
 from aerospike_cluster_manager_api.predicate import UnknownPredicateOperator
 from aerospike_cluster_manager_api.services.clusters_service import (
     NamespaceConfigError,
@@ -138,6 +139,23 @@ def map_aerospike_errors(
         # verb, not escalate, so ``invalid_argument`` (not ``access_denied``)
         # is the right signal.
         raise MCPToolError(str(e), code="invalid_argument") from e
+    except K8sApiError as e:
+        # K8s API errors carry an HTTP-style status code from the underlying
+        # kubernetes-client ``ApiException``. Translate to the MCP code family
+        # used by the rest of this module so AI clients see stable wire codes
+        # (404 -> ``not_found``, 403 -> ``access_denied``, 409 -> ``conflict``,
+        # other 4xx -> ``invalid_argument``, 5xx -> ``internal_error``).
+        if e.status == 404:
+            raise MCPToolError(str(e), code="not_found") from e
+        if e.status == 403:
+            raise MCPToolError(str(e), code="access_denied") from e
+        if e.status == 409:
+            raise MCPToolError(str(e), code="conflict") from e
+        if 400 <= e.status < 500:
+            raise MCPToolError(str(e), code="invalid_argument") from e
+        # 5xx -- surface as internal_error so OTel records and operators can
+        # follow up; the message keeps the underlying detail.
+        raise MCPToolError(str(e), code="internal_error") from e
     except (
         ConnectionNotFoundError,
         WorkspaceNotFoundError,

--- a/api/src/aerospike_cluster_manager_api/mcp/serializers.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/serializers.py
@@ -122,6 +122,33 @@ def serialize_records(records: Iterable[Record]) -> list[dict[str, Any]]:
 
 
 # ---------------------------------------------------------------------------
+# K8s helpers (Phase 2 -- #305)
+# ---------------------------------------------------------------------------
+#
+# The K8s MCP tools return existing Pydantic models (``K8sClusterSummary``,
+# ``K8sPodStatus``, ``K8sClusterEvent``) that the REST routers also emit.
+# These helpers are thin wrappers around ``model_dump(by_alias=True)`` so the
+# wire shape (camelCase keys: ``connectionId``, ``isReady``, ``podIP``)
+# matches the OpenAPI doc -- what the LLM sees through MCP equals what it
+# would see calling the REST API directly.
+
+
+def k8s_cluster_summary(model: Any) -> dict[str, Any]:
+    """Convert a ``K8sClusterSummary`` instance to a JSON-safe dict."""
+    return model.model_dump(by_alias=True)
+
+
+def k8s_pod(model: Any) -> dict[str, Any]:
+    """Convert a ``K8sPodStatus`` instance to a JSON-safe dict."""
+    return model.model_dump(by_alias=True)
+
+
+def k8s_event(model: Any) -> dict[str, Any]:
+    """Convert a ``K8sClusterEvent`` instance to a JSON-safe dict."""
+    return model.model_dump(by_alias=True)
+
+
+# ---------------------------------------------------------------------------
 # Internal helpers
 # ---------------------------------------------------------------------------
 

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/__init__.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/__init__.py
@@ -21,6 +21,7 @@ from aerospike_cluster_manager_api.mcp.tools import (  # noqa: F401  — import 
     cluster_info,
     connections,
     info_commands,
+    k8s,
     query,
     records,
 )

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/k8s.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/k8s.py
@@ -1,0 +1,334 @@
+"""MCP tools for Kubernetes-managed AerospikeCluster CRs (Phase 2 -- #305).
+
+Five tools that wrap :mod:`aerospike_cluster_manager_api.k8s_client` and the
+helpers in :mod:`aerospike_cluster_manager_api.services.k8s_service`:
+
+* ``list_k8s_clusters`` -- enumerate AerospikeCluster CRs (read)
+* ``get_k8s_pods`` -- pod status for a cluster (read)
+* ``get_k8s_events`` -- recent K8s events for a cluster, bounded by
+  ``since_minutes`` (read)
+* ``scale_k8s_cluster`` -- patch ``spec.size`` (mutation; gated under
+  ``READ_ONLY``)
+* ``get_k8s_logs`` -- bounded log snapshot for a pod (read)
+
+Design notes (per ADR ``docs/plans/2026-05-07-k8s-mcp-tools-contract.md``):
+
+* ``cluster_id`` is ``"<namespace>/<name>"`` -- same convention used by the
+  ``K8sClusterSummary.id`` field and the REST router.
+* All five tools accept an optional ``workspace_id`` so the Phase 0a
+  registry workspace gate (which fires on ``conn_id`` *or* ``workspace_id``
+  parameter names) wires up uniformly. The tool body itself does not
+  re-check ownership -- the registry decorator is authoritative.
+* When ``K8S_MANAGEMENT_ENABLED=false`` every tool raises
+  ``MCPToolError(code="unavailable")`` immediately; no K8s client is
+  initialised. The flag is checked at call time (not import time) so the
+  same module loads cleanly in K8s-disabled deployments.
+* ``since_minutes``, ``since_seconds`` and ``tail_lines`` have hard upper
+  bounds (1440 / 3600 / 1000 respectively); out-of-range values raise
+  ``MCPToolError(code="invalid_argument")``.
+* ``K8sApiError`` propagates via the registry decorator's
+  :func:`map_aerospike_errors` context manager, which translates 404 ->
+  ``not_found``, 403 -> ``access_denied``, 409 -> ``conflict``, other 4xx ->
+  ``invalid_argument``, 5xx -> ``internal_error``.
+* No cluster create / delete tools -- those high-blast-radius actions stay
+  in the REST surface (see ADR "Out of scope").
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from aerospike_cluster_manager_api import config
+from aerospike_cluster_manager_api.k8s_client import k8s_client
+from aerospike_cluster_manager_api.mcp import serializers
+from aerospike_cluster_manager_api.mcp.errors import MCPToolError
+from aerospike_cluster_manager_api.mcp.registry import tool
+from aerospike_cluster_manager_api.models.k8s_cluster import (
+    K8sClusterEvent,
+    K8sClusterSummary,
+    K8sPodStatus,
+)
+from aerospike_cluster_manager_api.services import k8s_service
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Bounds (per ADR section "Param decisions")
+# ---------------------------------------------------------------------------
+
+_MAX_SINCE_MINUTES = 1440  # 24h ceiling for event windows
+_MAX_SINCE_SECONDS = 3600  # 1h ceiling for log windows
+_MAX_TAIL_LINES = 1000  # cap on log lines returned per call
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _assert_k8s_enabled() -> None:
+    """Reject the call early when K8s management is disabled at config time.
+
+    Called at the top of every K8s tool body. Without this check, the
+    underlying ``k8s_client`` would attempt to load in-cluster config /
+    kubeconfig and surface a confusing ``RuntimeError`` to the LLM instead
+    of a stable ``unavailable`` code. The flag is read live (not snapshotted
+    at import) so test fixtures can flip it via ``monkeypatch``.
+    """
+    if not config.K8S_MANAGEMENT_ENABLED:
+        raise MCPToolError(
+            "Kubernetes management is not enabled on this deployment; "
+            "set K8S_MANAGEMENT_ENABLED=true to expose the K8s tools.",
+            code="unavailable",
+        )
+
+
+def _parse_cluster_id(cluster_id: str) -> tuple[str, str]:
+    """Split ``"<namespace>/<name>"`` into ``(namespace, name)``.
+
+    Raises ``MCPToolError(code="invalid_argument")`` on malformed input --
+    the message includes the expected format so the LLM can recover.
+    """
+    if not isinstance(cluster_id, str) or "/" not in cluster_id:
+        raise MCPToolError(
+            f"cluster_id must be '<namespace>/<name>', got {cluster_id!r}",
+            code="invalid_argument",
+        )
+    namespace, _, name = cluster_id.partition("/")
+    if not namespace or not name or "/" in name:
+        raise MCPToolError(
+            f"cluster_id must be '<namespace>/<name>', got {cluster_id!r}",
+            code="invalid_argument",
+        )
+    return namespace, name
+
+
+def _check_bound(value: int, *, max_value: int, name: str) -> None:
+    """Validate that ``value`` is within ``[1, max_value]``."""
+    if value < 1 or value > max_value:
+        raise MCPToolError(
+            f"{name} must be between 1 and {max_value}, got {value}",
+            code="invalid_argument",
+        )
+
+
+def _workspace_label_selector(workspace_id: str | None) -> str | None:
+    """Build a label selector that filters CRs by workspace label.
+
+    ``workspace_id=None`` returns ``None`` so the underlying call lists
+    every CR the caller can see. Existing CRs without the label are
+    invisible to a workspace-scoped lookup -- matching the REST API
+    behaviour established by PR #297.
+    """
+    if workspace_id is None:
+        return None
+    return f"acm.aerospike.com/workspace={workspace_id}"
+
+
+# ---------------------------------------------------------------------------
+# Tool wrappers
+# ---------------------------------------------------------------------------
+
+
+@tool(category="k8s", mutation=False)
+async def list_k8s_clusters(workspace_id: str | None = None) -> list[dict[str, Any]]:
+    """List AerospikeCluster CRs visible to the caller.
+
+    Returns a list of ``K8sClusterSummary`` dicts (camelCase keys per the
+    REST OpenAPI shape: ``connectionId``, ``failedReconcileCount``,
+    ``templateDrifted``).
+
+    With ``workspace_id`` set the listing is restricted to CRs labelled
+    ``acm.aerospike.com/workspace=<workspace_id>``. With ``workspace_id=None``
+    (default) every visible CR is returned, including legacy CRs that
+    pre-date workspace labelling.
+    """
+    _assert_k8s_enabled()
+    label_selector = _workspace_label_selector(workspace_id)
+    items, _ = await k8s_client.list_clusters(label_selector=label_selector)
+    summaries = [k8s_service.extract_summary(item) for item in items]
+    return [serializers.k8s_cluster_summary(s) for s in summaries]
+
+
+@tool(category="k8s", mutation=False)
+async def get_k8s_pods(
+    cluster_id: str,
+    workspace_id: str | None = None,
+) -> list[dict[str, Any]]:
+    """Return pod status for an AerospikeCluster CR.
+
+    ``cluster_id`` is ``"<namespace>/<name>"`` as returned by
+    ``list_k8s_clusters``. Cross-workspace access (when ``workspace_id`` is
+    supplied) is rejected with ``code=workspace_mismatch`` by the registry
+    gate before the tool body runs.
+
+    Returns a list of ``K8sPodStatus`` dicts (camelCase keys: ``isReady``,
+    ``podIP``, ``hostIP``, ``rackId``, etc.).
+    """
+    _assert_k8s_enabled()
+    namespace, name = _parse_cluster_id(cluster_id)
+    pods_raw = await k8s_client.list_pods(
+        namespace,
+        f"app.kubernetes.io/name=aerospike-cluster,app.kubernetes.io/instance={name}",
+    )
+    pods = [K8sPodStatus(**p) for p in pods_raw]
+    return [serializers.k8s_pod(p) for p in pods]
+
+
+@tool(category="k8s", mutation=False)
+async def get_k8s_events(
+    cluster_id: str,
+    workspace_id: str | None = None,
+    since_minutes: int = 30,
+) -> list[dict[str, Any]]:
+    """Return Kubernetes events involving an AerospikeCluster CR.
+
+    Bounded by ``since_minutes`` (default 30, max 1440). Events older than
+    the window are dropped; ``invalid_argument`` is raised for values
+    outside ``[1, 1440]``.
+
+    Returns a list of ``K8sClusterEvent`` dicts with the operator-specific
+    ``category`` field populated (Rolling Restart / Configuration /
+    Scaling / etc.) so the LLM can group events without re-running the
+    classifier.
+    """
+    _assert_k8s_enabled()
+    _check_bound(since_minutes, max_value=_MAX_SINCE_MINUTES, name="since_minutes")
+    namespace, name = _parse_cluster_id(cluster_id)
+
+    field_selector = f"involvedObject.name={name},involvedObject.kind=AerospikeCluster"
+    events_raw = await k8s_client.list_events(namespace, field_selector)
+
+    # Filter to the requested time window. ``lastTimestamp`` is RFC3339
+    # from ``_list_events_sync``; fall back to ``firstTimestamp`` when the
+    # event has not been seen since (single occurrence).
+    cutoff = datetime.now(UTC) - timedelta(minutes=since_minutes)
+    filtered = []
+    for raw in events_raw:
+        ts_str = raw.get("lastTimestamp") or raw.get("firstTimestamp")
+        if ts_str:
+            try:
+                ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+            except ValueError:
+                ts = None
+            if ts is not None and ts < cutoff:
+                continue
+        filtered.append(raw)
+
+    events = [K8sClusterEvent(**e) for e in filtered]
+    for event in events:
+        event.category = k8s_service.categorize_event(event.reason)
+    return [serializers.k8s_event(e) for e in events]
+
+
+@tool(category="k8s", mutation=True)
+async def scale_k8s_cluster(
+    cluster_id: str,
+    size: int,
+    workspace_id: str | None = None,
+) -> dict[str, Any]:
+    """Patch ``spec.size`` on an AerospikeCluster CR.
+
+    Returns ``{"clusterId": str, "previousSize": int, "newSize": int}`` --
+    deliberately small so the LLM can confirm the patch landed without
+    having to parse a full cluster snapshot.
+
+    CE caps cluster size at 8 nodes; the operator's webhook enforces the
+    ceiling and returns ``conflict`` (mapped from a 409 K8s API error)
+    when exceeded.
+
+    Mutation: requires ``ACM_MCP_ACCESS_PROFILE=full``; returns
+    ``code=access_denied`` under READ_ONLY.
+    """
+    _assert_k8s_enabled()
+    if size < 1:
+        raise MCPToolError(
+            f"size must be >= 1, got {size}",
+            code="invalid_argument",
+        )
+    namespace, name = _parse_cluster_id(cluster_id)
+
+    # Read previous size first so the response carries an audit-style diff.
+    current = await k8s_client.get_cluster(namespace, name)
+    previous_size = int(current.get("spec", {}).get("size", 0) or 0)
+
+    patch = {"spec": {"size": size}}
+    result = await k8s_client.patch_cluster(namespace, name, patch)
+    new_size = int(result.get("spec", {}).get("size", size) or size)
+
+    # Use a non-aliased camelCase form directly so the response matches the
+    # ADR shape regardless of Pydantic round-trips.
+    return {
+        "clusterId": cluster_id,
+        "previousSize": previous_size,
+        "newSize": new_size,
+    }
+
+
+@tool(category="k8s", mutation=False)
+async def get_k8s_logs(
+    cluster_id: str,
+    pod_name: str,
+    workspace_id: str | None = None,
+    since_seconds: int = 300,
+    tail_lines: int = 200,
+) -> dict[str, Any]:
+    """Return a bounded log snapshot for a pod inside an AerospikeCluster.
+
+    ``pod_name`` must belong to the named cluster -- pods labelled
+    ``app.kubernetes.io/instance=<cluster-name>``. Cross-cluster pod
+    access is rejected with ``code=not_found``.
+
+    ``since_seconds`` is currently informational (the underlying client
+    reads the last ``tail_lines`` lines via the K8s API; future versions
+    can switch to ``sinceSeconds``-based truncation). It is still bounds-
+    checked so callers cannot pass arbitrarily large values.
+
+    Bounds: ``since_seconds`` <= 3600, ``tail_lines`` <= 1000. Out-of-range
+    values raise ``invalid_argument``.
+
+    Returns ``{"podName": str, "lines": list[str], "truncated": bool}``.
+    ``truncated`` is true when the pod returned at least ``tail_lines``
+    lines (so older history was elided by the K8s API).
+    """
+    _assert_k8s_enabled()
+    _check_bound(since_seconds, max_value=_MAX_SINCE_SECONDS, name="since_seconds")
+    _check_bound(tail_lines, max_value=_MAX_TAIL_LINES, name="tail_lines")
+    namespace, name = _parse_cluster_id(cluster_id)
+
+    cluster_pods = await k8s_client.list_pods(namespace, f"app.kubernetes.io/instance={name}")
+    pod_names = {p["name"] for p in cluster_pods}
+    if pod_name not in pod_names:
+        raise MCPToolError(
+            f"Pod '{pod_name}' does not belong to cluster '{cluster_id}'",
+            code="not_found",
+        )
+
+    raw_logs = await k8s_client.read_pod_log(namespace, pod_name, tail_lines=tail_lines)
+    # ``read_namespaced_pod_log`` returns a single string; split into lines
+    # so the LLM gets a structured payload it can iterate over.
+    lines = raw_logs.splitlines() if raw_logs else []
+    truncated = len(lines) >= tail_lines
+    return {
+        "podName": pod_name,
+        "lines": lines,
+        "truncated": truncated,
+    }
+
+
+# Re-export the model classes for tests / introspection. Without these the
+# test file would have to reach into ``models.k8s_cluster`` directly which
+# couples the test to the model layout rather than the tool surface.
+__all__ = [
+    "K8sClusterEvent",
+    "K8sClusterSummary",
+    "K8sPodStatus",
+    "get_k8s_events",
+    "get_k8s_logs",
+    "get_k8s_pods",
+    "list_k8s_clusters",
+    "scale_k8s_cluster",
+]

--- a/api/tests/mcp/conftest.py
+++ b/api/tests/mcp/conftest.py
@@ -34,6 +34,7 @@ from aerospike_cluster_manager_api.mcp.tools import (  # noqa: F401
     cluster_info,
     connections,
     info_commands,
+    k8s,
     query,
     records,
 )
@@ -42,8 +43,8 @@ from aerospike_cluster_manager_api.mcp.tools import (  # noqa: F401
 # Tool count constant — replaces the magic number ``21`` everywhere.
 # ---------------------------------------------------------------------------
 
-EXPECTED_TOOL_COUNT: int = 22
-"""Total number of MCP tools registered by Phase 1 + the read-only info follow-up.
+EXPECTED_TOOL_COUNT: int = 27
+"""Total number of MCP tools registered by Phase 1 + read-only info + Phase 2 K8s.
 
 Breakdown:
 * 8 connection tools (create, get, update, delete, list, connect, disconnect,
@@ -52,6 +53,8 @@ Breakdown:
 * 7 record (get, exists, create, update, delete, delete_bin, truncate_set)
 * 1 query
 * 3 info commands (execute_info, execute_info_on_node, execute_info_read_only)
+* 5 K8s (list_k8s_clusters, get_k8s_pods, get_k8s_events, scale_k8s_cluster,
+  get_k8s_logs) -- Phase 2, #305
 """
 
 

--- a/api/tests/mcp/test_auto_discovery.py
+++ b/api/tests/mcp/test_auto_discovery.py
@@ -40,6 +40,12 @@ def test_build_mcp_app_registers_all_phase1_tools() -> None:
     assert "execute_info" in names
     assert "execute_info_on_node" in names
     assert "execute_info_read_only" in names
+    # 5 K8s (Phase 2, #305)
+    assert "list_k8s_clusters" in names
+    assert "get_k8s_pods" in names
+    assert "get_k8s_events" in names
+    assert "scale_k8s_cluster" in names
+    assert "get_k8s_logs" in names
 
     assert len(names) == EXPECTED_TOOL_COUNT, f"expected {EXPECTED_TOOL_COUNT} tools, got {len(names)}: {sorted(names)}"
 

--- a/api/tests/mcp/test_e2e_readonly.py
+++ b/api/tests/mcp/test_e2e_readonly.py
@@ -141,6 +141,25 @@ async def test_execute_info_read_only_works_under_read_only(read_only_profile: N
     assert out["response"] == "test;bar"
 
 
+async def test_scale_k8s_cluster_blocked_under_read_only(
+    read_only_profile: None,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``scale_k8s_cluster`` patches ``spec.size``, so it is a write tool --
+    READ_ONLY must reject it with ``access_denied`` BEFORE the K8s client is
+    touched. We flip ``K8S_MANAGEMENT_ENABLED`` on so the gate is exercised
+    rather than the unavailable path; the access gate fires first."""
+    from aerospike_cluster_manager_api import config as app_config
+    from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+    monkeypatch.setattr(app_config, "K8S_MANAGEMENT_ENABLED", True)
+
+    with pytest.raises(MCPToolError) as exc_info:
+        await k8s_tools.scale_k8s_cluster(cluster_id="default/cl", size=3)
+    assert exc_info.value.code == "access_denied"
+    assert "scale_k8s_cluster" in str(exc_info.value)
+
+
 async def test_execute_info_read_only_unwhitelisted_verb_yields_invalid_argument(
     read_only_profile: None,
 ) -> None:

--- a/api/tests/mcp/test_k8s_tools.py
+++ b/api/tests/mcp/test_k8s_tools.py
@@ -1,0 +1,395 @@
+"""Tests for the MCP K8s tools (Phase 2 -- #305).
+
+Direct callable invocation is enough to exercise the wrapping layer the
+registry decorator applies (access profile gate, error mapping, the
+``_assert_k8s_enabled`` guard, ``_parse_cluster_id`` validation, and bound
+checks on ``since_minutes`` / ``since_seconds`` / ``tail_lines``).
+
+The K8sClient surface is fully mocked -- service-layer tests already cover
+the underlying helpers (``extract_summary``, ``categorize_event``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aerospike_cluster_manager_api import config as app_config
+from aerospike_cluster_manager_api.k8s_client import K8sApiError
+from aerospike_cluster_manager_api.mcp.errors import MCPToolError
+from aerospike_cluster_manager_api.mcp.registry import registered_tools
+
+
+@pytest.fixture
+def k8s_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Flip ``K8S_MANAGEMENT_ENABLED`` on for the test body.
+
+    Also forces ``ACCESS_PROFILE=FULL`` so the access-profile gate does not
+    pre-empt the body of mutation tools (``scale_k8s_cluster``). Tests that
+    specifically want to exercise the read-only gate flip the profile back
+    explicitly (see ``test_scale_k8s_cluster_blocked_under_read_only`` in
+    ``test_e2e_readonly.py``).
+    """
+    from aerospike_cluster_manager_api.mcp.access_profile import AccessProfile
+
+    monkeypatch.setattr(app_config, "K8S_MANAGEMENT_ENABLED", True)
+    monkeypatch.setattr(app_config, "ACM_MCP_ACCESS_PROFILE", AccessProfile.FULL)
+
+
+def test_k8s_module_registers_five_tools() -> None:
+    from aerospike_cluster_manager_api.mcp.tools import k8s as _k8s  # noqa: F401
+
+    names = {entry.name for entry in registered_tools() if entry.category == "k8s"}
+    assert names == {
+        "list_k8s_clusters",
+        "get_k8s_pods",
+        "get_k8s_events",
+        "scale_k8s_cluster",
+        "get_k8s_logs",
+    }
+
+
+def test_only_scale_k8s_cluster_is_mutation() -> None:
+    from aerospike_cluster_manager_api.mcp.tools import k8s as _k8s  # noqa: F401
+
+    by_name = {entry.name: entry for entry in registered_tools() if entry.category == "k8s"}
+    assert by_name["scale_k8s_cluster"].mutation is True
+    for read_tool in ("list_k8s_clusters", "get_k8s_pods", "get_k8s_events", "get_k8s_logs"):
+        assert by_name[read_tool].mutation is False, read_tool
+
+
+@pytest.mark.parametrize(
+    "tool_name,kwargs",
+    [
+        ("list_k8s_clusters", {}),
+        ("get_k8s_pods", {"cluster_id": "default/cl"}),
+        ("get_k8s_events", {"cluster_id": "default/cl"}),
+        ("scale_k8s_cluster", {"cluster_id": "default/cl", "size": 3}),
+        ("get_k8s_logs", {"cluster_id": "default/cl", "pod_name": "cl-0-0"}),
+    ],
+)
+async def test_disabled_flag_returns_unavailable(
+    monkeypatch: pytest.MonkeyPatch, tool_name: str, kwargs: dict[str, Any]
+) -> None:
+    """When K8S_MANAGEMENT_ENABLED=false every tool short-circuits with
+    ``code="unavailable"`` -- no K8s client init, no body execution.
+
+    Forced FULL profile so the access-profile gate does not pre-empt the
+    unavailability check on ``scale_k8s_cluster`` (READ_ONLY would yield
+    ``access_denied`` before ``_assert_k8s_enabled`` runs).
+    """
+    from aerospike_cluster_manager_api.mcp.access_profile import AccessProfile
+    from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+    monkeypatch.setattr(app_config, "K8S_MANAGEMENT_ENABLED", False)
+    monkeypatch.setattr(app_config, "ACM_MCP_ACCESS_PROFILE", AccessProfile.FULL)
+
+    fn = getattr(k8s_tools, tool_name)
+    with pytest.raises(MCPToolError) as exc_info:
+        await fn(**kwargs)
+    assert exc_info.value.code == "unavailable"
+
+
+@pytest.mark.parametrize("bad_id", ["", "noslash", "/missing-ns", "ns/", "ns/name/extra"])
+async def test_malformed_cluster_id_yields_invalid_argument(k8s_enabled: None, bad_id: str) -> None:
+    from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+    with pytest.raises(MCPToolError) as exc_info:
+        await k8s_tools.get_k8s_pods(cluster_id=bad_id)
+    assert exc_info.value.code == "invalid_argument"
+
+
+_SAMPLE_CR = {
+    "apiVersion": "acko.io/v1alpha1",
+    "kind": "AerospikeCluster",
+    "metadata": {
+        "name": "cl",
+        "namespace": "default",
+        "creationTimestamp": "2026-05-01T12:00:00Z",
+        "labels": {"acm.aerospike.com/workspace": "ws-default"},
+    },
+    "spec": {"size": 3, "image": "aerospike/aerospike-server:8.1"},
+    "status": {"phase": "Completed", "failedReconcileCount": 0},
+}
+
+
+class TestListK8sClusters:
+    async def test_happy_path_returns_summary_dicts(self, k8s_enabled: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+        with patch.object(
+            k8s_tools.k8s_client,
+            "list_clusters",
+            new=AsyncMock(return_value=([_SAMPLE_CR], None)),
+        ):
+            result = await k8s_tools.list_k8s_clusters()
+
+        assert len(result) == 1
+        item = result[0]
+        assert item["name"] == "cl"
+        assert item["namespace"] == "default"
+        assert item["size"] == 3
+        assert item["phase"] == "Completed"
+
+    async def test_workspace_filter_passes_label_selector(self, k8s_enabled: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+        mock = AsyncMock(return_value=([], None))
+        with patch.object(k8s_tools.k8s_client, "list_clusters", new=mock):
+            await k8s_tools.list_k8s_clusters(workspace_id="ws-team")
+
+        _, kwargs = mock.call_args
+        assert kwargs["label_selector"] == "acm.aerospike.com/workspace=ws-team"
+
+    async def test_no_workspace_omits_label_selector(self, k8s_enabled: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+        mock = AsyncMock(return_value=([], None))
+        with patch.object(k8s_tools.k8s_client, "list_clusters", new=mock):
+            await k8s_tools.list_k8s_clusters()
+
+        _, kwargs = mock.call_args
+        assert kwargs["label_selector"] is None
+
+
+class TestGetK8sPods:
+    async def test_happy_path_returns_pod_status_dicts(self, k8s_enabled: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+        raw_pods = [
+            {
+                "name": "cl-0-0",
+                "podIP": "10.0.0.5",
+                "hostIP": "10.0.0.1",
+                "isReady": True,
+                "phase": "Running",
+                "image": "aerospike/aerospike-server:8.1",
+            }
+        ]
+        with patch.object(
+            k8s_tools.k8s_client,
+            "list_pods",
+            new=AsyncMock(return_value=raw_pods),
+        ):
+            result = await k8s_tools.get_k8s_pods(cluster_id="default/cl")
+
+        assert len(result) == 1
+        assert result[0]["name"] == "cl-0-0"
+        assert result[0]["isReady"] is True
+        assert result[0]["podIP"] == "10.0.0.5"
+
+    async def test_404_from_k8s_maps_to_not_found(self, k8s_enabled: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+        with (
+            patch.object(
+                k8s_tools.k8s_client,
+                "list_pods",
+                new=AsyncMock(side_effect=K8sApiError(status=404, reason="NotFound", message="cl missing")),
+            ),
+            pytest.raises(MCPToolError) as exc_info,
+        ):
+            await k8s_tools.get_k8s_pods(cluster_id="default/cl")
+
+        assert exc_info.value.code == "not_found"
+
+
+class TestGetK8sEvents:
+    async def test_happy_path_assigns_category(self, k8s_enabled: None) -> None:
+        from datetime import UTC, datetime
+
+        from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+        now_iso = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        raw_events = [
+            {
+                "type": "Normal",
+                "reason": "RollingRestartStarted",
+                "message": "rolling restart kicked off",
+                "count": 1,
+                "firstTimestamp": now_iso,
+                "lastTimestamp": now_iso,
+                "source": "operator",
+            }
+        ]
+        with patch.object(
+            k8s_tools.k8s_client,
+            "list_events",
+            new=AsyncMock(return_value=raw_events),
+        ):
+            result = await k8s_tools.get_k8s_events(cluster_id="default/cl")
+
+        assert len(result) == 1
+        assert result[0]["reason"] == "RollingRestartStarted"
+        assert result[0]["category"] == "Rolling Restart"
+
+    async def test_old_events_filtered_out(self, k8s_enabled: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+        old_iso = "2020-01-01T00:00:00Z"
+        raw_events = [
+            {
+                "type": "Normal",
+                "reason": "ClusterCreated",
+                "message": "old event",
+                "count": 1,
+                "firstTimestamp": old_iso,
+                "lastTimestamp": old_iso,
+                "source": "operator",
+            }
+        ]
+        with patch.object(
+            k8s_tools.k8s_client,
+            "list_events",
+            new=AsyncMock(return_value=raw_events),
+        ):
+            result = await k8s_tools.get_k8s_events(cluster_id="default/cl", since_minutes=10)
+
+        assert result == []
+
+    @pytest.mark.parametrize("bad", [0, -1, 1441, 100000])
+    async def test_since_minutes_bounds(self, k8s_enabled: None, bad: int) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+        with pytest.raises(MCPToolError) as exc_info:
+            await k8s_tools.get_k8s_events(cluster_id="default/cl", since_minutes=bad)
+        assert exc_info.value.code == "invalid_argument"
+
+
+class TestScaleK8sCluster:
+    async def test_happy_path_returns_size_diff(self, k8s_enabled: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+        before = {**_SAMPLE_CR, "spec": {**_SAMPLE_CR["spec"], "size": 3}}
+        after = {**_SAMPLE_CR, "spec": {**_SAMPLE_CR["spec"], "size": 5}}
+
+        with (
+            patch.object(k8s_tools.k8s_client, "get_cluster", new=AsyncMock(return_value=before)),
+            patch.object(k8s_tools.k8s_client, "patch_cluster", new=AsyncMock(return_value=after)) as patch_mock,
+        ):
+            result = await k8s_tools.scale_k8s_cluster(cluster_id="default/cl", size=5)
+
+        assert result == {"clusterId": "default/cl", "previousSize": 3, "newSize": 5}
+        args, _ = patch_mock.call_args
+        assert args == ("default", "cl", {"spec": {"size": 5}})
+
+    async def test_negative_size_yields_invalid_argument(self, k8s_enabled: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+        with pytest.raises(MCPToolError) as exc_info:
+            await k8s_tools.scale_k8s_cluster(cluster_id="default/cl", size=0)
+        assert exc_info.value.code == "invalid_argument"
+
+    async def test_409_from_webhook_maps_to_conflict(self, k8s_enabled: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+        before = {**_SAMPLE_CR, "spec": {**_SAMPLE_CR["spec"], "size": 3}}
+        with (
+            patch.object(k8s_tools.k8s_client, "get_cluster", new=AsyncMock(return_value=before)),
+            patch.object(
+                k8s_tools.k8s_client,
+                "patch_cluster",
+                new=AsyncMock(
+                    side_effect=K8sApiError(status=409, reason="Conflict", message="size > 8 not allowed on CE")
+                ),
+            ),
+            pytest.raises(MCPToolError) as exc_info,
+        ):
+            await k8s_tools.scale_k8s_cluster(cluster_id="default/cl", size=9)
+
+        assert exc_info.value.code == "conflict"
+
+    async def test_500_from_k8s_maps_to_internal_error(self, k8s_enabled: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+        with (
+            patch.object(
+                k8s_tools.k8s_client,
+                "get_cluster",
+                new=AsyncMock(side_effect=K8sApiError(status=500, reason="ServerError", message="api server flake")),
+            ),
+            pytest.raises(MCPToolError) as exc_info,
+        ):
+            await k8s_tools.scale_k8s_cluster(cluster_id="default/cl", size=3)
+
+        assert exc_info.value.code == "internal_error"
+
+
+class TestGetK8sLogs:
+    async def test_happy_path_returns_lines_and_truncated_flag(self, k8s_enabled: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+        with (
+            patch.object(
+                k8s_tools.k8s_client,
+                "list_pods",
+                new=AsyncMock(return_value=[{"name": "cl-0-0"}]),
+            ),
+            patch.object(
+                k8s_tools.k8s_client,
+                "read_pod_log",
+                new=AsyncMock(return_value="line1\nline2\nline3"),
+            ),
+        ):
+            result = await k8s_tools.get_k8s_logs(cluster_id="default/cl", pod_name="cl-0-0", tail_lines=10)
+
+        assert result["podName"] == "cl-0-0"
+        assert result["lines"] == ["line1", "line2", "line3"]
+        assert result["truncated"] is False
+
+    async def test_truncated_flag_set_when_at_limit(self, k8s_enabled: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+        log_text = "\n".join(f"line{i}" for i in range(5))
+        with (
+            patch.object(
+                k8s_tools.k8s_client,
+                "list_pods",
+                new=AsyncMock(return_value=[{"name": "cl-0-0"}]),
+            ),
+            patch.object(
+                k8s_tools.k8s_client,
+                "read_pod_log",
+                new=AsyncMock(return_value=log_text),
+            ),
+        ):
+            result = await k8s_tools.get_k8s_logs(cluster_id="default/cl", pod_name="cl-0-0", tail_lines=5)
+
+        assert result["truncated"] is True
+
+    async def test_pod_not_in_cluster_yields_not_found(self, k8s_enabled: None) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+        with (
+            patch.object(
+                k8s_tools.k8s_client,
+                "list_pods",
+                new=AsyncMock(return_value=[{"name": "cl-0-0"}]),
+            ),
+            pytest.raises(MCPToolError) as exc_info,
+        ):
+            await k8s_tools.get_k8s_logs(cluster_id="default/cl", pod_name="other-pod")
+
+        assert exc_info.value.code == "not_found"
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"since_seconds": 0},
+            {"since_seconds": 3601},
+            {"tail_lines": 0},
+            {"tail_lines": 1001},
+        ],
+    )
+    async def test_log_bounds_enforced(self, k8s_enabled: None, kwargs: dict[str, int]) -> None:
+        from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
+
+        with pytest.raises(MCPToolError) as exc_info:
+            await k8s_tools.get_k8s_logs(
+                cluster_id="default/cl",
+                pod_name="cl-0-0",
+                **kwargs,
+            )
+        assert exc_info.value.code == "invalid_argument"


### PR DESCRIPTION
## Summary

Implements 5 K8s MCP tools per Phase 0c contract ADR `docs/plans/2026-05-07-k8s-mcp-tools-contract.md`:

- `list_k8s_clusters(workspace_id)` — enumerate AerospikeCluster CRs (read).
- `get_k8s_pods(cluster_id, workspace_id)` — pod status (read).
- `get_k8s_events(cluster_id, workspace_id, since_minutes)` — recent K8s events with category labels (read; `since_minutes` ≤ 1440).
- `scale_k8s_cluster(cluster_id, size, workspace_id)` — patches `spec.size`; returns `{clusterId, previousSize, newSize}` (mutation; gated by `READ_ONLY`).
- `get_k8s_logs(cluster_id, pod_name, workspace_id, since_seconds, tail_lines)` — bounded log snapshot (read; `tail_lines` ≤ 1000, `since_seconds` ≤ 3600).

Tool count: `EXPECTED_TOOL_COUNT 22 → 27`. New `k8s` category. `scale_k8s_cluster` added to `WRITE_TOOLS`.

`mcp/errors.py` extended with `K8sApiError` mapping (404 → `not_found`, 403 → `access_denied`, 409 → `conflict`, other 4xx → `invalid_argument`, 5xx → `internal_error`). When `K8S_MANAGEMENT_ENABLED=false` every K8s tool short-circuits with `code="unavailable"` via `_assert_k8s_enabled()` at the top of each body — no client init, no flag-check on import.

`workspace_id` is forwarded as a regular `str | None` param so the Phase 0a registry workspace gate (Stream B/E) wires up uniformly without needing `ctx` in tool bodies.

## Test plan

- [x] `tests/mcp/test_k8s_tools.py` — happy path per tool, `K8sApiError` 404/409/500 mappings, `_parse_cluster_id` validation, `since_minutes` / `since_seconds` / `tail_lines` bound checks, `K8S_MANAGEMENT_ENABLED=false` → `unavailable` for all 5 tools, `scale_k8s_cluster` patch shape.
- [x] `tests/mcp/test_e2e_readonly.py` — `scale_k8s_cluster` blocked with `access_denied` under `READ_ONLY`.
- [x] `tests/mcp/test_auto_discovery.py` — 5 tool names asserted by name + count.
- [x] `uv run ruff check src tests` clean; `uv run ruff format src tests` clean.
- [x] `uv run pyright src/aerospike_cluster_manager_api/mcp/tools/k8s.py tests/mcp/test_k8s_tools.py` 0 errors.
- [x] `uv run pytest tests/mcp/` — 278 passed.
- [x] `uv run pytest tests/` — 856 passed.
- [x] `pre-commit run --files <changed>` clean.

## Out of scope (per ADR)

- Cluster create / delete via MCP — REST API only; MCP stays diagnostic-and-scale.
- Streaming logs / event watch — bounded snapshot only.
- Custom label selectors — workspace label is the only filter.

Closes #305