### PR TITLE
fix(api): thread since_seconds through to K8sClient.read_pod_log

### DIFF
--- a/api/src/aerospike_cluster_manager_api/k8s_client.py
+++ b/api/src/aerospike_cluster_manager_api/k8s_client.py
@@ -609,9 +609,21 @@ class K8sClient:
             raise self._wrap_api_exception(e) from e
 
     def _read_pod_log_sync(
-        self, namespace: str, pod_name: str, container: str | None = None, tail_lines: int = 500
+        self,
+        namespace: str,
+        pod_name: str,
+        container: str | None = None,
+        tail_lines: int = 500,
+        since_seconds: int | None = None,
     ) -> str:
-        """Read logs from a pod."""
+        """Read logs from a pod.
+
+        ``since_seconds`` (when set) restricts the response to log lines
+        emitted within that many seconds before the request, mirroring
+        the Kubernetes API's ``sinceSeconds`` query parameter. Combined
+        with ``tail_lines``, the K8s API returns the intersection: the
+        last ``tail_lines`` of the lines emitted within ``since_seconds``.
+        """
         logger.debug("_read_pod_log_sync(namespace=%s, pod=%s)", namespace, pod_name)
         self._ensure_initialized()
         try:
@@ -623,6 +635,8 @@ class K8sClient:
             }
             if container:
                 kwargs["container"] = container
+            if since_seconds is not None:
+                kwargs["since_seconds"] = since_seconds
             return cast(str, self._get_core_api().read_namespaced_pod_log(**kwargs))
         except Exception as e:
             raise self._wrap_api_exception(e) from e
@@ -710,9 +724,21 @@ class K8sClient:
         return await asyncio.to_thread(self._get_pod_pvc_map_sync, namespace, label_selector)
 
     async def read_pod_log(
-        self, namespace: str, pod_name: str, container: str | None = None, tail_lines: int = 500
+        self,
+        namespace: str,
+        pod_name: str,
+        container: str | None = None,
+        tail_lines: int = 500,
+        since_seconds: int | None = None,
     ) -> str:
-        return await asyncio.to_thread(self._read_pod_log_sync, namespace, pod_name, container, tail_lines)
+        return await asyncio.to_thread(
+            self._read_pod_log_sync,
+            namespace,
+            pod_name,
+            container,
+            tail_lines,
+            since_seconds,
+        )
 
     # ------------------------------------------------------------------
     # HPA sync helpers

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/k8s.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/k8s.py
@@ -282,10 +282,10 @@ async def get_k8s_logs(
     ``app.kubernetes.io/instance=<cluster-name>``. Cross-cluster pod
     access is rejected with ``code=not_found``.
 
-    ``since_seconds`` is currently informational (the underlying client
-    reads the last ``tail_lines`` lines via the K8s API; future versions
-    can switch to ``sinceSeconds``-based truncation). It is still bounds-
-    checked so callers cannot pass arbitrarily large values.
+    ``since_seconds`` and ``tail_lines`` combine on the K8s API side:
+    the response is the intersection (last ``tail_lines`` lines emitted
+    within ``since_seconds`` of the request). This matches the Kubernetes
+    ``sinceSeconds`` semantics. Both are bounds-checked.
 
     Bounds: ``since_seconds`` <= 3600, ``tail_lines`` <= 1000. Out-of-range
     values raise ``invalid_argument``.
@@ -307,7 +307,12 @@ async def get_k8s_logs(
             code="not_found",
         )
 
-    raw_logs = await k8s_client.read_pod_log(namespace, pod_name, tail_lines=tail_lines)
+    raw_logs = await k8s_client.read_pod_log(
+        namespace,
+        pod_name,
+        tail_lines=tail_lines,
+        since_seconds=since_seconds,
+    )
     # ``read_namespaced_pod_log`` returns a single string; split into lines
     # so the LLM gets a structured payload it can iterate over.
     lines = raw_logs.splitlines() if raw_logs else []

--- a/api/tests/mcp/test_k8s_tools.py
+++ b/api/tests/mcp/test_k8s_tools.py
@@ -321,6 +321,7 @@ class TestGetK8sLogs:
     async def test_happy_path_returns_lines_and_truncated_flag(self, k8s_enabled: None) -> None:
         from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
 
+        read_pod_log_mock = AsyncMock(return_value="line1\nline2\nline3")
         with (
             patch.object(
                 k8s_tools.k8s_client,
@@ -330,14 +331,28 @@ class TestGetK8sLogs:
             patch.object(
                 k8s_tools.k8s_client,
                 "read_pod_log",
-                new=AsyncMock(return_value="line1\nline2\nline3"),
+                new=read_pod_log_mock,
             ),
         ):
-            result = await k8s_tools.get_k8s_logs(cluster_id="default/cl", pod_name="cl-0-0", tail_lines=10)
+            result = await k8s_tools.get_k8s_logs(
+                cluster_id="default/cl",
+                pod_name="cl-0-0",
+                tail_lines=10,
+                since_seconds=120,
+            )
 
         assert result["podName"] == "cl-0-0"
         assert result["lines"] == ["line1", "line2", "line3"]
         assert result["truncated"] is False
+        # Both bound-checked params must reach the K8s client; previously
+        # ``since_seconds`` was bounds-checked but never threaded through
+        # (#305 follow-up).
+        read_pod_log_mock.assert_awaited_once_with(
+            "default",
+            "cl-0-0",
+            tail_lines=10,
+            since_seconds=120,
+        )
 
     async def test_truncated_flag_set_when_at_limit(self, k8s_enabled: None) -> None:
         from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools


### PR DESCRIPTION
## Summary

Single follow-up from the Phase 2 MCP work batch (PRs #310-#316). Closes the open minor surfaced in PR #313's review:

> ``since_seconds`` is bounds-checked but not threaded through to ``read_pod_log``.

The flake hypothesis from PR #316's body (``test_tools_call_test_connection_over_wire_succeeds`` failing in suite context) is **withdrawn** -- 5 consecutive full-suite runs on a fresh main check-out all pass. The earlier observation was caused by stale local working-tree state during in-flight E.2 development; the test is not flaky on main.

## Change

- ``K8sClient._read_pod_log_sync`` and the async wrapper accept an optional ``since_seconds: int | None = None`` keyword and forward it to the Kubernetes API's ``read_namespaced_pod_log`` call.
- ``mcp/tools/k8s.py::get_k8s_logs`` passes the (already bounds-checked) ``since_seconds`` to the client.
- The tool docstring is updated to reflect that ``since_seconds`` and ``tail_lines`` now combine on the K8s API side (intersection of both filters), matching the K8s API's documented behavior.

## Test plan

- [x] ``uv run ruff check src tests --fix && uv run ruff format src tests`` -- clean
- [x] ``uv run pyright`` on the changed files -- 0 errors
- [x] ``uv run pytest tests/mcp/test_k8s_tools.py -v`` -- 34 / 34 pass
- [x] ``uv run pytest tests/`` -- 930 / 930 pass
- [x] Regression assertion added: ``TestGetK8sLogs.test_happy_path_returns_lines_and_truncated_flag`` now ``assert_awaited_once_with(... tail_lines=..., since_seconds=...)`` so a future regression where the param goes ungated again will trip the test.

## Compatibility

No wire-format change. Callers that omit ``since_seconds`` see identical behavior (the kwarg is dropped from the K8s API call when ``None``, so K8s applies no time-window filter as before).