### PR TITLE
feat(api): per-session client_manager cache

### DIFF
--- a/api/src/aerospike_cluster_manager_api/client_manager.py
+++ b/api/src/aerospike_cluster_manager_api/client_manager.py
@@ -1,13 +1,39 @@
 """Aerospike async client pool manager.
 
-Manages one AsyncClient per connection-id, with per-connection asyncio.Lock()
-for safe concurrent access without global serialization.
+Manages one ``AsyncClient`` per ``(session_id, conn_id)`` pair, with a
+per-pair :class:`asyncio.Lock` for safe concurrent access without global
+serialization.
+
+Phase 2 (#303) -- per-session scoping
+-------------------------------------
+
+Cached entries are keyed by ``(session_id, conn_id)`` rather than just
+``conn_id`` so one MCP session's ``disconnect("X")`` cannot evict another
+session's cached client for the same connection profile. The
+``session_id`` is read transparently from a module-level
+:class:`contextvars.ContextVar` (``_SESSION_CTXVAR``); the MCP registry
+decorator stashes it before calling the tool body, and unsets it on the
+way out so the contextvar never leaks across calls.
+
+The REST API path has no MCP session -- the contextvar stays at its
+default ``None`` and every REST caller therefore shares one cache slot
+per ``conn_id`` (the Phase 1 behaviour the existing REST routers and
+``test_client_manager.py`` rely on). ``close_client(conn_id)`` only
+evicts the caller's *own* slot: an MCP session's disconnect cannot tear
+down the REST cache, and the REST path's eviction does not touch any
+MCP session.
+
+If FastMCP exposes a session-cleanup hook in the future, call
+:meth:`ClientManager.close_session` from it; until then the per-session
+slots sit until process exit, which is acceptable for the short-lived
+sessions FastMCP creates over StreamableHTTP.
 """
 
 from __future__ import annotations
 
 import asyncio
 import contextlib
+from contextvars import ContextVar
 from typing import Any
 
 import aerospike_py
@@ -22,25 +48,68 @@ from aerospike_cluster_manager_api.utils import parse_host_port
 _tracer = trace.get_tracer("aerospike_cluster_manager_api.client_manager")
 
 
+# Per-call session id used to key the cache. The MCP registry decorator
+# (mcp/registry.py) sets this before invoking a tool body and resets it
+# on the way out. The REST API path leaves it at its default ``None``,
+# which collapses to the Phase 1 single-cache-per-conn_id behaviour the
+# REST routers expect.
+_SESSION_CTXVAR: ContextVar[str | None] = ContextVar(
+    "asm_mcp_session_id",
+    default=None,
+)
+
+# Cache key: ``(session_id, conn_id)`` where ``session_id is None``
+# represents the REST API path (no MCP session). Aliasing keeps the type
+# annotations self-documenting in a few places below.
+_CacheKey = tuple[str | None, str]
+
+
 class ClientManager:
     def __init__(self) -> None:
-        self._clients: dict[str, aerospike_py.AsyncClient] = {}
+        self._clients: dict[_CacheKey, aerospike_py.AsyncClient] = {}
         self._global_lock = asyncio.Lock()
-        self._conn_locks: dict[str, asyncio.Lock] = {}
-        # Instruments are NoOps when OTel is disabled — safe to bind eagerly.
+        self._conn_locks: dict[_CacheKey, asyncio.Lock] = {}
+        # Instruments are NoOps when OTel is disabled -- safe to bind eagerly.
         self._instruments = make_instruments()
 
-    async def _get_conn_lock(self, conn_id: str) -> asyncio.Lock:
-        """Return the per-connection lock, creating one if needed."""
+    @staticmethod
+    def _current_session_id() -> str | None:
+        """Read the per-call session id stashed by the MCP registry decorator.
+
+        Returns ``None`` for the REST API path. Exposed as a method so
+        tests can monkey-patch it cleanly.
+        """
+        return _SESSION_CTXVAR.get()
+
+    def _key(self, conn_id: str) -> _CacheKey:
+        return (self._current_session_id(), conn_id)
+
+    def _metric_attrs(self, conn_id: str) -> dict[str, str]:
+        """OTel attributes for the ``active_aerospike_connections`` metric.
+
+        Includes the session id when present so the metric is per-session
+        in dashboards. The REST path emits ``asm.session.id="rest"`` so
+        the dimension is always populated and queries don't have to
+        special-case ``null``.
+        """
+        session_id = self._current_session_id()
+        return {
+            "asm.connection.id": conn_id,
+            "asm.session.id": session_id if session_id is not None else "rest",
+        }
+
+    async def _get_conn_lock(self, key: _CacheKey) -> asyncio.Lock:
+        """Return the per-(session,conn) lock, creating one if needed."""
         async with self._global_lock:
-            if conn_id not in self._conn_locks:
-                self._conn_locks[conn_id] = asyncio.Lock()
-            return self._conn_locks[conn_id]
+            if key not in self._conn_locks:
+                self._conn_locks[key] = asyncio.Lock()
+            return self._conn_locks[key]
 
     async def get_client(self, conn_id: str) -> aerospike_py.AsyncClient:
-        conn_lock = await self._get_conn_lock(conn_id)
+        key = self._key(conn_id)
+        conn_lock = await self._get_conn_lock(key)
         async with conn_lock:
-            client = self._clients.get(conn_id)
+            client = self._clients.get(key)
             if client is not None and client.is_connected():
                 return client
 
@@ -59,37 +128,89 @@ class ClientManager:
                 attributes={
                     "asm.connection.id": conn_id,
                     "asm.connection.host_count": len(hosts),
+                    "asm.session.id": key[0] if key[0] is not None else "rest",
                 },
             ):
                 client = aerospike_py.AsyncClient(as_config)
                 await client.connect()
 
-            old = self._clients.get(conn_id)
+            old = self._clients.get(key)
             if old is not None:
                 with contextlib.suppress(AerospikeError, OSError):
                     await old.close()
