### PR TITLE
feat(api): default-deny workspace ACL + per-route rate limits

### DIFF
--- a/api/src/aerospike_cluster_manager_api/dependencies.py
+++ b/api/src/aerospike_cluster_manager_api/dependencies.py
@@ -57,10 +57,50 @@ def _resolve_caller_owner_id(request: Request) -> str:
     return raw
 
 
-async def _get_verified_connection(conn_id: str = Path()) -> str:
-    """Verify that a connection profile exists and return its id."""
+async def _get_verified_connection(
+    conn_id: str = Path(),
+    caller_owner_id: str = Depends(_resolve_caller_owner_id),
+) -> str:
+    """Verify that a connection profile exists and the caller owns its workspace.
+
+    Default-deny ACL gate (#307 — Phase 2). Returns the connection id when
+    the caller can see the connection's workspace. Raises 404 when:
+
+    * the connection does not exist;
+    * the connection's workspace was deleted between the load and now;
+    * the workspace exists but belongs to a different owner (and is not
+      the synthetic ``SYSTEM_OWNER_ID`` shared-default workspace).
+
+    Identity-404 (instead of 403) prevents id enumeration — the wire shape
+    matches the missing-row case so a probing caller cannot distinguish
+    "doesn't exist" from "exists but not yours". Anonymous deployments
+    (``caller_owner_id == SYSTEM_OWNER_ID``) keep the legacy
+    every-workspace-visible behaviour because system-owned rows always
+    pass and the resolver returns the system sentinel when no auth
+    middleware ran.
+
+    Unit-test paths that exercise the dependency without a workspace DB
+    (``DBNotInitialized``) skip the visibility check -- the connection
+    existence gate alone is the legacy behaviour.
+    """
     conn = await db.get_connection(conn_id)
     if not conn:
+        raise HTTPException(status_code=404, detail=f"Connection '{conn_id}' not found")
+    workspace_id = getattr(conn, "workspaceId", None)
+    if workspace_id is None:
+        # Connection has no workspace association (legacy / test fixture
+        # using a bare dict). Treat as system-shared — visible to every
+        # authenticated caller, matching the pre-#307 wire shape.
+        return conn_id
+    try:
+        workspace = await db.get_workspace(workspace_id)
+    except db.DBNotInitialized:
+        return conn_id
+    if workspace is None:
+        # Workspace deleted underneath us. Surface as connection 404 so
+        # the wire shape matches the no-ACL case.
+        raise HTTPException(status_code=404, detail=f"Connection '{conn_id}' not found")
+    if workspace.ownerId != caller_owner_id and workspace.ownerId != SYSTEM_OWNER_ID:
         raise HTTPException(status_code=404, detail=f"Connection '{conn_id}' not found")
     return conn_id
 
@@ -81,16 +121,31 @@ async def _get_workspace(workspace_id: str = Path()) -> Workspace:
     return ws
 
 
-async def _get_connection_profile(conn_id: str = Path()) -> ConnectionProfile:
+async def _get_connection_profile(
+    conn_id: str = Path(),
+    caller_owner_id: str = Depends(_resolve_caller_owner_id),
+) -> ConnectionProfile:
     """Fetch and return the full ``ConnectionProfile`` for *conn_id*.
 
-    Raises 404 if the profile does not exist.  Unlike
-    ``_get_verified_connection`` (which returns only the id string),
-    this dependency returns the full model so callers can avoid a
-    redundant database round-trip.
+    Same default-deny ACL gate as :func:`_get_verified_connection` —
+    raises 404 for missing rows AND for rows whose workspace is invisible
+    to the caller. Unlike ``_get_verified_connection`` (which returns
+    only the id string), this dependency returns the full model so
+    callers can avoid a redundant database round-trip.
     """
     conn = await db.get_connection(conn_id)
     if not conn:
+        raise HTTPException(status_code=404, detail=f"Connection '{conn_id}' not found")
+    workspace_id = getattr(conn, "workspaceId", None)
+    if workspace_id is None:
+        return conn
+    try:
+        workspace = await db.get_workspace(workspace_id)
+    except db.DBNotInitialized:
+        return conn
+    if workspace is None:
+        raise HTTPException(status_code=404, detail=f"Connection '{conn_id}' not found")
+    if workspace.ownerId != caller_owner_id and workspace.ownerId != SYSTEM_OWNER_ID:
         raise HTTPException(status_code=404, detail=f"Connection '{conn_id}' not found")
     return conn
 

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/connections.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/connections.py
@@ -32,21 +32,44 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from aerospike_cluster_manager_api import config
 from aerospike_cluster_manager_api.client_manager import client_manager
 from aerospike_cluster_manager_api.constants import INFO_NAMESPACES
 from aerospike_cluster_manager_api.info_parser import parse_list
 from aerospike_cluster_manager_api.mcp.registry import tool
+from aerospike_cluster_manager_api.mcp.user_context import current_caller_claims
 from aerospike_cluster_manager_api.models.connection import (
     CreateConnectionRequest,
     TestConnectionRequest,
     UpdateConnectionRequest,
 )
