### PR TITLE
feat(api): Workspace.ownerId schema + ACL (E.1 of #307)

### DIFF
--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -165,6 +165,15 @@ OIDC_EXCLUDE_PATHS: list[str] = _parse_str_list(
     os.getenv("OIDC_EXCLUDE_PATHS", "/api/health,/api/openapi.json,/api/docs")
 ) or ["/api/health", "/api/openapi.json", "/api/docs"]
 
+# OIDC claim used as the workspace owner identity. Defaults to ``sub`` (the
+# stable subject identifier mandated by the OIDC core spec). Operators
+# running against an IdP whose ``sub`` is unstable across logins can switch
+# to ``preferred_username`` / a custom claim. See
+# ``docs/plans/2026-05-07-workspace-ownership-schema.md`` Migration risk
+# table. Read once at module import time so request hot-paths avoid an
+# os.environ lookup on every call.
+ACM_OIDC_OWNER_CLAIM: str = os.getenv("ACM_OIDC_OWNER_CLAIM", "sub")
+
 # ---------------------------------------------------------------------------
 # MCP (Model Context Protocol) server — phase 1
 # ---------------------------------------------------------------------------

--- a/api/src/aerospike_cluster_manager_api/db/__init__.py
+++ b/api/src/aerospike_cluster_manager_api/db/__init__.py
@@ -86,6 +86,10 @@ async def get_workspace(workspace_id: str) -> Workspace | None:
     return await _get_backend().get_workspace(workspace_id)
 
 
+async def get_workspaces_owned_by(owner_id: str) -> list[Workspace]:
+    return await _get_backend().get_workspaces_owned_by(owner_id)
+
+
 async def create_workspace(ws: Workspace) -> None:
     await _get_backend().create_workspace(ws)
 

--- a/api/src/aerospike_cluster_manager_api/db/_base.py
+++ b/api/src/aerospike_cluster_manager_api/db/_base.py
@@ -10,7 +10,11 @@ from datetime import UTC, datetime
 from typing import Any, Protocol, runtime_checkable
 
 from aerospike_cluster_manager_api.models.connection import ConnectionProfile
-from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID, Workspace
+from aerospike_cluster_manager_api.models.workspace import (
+    DEFAULT_WORKSPACE_ID,
+    SYSTEM_OWNER_ID,
+    Workspace,
+)
 
 
 @runtime_checkable
@@ -36,6 +40,8 @@ class DatabaseBackend(Protocol):
     async def get_all_workspaces(self) -> list[Workspace]: ...
 
     async def get_workspace(self, workspace_id: str) -> Workspace | None: ...
+
+    async def get_workspaces_owned_by(self, owner_id: str) -> list[Workspace]: ...
 
     async def create_workspace(self, ws: Workspace) -> None: ...
 
@@ -105,13 +111,22 @@ def row_to_profile(row: Any) -> ConnectionProfile:
 
 
 def row_to_workspace(row: Any) -> Workspace:
-    """Convert a database row (dict-like) to a Workspace model."""
+    """Convert a database row (dict-like) to a Workspace model.
+
+    ``owner_id`` falls back to :data:`SYSTEM_OWNER_ID` when the column is
+    absent (defensive — both backends migrate the column on init_db, but
+    tests that build legacy rows by hand exercise this path).
+    """
+    # sqlite3.Row / asyncpg.Record use `key in row` for value membership,
+    # not column lookup; explicit keys() is the documented way.
+    owner_id = row["owner_id"] if "owner_id" in row.keys() else None  # noqa: SIM118
     return Workspace(
         id=row["id"],
         name=row["name"],
         color=row["color"],
         description=row["description"] if "description" in row.keys() else None,  # noqa: SIM118
         isDefault=bool(row["is_default"]),
+        ownerId=owner_id or SYSTEM_OWNER_ID,
         createdAt=row["created_at"],
         updatedAt=row["updated_at"],
     )
@@ -121,7 +136,14 @@ def build_merged_workspace(
     existing: Workspace,
     data: dict[str, Any],
 ) -> Workspace:
-    """Merge update data into an existing workspace, refreshing ``updatedAt``."""
+    """Merge update data into an existing workspace, refreshing ``updatedAt``.
+
+    ``isDefault`` and ``ownerId`` are explicitly held constant: neither
+    field is mutable through the update path. ``isDefault`` only flips at
+    migration time, and ``ownerId`` transfers are out of scope per the
+    workspace ownership ADR. Defense-in-depth: even if a future caller
+    smuggles the keys into ``data``, we never honour them.
+    """
     merged = existing.model_dump()
     merged.update(data)
     merged["updatedAt"] = datetime.now(UTC).isoformat()
@@ -133,6 +155,8 @@ def build_merged_workspace(
         # is_default is intentionally never overwritten through update — only
         # the migration sets it. Preserves the built-in default flag.
         isDefault=existing.isDefault,
+        # ownerId is read-only after creation. No transfers in Phase 2.
+        ownerId=existing.ownerId,
         createdAt=existing.createdAt,
         updatedAt=merged["updatedAt"],
     )

--- a/api/src/aerospike_cluster_manager_api/db/_postgres.py
+++ b/api/src/aerospike_cluster_manager_api/db/_postgres.py
@@ -19,7 +19,11 @@ from aerospike_cluster_manager_api.db._base import (
     row_to_workspace,
 )
 from aerospike_cluster_manager_api.models.connection import ConnectionProfile
-from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID, Workspace
+from aerospike_cluster_manager_api.models.workspace import (
+    DEFAULT_WORKSPACE_ID,
+    SYSTEM_OWNER_ID,
+    Workspace,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -48,6 +52,7 @@ CREATE TABLE IF NOT EXISTS workspaces (
     color       TEXT NOT NULL DEFAULT '#6366F1',
     description TEXT,
     is_default  BOOLEAN NOT NULL DEFAULT FALSE,
+    owner_id    TEXT NOT NULL DEFAULT 'system',
     created_at  TEXT NOT NULL,
     updated_at  TEXT NOT NULL
 );
@@ -70,18 +75,27 @@ async def _apply_migrations(conn: asyncpg.Connection | asyncpg.pool.PoolConnecti
     await conn.execute("ALTER TABLE connections ADD COLUMN IF NOT EXISTS labels JSONB")
     await conn.execute("ALTER TABLE connections ADD COLUMN IF NOT EXISTS workspace_id TEXT")
 
+    # workspaces.owner_id (issue #307 — Phase 0b). On PG the
+    # ``IF NOT EXISTS`` clause makes the migration idempotent and
+    # metadata-only on PG ≥ 11 (no full table rewrite). Existing rows
+    # backfill via the column ``DEFAULT 'system'``; the workspace ACL
+    # treats that sentinel as accessible to any authenticated caller
+    # (legacy single-tenant semantics).
+    await conn.execute("ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS owner_id TEXT NOT NULL DEFAULT 'system'")
+
     # Seed the built-in default workspace and back-fill any pre-existing
     # connections. Idempotent: ON CONFLICT DO NOTHING / WHERE workspace_id IS NULL.
     now = datetime.now(UTC).isoformat()
     await conn.execute(
         """INSERT INTO workspaces
-               (id, name, color, description, is_default, created_at, updated_at)
-           VALUES ($1, $2, $3, $4, TRUE, $5, $6)
+               (id, name, color, description, is_default, owner_id, created_at, updated_at)
+           VALUES ($1, $2, $3, $4, TRUE, $5, $6, $7)
            ON CONFLICT (id) DO NOTHING""",
         DEFAULT_WORKSPACE_ID,
         "Default",
         "#6366F1",
         "Default workspace",
+        SYSTEM_OWNER_ID,
         now,
         now,
     )
@@ -240,16 +254,37 @@ async def get_workspace(workspace_id: str) -> Workspace | None:
     return _row_to_workspace(row) if row else None
 
 
+async def get_workspaces_owned_by(owner_id: str) -> list[Workspace]:
+    """Return workspaces visible to ``owner_id``.
+
+    Visibility = ``ownerId == owner_id`` OR ``ownerId == 'system'``. The
+    second leg keeps the built-in default and any pre-migration rows
+    accessible to every authenticated caller, matching the ACL contract
+    in the ownership ADR.
+    """
+    pool = _get_pool()
+    rows = await pool.fetch(
+        """SELECT * FROM workspaces
+               WHERE owner_id = $1 OR owner_id = $2
+               ORDER BY is_default DESC, created_at""",
+        owner_id,
+        SYSTEM_OWNER_ID,
+    )
+    return [_row_to_workspace(row) for row in rows]
+
+
 async def create_workspace(ws: Workspace) -> None:
     pool = _get_pool()
     await pool.execute(
-        """INSERT INTO workspaces (id, name, color, description, is_default, created_at, updated_at)
-           VALUES ($1, $2, $3, $4, $5, $6, $7)""",
+        """INSERT INTO workspaces
+               (id, name, color, description, is_default, owner_id, created_at, updated_at)
+           VALUES ($1, $2, $3, $4, $5, $6, $7, $8)""",
         ws.id,
         ws.name,
         ws.color,
         ws.description,
         ws.isDefault,
+        ws.ownerId,
         ws.createdAt,
         ws.updatedAt,
     )

--- a/api/src/aerospike_cluster_manager_api/db/_sqlite.py
+++ b/api/src/aerospike_cluster_manager_api/db/_sqlite.py
@@ -21,7 +21,11 @@ from aerospike_cluster_manager_api.db._base import (
     row_to_workspace,
 )
 from aerospike_cluster_manager_api.models.connection import ConnectionProfile
-from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID, Workspace
+from aerospike_cluster_manager_api.models.workspace import (
+    DEFAULT_WORKSPACE_ID,
+    SYSTEM_OWNER_ID,
+    Workspace,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +55,7 @@ CREATE TABLE IF NOT EXISTS workspaces (
     color       TEXT NOT NULL DEFAULT '#6366F1',
     description TEXT,
     is_default  INTEGER NOT NULL DEFAULT 0,
+    owner_id    TEXT NOT NULL DEFAULT 'system',
     created_at  TEXT NOT NULL,
     updated_at  TEXT NOT NULL
 );
@@ -83,18 +88,33 @@ async def _apply_migrations(conn: aiosqlite.Connection) -> None:
         await conn.execute("ALTER TABLE connections ADD COLUMN workspace_id TEXT")
         await conn.commit()
 
+    # workspaces.owner_id (issue #307 — Phase 0b). Idempotent: only ALTER
+    # when the column is missing. SQLite does not support
+    # ``ADD COLUMN IF NOT EXISTS`` until 3.35; inspect ``PRAGMA table_info``
+    # explicitly so the migration is safe to re-run on every startup.
+    # Existing rows backfill to ``'system'`` via the column default — the
+    # workspace ACL treats that as accessible to any authenticated caller
+    # (legacy single-tenant semantics).
+    async with conn.execute("PRAGMA table_info(workspaces)") as cursor:
+        ws_columns = {row[1] for row in await cursor.fetchall()}
+    if "owner_id" not in ws_columns:
+        logger.info("Migrating SQLite: adding workspaces.owner_id column")
+        await conn.execute("ALTER TABLE workspaces ADD COLUMN owner_id TEXT NOT NULL DEFAULT 'system'")
+        await conn.commit()
+
     # Seed the built-in default workspace and back-fill any pre-existing
     # connections. Idempotent: INSERT OR IGNORE / UPDATE WHERE NULL.
     now = datetime.now(UTC).isoformat()
     await conn.execute(
         """INSERT OR IGNORE INTO workspaces
-               (id, name, color, description, is_default, created_at, updated_at)
-           VALUES (?, ?, ?, ?, 1, ?, ?)""",
+               (id, name, color, description, is_default, owner_id, created_at, updated_at)
+           VALUES (?, ?, ?, ?, 1, ?, ?, ?)""",
         (
             DEFAULT_WORKSPACE_ID,
             "Default",
             "#6366F1",
             "Default workspace",
+            SYSTEM_OWNER_ID,
             now,
             now,
         ),
@@ -286,18 +306,40 @@ async def get_workspace(workspace_id: str) -> Workspace | None:
     return _row_to_workspace(row) if row else None
 
 
+async def get_workspaces_owned_by(owner_id: str) -> list[Workspace]:
+    """Return workspaces visible to ``owner_id``.
+
+    Visibility = ``ownerId == owner_id`` OR ``ownerId == 'system'``. The
+    second leg keeps the built-in default and any pre-migration rows
+    accessible to every authenticated caller, matching the ACL contract
+    in the ownership ADR. Default workspace sorts first so the UI can
+    pick a stable initial selection without an extra query.
+    """
+    conn = _get_conn()
+    async with conn.execute(
+        """SELECT * FROM workspaces
+               WHERE owner_id = ? OR owner_id = ?
+               ORDER BY is_default DESC, created_at""",
+        (owner_id, SYSTEM_OWNER_ID),
+    ) as cursor:
+        rows = await cursor.fetchall()
+    return [_row_to_workspace(row) for row in rows]
+
+
 async def create_workspace(ws: Workspace) -> None:
     db_conn = _get_conn()
     try:
         await db_conn.execute(
-            """INSERT INTO workspaces (id, name, color, description, is_default, created_at, updated_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            """INSERT INTO workspaces
+                   (id, name, color, description, is_default, owner_id, created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
             (
                 ws.id,
                 ws.name,
                 ws.color,
                 ws.description,
                 1 if ws.isDefault else 0,
+                ws.ownerId,
                 ws.createdAt,
                 ws.updatedAt,
             ),

--- a/api/src/aerospike_cluster_manager_api/dependencies.py
+++ b/api/src/aerospike_cluster_manager_api/dependencies.py
@@ -3,18 +3,59 @@
 from __future__ import annotations
 
 import logging
-from typing import Annotated
+from typing import Annotated, Any
 
 import aerospike_py
 from aerospike_py.exception import AerospikeError, ClusterError
 from fastapi import Depends, HTTPException, Path
+from starlette.requests import Request
 
-from aerospike_cluster_manager_api import db
+from aerospike_cluster_manager_api import config, db
 from aerospike_cluster_manager_api.client_manager import client_manager
 from aerospike_cluster_manager_api.models.connection import ConnectionProfile
-from aerospike_cluster_manager_api.models.workspace import Workspace
+from aerospike_cluster_manager_api.models.workspace import SYSTEM_OWNER_ID, Workspace
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_caller_owner_id(request: Request) -> str:
+    """Return the caller's workspace-owner identity for ACL checks.
+
+    Reads ``request.state.user_claims`` populated by
+    :class:`OIDCAuthMiddleware` (PR #298) or by the MCP bearer-token
+    middleware (PR #302). Falls back to the synthetic
+    :data:`SYSTEM_OWNER_ID` when:
+
+    * the bearer-token sentinel is set (``_mcp_bearer=True``) — MCP
+      callers in single-tenant mode behave like the legacy global-access
+      path; the workspace gate would otherwise be meaningless because
+      there is no per-user workspace concept.
+    * neither OIDC nor the bearer middleware ran (anonymous request,
+      e.g. ``OIDC_ENABLED=false`` deployments) — preserves the Phase 1
+      single-tenant behaviour where every workspace is reachable.
+
+    Otherwise, the configured OIDC claim
+    (:data:`config.ACM_OIDC_OWNER_CLAIM`, default ``sub``) is returned.
+    A missing/empty claim also degrades to :data:`SYSTEM_OWNER_ID` so a
+    misconfigured IdP cannot lock callers out of the default workspace.
+
+    TODO(#307-E2): Stream E.2 plumbs this same OIDC claim into the MCP
+    Context so the registry decorator can read the caller identity
+    without re-reading the FastAPI ``request.state``. The OIDC →
+    Context bridge lives in ``mcp/auth.py``; until it ships, MCP tool
+    callers all resolve to the bearer/system path.
+    """
+    claims: dict[str, Any] | None = getattr(request.state, "user_claims", None)
+    if claims is None:
+        # Anonymous (no auth middleware ran). Phase 1 semantics.
+        return SYSTEM_OWNER_ID
+    if claims.get("_mcp_bearer"):
+        # Bearer-token sentinel (single-tenant deployments).
+        return SYSTEM_OWNER_ID
+    raw = claims.get(config.ACM_OIDC_OWNER_CLAIM)
+    if not isinstance(raw, str) or not raw:
+        return SYSTEM_OWNER_ID
+    return raw
 
 
 async def _get_verified_connection(conn_id: str = Path()) -> str:
@@ -81,3 +122,7 @@ VerifiedWorkspaceId = Annotated[str, Depends(_get_verified_workspace)]
 
 VerifiedWorkspace = Annotated[Workspace, Depends(_get_workspace)]
 """Inject a full ``Workspace`` looked up from the path ``workspace_id``."""
+
+
+CallerOwnerId = Annotated[str, Depends(_resolve_caller_owner_id)]
+"""Inject the caller's workspace-owner identity (OIDC claim or system sentinel)."""

--- a/api/src/aerospike_cluster_manager_api/models/workspace.py
+++ b/api/src/aerospike_cluster_manager_api/models/workspace.py
@@ -7,6 +7,13 @@ from pydantic import BaseModel, ConfigDict, Field
 # CreateConnectionRequest does not specify a workspace.
 DEFAULT_WORKSPACE_ID = "ws-default"
 
+# Synthetic owner id for rows that predate ownership and for the bearer-token
+# / unauthenticated single-tenant code paths. The ACL allows any caller to
+# read rows owned by ``"system"`` so legacy data and the built-in default
+# workspace remain accessible after migration. See
+# ``docs/plans/2026-05-07-workspace-ownership-schema.md`` for the contract.
+SYSTEM_OWNER_ID = "system"
+
 
 class Workspace(BaseModel):
     id: str
@@ -14,11 +21,26 @@ class Workspace(BaseModel):
     color: str = Field(pattern=r"^#[0-9a-fA-F]{6}$", default="#6366F1")
     description: str | None = None
     isDefault: bool = False
+    # Required. Either an OIDC ``sub`` claim or the synthetic
+    # ``SYSTEM_OWNER_ID`` sentinel for legacy / single-tenant rows. No
+    # default at the model layer — the DB migration provides
+    # ``DEFAULT 'system'`` for backfilled rows; new rows must be populated
+    # by the router from the caller's claims.
+    ownerId: str = Field(min_length=1)
     createdAt: str
     updatedAt: str
 
 
 class CreateWorkspaceRequest(BaseModel):
+    """Workspace creation payload.
+
+    ``ownerId`` is intentionally absent — the router populates it from the
+    caller's authenticated identity (OIDC claim or the bearer/
+    unauthenticated ``SYSTEM_OWNER_ID`` fallback). Accepting an owner id
+    from the wire would let any client claim ownership of any string,
+    defeating the ACL.
+    """
+
     model_config = ConfigDict(populate_by_name=True)
 
     name: str = Field(min_length=1, max_length=255)
@@ -27,6 +49,15 @@ class CreateWorkspaceRequest(BaseModel):
 
 
 class UpdateWorkspaceRequest(BaseModel):
+    """Workspace update payload.
+
+    ``ownerId`` is intentionally absent. Phase 2 forbids workspace
+    transfers — see the ADR's "Workspace creation flow changes" table —
+    so the field is stripped from the request schema. Defense-in-depth:
+    the service layer also rejects any ``ownerId`` key that sneaks in
+    via the underlying dict.
+    """
+
     model_config = ConfigDict(populate_by_name=True)
 
     name: str | None = Field(default=None, min_length=1, max_length=255)
@@ -47,6 +78,7 @@ class WorkspaceResponse(BaseModel):
     color: str
     description: str | None = None
     isDefault: bool = False
+    ownerId: str
     createdAt: str
     updatedAt: str
 

--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -9,7 +9,7 @@ from starlette.responses import Response
 
 from aerospike_cluster_manager_api.client_manager import client_manager
 from aerospike_cluster_manager_api.constants import INFO_BUILD, INFO_EDITION, INFO_NAMESPACES
-from aerospike_cluster_manager_api.dependencies import _get_verified_connection
+from aerospike_cluster_manager_api.dependencies import CallerOwnerId, _get_verified_connection
 from aerospike_cluster_manager_api.info_parser import parse_kv_pairs, parse_list, safe_int
 from aerospike_cluster_manager_api.models.connection import (
     ConnectionProfileResponse,
@@ -32,21 +32,35 @@ router = APIRouter(prefix="/connections", tags=["connections"])
 
 @router.get("", summary="List connections", description="Retrieve all saved Aerospike connection profiles.")
 async def list_connections(
+    caller_owner_id: CallerOwnerId,
     workspace_id: str | None = Query(default=None, description="Filter by workspace id."),
 ) -> list[ConnectionProfileResponse]:
-    """Retrieve all saved Aerospike connection profiles, optionally filtered by workspace."""
+    """Retrieve all saved Aerospike connection profiles, optionally filtered by workspace.
+
+    Phase 2: when ``workspace_id`` is supplied, the workspace must be visible
+    to the caller (owned by them or by the synthetic ``system`` user). Cross-
+    owner filters return 404 to avoid leaking workspace existence.
+    """
     try:
-        return await connections_service.list_connections(workspace_id)
+        return await connections_service.list_connections(workspace_id, caller_owner_id)
     except WorkspaceNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.post("", status_code=201, summary="Create connection", description="Create a new Aerospike connection profile.")
 @limiter.limit("10/minute")
-async def create_connection(request: Request, body: CreateConnectionRequest) -> ConnectionProfileResponse:
-    """Create a new Aerospike connection profile."""
+async def create_connection(
+    request: Request,
+    body: CreateConnectionRequest,
+    caller_owner_id: CallerOwnerId,
+) -> ConnectionProfileResponse:
+    """Create a new Aerospike connection profile.
+
+    Phase 2: the supplied ``workspaceId`` (or the default fallback) must be
+    visible to the caller; otherwise 404.
+    """
     try:
-        return await connections_service.create_connection(body)
+        return await connections_service.create_connection(body, caller_owner_id)
     except WorkspaceNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
@@ -70,6 +84,7 @@ async def get_connection(conn_id: str = Path()) -> ConnectionProfileResponse:
 )
 async def update_connection(
     body: UpdateConnectionRequest,
+    caller_owner_id: CallerOwnerId,
     conn_id: str = Path(),
 ) -> ConnectionProfileResponse:
     """Update an existing connection profile with new settings.
@@ -77,14 +92,25 @@ async def update_connection(
     The service's :func:`update_connection` raises
     :class:`ConnectionNotFoundError` when the id is missing, so the
     existence-check dependency is redundant — drop it to avoid the
-    duplicate ``db.get_connection`` round trip on each PUT.
+    duplicate ``db.get_connection`` round trip on each PUT. Phase 2:
+    moving the connection to a workspace invisible to the caller is a
+    404, same wire shape as a missing workspace.
     """
     try:
-        return await connections_service.update_connection(conn_id, body)
+        return await connections_service.update_connection(conn_id, body, caller_owner_id)
     except ConnectionNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except WorkspaceNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+
+# TODO(#307-E3): MCP registry workspace gate (the body of
+# ``_assert_workspace_owns_conn`` from the ADR) consumes the same
+# ``ownerId`` field plumbed in this PR. Stream E.3 wires the gate into
+# ``mcp/registry.py`` so MCP tool callers see ``workspace_mismatch``
+# errors when their ``conn_id`` resolves to a workspace they do not own.
+# Until E.3 lands, MCP tool callers behave as today (single-tenant
+# bearer or anonymous deployments).
 
 
 @router.get(

--- a/api/src/aerospike_cluster_manager_api/routers/workspaces.py
+++ b/api/src/aerospike_cluster_manager_api/routers/workspaces.py
@@ -1,73 +1,92 @@
 from __future__ import annotations
 
 import logging
-import uuid
-from datetime import UTC, datetime
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, HTTPException, Path, Request
 from starlette.responses import Response
 
-from aerospike_cluster_manager_api import db
-from aerospike_cluster_manager_api.dependencies import VerifiedWorkspace
+from aerospike_cluster_manager_api.dependencies import CallerOwnerId
 from aerospike_cluster_manager_api.models.workspace import (
-    DEFAULT_WORKSPACE_ID,
     CreateWorkspaceRequest,
     UpdateWorkspaceRequest,
-    Workspace,
     WorkspaceResponse,
 )
 from aerospike_cluster_manager_api.rate_limit import limiter
+from aerospike_cluster_manager_api.services import workspaces_service
+from aerospike_cluster_manager_api.services.connections_service import (
+    WorkspaceNotFoundError,
+)
+from aerospike_cluster_manager_api.services.workspaces_service import (
+    WorkspaceHasConnectionsError,
+    WorkspaceIsDefaultError,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/workspaces", tags=["workspaces"])
 
 
-@router.get("", summary="List workspaces", description="Retrieve all workspaces. The built-in default sorts first.")
-async def list_workspaces() -> list[WorkspaceResponse]:
-    workspaces = await db.get_all_workspaces()
-    return [WorkspaceResponse.from_workspace(w) for w in workspaces]
+@router.get(
+    "",
+    summary="List workspaces",
+    description=(
+        "Retrieve workspaces visible to the caller. The built-in default sorts first. "
+        "Phase 2 (issue #307): rows owned by other OIDC subjects are filtered out; "
+        "rows owned by the synthetic ``system`` user (the default workspace and any "
+        "pre-migration rows) remain visible to every authenticated caller."
+    ),
+)
+async def list_workspaces(caller_owner_id: CallerOwnerId) -> list[WorkspaceResponse]:
+    return await workspaces_service.list_workspaces(caller_owner_id)
 
 
 @router.post(
     "",
     status_code=201,
     summary="Create workspace",
-    description="Create a new workspace. The id is generated server-side.",
+    description="Create a new workspace. The id and ownerId are populated server-side.",
 )
 @limiter.limit("10/minute")
-async def create_workspace(request: Request, body: CreateWorkspaceRequest) -> WorkspaceResponse:
-    now = datetime.now(UTC).isoformat()
-    ws = Workspace(
-        id=f"ws-{uuid.uuid4().hex[:12]}",
-        name=body.name,
-        color=body.color,
-        description=body.description,
-        isDefault=False,
-        createdAt=now,
-        updatedAt=now,
-    )
-    await db.create_workspace(ws)
-    return WorkspaceResponse.from_workspace(ws)
+async def create_workspace(
+    request: Request,
+    body: CreateWorkspaceRequest,
+    caller_owner_id: CallerOwnerId,
+) -> WorkspaceResponse:
+    return await workspaces_service.create_workspace(body, caller_owner_id)
 
 
-@router.get("/{workspace_id}", summary="Get workspace", description="Retrieve a single workspace by id.")
-async def get_workspace(ws: VerifiedWorkspace) -> WorkspaceResponse:
-    return WorkspaceResponse.from_workspace(ws)
+@router.get(
+    "/{workspace_id}",
+    summary="Get workspace",
+    description="Retrieve a single workspace by id. Returns 404 when the row is invisible to the caller.",
+)
+async def get_workspace(
+    caller_owner_id: CallerOwnerId,
+    workspace_id: str = Path(),
+) -> WorkspaceResponse:
+    try:
+        return await workspaces_service.get_workspace(workspace_id, caller_owner_id)
+    except WorkspaceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.put(
     "/{workspace_id}",
     summary="Update workspace",
-    description="Update a workspace's name, color, or description. The default workspace can be renamed.",
+    description=(
+        "Update a workspace's name, color, or description. The default workspace can be renamed. "
+        "``ownerId`` is read-only and silently ignored — Phase 2 forbids workspace transfers."
+    ),
 )
-async def update_workspace(body: UpdateWorkspaceRequest, ws: VerifiedWorkspace) -> WorkspaceResponse:
-    update_data = body.model_dump(exclude_unset=True, by_alias=False)
-    updated = await db.update_workspace(ws.id, update_data)
-    if not updated:
-        # Race: workspace deleted between dependency resolution and update.
-        raise HTTPException(status_code=404, detail=f"Workspace '{ws.id}' not found")
-    return WorkspaceResponse.from_workspace(updated)
+async def update_workspace(
+    body: UpdateWorkspaceRequest,
+    caller_owner_id: CallerOwnerId,
+    workspace_id: str = Path(),
+) -> WorkspaceResponse:
+    try:
+        return await workspaces_service.update_workspace(workspace_id, body, caller_owner_id)
+    except WorkspaceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
 @router.delete(
@@ -81,17 +100,17 @@ async def update_workspace(body: UpdateWorkspaceRequest, ws: VerifiedWorkspace) 
     ),
 )
 @limiter.limit("10/minute")
-async def delete_workspace(request: Request, ws: VerifiedWorkspace) -> Response:
-    if ws.isDefault or ws.id == DEFAULT_WORKSPACE_ID:
-        raise HTTPException(status_code=400, detail="The default workspace cannot be deleted")
-    remaining = await db.count_connections_in_workspace(ws.id)
-    if remaining > 0:
-        raise HTTPException(
-            status_code=409,
-            detail=(
-                f"Workspace '{ws.id}' still has {remaining} connection(s). "
-                "Move or delete them before deleting the workspace."
-            ),
-        )
-    await db.delete_workspace(ws.id)
+async def delete_workspace(
+    request: Request,
+    caller_owner_id: CallerOwnerId,
+    workspace_id: str = Path(),
+) -> Response:
+    try:
+        await workspaces_service.delete_workspace(workspace_id, caller_owner_id)
+    except WorkspaceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except WorkspaceIsDefaultError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except WorkspaceHasConnectionsError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     return Response(status_code=204)

--- a/api/src/aerospike_cluster_manager_api/services/connections_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/connections_service.py
@@ -33,7 +33,10 @@ from aerospike_cluster_manager_api.models.connection import (
     TestConnectionRequest,
     UpdateConnectionRequest,
 )
-from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID
+from aerospike_cluster_manager_api.models.workspace import (
+    DEFAULT_WORKSPACE_ID,
+    SYSTEM_OWNER_ID,
+)
 from aerospike_cluster_manager_api.utils import parse_host_port
 
 logger = logging.getLogger(__name__)
@@ -84,16 +87,39 @@ class TestConnectionResult(NamedTuple):
 # ---------------------------------------------------------------------------
 
 
-async def list_connections(workspace_id: str | None) -> list[ConnectionProfileResponse]:
+async def _assert_workspace_visible(workspace_id: str, caller_owner_id: str | None) -> None:
+    """Raise :class:`WorkspaceNotFoundError` if the workspace is missing or invisible.
+
+    ``caller_owner_id`` is ``None`` for legacy callers that have not yet
+    been threaded through the ACL (none in Phase 0b — every path passes
+    a real value). When provided, visibility is the same rule the
+    workspaces service applies: ``ownerId == caller`` OR
+    ``ownerId == 'system'``. Treating "exists but you don't own it" as a
+    plain 404 prevents id enumeration.
+    """
+    ws = await db.get_workspace(workspace_id)
+    if ws is None:
+        raise WorkspaceNotFoundError(workspace_id)
+    if caller_owner_id is None:
+        return
+    if ws.ownerId != caller_owner_id and ws.ownerId != SYSTEM_OWNER_ID:
+        raise WorkspaceNotFoundError(workspace_id)
+
+
+async def list_connections(
+    workspace_id: str | None,
+    caller_owner_id: str | None = None,
+) -> list[ConnectionProfileResponse]:
     """Return all saved connection profiles, optionally filtered by workspace.
 
-    Raises ``WorkspaceNotFoundError`` if a non-None ``workspace_id`` is
-    provided and no such workspace exists.
+    Raises :class:`WorkspaceNotFoundError` if a non-None ``workspace_id``
+    is provided and no such workspace exists, *or* the workspace exists
+    but is invisible to ``caller_owner_id`` (Phase 2 — issue #307).
+    ``caller_owner_id=None`` keeps the legacy single-tenant behaviour
+    for code paths that have not been threaded through the ACL yet.
     """
     if workspace_id is not None:
-        ws = await db.get_workspace(workspace_id)
-        if not ws:
-            raise WorkspaceNotFoundError(workspace_id)
+        await _assert_workspace_visible(workspace_id, caller_owner_id)
     profiles = await db.get_all_connections(workspace_id)
     return [ConnectionProfileResponse.from_profile(p) for p in profiles]
 
@@ -109,15 +135,19 @@ async def get_connection(conn_id: str) -> ConnectionProfileResponse:
     return ConnectionProfileResponse.from_profile(conn)
 
 
-async def create_connection(payload: CreateConnectionRequest) -> ConnectionProfileResponse:
+async def create_connection(
+    payload: CreateConnectionRequest,
+    caller_owner_id: str | None = None,
+) -> ConnectionProfileResponse:
     """Persist a new connection profile and return it (without password).
 
-    Falls back to ``DEFAULT_WORKSPACE_ID`` when the request omits the workspace.
-    Raises ``WorkspaceNotFoundError`` if the resolved workspace does not exist.
+    Falls back to :data:`DEFAULT_WORKSPACE_ID` when the request omits the
+    workspace. Raises :class:`WorkspaceNotFoundError` if the resolved
+    workspace does not exist OR (Phase 2) is invisible to
+    ``caller_owner_id``.
     """
     workspace_id = payload.workspaceId or DEFAULT_WORKSPACE_ID
-    if not await db.get_workspace(workspace_id):
-        raise WorkspaceNotFoundError(workspace_id)
+    await _assert_workspace_visible(workspace_id, caller_owner_id)
 
     now = datetime.now(UTC).isoformat()
     conn = ConnectionProfile(
@@ -139,17 +169,22 @@ async def create_connection(payload: CreateConnectionRequest) -> ConnectionProfi
     return ConnectionProfileResponse.from_profile(conn)
 
 
-async def update_connection(conn_id: str, payload: UpdateConnectionRequest) -> ConnectionProfileResponse:
+async def update_connection(
+    conn_id: str,
+    payload: UpdateConnectionRequest,
+    caller_owner_id: str | None = None,
+) -> ConnectionProfileResponse:
     """Apply a partial update to ``conn_id`` and return the new state.
 
-    Raises ``ConnectionNotFoundError`` if the connection does not exist, or
-    ``WorkspaceNotFoundError`` if the request moves it to a missing workspace.
+    Raises :class:`ConnectionNotFoundError` if the connection does not
+    exist, or :class:`WorkspaceNotFoundError` if the request moves it to
+    a workspace that is missing or (Phase 2) invisible to
+    ``caller_owner_id``.
     """
     update_data = payload.model_dump(exclude_unset=True, by_alias=False)
     if "workspaceId" in update_data and update_data["workspaceId"] is not None:
         target_ws = update_data["workspaceId"]
-        if not await db.get_workspace(target_ws):
-            raise WorkspaceNotFoundError(target_ws)
+        await _assert_workspace_visible(target_ws, caller_owner_id)
 
     conn = await db.update_connection(conn_id, update_data)
     if not conn:

--- a/api/src/aerospike_cluster_manager_api/services/workspaces_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/workspaces_service.py
@@ -1,0 +1,195 @@
+"""Business logic for workspace management.
+
+Lives alongside :mod:`connections_service` and follows the same pure-Python /
+no-FastAPI shape so the same functions can power both the HTTP router and a
+future MCP tool layer. Domain failures are signalled by plain exceptions
+defined here (or re-exported from the connections service); the router
+translates them to HTTP status codes.
+
+Phase 2 ownership rules (see
+``docs/plans/2026-05-07-workspace-ownership-schema.md``):
+
+* ``create_workspace`` populates ``ownerId`` from the caller's identity.
+* ``list_workspaces`` filters via the DB-side
+  :func:`db.get_workspaces_owned_by` helper, returning only rows the caller
+  may see (``ownerId == caller`` OR ``ownerId == 'system'``).
+* ``get_workspace`` / ``update_workspace`` / ``delete_workspace`` raise
+  :class:`WorkspaceNotFoundError` when the row is invisible to the caller.
+  Treating "exists but you don't own it" as 404 prevents id enumeration.
+* ``ownerId`` is read-only after creation: any attempt to mutate it via
+  the update path is dropped (defense-in-depth — the request model
+  already strips the field).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import UTC, datetime
+
+from aerospike_cluster_manager_api import db
+from aerospike_cluster_manager_api.models.workspace import (
+    DEFAULT_WORKSPACE_ID,
+    SYSTEM_OWNER_ID,
+    CreateWorkspaceRequest,
+    UpdateWorkspaceRequest,
+    Workspace,
+    WorkspaceResponse,
+)
+from aerospike_cluster_manager_api.services.connections_service import (
+    WorkspaceNotFoundError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = [
+    "DEFAULT_WORKSPACE_ID",
+    "SYSTEM_OWNER_ID",
+    "WorkspaceNotFoundError",
+    "create_workspace",
+    "delete_workspace",
+    "get_workspace",
+    "list_workspaces",
+    "update_workspace",
+]
+
+
+# ---------------------------------------------------------------------------
+# Domain exceptions
+# ---------------------------------------------------------------------------
+
+
+class WorkspaceHasConnectionsError(RuntimeError):
+    """Raised when delete_workspace would orphan connection profiles."""
+
+    def __init__(self, workspace_id: str, count: int) -> None:
+        super().__init__(
+            f"Workspace '{workspace_id}' still has {count} connection(s). "
+            "Move or delete them before deleting the workspace."
+        )
+        self.workspace_id = workspace_id
+        self.count = count
+
+
+class WorkspaceIsDefaultError(RuntimeError):
+    """Raised when delete_workspace targets the built-in default."""
+
+    def __init__(self, workspace_id: str) -> None:
+        super().__init__("The default workspace cannot be deleted")
+        self.workspace_id = workspace_id
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_visible_to(ws: Workspace, caller_owner_id: str) -> bool:
+    """Return True iff ``caller_owner_id`` may read ``ws``.
+
+    Visibility rule = ``ownerId == caller`` OR ``ownerId == 'system'``.
+    The ``'system'`` leg keeps the built-in default and any pre-migration
+    rows accessible to every authenticated caller.
+    """
+    return ws.ownerId == caller_owner_id or ws.ownerId == SYSTEM_OWNER_ID
+
+
+# ---------------------------------------------------------------------------
+# Service entry points
+# ---------------------------------------------------------------------------
+
+
+async def list_workspaces(caller_owner_id: str) -> list[WorkspaceResponse]:
+    """Return all workspaces visible to ``caller_owner_id``."""
+    rows = await db.get_workspaces_owned_by(caller_owner_id)
+    return [WorkspaceResponse.from_workspace(w) for w in rows]
+
+
+async def get_workspace(workspace_id: str, caller_owner_id: str) -> WorkspaceResponse:
+    """Return the workspace with id ``workspace_id`` if visible to caller.
+
+    Raises :class:`WorkspaceNotFoundError` when the row does not exist
+    *or* when it exists but belongs to a different owner. The two cases
+    return the same error to avoid leaking the existence of other
+    callers' workspaces (id enumeration).
+    """
+    ws = await db.get_workspace(workspace_id)
+    if ws is None or not _is_visible_to(ws, caller_owner_id):
+        raise WorkspaceNotFoundError(workspace_id)
+    return WorkspaceResponse.from_workspace(ws)
+
+
+async def create_workspace(
+    payload: CreateWorkspaceRequest,
+    owner_id: str,
+) -> WorkspaceResponse:
+    """Persist a new workspace owned by ``owner_id``.
+
+    The id is generated server-side. The caller-supplied request model
+    intentionally has no ``ownerId`` field — the service is the single
+    place ownership is assigned.
+    """
+    now = datetime.now(UTC).isoformat()
+    ws = Workspace(
+        id=f"ws-{uuid.uuid4().hex[:12]}",
+        name=payload.name,
+        color=payload.color,
+        description=payload.description,
+        isDefault=False,
+        ownerId=owner_id,
+        createdAt=now,
+        updatedAt=now,
+    )
+    await db.create_workspace(ws)
+    return WorkspaceResponse.from_workspace(ws)
+
+
+async def update_workspace(
+    workspace_id: str,
+    payload: UpdateWorkspaceRequest,
+    caller_owner_id: str,
+) -> WorkspaceResponse:
+    """Apply a partial update if ``caller_owner_id`` owns the row.
+
+    Raises :class:`WorkspaceNotFoundError` when the workspace does not
+    exist or is invisible to the caller — same wire shape so id
+    enumeration is impossible.
+    """
+    ws = await db.get_workspace(workspace_id)
+    if ws is None or not _is_visible_to(ws, caller_owner_id):
+        raise WorkspaceNotFoundError(workspace_id)
+
+    update_data = payload.model_dump(exclude_unset=True, by_alias=False)
+    # Defense-in-depth: ``UpdateWorkspaceRequest`` does not declare
+    # ``ownerId``, but if a future caller bypasses the model we still
+    # refuse to mutate ownership here. ``build_merged_workspace`` makes
+    # the same guarantee at the persistence layer.
+    update_data.pop("ownerId", None)
+
+    updated = await db.update_workspace(workspace_id, update_data)
+    if updated is None:
+        # Race: another writer deleted the workspace between our read
+        # and the update. Treat as 404 to keep the wire contract simple.
+        raise WorkspaceNotFoundError(workspace_id)
+    return WorkspaceResponse.from_workspace(updated)
+
+
+async def delete_workspace(workspace_id: str, caller_owner_id: str) -> None:
+    """Delete a workspace if ``caller_owner_id`` owns it.
+
+    Raises :class:`WorkspaceIsDefaultError` for the built-in default
+    (rejected with 400 by the router), :class:`WorkspaceHasConnectionsError`
+    when connection profiles still reference the workspace (rejected with
+    409), and :class:`WorkspaceNotFoundError` for missing or invisible
+    rows.
+    """
+    ws = await db.get_workspace(workspace_id)
+    if ws is None or not _is_visible_to(ws, caller_owner_id):
+        raise WorkspaceNotFoundError(workspace_id)
+    if ws.isDefault or ws.id == DEFAULT_WORKSPACE_ID:
+        raise WorkspaceIsDefaultError(workspace_id)
+    remaining = await db.count_connections_in_workspace(workspace_id)
+    if remaining > 0:
+        raise WorkspaceHasConnectionsError(workspace_id, remaining)
+    await db.delete_workspace(workspace_id)

--- a/api/tests/test_connections_router.py
+++ b/api/tests/test_connections_router.py
@@ -14,6 +14,7 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
+from aerospike_cluster_manager_api.dependencies import _resolve_caller_owner_id
 from aerospike_cluster_manager_api.main import app
 
 
@@ -21,6 +22,14 @@ from aerospike_cluster_manager_api.main import app
 async def _noop_lifespan(_app: FastAPI) -> AsyncIterator[None]:
     """No-op lifespan — the database is managed by the init_test_db fixture."""
     yield
+
+
+def _override_caller(owner_id: str) -> None:
+    app.dependency_overrides[_resolve_caller_owner_id] = lambda: owner_id
+
+
+def _clear_caller_override() -> None:
+    app.dependency_overrides.pop(_resolve_caller_owner_id, None)
 
 
 @pytest.fixture()
@@ -366,3 +375,76 @@ class TestTestConnection:
         call_args = mock_cls.call_args[0][0]
         assert call_args["user"] == "admin"
         assert call_args["password"] == "secret"
+
+
+class TestCrossOwnerWorkspaceAccess:
+    """Phase 2 ACL — connections endpoints reject cross-owner workspace ids
+    with 404 to avoid leaking workspace existence."""
+
+    async def test_create_with_other_owners_workspace_id_rejected(self, client: AsyncClient):
+        # Owner A creates a workspace
+        _override_caller("user-a")
+        try:
+            ws_resp = await client.post("/api/workspaces", json={"name": "a-only", "color": "#FF8800"})
+            a_ws_id = ws_resp.json()["id"]
+        finally:
+            _clear_caller_override()
+
+        # Owner B tries to attach a connection to A's workspace
+        _override_caller("user-b")
+        try:
+            response = await client.post(
+                "/api/connections",
+                json={**CREATE_PAYLOAD, "workspaceId": a_ws_id},
+            )
+            assert response.status_code == 404
+        finally:
+            _clear_caller_override()
+
+    async def test_list_with_other_owners_workspace_id_returns_404(self, client: AsyncClient):
+        _override_caller("user-a")
+        try:
+            ws_resp = await client.post("/api/workspaces", json={"name": "a-only", "color": "#FF8800"})
+            a_ws_id = ws_resp.json()["id"]
+        finally:
+            _clear_caller_override()
+
+        _override_caller("user-b")
+        try:
+            response = await client.get(f"/api/connections?workspace_id={a_ws_id}")
+            assert response.status_code == 404
+        finally:
+            _clear_caller_override()
+
+    async def test_default_workspace_remains_writable_by_any_caller(self, client: AsyncClient):
+        """The synthetic ``system`` owner means the default is shared. Any
+        authenticated caller can create connections in it."""
+        _override_caller("user-anyone")
+        try:
+            response = await client.post("/api/connections", json=CREATE_PAYLOAD)
+            assert response.status_code == 201
+            assert response.json()["workspaceId"] == "ws-default"
+        finally:
+            _clear_caller_override()
+
+    async def test_update_to_other_owners_workspace_id_rejected(self, client: AsyncClient):
+        _override_caller("user-a")
+        try:
+            ws_resp = await client.post("/api/workspaces", json={"name": "a-only", "color": "#FF8800"})
+            a_ws_id = ws_resp.json()["id"]
+        finally:
+            _clear_caller_override()
+
+        # Owner B creates a connection (default workspace) then tries to move
+        # it to A's workspace.
+        _override_caller("user-b")
+        try:
+            create = await client.post("/api/connections", json=CREATE_PAYLOAD)
+            conn_id = create.json()["id"]
+            update = await client.put(
+                f"/api/connections/{conn_id}",
+                json={"workspaceId": a_ws_id},
+            )
+            assert update.status_code == 404
+        finally:
+            _clear_caller_override()

--- a/api/tests/test_connections_service.py
+++ b/api/tests/test_connections_service.py
@@ -68,13 +68,14 @@ class TestListConnections:
         from datetime import UTC, datetime
 
         from aerospike_cluster_manager_api import db
-        from aerospike_cluster_manager_api.models.workspace import Workspace
+        from aerospike_cluster_manager_api.models.workspace import SYSTEM_OWNER_ID, Workspace
 
         now = datetime.now(UTC).isoformat()
         ws = Workspace(
             id="ws-team-svc",
             name="team-svc",
             color="#123456",
+            ownerId=SYSTEM_OWNER_ID,
             createdAt=now,
             updatedAt=now,
         )

--- a/api/tests/test_workspace_migrations.py
+++ b/api/tests/test_workspace_migrations.py
@@ -9,7 +9,10 @@ from unittest.mock import patch
 import aiosqlite
 
 from aerospike_cluster_manager_api import db
-from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID
+from aerospike_cluster_manager_api.models.workspace import (
+    DEFAULT_WORKSPACE_ID,
+    SYSTEM_OWNER_ID,
+)
 
 
 class TestDefaultWorkspaceSeed:
@@ -81,3 +84,109 @@ class TestConnectionBackfill:
         assert conn_profile is not None
         assert conn_profile.workspaceId == DEFAULT_WORKSPACE_ID
         assert any(w.id == DEFAULT_WORKSPACE_ID and w.isDefault for w in workspaces)
+
+
+class TestWorkspaceOwnerIdMigration:
+    """Phase 0b — workspaces.owner_id ALTER + ``DEFAULT 'system'`` backfill.
+
+    Together these guarantee:
+
+    * The default workspace always lands with ``ownerId='system'`` after a
+      fresh init_db (system sentinel grants any caller access).
+    * A pre-existing workspaces row that predates the column gets the
+      ``'system'`` value via the column DEFAULT — no data migration code.
+    * The ALTER is idempotent: a re-run on a DB that already has the
+      column does nothing, and the existing rows keep their values.
+    * New rows can carry a real OIDC sub as ``ownerId``.
+    """
+
+    async def test_default_workspace_owner_is_system_after_init(self, init_test_db):
+        ws = await db.get_workspace(DEFAULT_WORKSPACE_ID)
+        assert ws is not None
+        assert ws.ownerId == SYSTEM_OWNER_ID
+
+    async def test_pre_existing_workspace_row_backfilled_to_system(self, tmp_path):
+        db_path = str(tmp_path / "legacy-ws.db")
+
+        # Build a legacy workspaces table without owner_id and seed one row.
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute(
+                """CREATE TABLE workspaces (
+                    id          TEXT PRIMARY KEY,
+                    name        TEXT NOT NULL,
+                    color       TEXT NOT NULL DEFAULT '#6366F1',
+                    description TEXT,
+                    is_default  INTEGER NOT NULL DEFAULT 0,
+                    created_at  TEXT NOT NULL,
+                    updated_at  TEXT NOT NULL
+                )"""
+            )
+            await conn.execute(
+                """CREATE TABLE connections (
+                    id           TEXT PRIMARY KEY,
+                    name         TEXT NOT NULL,
+                    hosts        TEXT NOT NULL,
+                    port         INTEGER NOT NULL DEFAULT 3000,
+                    cluster_name TEXT,
+                    username     TEXT,
+                    password     TEXT,
+                    color        TEXT NOT NULL DEFAULT '#0097D3',
+                    description  TEXT,
+                    labels       TEXT,
+                    workspace_id TEXT,
+                    created_at   TEXT NOT NULL,
+                    updated_at   TEXT NOT NULL
+                )"""
+            )
+            now = datetime.now(UTC).isoformat()
+            await conn.execute(
+                """INSERT INTO workspaces (id, name, color, is_default, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                ("ws-legacy-1", "legacy", "#123456", 0, now, now),
+            )
+            await conn.commit()
+
+        with (
+            patch("aerospike_cluster_manager_api.config.ENABLE_POSTGRES", False),
+            patch("aerospike_cluster_manager_api.config.SQLITE_PATH", db_path),
+        ):
+            await db.init_db()
+            try:
+                ws = await db.get_workspace("ws-legacy-1")
+            finally:
+                await db.close_db()
+
+        assert ws is not None
+        # The migration's ``DEFAULT 'system'`` backfilled the legacy row.
+        assert ws.ownerId == SYSTEM_OWNER_ID
+
+    async def test_alter_is_idempotent(self, init_test_db):
+        """Running the SQLite migration twice on a DB that already has the
+        column must be a no-op (no error, no schema change, no data loss)."""
+        # Re-init the same DB — _apply_migrations runs again.
+        await db.close_db()
+        with (
+            patch("aerospike_cluster_manager_api.config.ENABLE_POSTGRES", False),
+            patch("aerospike_cluster_manager_api.config.SQLITE_PATH", init_test_db),
+        ):
+            await db.init_db()
+            ws = await db.get_workspace(DEFAULT_WORKSPACE_ID)
+        assert ws is not None
+        assert ws.ownerId == SYSTEM_OWNER_ID
+
+    async def test_new_row_carries_real_owner_id(self, init_test_db):
+        from aerospike_cluster_manager_api.models.workspace import Workspace
+
+        now = datetime.now(UTC).isoformat()
+        ws = Workspace(
+            id="ws-team-real",
+            name="real",
+            color="#123456",
+            ownerId="user-real",
+            createdAt=now,
+            updatedAt=now,
+        )
+        await db.create_workspace(ws)
+        fetched = await db.get_workspace("ws-team-real")
+        assert fetched is not None
+        assert fetched.ownerId == "user-real"

--- a/api/tests/test_workspaces_router.py
+++ b/api/tests/test_workspaces_router.py
@@ -9,7 +9,9 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
+from aerospike_cluster_manager_api.dependencies import _resolve_caller_owner_id
 from aerospike_cluster_manager_api.main import app
+from aerospike_cluster_manager_api.models.workspace import SYSTEM_OWNER_ID
 
 
 @asynccontextmanager
@@ -27,6 +29,35 @@ async def client(init_test_db):
         yield ac
     app.state.limiter.enabled = True
     app.router.lifespan_context = original_lifespan
+
+
+def _override_caller(owner_id: str) -> None:
+    """Pin the caller-owner-id dependency to ``owner_id`` for ACL tests.
+
+    The router reads it via :func:`dependencies._resolve_caller_owner_id`
+    which inspects ``request.state.user_claims``. Plumbing real claims
+    through the OIDC middleware in tests would require a Keycloak fixture;
+    overriding the dependency is the surgical way to drive the ACL.
+    """
+    app.dependency_overrides[_resolve_caller_owner_id] = lambda: owner_id
+
+
+def _clear_caller_override() -> None:
+    app.dependency_overrides.pop(_resolve_caller_owner_id, None)
+
+
+@pytest.fixture()
+def as_owner_a():
+    _override_caller("user-a")
+    yield "user-a"
+    _clear_caller_override()
+
+
+@pytest.fixture()
+def as_owner_b():
+    _override_caller("user-b")
+    yield "user-b"
+    _clear_caller_override()
 
 
 CREATE_PAYLOAD = {
@@ -167,3 +198,113 @@ class TestDeleteWorkspaceDbGuard:
         ws = await db.get_workspace("ws-default")
         assert ws is not None
         assert ws.isDefault is True
+
+
+class TestOwnerIdResponseShape:
+    """The wire response always includes ``ownerId``."""
+
+    async def test_create_response_carries_owner_id(self, client: AsyncClient):
+        response = await client.post("/api/workspaces", json=CREATE_PAYLOAD)
+        assert response.status_code == 201
+        body = response.json()
+        # Anonymous test client → SYSTEM_OWNER_ID.
+        assert body["ownerId"] == SYSTEM_OWNER_ID
+
+    async def test_create_request_owner_id_is_ignored(self, client: AsyncClient):
+        """Even if a client sneaks ``ownerId`` into the create payload, the
+        request schema rejects unknown fields. ``populate_by_name`` is true
+        but extras are not allowed by default — assert behaviour is stable
+        either way (server-side ownerId)."""
+        payload = {**CREATE_PAYLOAD, "ownerId": "evil"}
+        response = await client.post("/api/workspaces", json=payload)
+        assert response.status_code == 201
+        body = response.json()
+        assert body["ownerId"] != "evil"
+
+    async def test_get_default_workspace_owner_is_system(self, client: AsyncClient):
+        response = await client.get("/api/workspaces/ws-default")
+        assert response.status_code == 200
+        assert response.json()["ownerId"] == SYSTEM_OWNER_ID
+
+
+class TestOwnerScopedListing:
+    """Phase 2 ACL — ``GET /api/workspaces`` is filtered to caller's own
+    workspaces plus the synthetic ``system``-owned rows."""
+
+    async def test_owner_a_does_not_see_owner_b_workspaces(self, client: AsyncClient, as_owner_a):
+        # Owner A creates a workspace, then we switch to owner B and assert
+        # the row is not returned.
+        create = await client.post("/api/workspaces", json={**CREATE_PAYLOAD, "name": "a-only"})
+        assert create.status_code == 201
+        a_id = create.json()["id"]
+
+        _override_caller("user-b")
+        try:
+            response = await client.get("/api/workspaces")
+            assert response.status_code == 200
+            ids = {w["id"] for w in response.json()}
+            assert a_id not in ids
+            # Default is owned by system → still visible to user-b.
+            assert "ws-default" in ids
+        finally:
+            _override_caller("user-a")
+
+    async def test_default_visible_to_every_caller(self, client: AsyncClient, as_owner_a):
+        response = await client.get("/api/workspaces")
+        assert response.status_code == 200
+        ids = {w["id"] for w in response.json()}
+        assert "ws-default" in ids
+
+
+class TestOwnerScopedAccess:
+    """Phase 2 ACL — cross-owner read/update/delete returns 404 (not 403)
+    so id enumeration cannot leak workspace existence."""
+
+    async def test_get_cross_owner_returns_404(self, client: AsyncClient, as_owner_a):
+        create = await client.post("/api/workspaces", json={**CREATE_PAYLOAD, "name": "a-only"})
+        a_id = create.json()["id"]
+
+        _override_caller("user-b")
+        try:
+            response = await client.get(f"/api/workspaces/{a_id}")
+            assert response.status_code == 404
+        finally:
+            _override_caller("user-a")
+
+    async def test_put_cross_owner_returns_404(self, client: AsyncClient, as_owner_a):
+        create = await client.post("/api/workspaces", json={**CREATE_PAYLOAD, "name": "a-only"})
+        a_id = create.json()["id"]
+
+        _override_caller("user-b")
+        try:
+            response = await client.put(f"/api/workspaces/{a_id}", json={"name": "hijacked"})
+            assert response.status_code == 404
+        finally:
+            _override_caller("user-a")
+
+    async def test_delete_cross_owner_returns_404(self, client: AsyncClient, as_owner_a):
+        create = await client.post("/api/workspaces", json={**CREATE_PAYLOAD, "name": "a-only"})
+        a_id = create.json()["id"]
+
+        _override_caller("user-b")
+        try:
+            response = await client.delete(f"/api/workspaces/{a_id}")
+            assert response.status_code == 404
+        finally:
+            _override_caller("user-a")
+
+    async def test_owner_id_field_is_not_patchable(self, client: AsyncClient, as_owner_a):
+        """Even passing ``ownerId`` in the PATCH body is silently ignored —
+        the request model strips it and the service+DB layer enforces the
+        invariant a second time."""
+        create = await client.post("/api/workspaces", json=CREATE_PAYLOAD)
+        a_id = create.json()["id"]
+
+        response = await client.put(
+            f"/api/workspaces/{a_id}",
+            json={"name": "renamed", "ownerId": "user-b"},
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["name"] == "renamed"
+        assert body["ownerId"] == "user-a"

--- a/api/tests/test_workspaces_service.py
+++ b/api/tests/test_workspaces_service.py
@@ -1,0 +1,221 @@
+"""Unit tests for the workspaces service layer.
+
+Exercise ``services.workspaces_service`` directly so the same functions can
+be reused by an MCP tool layer in a later PR. The router-layer regression
+net lives in ``test_workspaces_router.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from aerospike_cluster_manager_api import db
+from aerospike_cluster_manager_api.models.workspace import (
+    DEFAULT_WORKSPACE_ID,
+    SYSTEM_OWNER_ID,
+    CreateWorkspaceRequest,
+    UpdateWorkspaceRequest,
+    Workspace,
+    WorkspaceResponse,
+)
+from aerospike_cluster_manager_api.services import workspaces_service
+from aerospike_cluster_manager_api.services.connections_service import (
+    WorkspaceNotFoundError,
+)
+from aerospike_cluster_manager_api.services.workspaces_service import (
+    WorkspaceHasConnectionsError,
+    WorkspaceIsDefaultError,
+)
+
+OWNER_A = "user-a"
+OWNER_B = "user-b"
+
+
+def _create_payload(name: str = "team-svc") -> CreateWorkspaceRequest:
+    return CreateWorkspaceRequest(name=name, color="#123456")
+
+
+# ---------------------------------------------------------------------------
+# create_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestCreateWorkspace:
+    async def test_populates_owner_id_from_caller(self, init_test_db):
+        result = await workspaces_service.create_workspace(_create_payload(), OWNER_A)
+        assert isinstance(result, WorkspaceResponse)
+        assert result.ownerId == OWNER_A
+        assert result.id.startswith("ws-")
+        assert result.id != DEFAULT_WORKSPACE_ID
+
+    async def test_persisted_can_be_retrieved(self, init_test_db):
+        created = await workspaces_service.create_workspace(_create_payload(), OWNER_A)
+        fetched = await workspaces_service.get_workspace(created.id, OWNER_A)
+        assert fetched.id == created.id
+        assert fetched.ownerId == OWNER_A
+
+
+# ---------------------------------------------------------------------------
+# list_workspaces
+# ---------------------------------------------------------------------------
+
+
+class TestListWorkspaces:
+    async def test_default_visible_to_any_owner(self, init_test_db):
+        rows = await workspaces_service.list_workspaces(OWNER_A)
+        assert any(w.id == DEFAULT_WORKSPACE_ID for w in rows)
+
+    async def test_filters_by_owner(self, init_test_db):
+        await workspaces_service.create_workspace(_create_payload("team-a-1"), OWNER_A)
+        await workspaces_service.create_workspace(_create_payload("team-b-1"), OWNER_B)
+
+        rows_a = await workspaces_service.list_workspaces(OWNER_A)
+        rows_b = await workspaces_service.list_workspaces(OWNER_B)
+
+        names_a = {w.name for w in rows_a}
+        names_b = {w.name for w in rows_b}
+
+        assert "team-a-1" in names_a
+        assert "team-a-1" not in names_b
+        assert "team-b-1" in names_b
+        assert "team-b-1" not in names_a
+        # Default is visible to both because its owner is the system sentinel.
+        assert any(w.id == DEFAULT_WORKSPACE_ID for w in rows_a)
+        assert any(w.id == DEFAULT_WORKSPACE_ID for w in rows_b)
+
+
+# ---------------------------------------------------------------------------
+# get_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestGetWorkspace:
+    async def test_owner_can_read(self, init_test_db):
+        created = await workspaces_service.create_workspace(_create_payload(), OWNER_A)
+        result = await workspaces_service.get_workspace(created.id, OWNER_A)
+        assert result.id == created.id
+
+    async def test_default_visible_to_any_caller(self, init_test_db):
+        result = await workspaces_service.get_workspace(DEFAULT_WORKSPACE_ID, OWNER_A)
+        assert result.id == DEFAULT_WORKSPACE_ID
+
+    async def test_cross_owner_returns_not_found(self, init_test_db):
+        created = await workspaces_service.create_workspace(_create_payload(), OWNER_A)
+        with pytest.raises(WorkspaceNotFoundError):
+            await workspaces_service.get_workspace(created.id, OWNER_B)
+
+    async def test_truly_missing_returns_not_found(self, init_test_db):
+        with pytest.raises(WorkspaceNotFoundError):
+            await workspaces_service.get_workspace("ws-missing", OWNER_A)
+
+
+# ---------------------------------------------------------------------------
+# update_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateWorkspace:
+    async def test_owner_can_update(self, init_test_db):
+        created = await workspaces_service.create_workspace(_create_payload(), OWNER_A)
+        result = await workspaces_service.update_workspace(created.id, UpdateWorkspaceRequest(name="renamed"), OWNER_A)
+        assert result.name == "renamed"
+        # ownerId is read-only — cannot change via update.
+        assert result.ownerId == OWNER_A
+
+    async def test_cross_owner_rejected(self, init_test_db):
+        created = await workspaces_service.create_workspace(_create_payload(), OWNER_A)
+        with pytest.raises(WorkspaceNotFoundError):
+            await workspaces_service.update_workspace(created.id, UpdateWorkspaceRequest(name="hijacked"), OWNER_B)
+
+    async def test_owner_id_in_db_layer_not_mutated(self, init_test_db):
+        """Defense-in-depth: even when a stale ``ownerId`` key reaches the
+        DB merge helper, ``build_merged_workspace`` holds the field
+        constant. Hits the persistence layer directly so the test does
+        not depend on any router/middleware shape."""
+        created = await workspaces_service.create_workspace(_create_payload(), OWNER_A)
+
+        # Bypass the service and pass a sneaky ownerId directly to the DB.
+        # The merge helper must drop it.
+        merged = await db.update_workspace(created.id, {"name": "renamed", "ownerId": OWNER_B})
+        assert merged is not None
+        assert merged.name == "renamed"
+        assert merged.ownerId == OWNER_A
+
+
+# ---------------------------------------------------------------------------
+# delete_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteWorkspace:
+    async def test_owner_can_delete(self, init_test_db):
+        created = await workspaces_service.create_workspace(_create_payload(), OWNER_A)
+        await workspaces_service.delete_workspace(created.id, OWNER_A)
+        with pytest.raises(WorkspaceNotFoundError):
+            await workspaces_service.get_workspace(created.id, OWNER_A)
+
+    async def test_cross_owner_rejected(self, init_test_db):
+        created = await workspaces_service.create_workspace(_create_payload(), OWNER_A)
+        with pytest.raises(WorkspaceNotFoundError):
+            await workspaces_service.delete_workspace(created.id, OWNER_B)
+
+    async def test_default_rejected(self, init_test_db):
+        with pytest.raises(WorkspaceIsDefaultError):
+            await workspaces_service.delete_workspace(DEFAULT_WORKSPACE_ID, OWNER_A)
+
+    async def test_with_connections_rejected(self, init_test_db):
+        created = await workspaces_service.create_workspace(_create_payload(), OWNER_A)
+
+        # Attach a connection directly so we don't pull in the connections
+        # service test machinery (test isolation: failures here should point
+        # at the workspace service, not the connection service).
+        from aerospike_cluster_manager_api.models.connection import ConnectionProfile
+
+        now = datetime.now(UTC).isoformat()
+        await db.create_connection(
+            ConnectionProfile(
+                id="conn-attached",
+                name="attached",
+                hosts=["10.0.0.1"],
+                port=3000,
+                color="#0097D3",
+                workspaceId=created.id,
+                createdAt=now,
+                updatedAt=now,
+            )
+        )
+
+        with pytest.raises(WorkspaceHasConnectionsError):
+            await workspaces_service.delete_workspace(created.id, OWNER_A)
+
+
+# ---------------------------------------------------------------------------
+# get_workspaces_owned_by — DB helper smoke test
+# ---------------------------------------------------------------------------
+
+
+class TestGetWorkspacesOwnedBy:
+    """Lock the SQL filter shape so future refactors don't silently change
+    the visibility semantics the workspaces service relies on."""
+
+    async def test_includes_default_for_any_owner(self, init_test_db):
+        rows = await db.get_workspaces_owned_by(OWNER_A)
+        assert any(w.id == DEFAULT_WORKSPACE_ID and w.ownerId == SYSTEM_OWNER_ID for w in rows)
+
+    async def test_excludes_other_owners(self, init_test_db):
+        # Insert directly (bypassing the service) with an explicit owner.
+        now = datetime.now(UTC).isoformat()
+        ws = Workspace(
+            id="ws-owned-b",
+            name="b",
+            color="#123456",
+            ownerId=OWNER_B,
+            createdAt=now,
+            updatedAt=now,
+        )
+        await db.create_workspace(ws)
+
+        rows = await db.get_workspaces_owned_by(OWNER_A)
+        assert all(w.id != "ws-owned-b" for w in rows)


### PR DESCRIPTION
## Summary

Phase 0b for #307 — adds the `Workspace.ownerId` schema, idempotent DB migration, and REST API ownership rules so the follow-up MCP work can consume the field.

**This is sub-PR 1 of 3 — E.2 (OIDC claim → MCP Context bridge) and E.3 (MCP registry workspace gate) land in separate PRs and depend on this one.**

ADR / contract: [`docs/plans/2026-05-07-workspace-ownership-schema.md`](docs/plans/2026-05-07-workspace-ownership-schema.md). Consumer contract for E.2 / E.3: [`docs/plans/2026-05-07-mcp-context-contract.md`](docs/plans/2026-05-07-mcp-context-contract.md).

### What changes

- `Workspace.ownerId` persisted on both backends. Migration is idempotent (`ALTER TABLE workspaces ADD COLUMN owner_id ... DEFAULT 'system'` guarded by `PRAGMA table_info` / `ADD COLUMN IF NOT EXISTS`). Existing rows backfill to the synthetic `'system'` user.
- `ACM_OIDC_OWNER_CLAIM` config knob (default `sub`) lets operators switch the claim used as workspace owner identity for non-compliant IdPs.
- `services.workspaces_service` (new) mirrors the `connections_service` shape so the MCP tool layer can reuse it later.
- `db.get_workspaces_owned_by(owner_id)` helper on the abstract base + both backends — same query E.3 will run, so E.3 doesn't have to amend the protocol.
- Bearer-token sentinel (`_mcp_bearer=True`) and unauthenticated callers resolve to the `'system'` synthetic owner so single-tenant deployments keep Phase 1 behaviour. OIDC callers resolve to the configured claim.

### REST API ACL (Phase 2 wire shape)

| Endpoint | Cross-owner caller | Self / `system`-owned |
|---|---|---|
| `GET /api/workspaces` | row hidden from list | row visible |
| `GET /api/workspaces/{id}` | **404** (avoids id enumeration) | 200 |
| `PUT /api/workspaces/{id}` | **404**; `ownerId` field is read-only and silently dropped (no transfers in Phase 2) | 200 |
| `DELETE /api/workspaces/{id}` | **404** | 204 (`isDefault` rejected with 400; non-empty workspace rejected with 409) |

`POST /api/connections` and `GET /api/connections?workspace_id=…` reject cross-owner `workspaceId` with the same 404. The default workspace remains writable by every caller because it is owned by `'system'`.

### Out of scope (deferred)

- E.2 — OIDC claim → MCP Context bridge in `mcp/auth.py` so the registry decorator can read the caller identity without touching `request.state` (TODO marker in `dependencies.py`).
- E.3 — MCP registry decorator workspace gate body (TODO marker in `routers/connections.py`).
- K8s tool changes (Stream A).
- Multi-member workspaces, workspace transfers, group-claim → workspace mapping (per ADR "Out of scope").

## Test plan

- [x] `cd api && uv run pytest tests/` — 860 passed
- [x] `cd api && uv run ruff check src tests` — All checks passed
- [x] `cd api && uv run ruff format --check src tests` — formatted
- [x] `cd api && uv run pyright` on changed files — 0 errors
- [x] `pre-commit run --files <changed>` — all passed
- [x] Migration idempotency: re-running `init_db` on a post-migration DB is a no-op (covered by `tests/test_workspace_migrations.py::TestWorkspaceOwnerIdMigration::test_alter_is_idempotent`)
- [x] Legacy row backfill: pre-migration workspace row picks up `ownerId='system'` via column default (`test_pre_existing_workspace_row_backfilled_to_system`)
- [ ] Manual smoke against a running instance (left for reviewer)