-            self._clients[conn_id] = client
-            self._instruments["active_aerospike_connections"].add(1, attributes={"asm.connection.id": conn_id})
+            self._clients[key] = client
+            self._instruments["active_aerospike_connections"].add(1, attributes=self._metric_attrs(conn_id))
 
             return client
 
     async def close_client(self, conn_id: str) -> None:
-        conn_lock = await self._get_conn_lock(conn_id)
+        """Evict the caller's *own* cached client for ``conn_id``.
+
+        REST callers (``session_id=None``) only ever evict the REST slot.
+        An MCP session evicts only its own slot, so disconnect from one
+        session leaves other sessions' (and the REST path's) cached
+        clients intact -- the core invariant of #303.
+        """
+        key = self._key(conn_id)
+        conn_lock = await self._get_conn_lock(key)
         async with conn_lock:
-            client = self._clients.pop(conn_id, None)
+            client = self._clients.pop(key, None)
+            # info_cache is keyed by conn_id only -- invalidating cross-
+            # session is the conservative choice since the underlying
+            # cluster info doesn't depend on which MCP session asked.
             info_cache.invalidate_connection(conn_id)
             async with self._global_lock:
-                self._conn_locks.pop(conn_id, None)
+                self._conn_locks.pop(key, None)
             if client is not None:
                 with (
                     _tracer.start_as_current_span(
                         "asm.aerospike.client.close",
-                        attributes={"asm.connection.id": conn_id},
+                        attributes={
+                            "asm.connection.id": conn_id,
+                            "asm.session.id": key[0] if key[0] is not None else "rest",
+                        },
                     ),
                     contextlib.suppress(AerospikeError, OSError),
                 ):
                     await client.close()
-                self._instruments["active_aerospike_connections"].add(-1, attributes={"asm.connection.id": conn_id})
+                self._instruments["active_aerospike_connections"].add(-1, attributes=self._metric_attrs(conn_id))
+
+    async def close_session(self, session_id: str) -> None:
+        """Evict every cached client for the given MCP session.
+
+        Intended to be called from a FastMCP session-cleanup hook when /
+        if one becomes available. Until then it is best-effort: the
+        cache entry sits until process exit, which is acceptable for the
+        short-lived sessions FastMCP currently produces. Passing
+        ``session_id=None`` would close the REST path's slots -- we
+        forbid that to avoid REST-vs-MCP confusion.
+        """
+        if session_id is None:
+            raise ValueError("close_session requires a non-None session id; use close_client/close_all instead")
+
+        async with self._global_lock:
+            keys = [k for k in self._clients if k[0] == session_id]
+            clients = [self._clients.pop(k) for k in keys]
+            for k in keys:
+                self._conn_locks.pop(k, None)
+        for key, client in zip(keys, clients, strict=True):
+            conn_id = key[1]
+            info_cache.invalidate_connection(conn_id)
+            with (
+                _tracer.start_as_current_span(
+                    "asm.aerospike.client.close",
+                    attributes={
+                        "asm.connection.id": conn_id,
+                        "asm.session.id": session_id,
+                    },
+                ),
+                contextlib.suppress(AerospikeError, OSError),
+            ):
+                await client.close()
+            self._instruments["active_aerospike_connections"].add(
+                -1,
+                attributes={"asm.connection.id": conn_id, "asm.session.id": session_id},
+            )
 
     async def close_all(self) -> None:
         info_cache.clear()

--- a/api/src/aerospike_cluster_manager_api/mcp/registry.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/registry.py
@@ -5,7 +5,7 @@ Each decoration:
 
 * records :class:`ToolMetadata` (name, category, mutation, callable) in
   the module-level ``_REGISTRY`` accumulator;
-* wraps the function with the access-profile gate (A.8) — mutation tools
+* wraps the function with the access-profile gate (A.8) -- mutation tools
   named in ``access_profile.WRITE_TOOLS`` raise
   :class:`MCPToolError` with ``code="access_denied"`` under the
   ``READ_ONLY`` profile, **before** the body runs;
@@ -13,6 +13,20 @@ Each decoration:
   service-layer errors surface as :class:`MCPToolError` with stable codes
   while everything else propagates so the registry / OTel pipeline can
   log the real bug.
