### PR TITLE
chore(config): align compose / env / Dockerfile + UI error mapping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,30 @@ K8S_MANAGEMENT_ENABLED=false
 #   K8S_MANAGEMENT_ENABLED=true
 #   KUBECONFIG=${HOME}/.kube/config
 # The API auto-loads kubeconfig outside the cluster; the `kind-kind` context
-# from run-local is picked up automatically.
+# from run-local is picked up automatically. There is no separate
+# K8S_KUBECONFIG_PATH variable — the python ``kubernetes`` client honours
+# the standard ``KUBECONFIG`` env var directly.
+
+# ─── OIDC / Keycloak ───────────────────────────────────────────────────────
+# Native JWT verification middleware. When OIDC_ENABLED=false the middleware
+# is installed but no-ops, so non-prod and unit-test deployments need no IdP.
+# OIDC_ENABLED=false
+# Keycloak realm root, e.g. https://keycloak.example.com/realms/acko. The
+# middleware appends /.well-known/openid-configuration to discover jwks_uri.
+# OIDC_ISSUER_URL=
+# Single-audience claim (contract C-4). The SPA mints tokens with aud=acko-api.
+# OIDC_AUDIENCE=acko-api
+# CSV ("acko:dev,acko:prod") or JSON list ("[\"acko:dev\"]"). Empty = auth-only,
+# no role check. Resolved against decoded["realm_access"]["roles"].
+# OIDC_REQUIRED_ROLES=
+# JWKS cache TTL. Accepts "10m"/"1h"/"2d" or bare seconds ("600").
+# OIDC_JWKS_CACHE_TTL=10m
+# Comma-separated paths that bypass auth entirely (exact match).
+# OIDC_EXCLUDE_PATHS=/api/health,/api/openapi.json,/api/docs
+# OIDC claim used as workspace-owner identity. Defaults to ``sub`` (OIDC core
+# stable subject id). Switch to ``preferred_username`` only if the IdP's sub
+# is unstable across logins.
+# ACM_OIDC_OWNER_CLAIM=sub
 
 # ─── Security Headers ──────────────────────────────────────────────────────
 # Enable HSTS only when serving over TLS.

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,7 +1,7 @@
 # =============================================================================
 # API (FastAPI) — standalone image
 # =============================================================================
-FROM python:3.14-slim AS builder
+FROM python:3.13-slim AS builder
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app/api
@@ -15,7 +15,7 @@ RUN uv sync --frozen --no-dev
 # =============================================================================
 # Runtime
 # =============================================================================
-FROM python:3.14-slim AS runtime
+FROM python:3.13-slim AS runtime
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \

--- a/compose-pg.yaml
+++ b/compose-pg.yaml
@@ -23,7 +23,10 @@ services:
       - postgres-data:/var/lib/postgresql/data
     restart: unless-stopped
 
-  aerospike-cluster-manager:
+  # Override the API service from compose.yaml (split into -api / -web in #?)
+  # so the Postgres backend is reached from the FastAPI process. The web
+  # container has no DB awareness and does not need these vars.
+  aerospike-cluster-manager-api:
     environment:
       - ENABLE_POSTGRES=true
       - DATABASE_URL=postgresql://aerospike:aerospike@postgres:5432/aerospike_manager

--- a/compose.yaml
+++ b/compose.yaml
@@ -130,6 +130,36 @@ services:
       - AEROSPIKE_HOST=${AEROSPIKE_HOST:-aerospike-node-1}
       - AEROSPIKE_PORT=${AEROSPIKE_PORT:-3000}
       - SQLITE_PATH=/app/data/connections.db
+      # ── OIDC (off by default) ─────────────────────────────────────
+      - OIDC_ENABLED=${OIDC_ENABLED:-false}
+      - OIDC_ISSUER_URL=${OIDC_ISSUER_URL:-}
+      - OIDC_AUDIENCE=${OIDC_AUDIENCE:-acko-api}
+      - OIDC_REQUIRED_ROLES=${OIDC_REQUIRED_ROLES:-}
+      - OIDC_JWKS_CACHE_TTL=${OIDC_JWKS_CACHE_TTL:-10m}
+      - OIDC_EXCLUDE_PATHS=${OIDC_EXCLUDE_PATHS:-/api/health,/api/openapi.json,/api/docs}
+      - ACM_OIDC_OWNER_CLAIM=${ACM_OIDC_OWNER_CLAIM:-sub}
+      # ── MCP (off by default) ──────────────────────────────────────
+      - ACM_MCP_ENABLED=${ACM_MCP_ENABLED:-false}
+      - ACM_MCP_PATH=${ACM_MCP_PATH:-/mcp}
+      - ACM_MCP_TOKEN=${ACM_MCP_TOKEN:-}
+      - ACM_MCP_ACCESS_PROFILE=${ACM_MCP_ACCESS_PROFILE:-read_only}
+      - ACM_MCP_ALLOW_ANONYMOUS=${ACM_MCP_ALLOW_ANONYMOUS:-false}
+      # ── Kubernetes management (off by default) ────────────────────
+      - K8S_MANAGEMENT_ENABLED=${K8S_MANAGEMENT_ENABLED:-false}
+      - K8S_VERIFY_SSL=${K8S_VERIFY_SSL:-true}
+      - K8S_API_TIMEOUT=${K8S_API_TIMEOUT:-10}
+      - K8S_LOG_TIMEOUT=${K8S_LOG_TIMEOUT:-30}
+      - K8S_CA_FILE=${K8S_CA_FILE:-}
+      # ── Security headers / SSE ────────────────────────────────────
+      - ENABLE_HSTS=${ENABLE_HSTS:-false}
+      - CSP_ENABLED=${CSP_ENABLED:-true}
+      - CSP_REPORT_URI=${CSP_REPORT_URI:-}
+      - SSE_ENABLED=${SSE_ENABLED:-true}
+      - SSE_HEARTBEAT_INTERVAL=${SSE_HEARTBEAT_INTERVAL:-15}
+      - SSE_MAX_CONNECTIONS=${SSE_MAX_CONNECTIONS:-50}
+      # ── Logging ───────────────────────────────────────────────────
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - LOG_FORMAT=${LOG_FORMAT:-text}
     volumes:
       - app-data:/app/data
     healthcheck:

--- a/ui/src/app/(main)/acko/templates/page.tsx
+++ b/ui/src/app/(main)/acko/templates/page.tsx
@@ -65,7 +65,9 @@ export default function AckoTemplatesPage() {
           >
             Refresh
           </Button>
-          <Button variant="primary">New template</Button>
+          <Button variant="primary" disabled title="Coming soon">
+            New template
+          </Button>
         </div>
       </header>
 

--- a/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
@@ -20,7 +20,7 @@ import { mapApiError } from "@/lib/api/error-mapping"
 import { logFetchError } from "@/lib/api/log"
 import type { AerospikeRole, AerospikeUser } from "@/lib/types/admin"
 import { RiShieldKeyholeLine } from "@remixicon/react"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 type PageProps = { params: { clusterId: string } }
 
@@ -40,6 +40,7 @@ export default function AdminPage({ params }: PageProps) {
   const [securityDisabled, setSecurityDisabled] = useState(false)
   const [createUserOpen, setCreateUserOpen] = useState(false)
   const [createRoleOpen, setCreateRoleOpen] = useState(false)
+  const [userFilter, setUserFilter] = useState("")
 
   const load = useCallback(async () => {
     setUsersState((s) => ({ ...s, loading: true, error: null }))
@@ -100,6 +101,8 @@ export default function AdminPage({ params }: PageProps) {
           <UsersSection
             state={usersState}
             onCreate={() => setCreateUserOpen(true)}
+            filter={userFilter}
+            onFilterChange={setUserFilter}
           />
           <RolesSection
             state={rolesState}
@@ -163,10 +166,25 @@ function SecurityDisabledState() {
 function UsersSection({
   state,
   onCreate,
+  filter,
+  onFilterChange,
 }: {
   state: LoadState<AerospikeUser[]>
   onCreate: () => void
+  filter: string
+  onFilterChange: (value: string) => void
 }) {
+  const filtered = useMemo(() => {
+    if (!state.data) return null
+    const q = filter.trim().toLowerCase()
+    if (!q) return state.data
+    return state.data.filter(
+      (u) =>
+        u.username.toLowerCase().includes(q) ||
+        u.roles.some((r) => r.toLowerCase().includes(q)),
+    )
+  }, [state.data, filter])
+
   return (
     <section className="flex flex-col gap-3">
       <div className="flex items-end justify-between">
@@ -176,6 +194,8 @@ function UsersSection({
         <div className="flex gap-2">
           <Input
             type="search"
+            value={filter}
+            onChange={(e) => onFilterChange(e.target.value)}
             placeholder="Filter users..."
             className="sm:w-60"
           />
@@ -213,8 +233,8 @@ function UsersSection({
             <TableBody>
               {state.loading ? (
                 <SkeletonRows cols={6} rows={3} />
-              ) : state.data && state.data.length > 0 ? (
-                state.data.map((u) => (
+              ) : filtered && filtered.length > 0 ? (
+                filtered.map((u) => (
                   <TableRow key={u.username}>
                     <TableCell>
                       <span className="font-mono font-semibold text-gray-900 dark:text-gray-50">
@@ -240,7 +260,12 @@ function UsersSection({
                       {u.connections ?? 0}
                     </TableCell>
                     <TableCell className="text-right">
-                      <Button variant="ghost" className="h-7 px-2 text-xs">
+                      <Button
+                        variant="ghost"
+                        disabled
+                        title="Edit coming soon"
+                        className="h-7 px-2 text-xs"
+                      >
                         Edit
                       </Button>
                     </TableCell>
@@ -252,7 +277,9 @@ function UsersSection({
                     colSpan={6}
                     className="py-6 text-center text-sm text-gray-500"
                   >
-                    No users.
+                    {state.data && state.data.length > 0
+                      ? "No users match the filter."
+                      : "No users."}
                   </TableCell>
                 </TableRow>
               )}
@@ -329,7 +356,12 @@ function RolesSection({
                       )}
                     </TableCell>
                     <TableCell className="text-right">
-                      <Button variant="ghost" className="h-7 px-2 text-xs">
+                      <Button
+                        variant="ghost"
+                        disabled
+                        title="Edit coming soon"
+                        className="h-7 px-2 text-xs"
+                      >
                         Edit
                       </Button>
                     </TableCell>

--- a/ui/src/app/(main)/clusters/[clusterId]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/page.tsx
@@ -64,7 +64,13 @@ export default function ClusterOverview({ params }: PageProps) {
           >
             Refresh
           </Button>
-          <Button variant="primary">Open in AQL</Button>
+          <Button
+            variant="primary"
+            disabled
+            title="Use the dedicated terminal page"
+          >
+            Open in AQL
+          </Button>
         </div>
       </header>
 
@@ -93,8 +99,12 @@ export default function ClusterOverview({ params }: PageProps) {
               </p>
             </div>
             <div className="flex gap-2">
-              <Button variant="secondary">View CR</Button>
-              <Button variant="secondary">Events</Button>
+              <Button variant="secondary" disabled title="Coming soon">
+                View CR
+              </Button>
+              <Button variant="secondary" disabled title="Coming soon">
+                Events
+              </Button>
             </div>
           </div>
           <dl className="grid grid-cols-2 gap-4 sm:grid-cols-4">

--- a/ui/src/app/(main)/clusters/[clusterId]/secondary-indexes/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/secondary-indexes/page.tsx
@@ -3,6 +3,7 @@
 import { Badge } from "@/components/Badge"
 import { Button } from "@/components/Button"
 import { Card } from "@/components/Card"
+import { CreateIndexDialog } from "@/components/dialogs/CreateIndexDialog"
 import { ErrorBanner } from "@/components/ErrorBanner"
 import { Input } from "@/components/Input"
 import {
@@ -37,6 +38,7 @@ export default function SecondaryIndexesPage({ params }: PageProps) {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [filter, setFilter] = useState("")
+  const [createOpen, setCreateOpen] = useState(false)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -98,9 +100,20 @@ export default function SecondaryIndexesPage({ params }: PageProps) {
           >
             Refresh
           </Button>
-          <Button variant="primary">Create index</Button>
+          <Button variant="primary" onClick={() => setCreateOpen(true)}>
+            Create index
+          </Button>
         </div>
       </header>
+
+      <CreateIndexDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        connId={params.clusterId}
+        onSuccess={() => {
+          void load()
+        }}
+      />
 
       {error && (
         <ErrorBanner

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
@@ -180,9 +180,17 @@ function draftToBin(draft: string, kind: BinKind): BinValue {
 
 const TTL_NEVER_SENTINEL = 4_294_967_295
 
+// TTL semantics:
+//   -1                    → "never expire" (record stays forever)
+//    0                    → "keep current ttl" (only meaningful at write time;
+//                            on read this means "no expiry was set", i.e. keep
+//                            namespace default — render as "keep")
+//    TTL_NEVER_SENTINEL   → server's wire representation of "never" on the read path
+//    > 0                  → seconds remaining until expiry
 function formatTtl(ttl: number | undefined): string {
   if (ttl === undefined) return "—"
-  if (ttl === -1 || ttl === 0 || ttl === TTL_NEVER_SENTINEL) return "never"
+  if (ttl === -1 || ttl === TTL_NEVER_SENTINEL) return "never"
+  if (ttl === 0) return "keep"
   if (ttl >= 86400)
     return `${Math.floor(ttl / 86400)}d ${Math.floor((ttl % 86400) / 3600)}h`
   if (ttl >= 3600)
@@ -320,12 +328,19 @@ export default function RecordDetailPage({ params }: PageProps) {
     if (!record) return
     setDrafts(buildInitialDraft(record))
     const ttl = record.meta.ttl
-    // When the record is set to "never expire", start with 0 (= keep TTL) so we don't force a new TTL on save.
-    setTtlDraft(
-      ttl === undefined || ttl === -1 || ttl === TTL_NEVER_SENTINEL
-        ? "-1"
-        : String(ttl),
-    )
+    // Editor seeding:
+    //   -1 / sentinel → "-1" (record is set to never expire — preserve)
+    //   0             → "" (means "keep current TTL on save"; show empty so the
+    //                       placeholder explains the rules and the user can opt in)
+    //   undefined     → "" (no TTL info — same default behaviour as 0)
+    //   > 0           → echo the remaining seconds
+    if (ttl === -1 || ttl === TTL_NEVER_SENTINEL) {
+      setTtlDraft("-1")
+    } else if (ttl === undefined || ttl === 0) {
+      setTtlDraft("")
+    } else {
+      setTtlDraft(String(ttl))
+    }
     setBinErrors({})
     setIsEditing(true)
   }

--- a/ui/src/app/(main)/clusters/[clusterId]/udfs/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/udfs/page.tsx
@@ -3,6 +3,7 @@
 import { Badge } from "@/components/Badge"
 import { Button } from "@/components/Button"
 import { Card } from "@/components/Card"
+import { RegisterUdfDialog } from "@/components/dialogs/RegisterUdfDialog"
 import { ErrorBanner } from "@/components/ErrorBanner"
 import { Input } from "@/components/Input"
 import {
@@ -27,6 +28,7 @@ export default function UdfsPage({ params }: PageProps) {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [filter, setFilter] = useState("")
+  const [registerOpen, setRegisterOpen] = useState(false)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -82,9 +84,20 @@ export default function UdfsPage({ params }: PageProps) {
           >
             Refresh
           </Button>
-          <Button variant="primary">Register UDF</Button>
+          <Button variant="primary" onClick={() => setRegisterOpen(true)}>
+            Register UDF
+          </Button>
         </div>
       </header>
+
+      <RegisterUdfDialog
+        open={registerOpen}
+        onOpenChange={setRegisterOpen}
+        connId={params.clusterId}
+        onSuccess={() => {
+          void load()
+        }}
+      />
 
       {error && (
         <ErrorBanner

--- a/ui/src/components/clusters/AddressCopyCell.tsx
+++ b/ui/src/components/clusters/AddressCopyCell.tsx
@@ -59,6 +59,20 @@ export function AddressCopyCell({
   className,
 }: AddressCopyCellProps) {
   const [status, setStatus] = React.useState<CopyStatus>("idle")
+  // Tracks the most recent feedback-reset timer so rapid double-clicks don't
+  // race a stale callback into resetting the status, and so the timer is
+  // canceled if the cell unmounts mid-feedback (otherwise React warns about
+  // setState on an unmounted component).
+  const resetTimerRef = React.useRef<number | null>(null)
+
+  React.useEffect(() => {
+    return () => {
+      if (resetTimerRef.current !== null) {
+        window.clearTimeout(resetTimerRef.current)
+        resetTimerRef.current = null
+      }
+    }
+  }, [])
 
   if (hosts.length === 0) {
     return (
@@ -80,9 +94,17 @@ export function AddressCopyCell({
     event.stopPropagation()
     const ok = await copyText(seedList)
     setStatus(ok ? "copied" : "error")
+    // Cancel any in-flight reset before scheduling a new one so the feedback
+    // window doesn't get cut short by the previous click's pending timer.
+    if (resetTimerRef.current !== null) {
+      window.clearTimeout(resetTimerRef.current)
+    }
     // Hold the feedback long enough for a glance — the previous 1.5s window
     // was too short for the change to register reliably (#319 follow-up).
-    window.setTimeout(() => setStatus("idle"), 2500)
+    resetTimerRef.current = window.setTimeout(() => {
+      setStatus("idle")
+      resetTimerRef.current = null
+    }, 2500)
   }
 
   const tooltipContent =

--- a/ui/src/components/clusters/ClusterCard.tsx
+++ b/ui/src/components/clusters/ClusterCard.tsx
@@ -25,15 +25,31 @@ export function ClusterCard({
   const hasCustomLabels =
     Object.keys(row.labels).filter((k) => k !== ENV_LABEL_KEY).length > 0
 
-  const cardInner = (
+  // To keep the whole card clickable while still allowing nested interactive
+  // elements (the Edit button and the AddressCopyCell copy button), we render
+  // the navigation as an absolutely-positioned anchor *behind* the interactive
+  // controls (`relative` card + `absolute inset-0` link with `z-0`). All
+  // interactive children opt in with `relative z-10`. This avoids the invalid
+  // `<a><button></a>` nesting that the previous implementation produced.
+  return (
     <Card
       className={cx(
-        "flex h-full flex-col gap-3 transition",
+        "relative flex h-full flex-col gap-3 transition",
         row.connId &&
           "hover:border-indigo-300 hover:shadow-sm dark:hover:border-indigo-700",
       )}
     >
-      <div className="flex items-start gap-3">
+      {row.connId && (
+        <Link
+          href={clusterSections.overview(row.connId)}
+          aria-label={`Open ${row.displayName}`}
+          className={cx(
+            "absolute inset-0 z-0 rounded-md focus-visible:outline-none",
+            focusRing,
+          )}
+        />
+      )}
+      <div className="relative z-10 flex items-start gap-3">
         <span
           aria-hidden="true"
           className="mt-1 h-6 w-1 shrink-0 rounded-sm"
@@ -80,17 +96,21 @@ export function ClusterCard({
       </div>
 
       {row.profile && hasCustomLabels && (
-        <LabelsCell labels={row.labels} hideEnv />
+        <div className="relative z-10">
+          <LabelsCell labels={row.labels} hideEnv />
+        </div>
       )}
 
-      <AddressCopyCell
-        hosts={row.hosts}
-        port={row.port}
-        fallback={row.k8sNamespace ?? "—"}
-        className="text-xs"
-      />
+      <div className="relative z-10">
+        <AddressCopyCell
+          hosts={row.hosts}
+          port={row.port}
+          fallback={row.k8sNamespace ?? "—"}
+          className="text-xs"
+        />
+      </div>
 
-      <div className="mt-auto flex items-center justify-between gap-2 border-t border-gray-200 pt-3 dark:border-gray-800">
+      <div className="relative z-10 mt-auto flex items-center justify-between gap-2 border-t border-gray-200 pt-3 dark:border-gray-800">
         <span className="text-xs text-gray-500 dark:text-gray-500">
           {row.managedBy === "ACKO" ? "ACKO" : "Manual"}
         </span>
@@ -112,16 +132,4 @@ export function ClusterCard({
       </div>
     </Card>
   )
-
-  if (row.connId) {
-    return (
-      <Link
-        href={clusterSections.overview(row.connId)}
-        className={cx("block focus-visible:outline-none", focusRing)}
-      >
-        {cardInner}
-      </Link>
-    )
-  }
-  return cardInner
 }

--- a/ui/src/components/k8s/create-cluster-wizard/StepNamespaceStorage.tsx
+++ b/ui/src/components/k8s/create-cluster-wizard/StepNamespaceStorage.tsx
@@ -12,6 +12,7 @@ import type {
   CreateK8sClusterRequest,
   StorageVolumeConfig,
 } from "@/lib/types/k8s"
+import { useEffect } from "react"
 
 interface StepNamespaceStorageProps {
   form: CreateK8sClusterRequest
@@ -46,10 +47,20 @@ export function StepNamespaceStorage({
       ? form.namespaces
       : [defaultMemoryNamespace(clusterSize, 0)]
 
-  // Ensure the form always carries at least one namespace by syncing on mount when defaulted
-  if (!form.namespaces || form.namespaces.length === 0) {
-    updateForm({ namespaces })
-  }
+  // Ensure the form always carries at least one namespace by syncing once after mount
+  // when the form was constructed without any. Calling setState during render is a
+  // React error; an effect runs after commit so the parent receives the default
+  // without re-rendering the child mid-render.
+  const needsDefault = !form.namespaces || form.namespaces.length === 0
+  useEffect(() => {
+    if (needsDefault) {
+      updateForm({ namespaces: [defaultMemoryNamespace(clusterSize, 0)] })
+    }
+    // We intentionally only depend on whether a default is needed; ``updateForm``
+    // is a stable dispatcher from the parent reducer-style pattern and including
+    // it would re-fire if the parent recreates it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [needsDefault, clusterSize])
 
   const {
     keys: nsKeys,

--- a/ui/src/components/ui/navigation/DropdownUserProfile.tsx
+++ b/ui/src/components/ui/navigation/DropdownUserProfile.tsx
@@ -14,6 +14,8 @@ import {
   DropdownMenuSubMenuTrigger,
   DropdownMenuTrigger,
 } from "@/components/Dropdown"
+import { logout as keycloakLogout } from "@/lib/auth/keycloak"
+import { useAuthStore } from "@/stores/auth-store"
 import {
   RiArrowRightUpLine,
   RiComputerLine,
@@ -34,6 +36,7 @@ export function DropdownUserProfile({
 }: DropdownUserProfileProps) {
   const [mounted, setMounted] = React.useState(false)
   const { theme, setTheme } = useTheme()
+  const claims = useAuthStore((s) => s.claims)
   React.useEffect(() => {
     setMounted(true)
   }, [])
@@ -41,12 +44,40 @@ export function DropdownUserProfile({
   if (!mounted) {
     return null
   }
+
+  const labelText =
+    claims?.email?.trim() ||
+    claims?.preferred_username?.trim() ||
+    claims?.name?.trim() ||
+    "Local user"
+  const isAuthenticated = Boolean(claims)
+
+  const handleSignOut = async (event: Event) => {
+    // Prevent the menu's default close-on-select from racing the redirect.
+    event.preventDefault()
+    try {
+      if (isAuthenticated) {
+        await keycloakLogout()
+      } else {
+        // OIDC disabled — best we can do is clear local state and refresh.
+        useAuthStore.getState().clear()
+        if (typeof window !== "undefined") {
+          window.location.reload()
+        }
+      }
+    } catch {
+      // logout() already redirects on success; on failure, fall back to clearing
+      // local state so the next API call exits the broken session cleanly.
+      useAuthStore.getState().clear()
+    }
+  }
+
   return (
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
         <DropdownMenuContent align={align}>
-          <DropdownMenuLabel>emma.stone@acme.com</DropdownMenuLabel>
+          <DropdownMenuLabel>{labelText}</DropdownMenuLabel>
           <DropdownMenuGroup>
             <DropdownMenuSubMenu>
               <DropdownMenuSubMenuTrigger>Theme</DropdownMenuSubMenuTrigger>
@@ -117,7 +148,13 @@ export function DropdownUserProfile({
           </DropdownMenuGroup>
           <DropdownMenuSeparator />
           <DropdownMenuGroup>
-            <DropdownMenuItem>Sign out</DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={(event) => {
+                void handleSignOut(event)
+              }}
+            >
+              Sign out
+            </DropdownMenuItem>
           </DropdownMenuGroup>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/ui/src/components/ui/navigation/UserProfile.tsx
+++ b/ui/src/components/ui/navigation/UserProfile.tsx
@@ -2,11 +2,56 @@
 
 import { Button } from "@/components/Button"
 import { cx, focusRing } from "@/lib/utils"
+import { useAuthStore } from "@/stores/auth-store"
 import { RiMore2Fill } from "@remixicon/react"
 
 import { DropdownUserProfile } from "./DropdownUserProfile"
 
+/**
+ * Derive a "display name" + 1–2 char monogram for the avatar bubble.
+ *
+ * - Authenticated: prefer ``name`` → ``preferred_username`` → ``email``
+ * - Unauthenticated (OIDC disabled / not yet logged in): "Local user" / "LU"
+ *
+ * The monogram is computed from the same source as the display name to keep
+ * them in sync when one is missing.
+ */
+function deriveIdentity(): { display: string; initials: string } {
+  const claims = useAuthStore.getState().claims
+  if (!claims) {
+    return { display: "Local user", initials: "LU" }
+  }
+  const display =
+    claims.name?.trim() ||
+    claims.preferred_username?.trim() ||
+    claims.email?.trim() ||
+    "User"
+  const trimmed = display.trim()
+  const parts = trimmed.split(/\s+/).filter(Boolean)
+  let initials: string
+  if (parts.length >= 2) {
+    initials = (parts[0][0] + parts[1][0]).toUpperCase()
+  } else if (trimmed.includes("@")) {
+    // emails: take first 2 chars of the local part
+    initials = trimmed.split("@")[0].slice(0, 2).toUpperCase()
+  } else {
+    initials = trimmed.slice(0, 2).toUpperCase()
+  }
+  return { display, initials: initials || "U" }
+}
+
+function useIdentity(): { display: string; initials: string } {
+  const claims = useAuthStore((s) => s.claims)
+  if (!claims) {
+    return { display: "Local user", initials: "LU" }
+  }
+  // Re-use the pure helper but read from the current claims so React
+  // re-renders when the store changes.
+  return deriveIdentity()
+}
+
 export const UserProfileDesktop = () => {
+  const { display, initials } = useIdentity()
   return (
     <DropdownUserProfile>
       <Button
@@ -22,9 +67,9 @@ export const UserProfileDesktop = () => {
             className="flex size-8 shrink-0 items-center justify-center rounded-full border border-gray-300 bg-white text-xs text-gray-700 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-300"
             aria-hidden="true"
           >
-            ES
+            {initials}
           </span>
-          <span>Emma Stone</span>
+          <span className="truncate">{display}</span>
         </span>
         <RiMore2Fill
           className="size-4 shrink-0 text-gray-500 group-hover:text-gray-700 group-hover:dark:text-gray-400"
@@ -36,6 +81,7 @@ export const UserProfileDesktop = () => {
 }
 
 export const UserProfileMobile = () => {
+  const { initials } = useIdentity()
   return (
     <DropdownUserProfile align="end">
       <Button
@@ -49,7 +95,7 @@ export const UserProfileMobile = () => {
           className="flex size-7 shrink-0 items-center justify-center rounded-full border border-gray-300 bg-white text-xs text-gray-700 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-300"
           aria-hidden="true"
         >
-          ES
+          {initials}
         </span>
       </Button>
     </DropdownUserProfile>

--- a/ui/src/hooks/use-event-stream.ts
+++ b/ui/src/hooks/use-event-stream.ts
@@ -48,7 +48,12 @@ export function useEventStream<T = unknown>(
       sub = subscribeEvents<T>({
         types,
         onOpen: () => {
-          if (!cancelled) setConnected(true)
+          if (!cancelled) {
+            // A successful (re)open means whatever previous error we surfaced
+            // is no longer current — clear it so the consumer's banner clears.
+            setError(null)
+            setConnected(true)
+          }
         },
         onError: (err) => {
           if (cancelled) return

--- a/ui/src/lib/api/error-mapping.ts
+++ b/ui/src/lib/api/error-mapping.ts
@@ -10,14 +10,20 @@ import { ApiError } from "./client"
  *   - 403 with EE_MSG ("Security is not enabled…") → security-disabled card
  *   - 403 otherwise                                 → permission-denied
  *   - 404                                           → empty state for the resource
+ *   - 409                                           → conflict banner (record/version mismatch)
+ *   - 422                                           → validation banner, surface backend detail
  *   - 503                                           → banner + retry, do not hide page
+ *   - 504                                           → timeout banner, suggest retry
  *   - everything else                               → generic banner
  */
 export type ApiErrorKind =
   | { kind: "security-disabled"; message: string }
   | { kind: "permission-denied"; message: string }
   | { kind: "not-found"; message: string }
+  | { kind: "conflict"; message: string }
+  | { kind: "validation"; message: string }
   | { kind: "unreachable"; message: string }
+  | { kind: "timeout"; message: string }
   | { kind: "generic"; message: string }
 
 const SECURITY_DISABLED_MARKERS = ["security is not enabled", "ee_msg"] as const
@@ -37,8 +43,25 @@ export function mapApiError(err: unknown): ApiErrorKind {
         return { kind: "permission-denied", message: err.detail }
       case 404:
         return { kind: "not-found", message: err.detail }
+      case 409:
+        return {
+          kind: "conflict",
+          message: err.detail || "Conflict — record/version mismatch",
+        }
+      case 422:
+        // FastAPI validation + aerospike-py RustPanic land here. Prefer the
+        // backend detail string verbatim; only synthesize when it is empty.
+        return {
+          kind: "validation",
+          message: err.detail ? `Validation: ${err.detail}` : "Validation error",
+        }
       case 503:
         return { kind: "unreachable", message: err.detail }
+      case 504:
+        return {
+          kind: "timeout",
+          message: err.detail || "Aerospike timeout — try again",
+        }
       default:
         return { kind: "generic", message: err.detail }
     }

--- a/ui/src/lib/api/events.ts
+++ b/ui/src/lib/api/events.ts
@@ -12,6 +12,7 @@
  * Authorization header path.
  */
 
+import { refreshToken } from "@/lib/auth/keycloak"
 import { useAuthStore } from "@/stores/auth-store"
 import { useClusterSelectorStore } from "@/stores/cluster-selector-store"
 
@@ -36,19 +37,11 @@ export interface EventSubscription {
   readonly source: EventSource
 }
 
-/**
- * Subscribe to the backend SSE event stream. Returns a handle with a
- * `close()` method. Safe to call from the client only (EventSource is
- * browser-only; will throw in server components).
- */
-export function subscribeEvents<T = unknown>(
-  options: SubscribeEventsOptions<T> = {},
-): EventSubscription {
-  if (typeof window === "undefined" || typeof EventSource === "undefined") {
-    throw new Error("subscribeEvents can only be used in the browser")
-  }
-  const { types, onMessage, onError, onOpen } = options
+/** Backoff envelope for the auto-reconnect loop. */
+const RECONNECT_INITIAL_MS = 1_000
+const RECONNECT_MAX_MS = 30_000
 
+function buildStreamUrl(types?: string[]): string {
   const params = new URLSearchParams()
   if (types && types.length > 0) params.set("types", types.join(","))
 
@@ -80,9 +73,33 @@ export function subscribeEvents<T = unknown>(
 
   const qs = params.toString()
   const baseHost = active?.apiUrl?.replace(/\/+$/, "") ?? ""
-  const url = `${baseHost}${API_PREFIX}/events/stream${qs ? `?${qs}` : ""}`
+  return `${baseHost}${API_PREFIX}/events/stream${qs ? `?${qs}` : ""}`
+}
 
-  const source = new EventSource(url)
+/**
+ * Subscribe to the backend SSE event stream. Returns a handle with a
+ * `close()` method. Safe to call from the client only (EventSource is
+ * browser-only; will throw in server components).
+ *
+ * Auth-aware reconnect: when the EventSource transitions to ``CLOSED`` (the
+ * only state we can observe — ``EventSource`` does not surface HTTP status
+ * codes), we treat it as a likely 401/expired-token and try to refresh the
+ * access token before re-opening the stream. We back off exponentially
+ * (1s → 30s) on repeated failures so a permanently-broken auth doesn't melt
+ * the API into a reconnect storm.
+ */
+export function subscribeEvents<T = unknown>(
+  options: SubscribeEventsOptions<T> = {},
+): EventSubscription {
+  if (typeof window === "undefined" || typeof EventSource === "undefined") {
+    throw new Error("subscribeEvents can only be used in the browser")
+  }
+  const { types, onMessage, onError, onOpen } = options
+
+  let source: EventSource | null = null
+  let closed = false
+  let reconnectTimer: number | null = null
+  let backoffMs = RECONNECT_INITIAL_MS
 
   const messageHandler = (ev: MessageEvent) => {
     if (!onMessage) return
@@ -101,12 +118,88 @@ export function subscribeEvents<T = unknown>(
     onMessage(wrapped)
   }
 
-  source.addEventListener("message", messageHandler)
-  if (onOpen) source.addEventListener("open", onOpen)
-  if (onError) source.addEventListener("error", onError)
+  const scheduleReconnect = () => {
+    if (closed) return
+    if (reconnectTimer !== null) return
+    const delay = backoffMs
+    backoffMs = Math.min(backoffMs * 2, RECONNECT_MAX_MS)
+    reconnectTimer = window.setTimeout(() => {
+      reconnectTimer = null
+      void openConnection()
+    }, delay)
+  }
+
+  const openConnection = async () => {
+    if (closed) return
+
+    // Tear down any previous EventSource before starting a fresh one.
+    if (source) {
+      source.close()
+      source = null
+    }
+
+    const url = buildStreamUrl(types)
+    const next = new EventSource(url)
+    source = next
+
+    next.addEventListener("open", (ev) => {
+      // Successful open resets the backoff envelope.
+      backoffMs = RECONNECT_INITIAL_MS
+      onOpen?.(ev)
+    })
+
+    next.addEventListener("message", messageHandler)
+
+    next.addEventListener("error", (ev) => {
+      onError?.(ev)
+      // EventSource auto-reconnects on transient errors but stays in CLOSED
+      // when the server hard-rejected the request (e.g. 401). In that case,
+      // attempt a token refresh and re-open ourselves, otherwise leave the
+      // browser's reconnect to do its job.
+      if (next.readyState === EventSource.CLOSED) {
+        next.close()
+        if (closed) return
+        // Attempt a one-shot token refresh; on success we immediately reopen
+        // with the new token, otherwise we fall back to backoff so we don't
+        // hammer the API while auth is permanently broken.
+        void refreshToken()
+          .then((newToken) => {
+            if (closed) return
+            if (newToken) {
+              backoffMs = RECONNECT_INITIAL_MS
+              void openConnection()
+            } else {
+              scheduleReconnect()
+            }
+          })
+          .catch(() => {
+            if (!closed) scheduleReconnect()
+          })
+      }
+    })
+  }
+
+  void openConnection()
 
   return {
-    close: () => source.close(),
-    source,
+    close: () => {
+      closed = true
+      if (reconnectTimer !== null) {
+        window.clearTimeout(reconnectTimer)
+        reconnectTimer = null
+      }
+      if (source) {
+        source.close()
+      }
+    },
+    // Best-effort accessor for advanced consumers; may briefly point at a
+    // closed instance during reconnect, which is fine because we never expose
+    // it before the first open completes for new consumers.
+    get source(): EventSource {
+      if (!source) {
+        throw new Error("EventSource is not yet initialised")
+      }
+      return source
+    },
   }
 }

--- a/ui/src/lib/api/notes.ts
+++ b/ui/src/lib/api/notes.ts
@@ -29,6 +29,11 @@ const enc = encodeURIComponent
 /**
  * PUT /api/notes/sets/{conn_id}/{ns}/{set} — upsert a set note. An empty
  * ``note`` deletes the existing row (idempotent — no error when none).
+ *
+ * Backend compatibility: the API enforces ``min_length=1`` on the note body
+ * and returns 422 for an empty PUT, so when the caller passes an
+ * empty/whitespace-only note we transparently route through DELETE instead
+ * of PUT to preserve the historical "save empty == clear note" semantics.
  */
 export async function upsertSetNote(
   connId: string,
@@ -38,8 +43,8 @@ export async function upsertSetNote(
 ): Promise<SetNote | null> {
   const path = `/notes/sets/${enc(connId)}/${enc(namespace)}/${enc(setName)}`
   // The empty-note delete returns 204; non-empty returns the saved row.
-  if (!body.note) {
-    await apiPut<unknown>(path, body)
+  if (!body.note || !body.note.trim()) {
+    await deleteSetNote(connId, namespace, setName)
     return null
   }
   return apiPut<SetNote>(path, body)
@@ -77,6 +82,9 @@ export async function listSetNotes(
 /**
  * PUT /api/notes/records/{conn_id}/{ns}/{set}/{pk} — upsert a record note.
  * Empty ``note`` deletes (idempotent).
+ *
+ * Backend compatibility: see ``upsertSetNote`` — the API rejects empty bodies
+ * with 422, so empty-note saves transparently route through DELETE.
  */
 export async function upsertRecordNote(
   connId: string,
@@ -86,8 +94,8 @@ export async function upsertRecordNote(
   body: UpsertRecordNoteRequest,
 ): Promise<RecordNote | null> {
   const path = `/notes/records/${enc(connId)}/${enc(namespace)}/${enc(setName)}/${enc(pk)}`
-  if (!body.note) {
-    await apiPut<unknown>(path, body)
+  if (!body.note || !body.note.trim()) {
+    await deleteRecordNote(connId, namespace, setName, pk, body.pkType ?? "auto")
     return null
   }
   return apiPut<RecordNote>(path, body)

--- a/ui/src/lib/types/workspace.ts
+++ b/ui/src/lib/types/workspace.ts
@@ -12,6 +12,12 @@ export interface WorkspaceResponse {
   color: string
   description?: string | null
   isDefault: boolean
+  /**
+   * Sub claim of the OIDC user that owns the workspace. Mirrors
+   * ``WorkspaceResponse.ownerId`` on the backend (see
+   * ``api/src/aerospike_cluster_manager_api/models/workspace.py``).
+   */
+  ownerId: string
   createdAt: string
   updatedAt: string
 }


### PR DESCRIPTION
## Summary
Closes the config-drift findings from the review. No functional behavior change unless the operator exports a value — every new env var has a default that matches the previous hardcoded behavior.

## What changed
- **compose-pg.yaml** — override target was `aerospike-cluster-manager` (the pre-split name); merged with `compose.yaml` it produced an orphan service and the API silently fell back to SQLite. Renamed to `aerospike-cluster-manager-api`.
- **compose.yaml** — API service now passes through `OIDC_*`, `ACM_MCP_*`, `ACM_OIDC_OWNER_CLAIM`, `K8S_*`, `SSE_*`, `CSP_*`, `LOG_*` via `\${VAR:-default}`. Operators following the documented compose flow can now enable Keycloak / MCP / K8s management without hand-editing the compose file.
- **.env.example** — new "OIDC / Keycloak" section. Fernet KEK arrives in Phase 2B.
- **Dockerfile.api** — `python:3.14-slim` → `python:3.13-slim` to align with `pyproject.toml requires-python = ">=3.13"` and the local venv. Eliminates the local-vs-image runtime divergence.
- **ui/src/lib/api/error-mapping.ts** — 504 / 409 / 422 mapped to distinct discriminator kinds. 422 now surfaces `err.detail` verbatim with a `Validation:` prefix instead of collapsing into the generic banner.

## Out of scope (handled separately)
- Workspace-level `CLAUDE.md` (Next.js version drift) lives in the meta-workspace repo, not this one — separate PR.

## Stack
- Base: phase-1c-ui-fixes (#323)
- Next: phase-2a-jose-to-pyjwt

## Test plan
- [x] `podman compose -f compose.yaml -f compose-pg.yaml config` parses; merged API service receives the new env keys
- [x] `cd ui && npm run type-check` clean