+from aerospike_cluster_manager_api.models.workspace import SYSTEM_OWNER_ID
 from aerospike_cluster_manager_api.services import connections_service
 from aerospike_cluster_manager_api.services.connections_service import (
     ConnectionNotFoundError,
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _resolve_mcp_caller_owner_id() -> str:
+    """Translate MCP caller claims to the owner-id the service layer expects.
+
+    Mirrors :func:`dependencies._resolve_caller_owner_id` for the REST
+    surface so the same workspace ACL applies regardless of transport.
+    Bearer-token sessions and anonymous deployments degrade to
+    :data:`SYSTEM_OWNER_ID`, keeping the legacy single-tenant fallback
+    where every workspace is reachable.
+    """
+    claims = current_caller_claims()
+    if claims is None:
+        return SYSTEM_OWNER_ID
+    if claims.get("_mcp_bearer"):
+        return SYSTEM_OWNER_ID
+    raw = claims.get(config.ACM_OIDC_OWNER_CLAIM)
+    if not isinstance(raw, str) or not raw:
+        return SYSTEM_OWNER_ID
+    return raw
 
 
 @tool(category="connection", mutation=True)
@@ -86,7 +109,7 @@ async def create_connection(
         workspaceId=workspace_id,
         clusterName=cluster_name,
     )
-    result = await connections_service.create_connection(payload)
+    result = await connections_service.create_connection(payload, _resolve_mcp_caller_owner_id())
     return result.model_dump()
 
 
@@ -144,7 +167,7 @@ async def update_connection(
         update_kwargs["clusterName"] = cluster_name
 
     payload = UpdateConnectionRequest(**update_kwargs)
-    result = await connections_service.update_connection(conn_id, payload)
+    result = await connections_service.update_connection(conn_id, payload, _resolve_mcp_caller_owner_id())
     return result.model_dump()
 
 
@@ -163,8 +186,14 @@ async def delete_connection(conn_id: str) -> dict[str, Any]:
 
 @tool(category="connection", mutation=False)
 async def list_connections(workspace_id: str | None = None) -> list[dict[str, Any]]:
-    """List all connection profiles, optionally filtered by workspace id."""
-    results = await connections_service.list_connections(workspace_id)
+    """List all connection profiles, optionally filtered by workspace id.
+
+    The caller's identity (resolved from the MCP request context) is
+    threaded into the service layer so cross-tenant ``workspace_id``
+    filters return ``not_found`` rather than leaking another tenant's
+    connection list.
+    """
+    results = await connections_service.list_connections(workspace_id, _resolve_mcp_caller_owner_id())
     return [item.model_dump() for item in results]
 
 

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/k8s.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/k8s.py
@@ -40,19 +40,24 @@ import logging
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
-from aerospike_cluster_manager_api import config
-from aerospike_cluster_manager_api.k8s_client import k8s_client
+from aerospike_cluster_manager_api import config, db
+from aerospike_cluster_manager_api.k8s_client import K8sApiError, k8s_client
 from aerospike_cluster_manager_api.mcp import serializers
 from aerospike_cluster_manager_api.mcp.errors import MCPToolError
 from aerospike_cluster_manager_api.mcp.registry import tool
+from aerospike_cluster_manager_api.mcp.user_context import current_caller_claims
 from aerospike_cluster_manager_api.models.k8s_cluster import (
     K8sClusterEvent,
     K8sClusterSummary,
     K8sPodStatus,
 )
+from aerospike_cluster_manager_api.models.workspace import SYSTEM_OWNER_ID
 from aerospike_cluster_manager_api.services import k8s_service
 
 logger = logging.getLogger(__name__)
+
+
+_WORKSPACE_LABEL = "acm.aerospike.com/workspace"
 
 
 # ---------------------------------------------------------------------------
@@ -125,7 +130,76 @@ def _workspace_label_selector(workspace_id: str | None) -> str | None:
     """
     if workspace_id is None:
         return None
-    return f"acm.aerospike.com/workspace={workspace_id}"
+    return f"{_WORKSPACE_LABEL}={workspace_id}"
+
+
+def _resolve_caller_owner_id() -> str:
+    """Translate MCP caller claims into the service-layer owner id.
+
+    Mirrors :func:`mcp.tools.connections._resolve_mcp_caller_owner_id`
+    and :func:`dependencies._resolve_caller_owner_id` so the same ACL
+    rule applies regardless of transport. Anonymous and bearer-token
+    sessions degrade to :data:`SYSTEM_OWNER_ID` -- single-tenant
+    deployments keep the legacy permissive behaviour.
+    """
+    claims = current_caller_claims()
+    if claims is None:
+        return SYSTEM_OWNER_ID
+    if claims.get("_mcp_bearer"):
+        return SYSTEM_OWNER_ID
+    raw = claims.get(config.ACM_OIDC_OWNER_CLAIM)
+    if not isinstance(raw, str) or not raw:
+        return SYSTEM_OWNER_ID
+    return raw
+
+
+def _cr_workspace_id(item: dict[str, Any]) -> str | None:
+    """Return the workspace id stamped on a CR, if any."""
+    labels = item.get("metadata", {}).get("labels") or {}
+    raw = labels.get(_WORKSPACE_LABEL)
+    return raw if isinstance(raw, str) and raw else None
+
+
+async def _assert_caller_owns_cluster(namespace: str, name: str) -> None:
+    """Enforce the workspace ACL on a single cluster identified by namespace/name.
+
+    Reads the CR's ``acm.aerospike.com/workspace`` label and confirms it
+    is visible to the caller (same rule as the REST K8s router). CRs
+    without the label are treated as system-shared. A missing cluster or
+    invisible workspace surfaces as ``code="not_found"`` so the wire
+    shape matches a non-existent CR -- prevents id enumeration via the
+    MCP surface.
+
+    When the workspace metaDB has not been initialised (unit-test paths
+    that exercise the K8s tools in isolation) the visibility check
+    short-circuits to "permissive" -- matches the legacy single-tenant
+    behaviour used by the notes layer.
+    """
+    try:
+        cr = await k8s_client.get_cluster(namespace, name)
+    except K8sApiError as e:
+        if e.status == 404:
+            raise MCPToolError(
+                f"Cluster '{namespace}/{name}' not found",
+                code="not_found",
+            ) from e
+        raise
+    workspace_id = _cr_workspace_id(cr)
+    if workspace_id is None:
+        return
+    caller_owner_id = _resolve_caller_owner_id()
+    try:
+        ws = await db.get_workspace(workspace_id)
+    except db.DBNotInitialized:
+        return
+    if ws is None:
+        return
+    if ws.ownerId == caller_owner_id or ws.ownerId == SYSTEM_OWNER_ID:
+        return
+    raise MCPToolError(
+        f"Cluster '{namespace}/{name}' not found",
+        code="not_found",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -145,10 +219,37 @@ async def list_k8s_clusters(workspace_id: str | None = None) -> list[dict[str, A
     ``acm.aerospike.com/workspace=<workspace_id>``. With ``workspace_id=None``
     (default) every visible CR is returned, including legacy CRs that
     pre-date workspace labelling.
+
+    Without ``workspace_id`` the result is filtered down to CRs whose
+    workspace label is visible to the caller (or whose label is missing
+    -- the system-shared bucket). This mirrors the REST list endpoint so
+    a multi-tenant MCP caller cannot enumerate other tenants' clusters
+    just by omitting the filter.
     """
     _assert_k8s_enabled()
     label_selector = _workspace_label_selector(workspace_id)
     items, _ = await k8s_client.list_clusters(label_selector=label_selector)
+
+    if workspace_id is None:
+        caller_owner_id = _resolve_caller_owner_id()
+        workspace_ids: set[str] = set()
+        for item in items:
+            ws_id = _cr_workspace_id(item)
+            if ws_id is not None:
+                workspace_ids.add(ws_id)
+        visible: dict[str, bool] = {}
+        try:
+            for ws_id in workspace_ids:
+                ws = await db.get_workspace(ws_id)
+                visible[ws_id] = ws is not None and (ws.ownerId == caller_owner_id or ws.ownerId == SYSTEM_OWNER_ID)
+        except db.DBNotInitialized:
+            # Workspace metaDB not configured -- fall back to the legacy
+            # permissive listing (every CR returned). Matches the notes
+            # layer's tolerance for unit-test fixtures that don't drive
+            # the workspace DB.
+            visible = dict.fromkeys(workspace_ids, True)
+        items = [item for item in items if (ws_id := _cr_workspace_id(item)) is None or visible.get(ws_id, False)]
+
     summaries = [k8s_service.extract_summary(item) for item in items]
     return [serializers.k8s_cluster_summary(s) for s in summaries]
 
@@ -170,6 +271,7 @@ async def get_k8s_pods(
     """
     _assert_k8s_enabled()
     namespace, name = _parse_cluster_id(cluster_id)
+    await _assert_caller_owns_cluster(namespace, name)
     pods_raw = await k8s_client.list_pods(
         namespace,
         f"app.kubernetes.io/name=aerospike-cluster,app.kubernetes.io/instance={name}",
@@ -198,6 +300,7 @@ async def get_k8s_events(
     _assert_k8s_enabled()
     _check_bound(since_minutes, max_value=_MAX_SINCE_MINUTES, name="since_minutes")
     namespace, name = _parse_cluster_id(cluster_id)
+    await _assert_caller_owns_cluster(namespace, name)
 
     field_selector = f"involvedObject.name={name},involvedObject.kind=AerospikeCluster"
     events_raw = await k8s_client.list_events(namespace, field_selector)
@@ -254,7 +357,11 @@ async def scale_k8s_cluster(
         )
     namespace, name = _parse_cluster_id(cluster_id)
 
-    # Read previous size first so the response carries an audit-style diff.
+    # ACL gate runs the same ``get_cluster`` we'd otherwise use to read
+    # the previous size — fold the two reads into one to avoid a
+    # redundant API hop. ``_assert_caller_owns_cluster`` raises before
+    # we get here when the caller cannot see the workspace.
+    await _assert_caller_owns_cluster(namespace, name)
     current = await k8s_client.get_cluster(namespace, name)
     previous_size = int(current.get("spec", {}).get("size", 0) or 0)
 
@@ -301,6 +408,7 @@ async def get_k8s_logs(
     _check_bound(since_seconds, max_value=_MAX_SINCE_SECONDS, name="since_seconds")
     _check_bound(tail_lines, max_value=_MAX_TAIL_LINES, name="tail_lines")
     namespace, name = _parse_cluster_id(cluster_id)
+    await _assert_caller_owns_cluster(namespace, name)
 
     # Match the same label pair ``get_k8s_pods`` uses so a pod from another
     # workload that happens to share the ``instance`` label cannot be

--- a/api/src/aerospike_cluster_manager_api/routers/admin_roles.py
+++ b/api/src/aerospike_cluster_manager_api/routers/admin_roles.py
@@ -4,11 +4,12 @@ import logging
 from typing import cast
 
 from aerospike_py.types import Privilege as AerospikePrivilege
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from starlette.responses import Response
 
 from aerospike_cluster_manager_api.dependencies import AerospikeClient
 from aerospike_cluster_manager_api.models.admin import AerospikeRole, CreateRoleRequest, Privilege
+from aerospike_cluster_manager_api.rate_limit import limiter
 from aerospike_cluster_manager_api.routers._admin_utils import (
     PRIVILEGE_CODE_TO_NAME,
     PRIVILEGE_NAME_TO_CODE,
@@ -75,8 +76,9 @@ async def get_roles(client: AerospikeClient) -> list[AerospikeRole]:
     summary="Create role",
     description="Create a new Aerospike role with specified privileges. Requires security to be enabled in aerospike.conf.",
 )
+@limiter.limit("20/minute")
 @admin_endpoint
-async def create_role(body: CreateRoleRequest, client: AerospikeClient) -> AerospikeRole:
+async def create_role(request: Request, body: CreateRoleRequest, client: AerospikeClient) -> AerospikeRole:
     """Create a new Aerospike role with specified privileges. Requires security to be enabled in aerospike.conf."""
     if not body.name or not body.privileges:
         raise HTTPException(status_code=400, detail="Missing required fields: name, privileges")
@@ -123,8 +125,10 @@ async def create_role(body: CreateRoleRequest, client: AerospikeClient) -> Aeros
     summary="Delete role",
     description="Delete an Aerospike role by name. Requires security to be enabled in aerospike.conf.",
 )
+@limiter.limit("20/minute")
 @admin_endpoint
 async def delete_role(
+    request: Request,
     client: AerospikeClient,
     name: str = Query(..., min_length=1),
 ) -> Response:

--- a/api/src/aerospike_cluster_manager_api/routers/admin_users.py
+++ b/api/src/aerospike_cluster_manager_api/routers/admin_users.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from starlette.responses import Response
 
 from aerospike_cluster_manager_api.dependencies import AerospikeClient
 from aerospike_cluster_manager_api.models.admin import AerospikeUser, ChangePasswordRequest, CreateUserRequest
 from aerospike_cluster_manager_api.models.common import MessageResponse
+from aerospike_cluster_manager_api.rate_limit import limiter
 from aerospike_cluster_manager_api.routers._admin_utils import admin_endpoint
 
 logger = logging.getLogger(__name__)
@@ -44,8 +45,9 @@ async def get_users(client: AerospikeClient) -> list[AerospikeUser]:
     summary="Create user",
     description="Create a new Aerospike user with specified roles. Requires security to be enabled in aerospike.conf.",
 )
+@limiter.limit("20/minute")
 @admin_endpoint
-async def create_user(body: CreateUserRequest, client: AerospikeClient) -> AerospikeUser:
+async def create_user(request: Request, body: CreateUserRequest, client: AerospikeClient) -> AerospikeUser:
     """Create a new Aerospike user with specified roles. Requires security to be enabled in aerospike.conf."""
     if not body.username or not body.password:
         raise HTTPException(status_code=400, detail="Missing required fields: username, password")
@@ -67,8 +69,9 @@ async def create_user(body: CreateUserRequest, client: AerospikeClient) -> Aeros
     summary="Change user password",
     description="Change the password for an existing Aerospike user. Requires security to be enabled in aerospike.conf.",
 )
+@limiter.limit("20/minute")
 @admin_endpoint
-async def change_password(body: ChangePasswordRequest, client: AerospikeClient) -> MessageResponse:
+async def change_password(request: Request, body: ChangePasswordRequest, client: AerospikeClient) -> MessageResponse:
     """Change the password for an existing Aerospike user. Requires security to be enabled in aerospike.conf."""
     if not body.username or not body.password:
         raise HTTPException(status_code=400, detail="Missing required fields: username, password")
@@ -84,8 +87,10 @@ async def change_password(body: ChangePasswordRequest, client: AerospikeClient) 
     summary="Delete user",
     description="Delete an Aerospike user by username. Requires security to be enabled in aerospike.conf.",
 )
+@limiter.limit("20/minute")
 @admin_endpoint
 async def delete_user(
+    request: Request,
     client: AerospikeClient,
     username: str = Query(..., min_length=1),
 ) -> Response:

--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 
 from aerospike_py.exception import AerospikeError, AerospikeTimeoutError, ClusterError
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from starlette.responses import Response
 
 from aerospike_cluster_manager_api.client_manager import client_manager
@@ -66,12 +66,13 @@ async def create_connection(
 
 
 @router.get("/{conn_id}", summary="Get connection", description="Retrieve a single connection profile by its ID.")
-async def get_connection(conn_id: str = Path()) -> ConnectionProfileResponse:
+async def get_connection(conn_id: str = Depends(_get_verified_connection)) -> ConnectionProfileResponse:
     """Retrieve a single connection profile by its ID.
 
-    The service raises :class:`ConnectionNotFoundError` for missing ids, so
-    the dedicated existence-check dependency is redundant — dropping it
-    halves the database round trips on this hot path.
+    The dependency enforces the workspace ACL: the caller must own the
+    connection's workspace (or the row must live in the shared
+    ``SYSTEM_OWNER_ID`` workspace). Cross-tenant probes 404 to keep the
+    wire shape identical to the missing-row case.
     """
     try:
         return await connections_service.get_connection(conn_id)
@@ -85,16 +86,14 @@ async def get_connection(conn_id: str = Path()) -> ConnectionProfileResponse:
 async def update_connection(
     body: UpdateConnectionRequest,
     caller_owner_id: CallerOwnerId,
-    conn_id: str = Path(),
+    conn_id: str = Depends(_get_verified_connection),
 ) -> ConnectionProfileResponse:
     """Update an existing connection profile with new settings.
 
-    The service's :func:`update_connection` raises
-    :class:`ConnectionNotFoundError` when the id is missing, so the
-    existence-check dependency is redundant — drop it to avoid the
-    duplicate ``db.get_connection`` round trip on each PUT. Phase 2:
-    moving the connection to a workspace invisible to the caller is a
-    404, same wire shape as a missing workspace.
+    The dependency rejects callers who do not own the connection's
+    workspace (404, identity wire shape with missing-row). Moving the
+    connection to a workspace the caller cannot see is also a 404 — the
+    service-layer ``WorkspaceNotFoundError`` is mapped here.
     """
     try:
         return await connections_service.update_connection(conn_id, body, caller_owner_id)

--- a/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
@@ -14,12 +14,13 @@ import uuid
 from datetime import UTC, datetime
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request, Response
 from opentelemetry import trace
 from pydantic import BaseModel, Field
 
 from aerospike_cluster_manager_api import config, db
 from aerospike_cluster_manager_api.client_manager import client_manager
+from aerospike_cluster_manager_api.dependencies import CallerOwnerId
 from aerospike_cluster_manager_api.k8s_client import K8sApiError, k8s_client
 from aerospike_cluster_manager_api.models.connection import ConnectionProfile
 from aerospike_cluster_manager_api.models.k8s_cluster import (
@@ -46,7 +47,8 @@ from aerospike_cluster_manager_api.models.k8s_cluster import (
     UpdateK8sClusterRequest,
     UpdateK8sTemplateRequest,
 )
-from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID
+from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID, SYSTEM_OWNER_ID
+from aerospike_cluster_manager_api.rate_limit import limiter
 from aerospike_cluster_manager_api.services.k8s_service import (
     build_cr,
     build_template_cr,
@@ -74,6 +76,76 @@ _tracer = trace.get_tracer("aerospike_cluster_manager_api.routers.k8s_clusters")
 def _require_k8s() -> None:
     if not config.K8S_MANAGEMENT_ENABLED:
         raise HTTPException(status_code=404, detail="Kubernetes management is not enabled")
+
+
+_WORKSPACE_LABEL = "acm.aerospike.com/workspace"
+
+
+def _cr_workspace_id(item: dict[str, Any]) -> str | None:
+    """Return the workspace id stamped on a CR's metadata labels, if any.
+
+    CRs without the workspace label are treated as system-shared — the
+    same rule the connection-profile ACL applies for ``SYSTEM_OWNER_ID``.
+    Returning ``None`` lets the caller decide whether to gate (mutations
+    require an owned workspace, reads with no label show to everyone).
+    """
+    labels = item.get("metadata", {}).get("labels") or {}
+    raw = labels.get(_WORKSPACE_LABEL)
+    return raw if isinstance(raw, str) and raw else None
+
+
+async def _is_workspace_visible(workspace_id: str, caller_owner_id: str) -> bool:
+    """Return True iff the caller can see ``workspace_id``.
+
+    Visibility = ``ownerId == caller`` OR ``ownerId == SYSTEM_OWNER_ID``.
+    Missing rows are invisible. Mirrors the rule used by
+    :func:`dependencies._get_verified_connection` for connection
+    profiles, so K8s and connection ACLs stay in lock-step.
+
+    When the workspace metaDB has not been initialised (unit-test paths
+    that exercise the K8s router in isolation), the check degrades to
+    permissive -- the same convention notes / records use to keep
+    legacy single-tenant fixtures green.
+    """
+    try:
+        ws = await db.get_workspace(workspace_id)
+    except db.DBNotInitialized:
+        return True
+    if ws is None:
+        return False
+    return ws.ownerId == caller_owner_id or ws.ownerId == SYSTEM_OWNER_ID
+
+
+async def _assert_caller_owns_k8s_cluster(
+    namespace: str,
+    name: str,
+    caller_owner_id: str,
+) -> dict[str, Any]:
+    """Default-deny ACL gate for K8s cluster mutations.
+
+    Resolves the cluster CR, reads its ``acm.aerospike.com/workspace``
+    label, and verifies the caller can see that workspace. Clusters with
+    no workspace label are treated as system-shared (visible to every
+    authenticated caller) so legacy CRs created before workspace
+    labelling stay reachable. Returns the CR dict for callers that need
+    it, so we don't pay the ``get_cluster`` round trip twice.
+
+    Raises ``HTTPException(404)`` for a missing cluster (matching
+    ``K8sApiError`` mapping) or for a cluster the caller cannot see
+    (identity-404 to prevent enumeration).
+    """
+    try:
+        cr = await k8s_client.get_cluster(namespace, name)
+    except K8sApiError as e:
+        if e.status == 404:
+            raise HTTPException(status_code=404, detail=f"Cluster '{namespace}/{name}' not found") from e
+        raise _map_k8s_error(e) from e
+    workspace_id = _cr_workspace_id(cr)
+    if workspace_id is None:
+        return cr
+    if not await _is_workspace_visible(workspace_id, caller_owner_id):
+        raise HTTPException(status_code=404, detail=f"Cluster '{namespace}/{name}' not found")
+    return cr
 
 
 router = APIRouter(prefix="/k8s", tags=["k8s-clusters"], dependencies=[Depends(_require_k8s)])
@@ -133,6 +205,7 @@ def _k8s_endpoint(operation: str):
 @router.get("/clusters", summary="List K8s Aerospike clusters")
 @_k8s_endpoint("list Kubernetes clusters")
 async def list_k8s_clusters(
+    caller_owner_id: CallerOwnerId,
     namespace: str | None = None,
     limit: int = Query(20, ge=1, le=100),
     continue_token: str | None = Query(None, alias="continueToken"),
@@ -142,6 +215,20 @@ async def list_k8s_clusters(
     items, next_token = await k8s_client.list_clusters(
         namespace, limit=limit, continue_token=continue_token, label_selector=label_selector
     )
+
+    # Filter CRs by workspace visibility. CRs with no workspace label are
+    # treated as system-shared (legacy compatibility). For labelled CRs we
+    # batch the visibility check so a 100-cluster page does not run 100
+    # serial ``db.get_workspace`` round trips.
+    workspace_ids: set[str] = set()
+    for item in items:
+        ws_id = _cr_workspace_id(item)
+        if ws_id is not None:
+            workspace_ids.add(ws_id)
+    visible_workspaces: dict[str, bool] = {}
+    for ws_id in workspace_ids:
+        visible_workspaces[ws_id] = await _is_workspace_visible(ws_id, caller_owner_id)
+    items = [item for item in items if (ws := _cr_workspace_id(item)) is None or visible_workspaces.get(ws, False)]
 
     connections = await db.get_all_connections()
     conn_by_host: dict[str, str] = {}
@@ -174,11 +261,12 @@ async def list_k8s_clusters(
 @router.get("/clusters/{namespace}/{name}", summary="Get K8s Aerospike cluster detail")
 @_k8s_endpoint("get Kubernetes cluster")
 async def get_k8s_cluster(
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> K8sClusterDetail:
 
-    item = await k8s_client.get_cluster(namespace, name)
+    item = await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     pods_raw = await k8s_client.list_pods(
         namespace, f"app.kubernetes.io/name=aerospike-cluster,app.kubernetes.io/instance={name}"
     )
@@ -188,12 +276,13 @@ async def get_k8s_cluster(
 @router.get("/clusters/{namespace}/{name}/config-drift", summary="Get cluster config drift")
 @_k8s_endpoint("get cluster config drift")
 async def get_cluster_config_drift(
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ):
     """Compare desired spec vs applied spec and detect configuration drift."""
 
-    cr = await k8s_client.get_cluster(namespace, name)
+    cr = await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     result = compute_config_drift(cr)
     return ConfigDriftResponse(**result)
 
@@ -201,23 +290,25 @@ async def get_cluster_config_drift(
 @router.get("/clusters/{namespace}/{name}/health", summary="Get cluster health summary")
 @_k8s_endpoint("get cluster health")
 async def get_k8s_cluster_health(
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> ClusterHealthResponse:
 
-    item = await k8s_client.get_cluster(namespace, name)
+    item = await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     return extract_health(item)
 
 
 @router.get("/clusters/{namespace}/{name}/reconciliation-status", summary="Get reconciliation health")
 @_k8s_endpoint("get reconciliation status")
 async def get_cluster_reconciliation_status(
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ):
     """Get reconciliation health including circuit breaker state."""
 
-    cr = await k8s_client.get_cluster(namespace, name)
+    cr = await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     result = extract_reconciliation_status(cr)
     return ReconciliationStatus(**result)
 
@@ -225,12 +316,13 @@ async def get_cluster_reconciliation_status(
 @router.get("/clusters/{namespace}/{name}/migration-status", summary="Get cluster migration status")
 @_k8s_endpoint("get cluster migration status")
 async def get_migration_status(
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ):
     """Get migration status including per-pod migration info."""
 
-    cr = await k8s_client.get_cluster(namespace, name)
+    cr = await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     result = extract_migration_status(cr)
     return MigrationStatusResponse(**result)
 
@@ -241,12 +333,13 @@ async def get_migration_status(
 )
 @_k8s_endpoint("get reconciliation health")
 async def get_cluster_reconciliation_health(
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ):
     """Get reconciliation health including phase, error info, and health status."""
 
-    cr = await k8s_client.get_cluster(namespace, name)
+    cr = await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     result = extract_reconciliation_health(cr)
     return ReconciliationHealthResponse(**result)
 
@@ -254,40 +347,56 @@ async def get_cluster_reconciliation_health(
 @router.get("/clusters/{namespace}/{name}/pods/{pod}/logs", summary="Get pod logs")
 @_k8s_endpoint("get pod logs")
 async def get_k8s_pod_logs(
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
     pod: str = Path(..., min_length=1, max_length=253),
     tail: int = Query(default=500, ge=1, le=10000, description="Number of tail lines"),
     container: str | None = Query(default=None, description="Container name"),
+    since_seconds: int | None = Query(
+        default=None,
+        ge=1,
+        le=86400,
+        description="Restrict logs to lines emitted within this many seconds (max 24h)",
+    ),
 ) -> dict[str, Any]:
 
+    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     cluster_pods = await k8s_client.list_pods(namespace, f"app.kubernetes.io/instance={name}")
     pod_names = {p["name"] for p in cluster_pods}
     if pod not in pod_names:
         raise HTTPException(status_code=404, detail=f"Pod '{pod}' does not belong to cluster '{name}'")
-    logs = await k8s_client.read_pod_log(namespace, pod, container=container, tail_lines=tail)
-    return {"pod": pod, "logs": logs, "tailLines": tail}
+    logs = await k8s_client.read_pod_log(
+        namespace, pod, container=container, tail_lines=tail, since_seconds=since_seconds
+    )
+    response: dict[str, Any] = {"pod": pod, "logs": logs, "tailLines": tail}
+    if since_seconds is not None:
+        response["sinceSeconds"] = since_seconds
+    return response
 
 
 @router.get("/clusters/{namespace}/{name}/yaml", summary="Get cluster CR as YAML")
 @_k8s_endpoint("export cluster YAML")
 async def get_k8s_cluster_yaml(
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> dict[str, Any]:
 
-    item = await k8s_client.get_cluster(namespace, name)
+    item = await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     return {"yaml": clean_cr_for_export(item)}
 
 
 @router.get("/clusters/{namespace}/{name}/pvcs", summary="List PVCs for K8s Aerospike cluster")
 @_k8s_endpoint("list PVCs for Kubernetes cluster")
 async def list_k8s_cluster_pvcs(
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> list[PVCInfo]:
     """List PersistentVolumeClaims associated with the cluster's StatefulSets."""
 
+    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     label_selector = f"app.kubernetes.io/instance={name}"
     pvcs_raw, pod_pvc_map = await asyncio.gather(
         k8s_client.list_pvcs(namespace, label_selector),
@@ -309,13 +418,17 @@ async def list_k8s_cluster_pvcs(
     summary="Delete a PVC",
     response_model=dict,
 )
+@limiter.limit("20/minute")
 @_k8s_endpoint("delete PVC")
 async def delete_pvc(
+    request: Request,
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
     pvc_name: str = Path(..., min_length=1, max_length=253),
 ) -> dict[str, str]:
     """Delete an orphaned PVC. The PVC must belong to the cluster (label check)."""
+    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     label_selector = f"app.kubernetes.io/instance={name}"
     pvcs_raw = await k8s_client.list_pvcs(namespace, label_selector)
     pvc_names = [p.get("name") for p in pvcs_raw]
@@ -330,13 +443,17 @@ async def delete_pvc(
     "/clusters/{namespace}/{name}/force-reconcile",
     summary="Force reconcile a drifted cluster",
 )
+@limiter.limit("20/minute")
 @_k8s_endpoint("force reconcile Kubernetes cluster")
 async def force_reconcile_k8s_cluster(
+    request: Request,
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> K8sClusterSummary:
     """Add a force-reconcile annotation to trigger the operator to re-reconcile."""
 
+    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     patch: dict[str, Any] = {
         "metadata": {
             "annotations": {
@@ -353,12 +470,16 @@ async def force_reconcile_k8s_cluster(
     summary="Reset operator circuit breaker",
     response_model=dict,
 )
+@limiter.limit("20/minute")
 @_k8s_endpoint("reset circuit breaker")
 async def reset_circuit_breaker(
+    request: Request,
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> dict[str, str]:
     """Reset the circuit breaker by patching status counters and annotating the CR."""
+    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     # 1. Reset status subresource (clear error state)
     await k8s_client.patch_cluster_status(
         namespace,
@@ -381,8 +502,13 @@ async def reset_circuit_breaker(
 
 
 @router.post("/clusters/import", status_code=201, summary="Import K8s Aerospike cluster from CR")
+@limiter.limit("20/minute")
 @_k8s_endpoint("import Kubernetes cluster")
-async def import_k8s_cluster(body: ImportClusterRequest) -> K8sClusterSummary:
+async def import_k8s_cluster(
+    request: Request,
+    body: ImportClusterRequest,
+    caller_owner_id: CallerOwnerId,
+) -> K8sClusterSummary:
     """Create a cluster from a raw AerospikeCluster CR (JSON/YAML)."""
 
     cr = body.cr
@@ -409,6 +535,16 @@ async def import_k8s_cluster(body: ImportClusterRequest) -> K8sClusterSummary:
     metadata.pop("generation", None)
     metadata.pop("managedFields", None)
 
+    # Reject CRs that carry a workspace label the caller cannot see.
+    # Without this gate the caller could attach a CR to another tenant's
+    # workspace and inherit visibility through the workspace fan-out.
+    cr_workspace_id = _cr_workspace_id(cr)
+    if cr_workspace_id is not None and not await _is_workspace_visible(cr_workspace_id, caller_owner_id):
+        raise HTTPException(
+            status_code=404,
+            detail=f"Workspace '{cr_workspace_id}' not found",
+        )
+
     existing_namespaces = await k8s_client.list_namespaces()
     if cr_namespace not in existing_namespaces:
         raise HTTPException(
@@ -421,8 +557,19 @@ async def import_k8s_cluster(body: ImportClusterRequest) -> K8sClusterSummary:
 
 
 @router.post("/clusters", status_code=201, summary="Create K8s Aerospike cluster")
+@limiter.limit("20/minute")
 @_k8s_endpoint("create Kubernetes cluster")
-async def create_k8s_cluster(body: CreateK8sClusterRequest) -> K8sClusterSummary:
+async def create_k8s_cluster(
+    request: Request,
+    body: CreateK8sClusterRequest,
+    caller_owner_id: CallerOwnerId,
+) -> K8sClusterSummary:
+
+    # Reject creation in a workspace the caller cannot see. ``workspace_id``
+    # may be None (legacy clients) — fall through to the default workspace
+    # which is shared via SYSTEM_OWNER_ID.
+    if body.workspace_id is not None and not await _is_workspace_visible(body.workspace_id, caller_owner_id):
+        raise HTTPException(status_code=404, detail=f"Workspace '{body.workspace_id}' not found")
 
     existing_namespaces = await k8s_client.list_namespaces()
     if body.namespace not in existing_namespaces:
@@ -435,6 +582,13 @@ async def create_k8s_cluster(body: CreateK8sClusterRequest) -> K8sClusterSummary
         )
 
     cr = build_cr(body)
+    # Stamp the workspace label so subsequent ACL checks (list/get/mutate)
+    # can recognise the CR's tenant. Skipped when no workspace is named —
+    # the cluster lands in the system-shared bucket and stays visible to
+    # everyone, matching the legacy pre-#307 contract.
+    if body.workspace_id is not None:
+        labels = cr.setdefault("metadata", {}).setdefault("labels", {})
+        labels[_WORKSPACE_LABEL] = body.workspace_id
     result = await k8s_client.create_cluster(body.namespace, cr)
 
     connection_id: str | None = None
@@ -486,9 +640,12 @@ async def create_k8s_cluster(body: CreateK8sClusterRequest) -> K8sClusterSummary
 
 
 @router.patch("/clusters/{namespace}/{name}", summary="Update K8s Aerospike cluster")
+@limiter.limit("20/minute")
 @_k8s_endpoint("update Kubernetes cluster")
 async def update_k8s_cluster(
+    request: Request,
     body: UpdateK8sClusterRequest,
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> K8sClusterSummary:
@@ -496,18 +653,23 @@ async def update_k8s_cluster(
     if not has_update_fields(body):
         raise HTTPException(status_code=400, detail="At least one field must be provided")
 
+    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     patch = build_update_patch(body)
     result = await k8s_client.patch_cluster(namespace, name, patch)
     return extract_summary(result)
 
 
 @router.delete("/clusters/{namespace}/{name}", status_code=202, summary="Delete K8s Aerospike cluster")
+@limiter.limit("20/minute")
 @_k8s_endpoint("delete Kubernetes cluster")
 async def delete_k8s_cluster(
+    request: Request,
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> DeleteResponse:
 
+    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     await k8s_client.delete_cluster(namespace, name)
 
     try:
@@ -526,13 +688,17 @@ async def delete_k8s_cluster(
 
 
 @router.post("/clusters/{namespace}/{name}/scale", summary="Scale K8s Aerospike cluster")
+@limiter.limit("20/minute")
 @_k8s_endpoint("scale Kubernetes cluster")
 async def scale_k8s_cluster(
+    request: Request,
     body: ScaleK8sClusterRequest,
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> K8sClusterSummary:
 
+    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     patch = {"spec": {"size": body.size}}
     result = await k8s_client.patch_cluster(namespace, name, patch)
     return extract_summary(result)
@@ -542,14 +708,18 @@ async def scale_k8s_cluster(
     "/clusters/{namespace}/{name}/node-blocklist",
     summary="Update node blocklist for K8s Aerospike cluster",
 )
+@limiter.limit("20/minute")
 @_k8s_endpoint("update node blocklist")
 async def update_node_blocklist(
+    request: Request,
     body: NodeBlocklistRequest,
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> K8sClusterSummary:
     """Patch spec.k8sNodeBlockList on the AerospikeCluster CR."""
 
+    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     patch: dict[str, Any] = {"spec": {"k8sNodeBlockList": body.node_names}}
     result = await k8s_client.patch_cluster(namespace, name, patch)
     return extract_summary(result)
@@ -563,19 +733,24 @@ async def update_node_blocklist(
 @router.get("/clusters/{namespace}/{name}/hpa", summary="Get HPA for K8s Aerospike cluster")
 @_k8s_endpoint("get HPA for Kubernetes cluster")
 async def get_k8s_cluster_hpa(
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> HPAResponse:
 
+    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     raw = await k8s_client.get_hpa(namespace, name)
     return extract_hpa_response(raw)
 
 
 @router.post("/clusters/{namespace}/{name}/hpa", summary="Create or update HPA for K8s Aerospike cluster")
+@limiter.limit("20/minute")
 @_k8s_endpoint("create/update HPA for Kubernetes cluster")
 async def create_or_update_k8s_cluster_hpa(
+    request: Request,
     response: Response,
     body: HPAConfig,
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> HPAResponse:
@@ -584,6 +759,7 @@ async def create_or_update_k8s_cluster_hpa(
         raise HTTPException(
             status_code=400, detail="At least one of cpu_target_percent or memory_target_percent is required"
         )
+    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     # Check if HPA already exists — update if so, create if not
     try:
         await k8s_client.get_hpa(namespace, name)
@@ -613,12 +789,16 @@ async def create_or_update_k8s_cluster_hpa(
 
 
 @router.delete("/clusters/{namespace}/{name}/hpa", status_code=202, summary="Delete HPA for K8s Aerospike cluster")
+@limiter.limit("20/minute")
 @_k8s_endpoint("delete HPA for Kubernetes cluster")
 async def delete_k8s_cluster_hpa(
+    request: Request,
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> DeleteResponse:
 
+    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     await k8s_client.delete_hpa(namespace, name)
     return DeleteResponse(message=f"HPA for {namespace}/{name} deleted")
 
@@ -686,8 +866,9 @@ async def get_k8s_template(
 
 
 @router.post("/templates", status_code=201, summary="Create K8s AerospikeClusterTemplate")
+@limiter.limit("20/minute")
 @_k8s_endpoint("create Kubernetes template")
-async def create_k8s_template(body: CreateK8sTemplateRequest) -> K8sTemplateSummary:
+async def create_k8s_template(request: Request, body: CreateK8sTemplateRequest) -> K8sTemplateSummary:
 
     cr = build_template_cr(body)
     result = await k8s_client.create_template(cr)
@@ -695,8 +876,10 @@ async def create_k8s_template(body: CreateK8sTemplateRequest) -> K8sTemplateSumm
 
 
 @router.patch("/templates/{name}", summary="Update K8s AerospikeClusterTemplate")
+@limiter.limit("20/minute")
 @_k8s_endpoint("update Kubernetes template")
 async def update_k8s_template(
+    request: Request,
     body: UpdateK8sTemplateRequest,
     name: str = _K8S_NAME,
 ) -> K8sTemplateSummary:
@@ -709,8 +892,10 @@ async def update_k8s_template(
 
 
 @router.delete("/templates/{name}", status_code=202, summary="Delete K8s AerospikeClusterTemplate")
+@limiter.limit("20/minute")
 @_k8s_endpoint("delete Kubernetes template")
 async def delete_k8s_template(
+    request: Request,
     name: str = _K8S_NAME,
 ) -> DeleteResponse:
 
@@ -746,12 +931,14 @@ async def delete_k8s_template(
 @router.get("/clusters/{namespace}/{name}/events", summary="Get K8s cluster events")
 @_k8s_endpoint("get Kubernetes cluster events")
 async def get_k8s_cluster_events(
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
     limit: int = Query(default=50, ge=1, le=500, description="Maximum number of events to return"),
     category: str | None = Query(default=None, description="Filter events by category"),
 ) -> list[K8sClusterEvent]:
 
+    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     field_selector = f"involvedObject.name={name},involvedObject.kind=AerospikeCluster"
     events_raw = await k8s_client.list_events(namespace, field_selector)
     events = [K8sClusterEvent(**e) for e in events_raw]
@@ -766,12 +953,16 @@ async def get_k8s_cluster_events(
     "/clusters/{namespace}/{name}/resync-template",
     summary="Trigger template resync for K8s Aerospike cluster",
 )
+@limiter.limit("20/minute")
 @_k8s_endpoint("resync template for Kubernetes cluster")
 async def resync_k8s_cluster_template(
+    request: Request,
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> K8sClusterSummary:
 
+    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     patch: dict[str, Any] = {"metadata": {"annotations": {"acko.io/resync-template": "true"}}}
     result = await k8s_client.patch_cluster(namespace, name, patch)
     return extract_summary(result)
@@ -799,15 +990,18 @@ class CloneClusterRequest(BaseModel):
     status_code=201,
     summary="Clone an existing K8s Aerospike cluster",
 )
+@limiter.limit("20/minute")
 @_k8s_endpoint("clone Kubernetes cluster")
 async def clone_k8s_cluster(
+    request: Request,
     body: CloneClusterRequest,
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> K8sClusterSummary:
     """Clone a cluster by copying its spec into a new cluster with a different name."""
 
-    source = await k8s_client.get_cluster(namespace, name)
+    source = await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     target_ns = body.namespace or namespace
 
     existing_namespaces = await k8s_client.list_namespaces()
@@ -823,6 +1017,12 @@ async def clone_k8s_cluster(
         "metadata": {"name": body.name, "namespace": target_ns},
         "spec": copy.deepcopy(source.get("spec", {})),
     }
+    # Carry the workspace label so the clone inherits the source's tenancy.
+    # Without this the cloned CR would land in the system-shared bucket and
+    # become reachable to every authenticated caller.
+    source_workspace_id = _cr_workspace_id(source)
+    if source_workspace_id is not None:
+        cr["metadata"].setdefault("labels", {})[_WORKSPACE_LABEL] = source_workspace_id
     # Remove operation state that shouldn't carry over
     cr["spec"].pop("operations", None)
     cr["spec"].pop("paused", None)
@@ -849,13 +1049,17 @@ async def clone_k8s_cluster(
 
 
 @router.post("/clusters/{namespace}/{name}/operations", summary="Trigger operation on K8s cluster")
+@limiter.limit("20/minute")
 @_k8s_endpoint("trigger operation on Kubernetes cluster")
 async def trigger_k8s_cluster_operation(
+    request: Request,
     body: OperationRequest,
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> K8sClusterSummary:
 
+    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     op_id = body.id or f"ui-{uuid.uuid4().hex[:8]}"
     operation: dict[str, Any] = {"kind": body.kind, "id": op_id}
     if body.pod_list:
@@ -869,12 +1073,16 @@ async def trigger_k8s_cluster_operation(
     "/clusters/{namespace}/{name}/operations",
     summary="Clear operations on K8s cluster",
 )
+@limiter.limit("20/minute")
 @_k8s_endpoint("clear operations on Kubernetes cluster")
 async def clear_k8s_cluster_operations(
+    request: Request,
+    caller_owner_id: CallerOwnerId,
     namespace: str = _K8S_NAMESPACE,
     name: str = _K8S_NAME,
 ) -> K8sClusterSummary:
     """Clear spec.operations to unblock a stuck cluster."""
+    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     patch: dict[str, Any] = {"spec": {"operations": []}}
     result = await k8s_client.patch_cluster(namespace, name, patch)
     return extract_summary(result)

--- a/api/src/aerospike_cluster_manager_api/routers/query.py
+++ b/api/src/aerospike_cluster_manager_api/routers/query.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 
 from aerospike_cluster_manager_api.converters import record_to_model
 from aerospike_cluster_manager_api.dependencies import AerospikeClient
 from aerospike_cluster_manager_api.models.query import QueryRequest, QueryResponse
+from aerospike_cluster_manager_api.rate_limit import limiter
 from aerospike_cluster_manager_api.services import query_service
 from aerospike_cluster_manager_api.services.query_service import SetRequiredForPkLookup
 
@@ -20,7 +21,8 @@ router = APIRouter(prefix="/query", tags=["query"])
     summary="Execute query",
     description="Execute a query against Aerospike using primary key lookup, predicate filter, or full scan.",
 )
-async def execute_query(body: QueryRequest, client: AerospikeClient) -> QueryResponse:
+@limiter.limit("30/minute")
+async def execute_query(request: Request, body: QueryRequest, client: AerospikeClient) -> QueryResponse:
     """Execute a query against Aerospike using primary key lookup, predicate filter, or full scan."""
     try:
         result = await query_service.execute_query(client, body)

--- a/api/src/aerospike_cluster_manager_api/routers/records.py
+++ b/api/src/aerospike_cluster_manager_api/routers/records.py
@@ -4,7 +4,7 @@ import logging
 from typing import Literal
 
 from aerospike_py import Record
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from starlette.responses import Response
 
 from aerospike_cluster_manager_api import db
@@ -17,6 +17,7 @@ from aerospike_cluster_manager_api.models.record import (
     RecordListResponse,
     RecordWriteRequest,
 )
+from aerospike_cluster_manager_api.rate_limit import limiter
 from aerospike_cluster_manager_api.services import records_service
 from aerospike_cluster_manager_api.services.records_service import (
     InvalidPkPattern,
@@ -202,7 +203,8 @@ async def get_record_detail(
     summary="Create or update record",
     description="Write a record to Aerospike with the specified key, bins, and optional TTL.",
 )
-async def put_record(body: RecordWriteRequest, client: AerospikeClient) -> AerospikeRecord:
+@limiter.limit("30/minute")
+async def put_record(request: Request, body: RecordWriteRequest, client: AerospikeClient) -> AerospikeRecord:
     """Write a record to Aerospike with the specified key, bins, and optional TTL.
 
     The key's particle type comes from ``body.key.pk_type`` ("auto" by default).
@@ -225,7 +227,9 @@ async def put_record(body: RecordWriteRequest, client: AerospikeClient) -> Aeros
     summary="Delete record",
     description="Delete a record identified by namespace, set, and primary key.",
 )
+@limiter.limit("30/minute")
 async def delete_record(
+    request: Request,
     client: AerospikeClient,
     ns: str = Query(..., min_length=1),
     set: str = Query(..., min_length=1),
@@ -251,7 +255,9 @@ async def delete_record(
     summary="Filtered record scan",
     description="Scan records with optional expression filters and pagination.",
 )
+@limiter.limit("30/minute")
 async def get_filtered_records(
+    request: Request,
     body: FilteredQueryRequest,
     client: AerospikeClient,
     conn_id: VerifiedConnId,

--- a/api/src/aerospike_cluster_manager_api/routers/sample_data.py
+++ b/api/src/aerospike_cluster_manager_api/routers/sample_data.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Request
 
 from aerospike_cluster_manager_api.dependencies import AerospikeClient
 from aerospike_cluster_manager_api.models.sample_data import CreateSampleDataRequest, CreateSampleDataResponse
+from aerospike_cluster_manager_api.rate_limit import limiter
 from aerospike_cluster_manager_api.services.sample_data_service import create_sample_records
 
 router = APIRouter(prefix="/sample-data", tags=["sample-data"])
@@ -15,7 +16,9 @@ router = APIRouter(prefix="/sample-data", tags=["sample-data"])
     summary="Create sample data set",
     description="Generate deterministic sample records with optional secondary indexes.",
 )
+@limiter.limit("10/minute")
 async def create_sample_data(
+    request: Request,
     body: CreateSampleDataRequest,
     client: AerospikeClient,
 ) -> CreateSampleDataResponse:

--- a/api/src/aerospike_cluster_manager_api/routers/udfs.py
+++ b/api/src/aerospike_cluster_manager_api/routers/udfs.py
@@ -5,13 +5,14 @@ import tempfile
 from pathlib import Path
 from typing import Literal, cast
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Request
 from starlette.responses import Response
 
 from aerospike_cluster_manager_api.constants import INFO_UDF_LIST
 from aerospike_cluster_manager_api.dependencies import AerospikeClient
 from aerospike_cluster_manager_api.info_parser import parse_records
 from aerospike_cluster_manager_api.models.udf import UDFModule, UploadUDFRequest
+from aerospike_cluster_manager_api.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +50,8 @@ async def get_udfs(client: AerospikeClient) -> list[UDFModule]:
     summary="Upload UDF module",
     description="Upload and register a Lua UDF module to the Aerospike cluster.",
 )
-async def upload_udf(body: UploadUDFRequest, client: AerospikeClient) -> UDFModule:
+@limiter.limit("20/minute")
+async def upload_udf(request: Request, body: UploadUDFRequest, client: AerospikeClient) -> UDFModule:
     """Upload and register a Lua UDF module to the Aerospike cluster."""
     tmp_path: str | None = None
     try:
@@ -76,7 +78,9 @@ async def upload_udf(body: UploadUDFRequest, client: AerospikeClient) -> UDFModu
     summary="Delete UDF module",
     description="Remove a registered UDF module from the Aerospike cluster by filename.",
 )
+@limiter.limit("20/minute")
 async def delete_udf(
+    request: Request,
     client: AerospikeClient,
     filename: str = Query(..., min_length=1),
 ) -> Response:

--- a/api/tests/mcp/test_k8s_tools.py
+++ b/api/tests/mcp/test_k8s_tools.py
@@ -168,10 +168,13 @@ class TestGetK8sPods:
                 "image": "aerospike/aerospike-server:8.1",
             }
         ]
-        with patch.object(
-            k8s_tools.k8s_client,
-            "list_pods",
-            new=AsyncMock(return_value=raw_pods),
+        with (
+            patch.object(k8s_tools.k8s_client, "get_cluster", new=AsyncMock(return_value=_SAMPLE_CR)),
+            patch.object(
+                k8s_tools.k8s_client,
+                "list_pods",
+                new=AsyncMock(return_value=raw_pods),
+            ),
         ):
             result = await k8s_tools.get_k8s_pods(cluster_id="default/cl")
 
@@ -186,7 +189,7 @@ class TestGetK8sPods:
         with (
             patch.object(
                 k8s_tools.k8s_client,
-                "list_pods",
+                "get_cluster",
                 new=AsyncMock(side_effect=K8sApiError(status=404, reason="NotFound", message="cl missing")),
             ),
             pytest.raises(MCPToolError) as exc_info,
@@ -214,10 +217,13 @@ class TestGetK8sEvents:
                 "source": "operator",
             }
         ]
-        with patch.object(
-            k8s_tools.k8s_client,
-            "list_events",
-            new=AsyncMock(return_value=raw_events),
+        with (
+            patch.object(k8s_tools.k8s_client, "get_cluster", new=AsyncMock(return_value=_SAMPLE_CR)),
+            patch.object(
+                k8s_tools.k8s_client,
+                "list_events",
+                new=AsyncMock(return_value=raw_events),
+            ),
         ):
             result = await k8s_tools.get_k8s_events(cluster_id="default/cl")
 
@@ -240,10 +246,13 @@ class TestGetK8sEvents:
                 "source": "operator",
             }
         ]
-        with patch.object(
-            k8s_tools.k8s_client,
-            "list_events",
-            new=AsyncMock(return_value=raw_events),
+        with (
+            patch.object(k8s_tools.k8s_client, "get_cluster", new=AsyncMock(return_value=_SAMPLE_CR)),
+            patch.object(
+                k8s_tools.k8s_client,
+                "list_events",
+                new=AsyncMock(return_value=raw_events),
+            ),
         ):
             result = await k8s_tools.get_k8s_events(cluster_id="default/cl", since_minutes=10)
 
@@ -323,6 +332,7 @@ class TestGetK8sLogs:
 
         read_pod_log_mock = AsyncMock(return_value="line1\nline2\nline3")
         with (
+            patch.object(k8s_tools.k8s_client, "get_cluster", new=AsyncMock(return_value=_SAMPLE_CR)),
             patch.object(
                 k8s_tools.k8s_client,
                 "list_pods",
@@ -359,6 +369,7 @@ class TestGetK8sLogs:
 
         log_text = "\n".join(f"line{i}" for i in range(5))
         with (
+            patch.object(k8s_tools.k8s_client, "get_cluster", new=AsyncMock(return_value=_SAMPLE_CR)),
             patch.object(
                 k8s_tools.k8s_client,
                 "list_pods",
@@ -378,6 +389,7 @@ class TestGetK8sLogs:
         from aerospike_cluster_manager_api.mcp.tools import k8s as k8s_tools
 
         with (
+            patch.object(k8s_tools.k8s_client, "get_cluster", new=AsyncMock(return_value=_SAMPLE_CR)),
             patch.object(
                 k8s_tools.k8s_client,
                 "list_pods",


### PR DESCRIPTION
## Summary
Closes the cross-tenant data-plane gap surfaced in the security review: the ACL was only enforced on `notes` endpoints, every other `conn_id`-bearing route only verified existence. After this PR a workspace's connections, records, clusters, queries, admin/udf/sample-data calls, and K8s management endpoints are all gated by `caller_owner_id`.

## What changed
- **Default-deny dependency**: `_get_verified_connection` / `_get_client` now resolve `caller_owner_id` and 404 when the connection's workspace ownerId doesn't match. SYSTEM_OWNER_ID workspaces remain visible (legacy single-tenant). Anonymous / `DBNotInitialized` falls back to permissive — covers unit tests and OIDC-disabled deployments.
- **K8s router**: each per-cluster endpoint resolves the workspace from `acm.aerospike.com/workspace` CR label and rejects cross-tenant access. `create_k8s_cluster` stamps the label when the caller owns a user workspace; `import_k8s_cluster` and `clone_k8s_cluster` validate caller ownership. Pod logs gain `since_seconds` query (#317 follow-up).
- **MCP tools**: `connections` (create/update/list) propagate `caller_owner_id`; `k8s` tools resolve the cluster's workspace inside the body so the registry decorator's `workspace_id`-only gate cannot be bypassed by passing only `cluster_id`.
- **Per-route rate limits**: records 30/min, query 30/min, admin/udfs/k8s mutations 20/min, sample-data 10/min. Limiter `default_limits` and SSE exempt land in Phase 2C.

## Stack
1. **This PR (Phase 1A)** ← `main`
2. Phase 1B — API stability
3. Phase 1C — UI fixes
4. Phase 1D — config alignment
5. Phase 2A — `python-jose` → PyJWT
6. Phase 2B — Fernet at-rest password encryption
7. Phase 2C — rate limiter core (default_limits + leftmost-untrusted XFF)

## Test plan
- [x] `cd api && uv run pytest --no-header -q` — 967 passed (single-PR scope)
- [x] e2e: workspace list returns `ownerId:"system"`; cross-tenant access on a foreign conn returns 404; mutation rate limit triggers 429 at the configured threshold
- [ ] Verify against a real Keycloak realm with two users (deferred to staging)