+
+Phase 2 (#303) -- Context plumbing
+----------------------------------
+
+The wrapper now declares an injected ``ctx: Context`` parameter so
+FastMCP supplies the per-call :class:`mcp.server.fastmcp.Context`. The
+wrapper then stashes the session id on
+:data:`client_manager._SESSION_CTXVAR` so
+``client_manager.get_client(conn_id)`` reads it transparently and
+returns a session-scoped cached client. The user-facing tool body is
+**unchanged** -- tool functions never see ``ctx``. See
+``docs/plans/2026-05-07-mcp-context-contract.md`` for the design.
+
+Workspace gate (#307) is a no-op stub here -- populated by Stream E.
 
 The decorator returns the *wrapped* form so tests and other callers that
 bypass FastMCP still see the gate. ``register_all(mcp)`` is invoked once
@@ -25,14 +39,14 @@ done at the call site rather than at registration time.
 
 from __future__ import annotations
 
-import functools
 import inspect
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.fastmcp import Context, FastMCP
 
+from aerospike_cluster_manager_api import client_manager as _client_manager_mod
 from aerospike_cluster_manager_api import config
 from aerospike_cluster_manager_api.mcp.access_profile import WRITE_TOOLS, AccessProfile, is_blocked
 from aerospike_cluster_manager_api.mcp.errors import MCPToolError, map_aerospike_errors
@@ -40,7 +54,7 @@ from aerospike_cluster_manager_api.mcp.errors import MCPToolError, map_aerospike
 
 @dataclass(frozen=True)
 class ToolMetadata:
-    """Snapshot of a registered tool — exposed for autodiscovery / docs.
+    """Snapshot of a registered tool -- exposed for autodiscovery / docs.
 
     ``func`` is the *wrapped* callable (with access-profile + error-mapping
     already applied). Direct callers see the same gate as FastMCP would.
@@ -60,6 +74,93 @@ _REGISTRY: list[ToolMetadata] = []
 # ``mcp.add_tool(...)`` would raise FastMCP's "duplicate tool name"
 # error. Skipping the second call is idempotent and cheap.
 _REGISTERED_MCP_IDS: set[int] = set()
+
+
+def _ctx_session_id(ctx: Context | None) -> str | None:
+    """Best-effort extraction of a stable session identifier from ``ctx``.
+
+    FastMCP's :class:`Context` does not expose a dedicated ``session_id``
+    attribute (the wire-level ``mcp-session-id`` lives on the
+    StreamableHTTP transport, not on Context). We use the
+    :class:`ServerSession` object identity as the proxy -- it is unique
+    per MCP session for the lifetime of that session, which is exactly
+    what the per-session cache needs to key on. Falls back to
+    ``ctx.client_id`` (when populated) and finally to ``None`` (the
+    REST-equivalent slot) if neither is available.
+    """
+    if ctx is None:
+        return None
+    # ``ctx.session`` raises if the request context is not bound (e.g. a
+    # bare Context constructed in a unit test). Treat that as "no session".
+    try:
+        session = ctx.session
+    except Exception:  # pragma: no cover -- defensive
+        session = None
+    if session is not None:
+        return f"session-{id(session):x}"
+    client_id = ctx.client_id if hasattr(ctx, "client_id") else None
+    if client_id:  # pragma: no cover -- exercised only when client populates _meta
+        return f"client-{client_id}"
+    return None
+
+
+async def _assert_workspace_owns_arg(
+    ctx: Context | None,  # noqa: ARG001
+    tool_name: str,  # noqa: ARG001
+    kwargs: dict[str, Any],  # noqa: ARG001
+) -> None:
+    """Workspace authorization gate (Phase 2, #307).
+
+    No-op stub -- Stream E (#307) populates the body. Kept here so the
+    contract from ``docs/plans/2026-05-07-mcp-context-contract.md`` lands
+    in one place and Streams B / A can reference the same call site.
+
+    TODO(#307): inspect ``kwargs`` for ``conn_id`` / ``workspace_id``
+    parameters and assert ``ctx.user_claims['sub']`` owns the referenced
+    workspace; raise ``MCPToolError(code="workspace_mismatch")`` on
+    mismatch. Bearer-token sessions bypass this gate.
+    """
+    return None
+
+
+def _build_wrapped_signature(func: Callable[..., Any]) -> inspect.Signature:
+    """Return a signature that mirrors ``func`` but appends a ``ctx`` kwarg.
+
+    FastMCP's ``Tool.from_function`` calls
+    :func:`mcp.server.fastmcp.utilities.context_injection.find_context_parameter`
+    via :func:`typing.get_type_hints` on the registered callable. Because
+    ``functools.wraps`` makes ``get_type_hints(wrapped)`` return the
+    *inner* function's hints (it walks ``__wrapped__``), we can't rely on
+    a plain ``ctx: Context`` annotation on the closure to be visible to
+    FastMCP. Instead we drop ``functools.wraps`` and overwrite
+    ``__signature__`` / ``__annotations__`` / ``__name__`` / ``__doc__``
+    manually so:
+
+    * FastMCP's introspection sees ``ctx: Context`` and excludes it from
+      the JSON schema (its ``find_context_parameter`` walks the
+      annotations dict, not ``__wrapped__``).
+    * Tests calling the wrapped form directly (``await tool_fn(...)``)
+      still see the original parameter names for binding.
+    * ``inspect.signature(wrapped)`` shows the real surface -- useful for
+      autodiscovery / docs.
+
+    We chose this manual route over ``functools.wraps`` because the
+    FastMCP version pinned in this project resolves type hints by
+    walking ``__wrapped__``, which would hide our ``ctx`` annotation and
+    cause FastMCP to fall back to passing ``ctx`` through the JSON
+    schema (leaking the implementation detail to the model). Synthesising
+    the signature is the smaller of two evils. See
+    ``docs/plans/2026-05-07-mcp-context-contract.md`` "What lives where"
+    for the rationale.
+    """
+    func_sig = inspect.signature(func)
+    ctx_param = inspect.Parameter(
+        "ctx",
+        inspect.Parameter.KEYWORD_ONLY,
+        annotation=Context,
+        default=None,
+    )
+    return func_sig.replace(parameters=[*func_sig.parameters.values(), ctx_param])
 
 
 def tool(
@@ -83,7 +184,7 @@ def tool(
         flag (default-allow); the flag is purely for introspection.
     name:
         Optional override; defaults to ``func.__name__``. Must be unique
-        across the registry — duplicates raise :class:`ValueError`.
+        across the registry -- duplicates raise :class:`ValueError`.
     """
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -91,7 +192,7 @@ def tool(
         if any(entry.name == tool_name for entry in _REGISTRY):
             raise ValueError(f"Duplicate tool registration: {tool_name}")
 
-        # M3 — registry-time consistency check. WRITE_TOOLS is the
+        # M3 -- registry-time consistency check. WRITE_TOOLS is the
         # authoritative list consulted by the call-time access profile
         # gate; the @tool(mutation=...) flag is purely declarative. If
         # the two ever drift (someone adds a mutation tool but forgets
@@ -111,18 +212,45 @@ def tool(
 
         is_async = inspect.iscoroutinefunction(func)
 
-        @functools.wraps(func)
-        async def wrapped(*args: Any, **kwargs: Any) -> Any:
+        async def wrapped(*args: Any, ctx: Context | None = None, **kwargs: Any) -> Any:
+            # 1. Profile gate (Phase 1, unchanged) -- purely deployment-level.
+            #    Run BEFORE setting the session contextvar so a rejected
+            #    call doesn't pollute caches with half-initialised state.
             profile: AccessProfile = config.ACM_MCP_ACCESS_PROFILE
             if mutation and is_blocked(tool_name, profile):
                 raise MCPToolError(
                     f"Tool '{tool_name}' is disabled by access profile '{profile.value}'.",
                     code="access_denied",
                 )
-            with map_aerospike_errors():
-                if is_async:
-                    return await func(*args, **kwargs)
-                return func(*args, **kwargs)
+
+            # 2. Workspace gate (Phase 2, #307) -- stub today; Stream E lands the body.
+            await _assert_workspace_owns_arg(ctx, tool_name, kwargs)
+
+            # 3. Session-scoped client lookup (Phase 2, #303). Set the
+            #    contextvar so client_manager.get_client(conn_id) keys the
+            #    cache by (session_id, conn_id) transparently. Reset on
+            #    the way out so the contextvar never leaks across calls
+            #    that share an event loop.
+            session_id = _ctx_session_id(ctx)
+            token = _client_manager_mod._SESSION_CTXVAR.set(session_id)
+            try:
+                with map_aerospike_errors():
+                    if is_async:
+                        return await func(*args, **kwargs)
+                    return func(*args, **kwargs)
+            finally:
+                _client_manager_mod._SESSION_CTXVAR.reset(token)
+
+        # Mirror ``func``'s name / docstring for introspection / docs but
+        # synthesise a signature that includes the injected ``ctx`` param
+        # so FastMCP's ``find_context_parameter`` recognises it. See
+        # ``_build_wrapped_signature`` for why we cannot use functools.wraps.
+        wrapped.__name__ = func.__name__
+        wrapped.__qualname__ = func.__qualname__
+        wrapped.__doc__ = func.__doc__
+        wrapped.__module__ = func.__module__
+        wrapped.__signature__ = _build_wrapped_signature(func)  # type: ignore[attr-defined]
+        wrapped.__annotations__ = {**getattr(func, "__annotations__", {}), "ctx": Context}
 
         _REGISTRY.append(ToolMetadata(name=tool_name, category=category, mutation=mutation, func=wrapped))
         return wrapped
@@ -150,10 +278,20 @@ def registered_tools() -> list[ToolMetadata]:
     """Return a snapshot copy of the current registry.
 
     Useful for introspection (docs, ``__repr__``, telemetry); callers
-    should not mutate the result — modifying the returned list does not
+    should not mutate the result -- modifying the returned list does not
     affect the registry.
     """
     return list(_REGISTRY)
+
+
+def current_session_id() -> str | None:
+    """Return the session id stashed by the active wrapper, if any.
+
+    Tool bodies should NOT depend on this -- it exists for the rare case
+    a future tool genuinely needs the session id (e.g. structured
+    logging) without threading ``ctx`` through its public signature.
+    """
+    return _client_manager_mod._SESSION_CTXVAR.get()
 
 
 def _reset_for_tests() -> None:

--- a/api/src/aerospike_cluster_manager_api/mcp/registry.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/registry.py
@@ -93,9 +93,12 @@ def _ctx_session_id(ctx: Context | None) -> str | None:
         return None
     # ``ctx.session`` raises if the request context is not bound (e.g. a
     # bare Context constructed in a unit test). Treat that as "no session".
+    # Narrow the catch to the same family ``ctx.client_id`` uses below so
+    # an unrelated FastMCP refactor that raises a different exception isn't
+    # silently masked into "no session".
     try:
         session = ctx.session
-    except Exception:  # pragma: no cover -- defensive
+    except (AttributeError, ValueError, LookupError, RuntimeError):  # pragma: no cover -- defensive
         session = None
     if session is not None:
         return f"session-{id(session):x}"
@@ -229,6 +232,14 @@ def tool(
 
         is_async = inspect.iscoroutinefunction(func)
 
+        # ``ctx`` carries a default of ``None`` so direct callers (tests
+        # exercising the wrapper without FastMCP) can omit it. FastMCP's
+        # ``find_context_parameter`` (resolved via the synthesised
+        # ``__signature__`` below) inspects the *annotation* (``Context``),
+        # not the default, so this default does not interfere with
+        # injection in versions pinned today. If a future FastMCP rejects
+        # defaulted Context params, ``test_wrapped_signature_exposes_ctx_for_fastmcp``
+        # will fail and force a re-evaluation.
         async def wrapped(*args: Any, ctx: Context | None = None, **kwargs: Any) -> Any:
             # 1. Profile gate (Phase 1, unchanged) -- purely deployment-level.
             #    Run BEFORE setting the session contextvar so a rejected

--- a/api/src/aerospike_cluster_manager_api/mcp/registry.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/registry.py
@@ -40,6 +40,7 @@ done at the call site rather than at registration time.
 from __future__ import annotations
 
 import inspect
+import typing
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -98,16 +99,23 @@ def _ctx_session_id(ctx: Context | None) -> str | None:
         session = None
     if session is not None:
         return f"session-{id(session):x}"
-    client_id = ctx.client_id if hasattr(ctx, "client_id") else None
+    # ``ctx.client_id`` is a property that raises when ``request_context``
+    # is unbound (FastMCP's in-process call_tool path constructs a Context
+    # without a request when the test fixture doesn't drive the transport).
+    # Treat the unbound case as "no session" -- the REST equivalent slot.
+    try:
+        client_id = ctx.client_id
+    except (AttributeError, ValueError):
+        client_id = None
     if client_id:  # pragma: no cover -- exercised only when client populates _meta
         return f"client-{client_id}"
     return None
 
 
 async def _assert_workspace_owns_arg(
-    ctx: Context | None,  # noqa: ARG001
-    tool_name: str,  # noqa: ARG001
-    kwargs: dict[str, Any],  # noqa: ARG001
+    ctx: Context | None,
+    tool_name: str,
+    kwargs: dict[str, Any],
 ) -> None:
     """Workspace authorization gate (Phase 2, #307).
 
@@ -153,7 +161,16 @@ def _build_wrapped_signature(func: Callable[..., Any]) -> inspect.Signature:
     ``docs/plans/2026-05-07-mcp-context-contract.md`` "What lives where"
     for the rationale.
     """
-    func_sig = inspect.signature(func)
+    # ``eval_str=True`` resolves string annotations (the ones produced by
+    # ``from __future__ import annotations`` in the tool modules) relative
+    # to ``func``'s own module globals. Without this, the cached
+    # ``__signature__`` we attach to ``wrapped`` would carry raw strings
+    # like ``"Literal['equals', ...]"`` -- pydantic's
+    # ``model_json_schema`` then re-evaluates them in ``wrapped``'s module
+    # (registry), where ``Literal`` is not in scope, and blows up with
+    # ``PydanticUserError: ... is not fully defined``. Resolving up-front
+    # avoids that mismatch.
+    func_sig = inspect.signature(func, eval_str=True)
     ctx_param = inspect.Parameter(
         "ctx",
         inspect.Parameter.KEYWORD_ONLY,
@@ -250,7 +267,18 @@ def tool(
         wrapped.__doc__ = func.__doc__
         wrapped.__module__ = func.__module__
         wrapped.__signature__ = _build_wrapped_signature(func)  # type: ignore[attr-defined]
-        wrapped.__annotations__ = {**getattr(func, "__annotations__", {}), "ctx": Context}
+        # Resolve func's annotations against its own module globals so the
+        # copied dict carries real types (Literal[...], list[str], etc.)
+        # rather than raw forward-reference strings produced by
+        # ``from __future__ import annotations``. ``include_extras=True``
+        # preserves Annotated[...] metadata that some tool args use for
+        # FastMCP / pydantic field config. See the matching comment in
+        # ``_build_wrapped_signature`` for why this matters.
+        try:
+            resolved = typing.get_type_hints(func, include_extras=True)
+        except Exception:  # pragma: no cover -- defensive
+            resolved = dict(getattr(func, "__annotations__", {}))
+        wrapped.__annotations__ = {**resolved, "ctx": Context}
 
         _REGISTRY.append(ToolMetadata(name=tool_name, category=category, mutation=mutation, func=wrapped))
         return wrapped

--- a/api/tests/mcp/test_registry.py
+++ b/api/tests/mcp/test_registry.py
@@ -308,3 +308,141 @@ def test_reset_for_tests_clears_registry() -> None:
     assert len(registered_tools()) == 1
     _reset_for_tests()
     assert registered_tools() == []
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 / #303 -- Context plumbing into client_manager._SESSION_CTXVAR
+# ---------------------------------------------------------------------------
+
+
+async def test_wrapped_does_not_leak_ctx_into_body(full_profile: None) -> None:
+    """Tool authors never see ``ctx`` -- the contract from
+    ``docs/plans/2026-05-07-mcp-context-contract.md`` "Tool body
+    invariant". The wrapper extracts everything from FastMCP's
+    :class:`Context` and applies gates before delegating; the inner
+    function's signature stays pure data.
+    """
+    received: dict[str, object] = {}
+
+    @tool(category="record", mutation=False)
+    async def echo(value: str) -> str:
+        # Body intentionally captures locals to inspect what got passed in.
+        # If ``ctx`` ever leaks here, this dict will surface it.
+        received["value"] = value
+        received["locals"] = dict(locals())
+        return value
+
+    result = await echo(value="hello")
+    assert result == "hello"
+    assert received["value"] == "hello"
+    # Body's local namespace must not contain ``ctx``.
+    assert "ctx" not in received["locals"]
+
+
+async def test_wrapped_signature_exposes_ctx_for_fastmcp(full_profile: None) -> None:
+    """FastMCP's ``Tool.from_function`` introspects the wrapped callable
+    via :func:`typing.get_type_hints` to find a ``Context``-typed param.
+    The wrapper must surface ``ctx: Context`` even though the inner
+    function does not declare it -- otherwise FastMCP cannot inject the
+    per-call context and #303's session-scoping silently fails.
+    """
+    import inspect
+    import typing
+
+    from mcp.server.fastmcp import Context
+    from mcp.server.fastmcp.utilities.context_injection import find_context_parameter
+
+    @tool(category="record", mutation=False)
+    async def take_one(value: str) -> str:
+        return value
+
+    sig = inspect.signature(take_one)
+    assert "value" in sig.parameters
+    assert "ctx" in sig.parameters
+    assert sig.parameters["ctx"].annotation is Context
+
+    hints = typing.get_type_hints(take_one)
+    assert hints.get("ctx") is Context
+    assert find_context_parameter(take_one) == "ctx"
+
+
+async def test_wrapped_sets_session_contextvar_from_ctx(full_profile: None) -> None:
+    """The wrapper must stash ``ctx``'s session id onto
+    :data:`client_manager._SESSION_CTXVAR` before calling the body, so
+    ``client_manager.get_client(conn_id)`` sees the right session and
+    returns a per-session cache slot. After the body returns, the
+    contextvar must be reset to its previous value (no leak across
+    calls sharing an event loop).
+    """
+    from unittest.mock import MagicMock
+
+    from aerospike_cluster_manager_api import client_manager as cm_mod
+
+    seen: dict[str, object] = {}
+
+    @tool(category="record", mutation=False)
+    async def probe() -> str:
+        seen["session_id_inside"] = cm_mod._SESSION_CTXVAR.get()
+        return "ok"
+
+    # Build a fake Context with a session attribute. The wrapper uses
+    # ``id(ctx.session)`` (via ``_ctx_session_id``) to derive a stable
+    # per-session string -- see ``mcp/registry._ctx_session_id``.
+    fake_session = MagicMock(name="server-session")
+    fake_ctx = MagicMock(spec=["session", "client_id"])
+    fake_ctx.session = fake_session
+    fake_ctx.client_id = None
+
+    # Sentinel: contextvar must be back to None after the call.
+    assert cm_mod._SESSION_CTXVAR.get() is None
+    result = await probe(ctx=fake_ctx)
+    assert result == "ok"
+
+    # Inside the body, the contextvar matched our fake session.
+    inside = seen["session_id_inside"]
+    assert isinstance(inside, str)
+    assert inside.startswith("session-")
+    assert hex(id(fake_session))[2:] in inside
+
+    # Outside, the contextvar was reset.
+    assert cm_mod._SESSION_CTXVAR.get() is None
+
+
+async def test_wrapped_with_no_ctx_leaves_session_id_none(full_profile: None) -> None:
+    """Tests / direct callers can invoke the wrapped form without ``ctx``;
+    the contextvar then defaults to ``None`` (the REST API path).
+    """
+    from aerospike_cluster_manager_api import client_manager as cm_mod
+
+    seen: dict[str, object] = {}
+
+    @tool(category="record", mutation=False)
+    async def probe() -> str:
+        seen["session_id_inside"] = cm_mod._SESSION_CTXVAR.get()
+        return "ok"
+
+    await probe()
+    assert seen["session_id_inside"] is None
+    assert cm_mod._SESSION_CTXVAR.get() is None
+
+
+async def test_wrapped_resets_ctxvar_on_exception(full_profile: None) -> None:
+    """Even when the body raises, the contextvar must be reset so the
+    next call (which may be a REST call on the same event loop) does
+    not inherit the prior session id.
+    """
+    from unittest.mock import MagicMock
+
+    from aerospike_cluster_manager_api import client_manager as cm_mod
+
+    @tool(category="record", mutation=False)
+    async def boom() -> str:
+        raise RuntimeError("nope")
+
+    fake_ctx = MagicMock(spec=["session", "client_id"])
+    fake_ctx.session = MagicMock()
+    fake_ctx.client_id = None
+
+    with pytest.raises(RuntimeError, match="nope"):
+        await boom(ctx=fake_ctx)
+    assert cm_mod._SESSION_CTXVAR.get() is None

--- a/api/tests/mcp/test_session_isolation.py
+++ b/api/tests/mcp/test_session_isolation.py
@@ -1,0 +1,205 @@
+"""Per-session client cache isolation -- Stream B / GitHub issue #303.
+
+The MCP registry decorator (``mcp/registry.py``) stashes a per-call
+session id on ``client_manager._SESSION_CTXVAR`` so
+``client_manager.get_client(conn_id)`` keys its cache by
+``(session_id, conn_id)``. This test file pins down the invariants:
+
+1. Two MCP sessions hitting the same ``conn_id`` get separate cached
+   ``AsyncClient`` instances.
+2. Session A's ``disconnect("X")`` (i.e. ``close_client``) does NOT
+   evict session B's cached client for the same ``conn_id``.
+3. The REST API path (``session_id=None``) preserves Phase 1 behaviour:
+   one cache slot per ``conn_id``.
+
+The tests drive the contextvar directly rather than spinning up a real
+FastMCP request -- that keeps the assertions focused on the cache shape
+without dragging the whole transport stack in. The wrapper-side
+plumbing (decorator -> contextvar) is covered by ``test_registry.py``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aerospike_cluster_manager_api.client_manager import (
+    _SESSION_CTXVAR,
+    ClientManager,
+)
+
+
+@pytest.fixture()
+def mock_db_profile(sample_connection):
+    """Patch ``client_manager.db.get_connection`` to return a sample profile.
+
+    Mirrors the fixture in ``tests/test_client_manager.py`` -- the
+    underlying ``db`` module is the only collaborator we don't want to
+    hit in unit tests.
+    """
+    with patch("aerospike_cluster_manager_api.client_manager.db") as mock_db:
+        mock_db.get_connection = AsyncMock(return_value=sample_connection)
+        yield mock_db
+
+
+def _make_connected_client(name: str) -> AsyncMock:
+    client = AsyncMock(name=name)
+    client.is_connected.return_value = True
+    return client
+
+
+class TestTwoSessionsShareConnId:
+    async def test_each_session_gets_its_own_async_client(self, mock_db_profile):
+        a = _make_connected_client("client-A")
+        b = _make_connected_client("client-B")
+
+        with patch(
+            "aerospike_cluster_manager_api.client_manager.aerospike_py.AsyncClient",
+            side_effect=[a, b],
+        ):
+            mgr = ClientManager()
+
+            token = _SESSION_CTXVAR.set("session-A")
+            try:
+                got_a = await mgr.get_client("conn-1")
+            finally:
+                _SESSION_CTXVAR.reset(token)
+
+            token = _SESSION_CTXVAR.set("session-B")
+            try:
+                got_b = await mgr.get_client("conn-1")
+            finally:
+                _SESSION_CTXVAR.reset(token)
+
+            assert got_a is a
+            assert got_b is b
+            # Cache shape: one slot per (session, conn) pair.
+            assert set(mgr._clients) == {("session-A", "conn-1"), ("session-B", "conn-1")}
+
+    async def test_get_client_within_same_session_is_idempotent(self, mock_db_profile):
+        a = _make_connected_client("client-A")
+
+        with patch(
+            "aerospike_cluster_manager_api.client_manager.aerospike_py.AsyncClient",
+            return_value=a,
+        ) as mock_cls:
+            mgr = ClientManager()
+            token = _SESSION_CTXVAR.set("session-A")
+            try:
+                first = await mgr.get_client("conn-1")
+                second = await mgr.get_client("conn-1")
+            finally:
+                _SESSION_CTXVAR.reset(token)
+
+            mock_cls.assert_called_once()
+            assert first is second is a
+
+
+class TestDisconnectIsolation:
+    async def test_session_a_disconnect_leaves_session_b_intact(self, mock_db_profile):
+        a = _make_connected_client("client-A")
+        b = _make_connected_client("client-B")
+
+        with patch(
+            "aerospike_cluster_manager_api.client_manager.aerospike_py.AsyncClient",
+            side_effect=[a, b],
+        ):
+            mgr = ClientManager()
+
+            for sid, expected in (("session-A", a), ("session-B", b)):
+                token = _SESSION_CTXVAR.set(sid)
+                try:
+                    got = await mgr.get_client("conn-1")
+                finally:
+                    _SESSION_CTXVAR.reset(token)
+                assert got is expected
+
+            # Session A disconnects.
+            token = _SESSION_CTXVAR.set("session-A")
+            try:
+                await mgr.close_client("conn-1")
+            finally:
+                _SESSION_CTXVAR.reset(token)
+
+            # Session A's slot is gone; session B's stays put.
+            assert ("session-A", "conn-1") not in mgr._clients
+            assert ("session-B", "conn-1") in mgr._clients
+
+            # Session B can still reach its cached client without
+            # rebuilding (no extra AsyncClient construction).
+            token = _SESSION_CTXVAR.set("session-B")
+            try:
+                still_b = await mgr.get_client("conn-1")
+            finally:
+                _SESSION_CTXVAR.reset(token)
+            assert still_b is b
+
+    async def test_mcp_disconnect_does_not_evict_rest_slot(self, mock_db_profile):
+        """REST cache must be invisible to MCP sessions and vice versa."""
+        rest_client = _make_connected_client("rest")
+        mcp_client = _make_connected_client("mcp")
+
+        with patch(
+            "aerospike_cluster_manager_api.client_manager.aerospike_py.AsyncClient",
+            side_effect=[rest_client, mcp_client],
+        ):
+            mgr = ClientManager()
+            # REST caller (no contextvar set) populates the (None, _) slot.
+            assert _SESSION_CTXVAR.get() is None
+            await mgr.get_client("conn-1")
+
+            token = _SESSION_CTXVAR.set("session-A")
+            try:
+                await mgr.get_client("conn-1")
+                await mgr.close_client("conn-1")
+            finally:
+                _SESSION_CTXVAR.reset(token)
+
+            assert ("session-A", "conn-1") not in mgr._clients
+            assert (None, "conn-1") in mgr._clients
+
+
+class TestRestPathPreserved:
+    async def test_two_rest_calls_share_one_cached_client(self, mock_db_profile):
+        """REST callers leave the contextvar at its default ``None``.
+
+        Phase 1 behaviour: one cached AsyncClient per conn_id across
+        all REST traffic. Regression net for ``test_client_manager.py``.
+        """
+        client = _make_connected_client("rest")
+
+        with patch(
+            "aerospike_cluster_manager_api.client_manager.aerospike_py.AsyncClient",
+            return_value=client,
+        ) as mock_cls:
+            mgr = ClientManager()
+
+            first = await mgr.get_client("conn-rest")
+            second = await mgr.get_client("conn-rest")
+
+            mock_cls.assert_called_once()
+            assert first is second is client
+            assert set(mgr._clients) == {(None, "conn-rest")}
+
+    async def test_rest_close_only_evicts_rest_slot(self, mock_db_profile):
+        rest_client = _make_connected_client("rest")
+        mcp_client = _make_connected_client("mcp")
+
+        with patch(
+            "aerospike_cluster_manager_api.client_manager.aerospike_py.AsyncClient",
+            side_effect=[rest_client, mcp_client],
+        ):
+            mgr = ClientManager()
+            await mgr.get_client("conn-1")  # REST
+
+            token = _SESSION_CTXVAR.set("session-A")
+            try:
+                await mgr.get_client("conn-1")
+            finally:
+                _SESSION_CTXVAR.reset(token)
+
+            await mgr.close_client("conn-1")  # REST close
+
+            assert (None, "conn-1") not in mgr._clients
+            assert ("session-A", "conn-1") in mgr._clients

--- a/api/tests/test_client_manager.py
+++ b/api/tests/test_client_manager.py
@@ -1,4 +1,4 @@
-"""Unit tests for ClientManager — verifies tend_interval and per-connection lock concurrency."""
+"""Unit tests for ClientManager -- verifies tend_interval and per-connection lock concurrency."""
 
 from __future__ import annotations
 
@@ -7,7 +7,10 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from aerospike_cluster_manager_api.client_manager import ClientManager
+from aerospike_cluster_manager_api.client_manager import (
+    _SESSION_CTXVAR,
+    ClientManager,
+)
 
 
 @pytest.fixture()
@@ -114,7 +117,12 @@ class TestClientManagerConcurrency:
             assert result_slow is slow_client
 
     async def test_close_client_cleans_up_lock(self, mock_db_profile):
-        """close_client() should remove the per-connection lock entry."""
+        """close_client() should remove the per-connection lock entry.
+
+        REST callers have ``session_id=None`` so the cache key is
+        ``(None, conn_id)`` -- see #303 for the per-session keying
+        rationale.
+        """
         mock_client = AsyncMock()
         mock_client.is_connected.return_value = True
 
@@ -124,8 +132,132 @@ class TestClientManagerConcurrency:
         ):
             mgr = ClientManager()
             await mgr.get_client("conn-1")
-            assert "conn-1" in mgr._conn_locks
+            assert (None, "conn-1") in mgr._conn_locks
 
             await mgr.close_client("conn-1")
-            assert "conn-1" not in mgr._conn_locks
-            assert "conn-1" not in mgr._clients
+            assert (None, "conn-1") not in mgr._conn_locks
+            assert (None, "conn-1") not in mgr._clients
+
+
+class TestClientManagerSessionKeying:
+    """Per-session cache keying -- Stream B / #303.
+
+    The MCP registry decorator stashes the session id on
+    ``_SESSION_CTXVAR`` before the tool body runs. The same conn_id seen
+    from two different sessions must produce two separate cached
+    AsyncClient instances; closing one must not evict the other.
+
+    The REST API path (``session_id=None``) is the regression check --
+    every existing test in this file implicitly exercises it, but we
+    add an explicit assertion here so a future refactor can't quietly
+    repurpose the ``None`` slot.
+    """
+
+    async def test_two_sessions_same_conn_get_separate_clients(self, mock_db_profile):
+        clients = [AsyncMock(name="client-A"), AsyncMock(name="client-B")]
+        for c in clients:
+            c.is_connected.return_value = True
+
+        with patch(
+            "aerospike_cluster_manager_api.client_manager.aerospike_py.AsyncClient",
+            side_effect=clients,
+        ):
+            mgr = ClientManager()
+
+            token_a = _SESSION_CTXVAR.set("session-A")
+            try:
+                client_a = await mgr.get_client("conn-1")
+            finally:
+                _SESSION_CTXVAR.reset(token_a)
+
+            token_b = _SESSION_CTXVAR.set("session-B")
+            try:
+                client_b = await mgr.get_client("conn-1")
+            finally:
+                _SESSION_CTXVAR.reset(token_b)
+
+            assert client_a is not client_b
+            assert ("session-A", "conn-1") in mgr._clients
+            assert ("session-B", "conn-1") in mgr._clients
+
+    async def test_close_client_only_evicts_callers_own_session(self, mock_db_profile):
+        clients = [AsyncMock(name="client-A"), AsyncMock(name="client-B")]
+        for c in clients:
+            c.is_connected.return_value = True
+
+        with patch(
+            "aerospike_cluster_manager_api.client_manager.aerospike_py.AsyncClient",
+            side_effect=clients,
+        ):
+            mgr = ClientManager()
+
+            token_a = _SESSION_CTXVAR.set("session-A")
+            try:
+                await mgr.get_client("conn-1")
+            finally:
+                _SESSION_CTXVAR.reset(token_a)
+
+            token_b = _SESSION_CTXVAR.set("session-B")
+            try:
+                await mgr.get_client("conn-1")
+                # Session B disconnects -- must not touch session A's slot.
+                await mgr.close_client("conn-1")
+            finally:
+                _SESSION_CTXVAR.reset(token_b)
+
+            assert ("session-A", "conn-1") in mgr._clients
+            assert ("session-B", "conn-1") not in mgr._clients
+
+    async def test_rest_path_session_id_none_shares_one_slot(self, mock_db_profile):
+        """Two REST callers (both session_id=None) share one cache slot.
+
+        Regression net for the existing REST routers -- Phase 1 behaviour
+        must be preserved when the contextvar is at its default.
+        """
+        mock_client = AsyncMock()
+        mock_client.is_connected.return_value = True
+
+        with patch(
+            "aerospike_cluster_manager_api.client_manager.aerospike_py.AsyncClient",
+            return_value=mock_client,
+        ) as mock_cls:
+            mgr = ClientManager()
+            # ``_SESSION_CTXVAR`` defaults to None -- no set() needed.
+            r1 = await mgr.get_client("conn-rest")
+            r2 = await mgr.get_client("conn-rest")
+
+            mock_cls.assert_called_once()
+            assert r1 is r2
+            assert (None, "conn-rest") in mgr._clients
+
+    async def test_close_session_evicts_only_that_session(self, mock_db_profile):
+        clients = [AsyncMock(name=f"c-{i}") for i in range(3)]
+        for c in clients:
+            c.is_connected.return_value = True
+
+        with patch(
+            "aerospike_cluster_manager_api.client_manager.aerospike_py.AsyncClient",
+            side_effect=clients,
+        ):
+            mgr = ClientManager()
+
+            for sid in ("session-A", "session-B"):
+                token = _SESSION_CTXVAR.set(sid)
+                try:
+                    await mgr.get_client("conn-shared")
+                finally:
+                    _SESSION_CTXVAR.reset(token)
+
+            # REST path has its own slot.
+            await mgr.get_client("conn-shared")
+
+            await mgr.close_session("session-A")
+
+            assert ("session-A", "conn-shared") not in mgr._clients
+            assert ("session-B", "conn-shared") in mgr._clients
+            assert (None, "conn-shared") in mgr._clients
+
+    async def test_close_session_rejects_none(self):
+        mgr = ClientManager()
+        with pytest.raises(ValueError, match="non-None session id"):
+            await mgr.close_session(None)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

Stream B of MCP Phase 2 (Closes #303). Cached `AsyncClient` entries are now keyed by `(session_id, conn_id)` tuples instead of just `conn_id`, so one MCP session's `disconnect("X")` cannot evict another session's cached client for the same connection profile.

The registry decorator stashes the per-call session id on a contextvar before invoking the tool body; `client_manager.get_client(conn_id)` reads it transparently. **Tool function signatures stay pure data** — `ctx` never leaks into the user-facing tool body. The wrapper synthesises a signature that exposes `ctx: Context` to FastMCP so its `find_context_parameter` sees the injected param and excludes it from the JSON schema.

The REST API path (no MCP session) keeps the contextvar at `None`, which collapses to the Phase 1 single-cache-per-conn_id behaviour the existing REST routers and `test_client_manager.py` rely on. `close_client` only ever evicts the caller's own slot.

Added `close_session(session_id)` for the future FastMCP session-cleanup hook (best-effort until that hook lands). Client instrumentation now carries `asm.session.id` (or `"rest"` for the REST path) so OTel dashboards can slice the active-connection count per session.

See `docs/plans/2026-05-07-mcp-context-contract.md` for the cross-stream contract this PR implements.

## What changed

- `api/src/aerospike_cluster_manager_api/client_manager.py` — `_clients` and `_conn_locks` keyed by `(session_id, conn_id)`; new `_SESSION_CTXVAR` ContextVar; new `close_session(session_id)` method; OTel attrs include `asm.session.id`.
- `api/src/aerospike_cluster_manager_api/mcp/registry.py` — wrapper declares `ctx: Context`; reads session id via `_ctx_session_id`; sets/resets `_SESSION_CTXVAR` around the body; synthesises a signature so FastMCP excludes `ctx` from the JSON schema; workspace-gate stub for #307; `current_session_id()` helper; `eval_str=True` and `typing.get_type_hints` to resolve `from __future__ import annotations` strings before pydantic schema build.
- `api/tests/mcp/test_session_isolation.py` (new) — per-session isolation contract.
- `api/tests/mcp/test_registry.py` — Context plumbing, ctx never leaks into body, contextvar reset on exception.
- `api/tests/test_client_manager.py` — REST path regression, per-session keying, `close_session` invariants.

## Tool body invariant preserved

Per the Phase 0a contract, the 22 existing Phase 1 tool bodies are **unchanged** — `connect`, `disconnect`, and the rest still call `client_manager.get_client(conn_id)` with no signature change. The session-scoping happens transparently via the contextvar.

## Out of scope

- `mcp/tools/k8s.py` (Stream A — #305).
- Workspace ownership gate body (Stream E — #307); the call site is wired here as a no-op stub.

## Test plan

- [x] `cd api && uv run pytest tests/` — full suite green (837 passed)
- [x] `uv run ruff check src tests --fix && uv run ruff format src tests` — clean
- [x] `uv run pyright src/aerospike_cluster_manager_api/client_manager.py src/aerospike_cluster_manager_api/mcp/registry.py tests/mcp/test_session_isolation.py` — 0 errors
- [x] `pre-commit run --files <changed files>` — clean
- [x] Existing `tests/test_client_manager.py` REST-path tests still pass (regression net)
- [ ] CI green