### PR TITLE
feat(api): workspace-aware MCP tool routing (E.2 + E.3 of #307)

### DIFF
--- a/api/src/aerospike_cluster_manager_api/dependencies.py
+++ b/api/src/aerospike_cluster_manager_api/dependencies.py
@@ -39,11 +39,10 @@ def _resolve_caller_owner_id(request: Request) -> str:
     A missing/empty claim also degrades to :data:`SYSTEM_OWNER_ID` so a
     misconfigured IdP cannot lock callers out of the default workspace.
 
-    TODO(#307-E2): Stream E.2 plumbs this same OIDC claim into the MCP
-    Context so the registry decorator can read the caller identity
-    without re-reading the FastAPI ``request.state``. The OIDC →
-    Context bridge lives in ``mcp/auth.py``; until it ships, MCP tool
-    callers all resolve to the bearer/system path.
+    The matching MCP-side bridge lives in
+    :mod:`aerospike_cluster_manager_api.mcp.user_context` -- it captures
+    the same ``request.state.user_claims`` into a contextvar that the
+    registry decorator's workspace gate reads (E.3 of #307).
     """
     claims: dict[str, Any] | None = getattr(request.state, "user_claims", None)
     if claims is None:

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -308,6 +308,17 @@ if (
         "isolated to localhost / a trusted network."
     )
 
+if config.ACM_MCP_ENABLED:
+    # E.2 (#307): bridge ``request.state.user_claims`` into a contextvar
+    # so the MCP registry's workspace gate can read the caller identity
+    # without re-threading the FastAPI ``Request``. Installed BEFORE
+    # OIDC + MCPBearerToken in the add_middleware order so it runs
+    # INNER to both at request time -- by then ``user_claims`` is
+    # populated (or correctly absent for anonymous deployments).
+    from aerospike_cluster_manager_api.mcp.user_context import MCPUserContextMiddleware
+
+    app.add_middleware(MCPUserContextMiddleware)
+
 if config.OIDC_ENABLED:
     app.add_middleware(
         OIDCAuthMiddleware,

--- a/api/src/aerospike_cluster_manager_api/mcp/registry.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/registry.py
@@ -26,7 +26,11 @@ returns a session-scoped cached client. The user-facing tool body is
 **unchanged** -- tool functions never see ``ctx``. See
 ``docs/plans/2026-05-07-mcp-context-contract.md`` for the design.
 
-Workspace gate (#307) is a no-op stub here -- populated by Stream E.
+Workspace gate (#307 / E.3) compares each call's ``conn_id`` /
+``workspace_id`` argument against the caller identity bridged in by
+:mod:`mcp.user_context`. Bearer-token sessions and anonymous deployments
+bypass; OIDC callers see ``code="workspace_mismatch"`` on a
+cross-tenant probe.
 
 The decorator returns the *wrapped* form so tests and other callers that
 bypass FastMCP still see the gate. ``register_all(mcp)`` is invoked once
@@ -48,9 +52,11 @@ from typing import Any
 from mcp.server.fastmcp import Context, FastMCP
 
 from aerospike_cluster_manager_api import client_manager as _client_manager_mod
-from aerospike_cluster_manager_api import config
+from aerospike_cluster_manager_api import config, db
+from aerospike_cluster_manager_api.mcp import user_context as _user_context_mod
 from aerospike_cluster_manager_api.mcp.access_profile import WRITE_TOOLS, AccessProfile, is_blocked
 from aerospike_cluster_manager_api.mcp.errors import MCPToolError, map_aerospike_errors
+from aerospike_cluster_manager_api.models.workspace import SYSTEM_OWNER_ID
 
 
 @dataclass(frozen=True)
@@ -120,18 +126,75 @@ async def _assert_workspace_owns_arg(
     tool_name: str,
     kwargs: dict[str, Any],
 ) -> None:
-    """Workspace authorization gate (Phase 2, #307).
+    """Workspace authorization gate (Phase 2 #307 / E.3).
 
-    No-op stub -- Stream E (#307) populates the body. Kept here so the
-    contract from ``docs/plans/2026-05-07-mcp-context-contract.md`` lands
-    in one place and Streams B / A can reference the same call site.
+    Fires for tools whose call kwargs name a ``conn_id`` or
+    ``workspace_id``. Resolves the caller's owner identity from the
+    contextvar populated by :class:`mcp.user_context.MCPUserContextMiddleware`
+    (E.2). Bypasses the check for:
 
-    TODO(#307): inspect ``kwargs`` for ``conn_id`` / ``workspace_id``
-    parameters and assert ``ctx.user_claims['sub']`` owns the referenced
-    workspace; raise ``MCPToolError(code="workspace_mismatch")`` on
-    mismatch. Bearer-token sessions bypass this gate.
+    * bearer-token sessions (``_mcp_bearer=True`` sentinel) — single
+      tenant deployments;
+    * anonymous requests (no ``user_claims``) — preserves the Phase 1
+      single-tenant fallback for ``OIDC_ENABLED=false`` deployments AND
+      direct unit-test invocations of the wrapper that don't drive the
+      HTTP layer.
+
+    Otherwise the workspace referenced by ``conn_id`` (resolved via
+    :func:`db.get_connection`) or ``workspace_id`` (used directly) must
+    be owned by the caller (or by ``SYSTEM_OWNER_ID`` — the default
+    workspace stays accessible to everyone). On mismatch we raise
+    :class:`MCPToolError` with ``code="workspace_mismatch"``.
+
+    Non-existent ``conn_id`` is NOT diagnosed here -- letting it fall
+    through means the tool body's normal "not found" path runs and the
+    caller sees ``code="not_found"`` from the standard error mapper.
+    Diagnosing it as ``workspace_mismatch`` would let a probing caller
+    distinguish "doesn't exist" from "exists but not yours" only by
+    correlating responses, but the wire shape stays clean if we let
+    ``not_found`` win the race.
     """
-    return None
+    claims = _user_context_mod.current_caller_claims()
+    if claims is None:
+        return
+    if claims.get("_mcp_bearer"):
+        return
+
+    # Resolve caller identity from the configured claim. A missing /
+    # empty claim degrades to SYSTEM_OWNER_ID -- same rule
+    # ``dependencies._resolve_caller_owner_id`` applies for REST
+    # callers, so misconfigured IdPs cannot lock callers out of the
+    # default workspace.
+    raw = claims.get(config.ACM_OIDC_OWNER_CLAIM)
+    if not isinstance(raw, str) or not raw:
+        return
+    caller_owner_id = raw
+
+    target_workspace_id: str | None = None
+    if "conn_id" in kwargs and isinstance(kwargs["conn_id"], str):
+        profile = await db.get_connection(kwargs["conn_id"])
+        if profile is None:
+            return  # let the tool body raise ``not_found``
+        target_workspace_id = profile.workspaceId
+    elif "workspace_id" in kwargs and isinstance(kwargs["workspace_id"], str):
+        target_workspace_id = kwargs["workspace_id"]
+
+    if target_workspace_id is None:
+        return
+
+    workspace = await db.get_workspace(target_workspace_id)
+    if workspace is None:
+        return  # let the tool body raise ``not_found``
+
+    if workspace.ownerId in (caller_owner_id, SYSTEM_OWNER_ID):
+        return
+
+    # Generic message -- intentionally does NOT name the workspace so a
+    # probing caller cannot enumerate other tenants' workspace ids.
+    raise MCPToolError(
+        f"Tool '{tool_name}' rejected: caller does not own the referenced workspace.",
+        code="workspace_mismatch",
+    )
 
 
 def _build_wrapped_signature(func: Callable[..., Any]) -> inspect.Signature:

--- a/api/src/aerospike_cluster_manager_api/mcp/user_context.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/user_context.py
@@ -1,0 +1,111 @@
+"""OIDC claim → MCP tool registry bridge (Phase 2 #307 / E.2).
+
+The MCP registry decorator runs inside FastMCP's session-manager task,
+which is reached *after* Starlette's request middleware has populated
+``request.state.user_claims``. By that point the original ``Request``
+object is no longer in scope (the FastMCP body executes inside a
+JSON-RPC dispatch with only ``Context`` available). This module bridges
+the gap by stashing the caller's claims on a :class:`contextvars.ContextVar`
+that the registry's workspace gate reads through
+:func:`current_caller_claims`.
+
+Why a contextvar
+----------------
+
+Per the Phase 0a contract (``docs/plans/2026-05-07-mcp-context-contract.md``)
+tool functions stay pure — they do NOT receive the caller identity as
+a parameter. The registry decorator is the only place that resolves it.
+A contextvar is the natural "ambient request data" mechanism in async
+Python: each ASGI request runs in its own task, contextvars are
+task-scoped, and the value set by a middleware is visible to anything
+downstream in the same task (including the FastMCP mount handler and
+the tool body it eventually calls).
+
+Why a dedicated middleware
+--------------------------
+
+The existing :class:`MCPBearerTokenMiddleware` short-circuits on bearer
+auth and otherwise delegates to OIDC; making it also do the contextvar
+plumbing would couple two unrelated concerns. The
+:class:`MCPUserContextMiddleware` here is purely a passthrough that
+captures ``request.state.user_claims`` *after* both auth gates have
+run. Installing it INNER to OIDC at runtime (i.e. ``add_middleware``
+before OIDC) means OIDC has already populated ``user_claims`` by the
+time we read them.
+
+The middleware only fires for MCP-mounted paths so the contextvar is
+not set (and not reset) on every REST call.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+from typing import Any
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+from aerospike_cluster_manager_api import config
+
+logger = logging.getLogger(__name__)
+
+
+_CLAIMS_CTXVAR: contextvars.ContextVar[dict[str, Any] | None] = contextvars.ContextVar(
+    "acm_mcp_caller_claims",
+    default=None,
+)
+"""Per-request OIDC / bearer-sentinel claims for MCP callers.
+
+Set by :class:`MCPUserContextMiddleware` on every ``/mcp/*`` request and
+reset on the way out. Reads outside an MCP request return ``None`` —
+the registry workspace gate treats that as "no caller identity, single
+tenant fallback" so REST-only call paths and unit-test fixtures keep
+the legacy permissive behavior.
+"""
+
+
+def current_caller_claims() -> dict[str, Any] | None:
+    """Return the OIDC claims (or bearer sentinel) attached to this request.
+
+    Returns ``None`` when no MCP middleware ran (e.g. REST endpoint, or
+    a unit test that drove a tool function without going through the
+    HTTP layer). Callers must treat ``None`` as "fall back to single-
+    tenant behavior" to preserve Phase 1 semantics.
+    """
+    return _CLAIMS_CTXVAR.get()
+
+
+class MCPUserContextMiddleware(BaseHTTPMiddleware):
+    """Capture ``request.state.user_claims`` into a contextvar for ``/mcp/*``.
+
+    Runs INNER to OIDC at request time (i.e. ``add_middleware`` is
+    called BEFORE the OIDC middleware in :mod:`main`). By the time
+    ``dispatch`` runs, OIDC and the MCP bearer-token middleware have
+    already either populated ``request.state.user_claims`` or rejected
+    the request.
+
+    Claims are reset to ``None`` in the ``finally`` so the contextvar
+    cannot leak across requests that share a worker thread.
+    """
+
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: RequestResponseEndpoint,
+    ) -> Response:
+        path = request.url.path
+        base = config.ACM_MCP_PATH
+        # Match on segment boundaries — same rule
+        # ``MCPBearerTokenMiddleware`` uses, so this middleware's path
+        # filter cannot be tricked by a sibling route like ``/mcp-evil``.
+        if path != base and not path.startswith(base.rstrip("/") + "/"):
+            return await call_next(request)
+
+        claims: dict[str, Any] | None = getattr(request.state, "user_claims", None)
+        token = _CLAIMS_CTXVAR.set(claims)
+        try:
+            return await call_next(request)
+        finally:
+            _CLAIMS_CTXVAR.reset(token)

--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -104,15 +104,6 @@ async def update_connection(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-# TODO(#307-E3): MCP registry workspace gate (the body of
-# ``_assert_workspace_owns_conn`` from the ADR) consumes the same
-# ``ownerId`` field plumbed in this PR. Stream E.3 wires the gate into
-# ``mcp/registry.py`` so MCP tool callers see ``workspace_mismatch``
-# errors when their ``conn_id`` resolves to a workspace they do not own.
-# Until E.3 lands, MCP tool callers behave as today (single-tenant
-# bearer or anonymous deployments).
-
-
 @router.get(
     "/{conn_id}/health",
     summary="Check connection health",

--- a/api/tests/mcp/test_user_context.py
+++ b/api/tests/mcp/test_user_context.py
@@ -1,0 +1,177 @@
+"""OIDC claim → MCP contextvar bridge -- E.2 of issue #307.
+
+:class:`mcp.user_context.MCPUserContextMiddleware` captures
+``request.state.user_claims`` for ``/mcp/*`` requests into a
+:class:`contextvars.ContextVar` so the registry workspace gate (E.3)
+can read the caller identity without re-threading the FastAPI
+``Request``. This module pins the contract:
+
+* the contextvar is set when the path matches ``/mcp/*``;
+* the contextvar is reset on the way out so the value never leaks
+  into the next request running on the same worker;
+* non-MCP paths short-circuit -- no contextvar mutation.
+
+The middleware is plain Starlette so we drive it with a fake
+``call_next`` rather than spinning up the full ASGI stack.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import Response
+
+from aerospike_cluster_manager_api.mcp.user_context import (
+    _CLAIMS_CTXVAR,
+    MCPUserContextMiddleware,
+    current_caller_claims,
+)
+
+
+def _make_request(path: str, claims: dict | None) -> Request:
+    """Build a Starlette ``Request`` with ``request.state.user_claims`` preset.
+
+    Stub ASGI scope -- only the ``url.path`` and ``state`` matter for the
+    middleware under test.
+    """
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "raw_path": path.encode(),
+        "query_string": b"",
+        "headers": [],
+        "scheme": "http",
+        "server": ("testserver", 80),
+        "client": ("127.0.0.1", 12345),
+        "state": {},
+    }
+    request = Request(scope)
+    if claims is not None:
+        request.state.user_claims = claims
+    return request
+
+
+@pytest.fixture(autouse=True)
+def isolate_contextvar():
+    """Reset the contextvar between tests so cases cannot bleed into each other.
+
+    We use ``set(None)`` on teardown rather than ``reset(token)`` because
+    pytest-asyncio's fixture setup and teardown can run in different
+    :class:`contextvars.Context`s, which invalidates the saved token.
+    Setting to ``None`` is the default and works across contexts.
+    """
+    _CLAIMS_CTXVAR.set(None)
+    yield
+    _CLAIMS_CTXVAR.set(None)
+
+
+@pytest.fixture()
+def middleware():
+    async def _noop_app(_scope, _receive, _send):
+        # The fixture's tests drive ``dispatch(request, call_next)`` directly,
+        # so the underlying ASGI app is never actually invoked. Defining it
+        # as an async function (rather than a lambda returning ``None``)
+        # satisfies Starlette's ``ASGIApp`` protocol.
+        return None
+
+    return MCPUserContextMiddleware(app=_noop_app)
+
+
+class TestPathFilter:
+    async def test_mcp_path_sets_contextvar_during_call(self, middleware) -> None:
+        captured: dict = {}
+
+        async def call_next(_request: Request) -> Response:
+            captured["claims_during"] = current_caller_claims()
+            return Response(status_code=200)
+
+        with patch("aerospike_cluster_manager_api.mcp.user_context.config.ACM_MCP_PATH", "/mcp"):
+            request = _make_request("/mcp/", claims={"sub": "alice"})
+            await middleware.dispatch(request, call_next)
+
+        assert captured["claims_during"] == {"sub": "alice"}
+        # Reset on exit -- contextvar is back to None outside the call.
+        assert current_caller_claims() is None
+
+    async def test_non_mcp_path_does_not_touch_contextvar(self, middleware) -> None:
+        captured: dict = {}
+
+        async def call_next(_request: Request) -> Response:
+            captured["claims_during"] = current_caller_claims()
+            return Response(status_code=200)
+
+        with patch("aerospike_cluster_manager_api.mcp.user_context.config.ACM_MCP_PATH", "/mcp"):
+            request = _make_request("/api/connections", claims={"sub": "bob"})
+            await middleware.dispatch(request, call_next)
+
+        # Untouched -- the REST path doesn't go through this bridge.
+        assert captured["claims_during"] is None
+
+    async def test_segment_boundary_match(self, middleware) -> None:
+        # ``/mcp-evil/foo`` must NOT be treated as an MCP path.
+        captured: dict = {}
+
+        async def call_next(_request: Request) -> Response:
+            captured["claims_during"] = current_caller_claims()
+            return Response(status_code=200)
+
+        with patch("aerospike_cluster_manager_api.mcp.user_context.config.ACM_MCP_PATH", "/mcp"):
+            request = _make_request("/mcp-evil/foo", claims={"sub": "evil"})
+            await middleware.dispatch(request, call_next)
+
+        assert captured["claims_during"] is None
+
+
+class TestClaimShapes:
+    async def test_no_user_claims_attribute_yields_none(self, middleware) -> None:
+        # Anonymous request -- no auth middleware ran. The contextvar
+        # is set to None explicitly so downstream code reads "no
+        # caller identity" rather than a stale value.
+        captured: dict = {}
+
+        async def call_next(_request: Request) -> Response:
+            captured["claims_during"] = current_caller_claims()
+            return Response(status_code=200)
+
+        with patch("aerospike_cluster_manager_api.mcp.user_context.config.ACM_MCP_PATH", "/mcp"):
+            request = _make_request("/mcp/", claims=None)
+            await middleware.dispatch(request, call_next)
+
+        assert captured["claims_during"] is None
+
+    async def test_bearer_sentinel_is_passed_through(self, middleware) -> None:
+        # Bearer token middleware sets ``_mcp_bearer=True``; the bridge
+        # does not unwrap it -- the registry gate inspects the sentinel
+        # itself.
+        captured: dict = {}
+
+        async def call_next(_request: Request) -> Response:
+            captured["claims_during"] = current_caller_claims()
+            return Response(status_code=200)
+
+        with patch("aerospike_cluster_manager_api.mcp.user_context.config.ACM_MCP_PATH", "/mcp"):
+            request = _make_request("/mcp/", claims={"sub": "mcp-bearer", "_mcp_bearer": True})
+            await middleware.dispatch(request, call_next)
+
+        assert captured["claims_during"] == {"sub": "mcp-bearer", "_mcp_bearer": True}
+
+
+class TestResetOnException:
+    async def test_contextvar_reset_when_call_next_raises(self, middleware) -> None:
+        # If the inner handler raises, the ``finally`` in the middleware
+        # must still reset the contextvar so the next request on the
+        # same worker thread doesn't see leaked claims.
+        async def call_next(_request: Request) -> Response:
+            raise RuntimeError("boom")
+
+        with (
+            patch("aerospike_cluster_manager_api.mcp.user_context.config.ACM_MCP_PATH", "/mcp"),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            request = _make_request("/mcp/", claims={"sub": "alice"})
+            await middleware.dispatch(request, call_next)
+
+        assert current_caller_claims() is None

--- a/api/tests/mcp/test_workspace_isolation.py
+++ b/api/tests/mcp/test_workspace_isolation.py
@@ -1,0 +1,274 @@
+"""Workspace gate -- Stream E.3 / GitHub issue #307.
+
+The MCP registry decorator (``mcp/registry._assert_workspace_owns_arg``)
+fires for tools whose call kwargs name a ``conn_id`` or ``workspace_id``
+parameter. It compares the referenced workspace's owner against the
+caller identity bridged in by :class:`mcp.user_context.MCPUserContextMiddleware`
+(E.2) and raises ``MCPToolError(code="workspace_mismatch")`` on a
+cross-tenant probe.
+
+These tests pin down the gate's behavior by driving the contextvar
+directly -- the same shortcut ``test_session_isolation.py`` uses for
+the per-session cache. The HTTP-layer plumbing (middleware sets the
+contextvar) is covered by ``test_user_context.py``; here we focus on
+the gate's allow/deny matrix.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aerospike_cluster_manager_api.mcp.errors import MCPToolError
+from aerospike_cluster_manager_api.mcp.registry import _assert_workspace_owns_arg
+from aerospike_cluster_manager_api.mcp.user_context import _CLAIMS_CTXVAR
+from aerospike_cluster_manager_api.models.connection import ConnectionProfile
+from aerospike_cluster_manager_api.models.workspace import (
+    DEFAULT_WORKSPACE_ID,
+    SYSTEM_OWNER_ID,
+    Workspace,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _workspace(workspace_id: str, owner_id: str, *, is_default: bool = False) -> Workspace:
+    now = datetime.now(UTC).isoformat()
+    return Workspace(
+        id=workspace_id,
+        name=f"ws-{workspace_id}",
+        color="#6366F1",
+        description=None,
+        isDefault=is_default,
+        ownerId=owner_id,
+        createdAt=now,
+        updatedAt=now,
+    )
+
+
+def _connection(conn_id: str, workspace_id: str) -> ConnectionProfile:
+    now = datetime.now(UTC).isoformat()
+    return ConnectionProfile(
+        id=conn_id,
+        name=f"conn-{conn_id}",
+        hosts=["localhost"],
+        port=3000,
+        clusterName="cluster",
+        username=None,
+        password=None,
+        color="#0097D3",
+        workspaceId=workspace_id,
+        createdAt=now,
+        updatedAt=now,
+    )
+
+
+@pytest.fixture()
+def mock_db():
+    """Patch ``mcp.registry.db`` so the gate's lookups are hermetic.
+
+    Tests configure ``mock_db.get_workspace`` and ``mock_db.get_connection``
+    return values per-case. The gate calls ``await db.get_workspace(id)``
+    and ``await db.get_connection(id)`` so we use ``AsyncMock``.
+    """
+    with patch("aerospike_cluster_manager_api.mcp.registry.db") as mock_db:
+        mock_db.get_workspace = AsyncMock()
+        mock_db.get_connection = AsyncMock()
+        yield mock_db
+
+
+@pytest.fixture()
+def in_oidc_session():
+    """Bridge an OIDC user_claims dict into the contextvar for the test.
+
+    Yields a callable so tests can switch between caller identities
+    inside a single function. After the test we set the var back to
+    ``None`` rather than reset()ing -- pytest-asyncio's setup and
+    teardown can run in different :class:`contextvars.Context`s,
+    which would invalidate the saved token. Setting to ``None`` is
+    semantically equivalent (the default) and works across contexts.
+    """
+
+    def _set(claims: dict | None) -> None:
+        _CLAIMS_CTXVAR.set(claims)
+
+    yield _set
+
+    _CLAIMS_CTXVAR.set(None)
+
+
+# ---------------------------------------------------------------------------
+# conn_id-based gate
+# ---------------------------------------------------------------------------
+
+
+class TestConnIdOwnershipGate:
+    async def test_caller_owns_workspace_passes(self, mock_db, in_oidc_session) -> None:
+        in_oidc_session({"sub": "alice"})
+        mock_db.get_connection.return_value = _connection("conn-x", "ws-alice")
+        mock_db.get_workspace.return_value = _workspace("ws-alice", owner_id="alice")
+
+        # No exception -- the call would proceed to the tool body.
+        await _assert_workspace_owns_arg(ctx=None, tool_name="get_record", kwargs={"conn_id": "conn-x"})
+
+    async def test_default_workspace_accessible_to_any_caller(self, mock_db, in_oidc_session) -> None:
+        # ``ws-default`` is owned by SYSTEM_OWNER_ID; the gate allows it
+        # regardless of the caller's identity. This preserves Phase 1
+        # behavior for connections placed in the default workspace.
+        in_oidc_session({"sub": "bob"})
+        mock_db.get_connection.return_value = _connection("conn-y", DEFAULT_WORKSPACE_ID)
+        mock_db.get_workspace.return_value = _workspace(DEFAULT_WORKSPACE_ID, SYSTEM_OWNER_ID, is_default=True)
+
+        await _assert_workspace_owns_arg(ctx=None, tool_name="get_record", kwargs={"conn_id": "conn-y"})
+
+    async def test_cross_owner_conn_id_rejected_with_workspace_mismatch(self, mock_db, in_oidc_session) -> None:
+        in_oidc_session({"sub": "alice"})
+        mock_db.get_connection.return_value = _connection("conn-z", "ws-bob")
+        mock_db.get_workspace.return_value = _workspace("ws-bob", owner_id="bob")
+
+        with pytest.raises(MCPToolError) as exc:
+            await _assert_workspace_owns_arg(ctx=None, tool_name="get_record", kwargs={"conn_id": "conn-z"})
+
+        assert exc.value.code == "workspace_mismatch"
+        # The wire message must NOT name the workspace -- a probing
+        # caller should not be able to enumerate other tenants' ids.
+        assert "ws-bob" not in str(exc.value)
+
+    async def test_missing_conn_id_falls_through_to_tool_body(self, mock_db, in_oidc_session) -> None:
+        # When the conn_id doesn't resolve, the gate is silent so the
+        # tool body's normal "not found" path runs and the caller sees
+        # ``code="not_found"`` -- not ``workspace_mismatch`` (would leak
+        # existence by side channel).
+        in_oidc_session({"sub": "alice"})
+        mock_db.get_connection.return_value = None  # not found
+
+        await _assert_workspace_owns_arg(ctx=None, tool_name="get_record", kwargs={"conn_id": "ghost"})
+        mock_db.get_workspace.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# workspace_id-based gate (K8s tools, etc.)
+# ---------------------------------------------------------------------------
+
+
+class TestWorkspaceIdOwnershipGate:
+    async def test_caller_owns_workspace_id_passes(self, mock_db, in_oidc_session) -> None:
+        in_oidc_session({"sub": "alice"})
+        mock_db.get_workspace.return_value = _workspace("ws-alice", owner_id="alice")
+
+        await _assert_workspace_owns_arg(
+            ctx=None,
+            tool_name="list_k8s_clusters",
+            kwargs={"workspace_id": "ws-alice"},
+        )
+        mock_db.get_connection.assert_not_called()  # short-circuits to direct workspace lookup
+
+    async def test_cross_owner_workspace_id_rejected(self, mock_db, in_oidc_session) -> None:
+        in_oidc_session({"sub": "alice"})
+        mock_db.get_workspace.return_value = _workspace("ws-bob", owner_id="bob")
+
+        with pytest.raises(MCPToolError) as exc:
+            await _assert_workspace_owns_arg(
+                ctx=None,
+                tool_name="list_k8s_clusters",
+                kwargs={"workspace_id": "ws-bob"},
+            )
+        assert exc.value.code == "workspace_mismatch"
+
+    async def test_missing_workspace_id_falls_through(self, mock_db, in_oidc_session) -> None:
+        in_oidc_session({"sub": "alice"})
+        mock_db.get_workspace.return_value = None
+
+        await _assert_workspace_owns_arg(
+            ctx=None,
+            tool_name="list_k8s_clusters",
+            kwargs={"workspace_id": "ghost"},
+        )
+
+    async def test_default_workspace_id_accessible_to_any_caller(self, mock_db, in_oidc_session) -> None:
+        in_oidc_session({"sub": "bob"})
+        mock_db.get_workspace.return_value = _workspace(DEFAULT_WORKSPACE_ID, SYSTEM_OWNER_ID, is_default=True)
+
+        await _assert_workspace_owns_arg(
+            ctx=None,
+            tool_name="list_k8s_clusters",
+            kwargs={"workspace_id": DEFAULT_WORKSPACE_ID},
+        )
+
+
+# ---------------------------------------------------------------------------
+# Bypass paths
+# ---------------------------------------------------------------------------
+
+
+class TestBypassPaths:
+    async def test_bearer_sentinel_bypasses_gate(self, mock_db, in_oidc_session) -> None:
+        # MCPBearerTokenMiddleware sets this exact sentinel on a successful
+        # bearer match. Bearer mode is single-tenant so the gate is moot.
+        in_oidc_session({"sub": "mcp-bearer", "_mcp_bearer": True})
+
+        # Even with a "cross-owner" conn_id, the gate must NOT touch the DB.
+        await _assert_workspace_owns_arg(ctx=None, tool_name="get_record", kwargs={"conn_id": "conn-anywhere"})
+        mock_db.get_connection.assert_not_called()
+        mock_db.get_workspace.assert_not_called()
+
+    async def test_no_claims_bypasses_gate(self, mock_db) -> None:
+        # No OIDC middleware ran (anonymous deployment, OIDC_ENABLED=false).
+        # The gate falls back to Phase 1 single-tenant behavior. Same
+        # path also covers direct unit-test invocations of tool bodies
+        # outside the HTTP layer.
+        await _assert_workspace_owns_arg(ctx=None, tool_name="get_record", kwargs={"conn_id": "conn-anywhere"})
+        mock_db.get_connection.assert_not_called()
+
+    async def test_missing_sub_claim_bypasses_gate(self, mock_db, in_oidc_session) -> None:
+        # A misconfigured IdP that does not emit ``sub`` would otherwise
+        # lock the caller out of every workspace. Match the
+        # ``dependencies._resolve_caller_owner_id`` behavior on the REST
+        # side -- degrade to "no caller identity, single tenant".
+        in_oidc_session({"iss": "https://idp.example", "aud": "acm"})
+
+        await _assert_workspace_owns_arg(ctx=None, tool_name="get_record", kwargs={"conn_id": "conn-anywhere"})
+        mock_db.get_connection.assert_not_called()
+
+    async def test_tool_with_neither_conn_id_nor_workspace_id_bypasses_gate(self, mock_db, in_oidc_session) -> None:
+        # ``test_connection`` takes ``hosts`` / ``port`` -- no ownership
+        # to check.
+        in_oidc_session({"sub": "alice"})
+
+        await _assert_workspace_owns_arg(
+            ctx=None,
+            tool_name="test_connection",
+            kwargs={"hosts": ["localhost"], "port": 3000},
+        )
+        mock_db.get_connection.assert_not_called()
+        mock_db.get_workspace.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Custom claim configuration
+# ---------------------------------------------------------------------------
+
+
+class TestClaimConfiguration:
+    async def test_custom_acm_oidc_owner_claim(self, mock_db, in_oidc_session) -> None:
+        # Some IdPs emit ``sub`` with an opaque uuid and expose the
+        # human-meaningful identity in ``preferred_username``. The
+        # ``ACM_OIDC_OWNER_CLAIM`` config knob (PR #314) lets operators
+        # pick which claim to use; the gate honours it.
+        in_oidc_session({"sub": "uuid-1234", "preferred_username": "alice"})
+        mock_db.get_connection.return_value = _connection("conn-x", "ws-alice")
+        mock_db.get_workspace.return_value = _workspace("ws-alice", owner_id="alice")
+
+        with patch(
+            "aerospike_cluster_manager_api.mcp.registry.config.ACM_OIDC_OWNER_CLAIM",
+            "preferred_username",
+        ):
+            await _assert_workspace_owns_arg(
+                ctx=None,
+                tool_name="get_record",
+                kwargs={"conn_id": "conn-x"},
+            )


### PR DESCRIPTION
## Summary

Closes #307. The final two sub-PRs (E.2 + E.3) on top of E.1 (#314) ship the workspace authorization gate the Phase 0a/0b contracts decided. Bundled because (a) E.2 alone has no observable behavior, (b) E.3 doesn't work without E.2, and (c) both are small.

| Sub-stream | What | Where |
|---|---|---|
| **E.2** | OIDC claim → MCP contextvar bridge | NEW \`mcp/user_context.py\`, wired in \`main.py\` |
| **E.3** | Registry decorator workspace gate body | \`mcp/registry._assert_workspace_owns_arg\` |

## Behavior matrix

| Caller path | conn_id / workspace_id arg | Result |
|---|---|---|
| Bearer sentinel (\`_mcp_bearer=True\`) | any | bypass — single-tenant deployments |
| No \`user_claims\` (anonymous / OIDC off) | any | bypass — Phase 1 fallback |
| OIDC, missing \`ACM_OIDC_OWNER_CLAIM\` claim | any | bypass — misconfigured IdP can't lock callers out |
| OIDC, target workspace owner is \`SYSTEM_OWNER_ID\` | any | allow — default workspace open to all |
| OIDC, target workspace owned by caller \`sub\` | any | allow |
| OIDC, cross-tenant \`conn_id\` → other workspace | resolved via \`db.get_connection\` | reject \`code=\"workspace_mismatch\"\` |
| OIDC, cross-tenant \`workspace_id\` arg | direct lookup | reject \`code=\"workspace_mismatch\"\` |
| OIDC, conn_id / workspace_id not found | — | fall through (tool body raises \`not_found\`) |
| Tool with neither arg (e.g. \`test_connection\`) | n/a | gate doesn't fire |

The mismatch error message is intentionally generic — it does not name the workspace, so a probing caller cannot enumerate other tenants' workspace ids.

## Tool body invariant

All 27 Phase 1+2 tools are unchanged. The gate runs entirely inside the registry decorator's \`wrapped\` function. Per Phase 0a, tool functions stay pure (no \`ctx\` parameter), and the contextvar pattern means \`client_manager.get_client(conn_id)\` calls inside tool bodies remain 1-arg.

## Files

| File | Change |
|---|---|
| \`mcp/user_context.py\` | **NEW** — \`MCPUserContextMiddleware\` (Starlette) captures \`request.state.user_claims\` for \`/mcp/*\` requests into a contextvar. \`current_caller_claims()\` reads it back. |
| \`main.py\` | Wire \`MCPUserContextMiddleware\` BEFORE OIDC + bearer in \`add_middleware\` order so it runs INNER to both at request time (claims populated by then). |
| \`mcp/registry.py\` | Fill \`_assert_workspace_owns_arg\` body. Imports \`db\`, \`user_context\`, \`SYSTEM_OWNER_ID\`. Module docstring updated. |
| \`dependencies.py\` | Remove \`TODO(#307-E2)\` marker. Function body unchanged. |
| \`routers/connections.py\` | Remove \`TODO(#307-E3)\` block. |
| \`tests/mcp/test_workspace_isolation.py\` | **NEW** — 13 cases. |
| \`tests/mcp/test_user_context.py\` | **NEW** — 6 cases. |

## Test plan

- [x] \`uv run ruff check src tests --fix\` clean
- [x] \`uv run ruff format src tests\` no changes
- [x] \`uv run pyright <changed files>\` 0 errors
- [x] \`uv run pytest tests/mcp/test_workspace_isolation.py tests/mcp/test_user_context.py -v\` — 19/19 pass
- [x] \`uv run pytest tests/ --ignore=tests/mcp/test_streamable_http_e2e.py\` — 925 passing
- [x] \`uv run pytest tests/mcp/test_streamable_http_e2e.py\` (in isolation) — 5/5 pass
- [x] \`pre-commit run --files <changed>\` — clean

## Heads-up: pre-existing flake

\`tests/mcp/test_streamable_http_e2e.py::test_tools_call_test_connection_over_wire_succeeds\` is flaky in the full suite **on \`main\`** (surfaced after #312 merged; not introduced by this PR — verified by git stash + re-run). The test passes in isolation. CI may surface this if it runs the full test session in the order that triggers the flake. Tracking as a separate test-infra follow-up; not a blocker for this PR's correctness, since the workspace isolation tests are independent of that file.

## Out of scope (deferred follow-ups)

- Multi-member workspaces (a \`WorkspaceMembership\` table) — explicitly deferred per Phase 0b.
- Workspace transfer (changing \`ownerId\`) — separate confirmation flow.
- Group-claim → workspace auto-creation — orthogonal to ownership model.
- Federation gateway across instances — covered by ADR-0041 in project-hub (#306, merged).

Closes #307.