### PR TITLE
feat(api): rate limiter core — leftmost-untrusted XFF + global default + SSE exempt

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,6 +136,20 @@ K8S_MANAGEMENT_ENABLED=false
 # call time. full allows everything. Default is read_only.
 # ACM_MCP_ACCESS_PROFILE=read_only
 
+# ─── At-rest encryption (connection passwords) ────────────────────────────
+# Fernet key (44-char urlsafe base64) used to encrypt the
+# ``connections.password`` column at rest. Generate with:
+#   python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'
+# REQUIRED in any deployment that stores Aerospike credentials. Without
+# this set, the API refuses to start unless ACM_ALLOW_EPHEMERAL_KEK=true
+# is also exported (dev-only — process-local key, all stored passwords
+# become unreadable on the next restart).
+# ACM_PASSWORD_KEK=
+# Dev-only escape hatch — generate a process-local ephemeral key when
+# ACM_PASSWORD_KEK is unset. Stored passwords do NOT survive a restart.
+# Never enable in production.
+# ACM_ALLOW_EPHEMERAL_KEK=false
+
 # ─── Logging ───────────────────────────────────────────────────────────────
 # LOG_LEVEL=INFO
 # LOG_FORMAT=text   # "text" (human-readable) or "json" (structured)

--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,30 @@ K8S_MANAGEMENT_ENABLED=false
 #   K8S_MANAGEMENT_ENABLED=true
 #   KUBECONFIG=${HOME}/.kube/config
 # The API auto-loads kubeconfig outside the cluster; the `kind-kind` context
-# from run-local is picked up automatically.
+# from run-local is picked up automatically. There is no separate
+# K8S_KUBECONFIG_PATH variable — the python ``kubernetes`` client honours
+# the standard ``KUBECONFIG`` env var directly.
+
+# ─── OIDC / Keycloak ───────────────────────────────────────────────────────
+# Native JWT verification middleware. When OIDC_ENABLED=false the middleware
+# is installed but no-ops, so non-prod and unit-test deployments need no IdP.
+# OIDC_ENABLED=false
+# Keycloak realm root, e.g. https://keycloak.example.com/realms/acko. The
+# middleware appends /.well-known/openid-configuration to discover jwks_uri.
+# OIDC_ISSUER_URL=
+# Single-audience claim (contract C-4). The SPA mints tokens with aud=acko-api.
+# OIDC_AUDIENCE=acko-api
+# CSV ("acko:dev,acko:prod") or JSON list ("[\"acko:dev\"]"). Empty = auth-only,
+# no role check. Resolved against decoded["realm_access"]["roles"].
+# OIDC_REQUIRED_ROLES=
+# JWKS cache TTL. Accepts "10m"/"1h"/"2d" or bare seconds ("600").
+# OIDC_JWKS_CACHE_TTL=10m
+# Comma-separated paths that bypass auth entirely (exact match).
+# OIDC_EXCLUDE_PATHS=/api/health,/api/openapi.json,/api/docs
+# OIDC claim used as workspace-owner identity. Defaults to ``sub`` (OIDC core
+# stable subject id). Switch to ``preferred_username`` only if the IdP's sub
+# is unstable across logins.
+# ACM_OIDC_OWNER_CLAIM=sub
 
 # ─── Security Headers ──────────────────────────────────────────────────────
 # Enable HSTS only when serving over TLS.

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,7 +1,7 @@
 # =============================================================================
 # API (FastAPI) — standalone image
 # =============================================================================
-FROM python:3.14-slim AS builder
+FROM python:3.13-slim AS builder
 
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app/api
@@ -15,7 +15,7 @@ RUN uv sync --frozen --no-dev
 # =============================================================================
 # Runtime
 # =============================================================================
-FROM python:3.14-slim AS runtime
+FROM python:3.13-slim AS runtime
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \

--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -33,7 +33,11 @@ dependencies = [
     "opentelemetry-instrumentation-asyncpg>=0.51b0",
     "opentelemetry-instrumentation-logging>=0.51b0",
     "httpx>=0.28.1",
-    "python-jose[cryptography]>=3.3,<4",
+    # PyJWT[crypto] replaces python-jose (unmaintained, CVE-2024-33663/4).
+    # The [crypto] extra pulls in `cryptography`, which we also use directly
+    # for Fernet at-rest encryption of stored connection passwords.
+    "pyjwt[crypto]>=2.9",
+    "cryptography>=42",
 ]
 
 [tool.uv]

--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -145,6 +145,22 @@ LOG_HANDLERS: str = os.getenv("LOG_HANDLERS", "")
 LOGGING_CONFIG_FILE: str = os.getenv("LOGGING_CONFIG_FILE", "")
 
 # ---------------------------------------------------------------------------
+# At-rest encryption for stored connection passwords
+# ---------------------------------------------------------------------------
+# Fernet key used by ``secrets_crypto.encrypt_password`` to wrap the
+# ``connections.password`` column before it touches the database. The
+# canonical shape is a 44-char urlsafe base64 string emitted by
+# ``Fernet.generate_key()``. The actual validation, ephemeral-mode
+# fallback, and process-startup error live in ``secrets_crypto.py`` —
+# we surface the variable name here only so operators have a single
+# place to grep for "where does ACM read this from?". Reading the env
+# at import time would be wrong: the secrets module needs to defer
+# until the first encrypt/decrypt call so unrelated tests can import
+# the package without setting the KEK.
+ACM_PASSWORD_KEK_ENV: str = "ACM_PASSWORD_KEK"
+ACM_ALLOW_EPHEMERAL_KEK_ENV: str = "ACM_ALLOW_EPHEMERAL_KEK"
+
+# ---------------------------------------------------------------------------
 # OIDC / Keycloak native JWT verification (Phase 0 contracts C-4, C-6, C-7)
 # ---------------------------------------------------------------------------
 # When OIDC_ENABLED=false the middleware is a no-op (still installed but

--- a/api/src/aerospike_cluster_manager_api/db/__init__.py
+++ b/api/src/aerospike_cluster_manager_api/db/__init__.py
@@ -48,6 +48,22 @@ async def init_db() -> None:
         from aerospike_cluster_manager_api.db import _sqlite as backend
     await backend.init_db()
     _backend = backend
+    # One-shot rewrite of any plaintext password rows from before the
+    # at-rest encryption migration. Idempotent (skips rows already
+    # carrying the ``enc:v1:`` ciphertext marker), so it's safe to run on
+    # every startup. Failures here must NOT block API readiness — a KEK
+    # misconfiguration should surface as decrypt errors on the actual
+    # CRUD path, not as a startup crash that hides the cause behind an
+    # unrelated traceback.
+    try:
+        await backend.migrate_passwords_to_encrypted()
+    except Exception:
+        import logging as _logging
+
+        _logging.getLogger(__name__).exception(
+            "Connection password encryption migration failed; the API will "
+            "start anyway but legacy plaintext rows remain on disk."
+        )
 
 
 async def close_db() -> None:

--- a/api/src/aerospike_cluster_manager_api/db/_base.py
+++ b/api/src/aerospike_cluster_manager_api/db/_base.py
@@ -28,6 +28,15 @@ class DatabaseBackend(Protocol):
 
     async def check_health(self) -> bool: ...
 
+    async def migrate_passwords_to_encrypted(self) -> int:
+        """Rewrite plaintext ``connections.password`` rows under the active KEK.
+
+        Idempotent — already-encrypted rows (carrying the ``enc:v1:`` prefix)
+        are skipped. Returns the number of rows rewritten so the caller
+        can log a single audit line rather than spamming per-row INFO.
+        """
+        ...
+
     async def get_all_connections(self, workspace_id: str | None = None) -> list[ConnectionProfile]: ...
 
     async def get_connection(self, conn_id: str) -> ConnectionProfile | None: ...

--- a/api/src/aerospike_cluster_manager_api/db/_postgres.py
+++ b/api/src/aerospike_cluster_manager_api/db/_postgres.py
@@ -25,6 +25,11 @@ from aerospike_cluster_manager_api.models.workspace import (
     SYSTEM_OWNER_ID,
     Workspace,
 )
+from aerospike_cluster_manager_api.secrets_crypto import (
+    decrypt_password,
+    encrypt_password,
+    is_encrypted,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -238,6 +243,36 @@ async def check_health() -> bool:
         return False
 
 
+async def migrate_passwords_to_encrypted() -> int:
+    """Rewrite any plaintext (``enc:v1:``-prefix-missing) password rows.
+
+    Idempotent. Mirrors :func:`db._sqlite.migrate_passwords_to_encrypted`.
+    Wrapped in a transaction so concurrent replicas serialise on each row;
+    the WHERE-clause shape is the canonical pattern for "rewrite if not
+    yet versioned" in this codebase.
+    """
+    pool = _get_pool()
+    rewritten = 0
+    async with pool.acquire() as conn, conn.transaction():
+        rows = await conn.fetch("SELECT id, password FROM connections")
+        for row in rows:
+            password = row["password"]
+            if password is None or password == "":
+                continue
+            if is_encrypted(password):
+                continue
+            encrypted = encrypt_password(password)
+            await conn.execute(
+                "UPDATE connections SET password = $1 WHERE id = $2",
+                encrypted,
+                row["id"],
+            )
+            rewritten += 1
+    if rewritten:
+        logger.info("Encrypted %d legacy plaintext password row(s) in PostgreSQL.", rewritten)
+    return rewritten
+
+
 async def close_db() -> None:
     global _pool
     if _pool:
@@ -249,7 +284,19 @@ async def close_db() -> None:
 # Row -> Model helper (delegated to _base.py)
 # ---------------------------------------------------------------------------
 
-_row_to_profile = row_to_profile
+
+def _row_to_profile(row: asyncpg.Record) -> ConnectionProfile:
+    """Wrap :func:`row_to_profile` to decrypt the password column on read.
+
+    Mirrors the SQLite backend so the encryption layer is transparent to
+    downstream consumers regardless of which DB is configured.
+    """
+    profile = row_to_profile(row)
+    if profile.password:
+        profile = profile.model_copy(update={"password": decrypt_password(profile.password)})
+    return profile
+
+
 _row_to_workspace = row_to_workspace
 
 
@@ -278,6 +325,9 @@ async def get_connection(conn_id: str) -> ConnectionProfile | None:
 
 async def create_connection(conn: ConnectionProfile) -> None:
     pool = _get_pool()
+    # Encrypt the password column before it touches the database. Empty
+    # / None passwords (anonymous binds) round-trip unchanged.
+    stored_password = encrypt_password(conn.password) if conn.password else conn.password
     await pool.execute(
         """INSERT INTO connections (id, name, hosts, port, cluster_name, username, password,
                                     color, note, labels, workspace_id, created_at, updated_at)
@@ -288,7 +338,7 @@ async def create_connection(conn: ConnectionProfile) -> None:
         conn.port,
         conn.clusterName,
         conn.username,
-        conn.password,
+        stored_password,
         conn.color,
         conn.note,
         json.dumps(conn.labels),
@@ -308,6 +358,11 @@ async def update_connection(conn_id: str, data: dict) -> ConnectionProfile | Non
         existing = _row_to_profile(row)
         updated = build_merged_profile(existing, data, conn_id)
 
+        # Re-encrypt the merged password before storing. ``existing.password``
+        # was decrypted by ``_row_to_profile``, so the merged result is
+        # plaintext regardless of whether the caller supplied a new
+        # password — we always encrypt on write.
+        stored_password = encrypt_password(updated.password) if updated.password else updated.password
         await conn.execute(
             """UPDATE connections
                    SET name = $1, hosts = $2::jsonb, port = $3, cluster_name = $4,
@@ -320,7 +375,7 @@ async def update_connection(conn_id: str, data: dict) -> ConnectionProfile | Non
             updated.port,
             updated.clusterName,
             updated.username,
-            updated.password,
+            stored_password,
             updated.color,
             updated.note,
             json.dumps(updated.labels),

--- a/api/src/aerospike_cluster_manager_api/db/_sqlite.py
+++ b/api/src/aerospike_cluster_manager_api/db/_sqlite.py
@@ -27,6 +27,11 @@ from aerospike_cluster_manager_api.models.workspace import (
     SYSTEM_OWNER_ID,
     Workspace,
 )
+from aerospike_cluster_manager_api.secrets_crypto import (
+    decrypt_password,
+    encrypt_password,
+    is_encrypted,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -227,6 +232,38 @@ async def check_health() -> bool:
         return False
 
 
+async def migrate_passwords_to_encrypted() -> int:
+    """Rewrite any plaintext (``enc:v1:``-prefix-missing) password rows.
+
+    Idempotent. Reads every row whose ``password`` column is non-empty and
+    not already ciphertext, encrypts it under the current KEK, and writes
+    it back. Returns the number of rows rewritten so the caller (init_db)
+    can log it. The query is deliberately uncorrelated with column-add
+    migrations — the fact that the connection might still be opening up
+    schema-wise is irrelevant; we only touch ``password``.
+    """
+    conn = _get_conn()
+    rewritten = 0
+    async with conn.execute("SELECT id, password FROM connections") as cursor:
+        rows = await cursor.fetchall()
+    for row in rows:
+        password = row["password"]
+        if password is None or password == "":
+            continue
+        if is_encrypted(password):
+            continue
+        encrypted = encrypt_password(password)
+        await conn.execute(
+            "UPDATE connections SET password = ? WHERE id = ?",
+            (encrypted, row["id"]),
+        )
+        rewritten += 1
+    if rewritten:
+        await conn.commit()
+        logger.info("Encrypted %d legacy plaintext password row(s) in SQLite.", rewritten)
+    return rewritten
+
+
 async def close_db() -> None:
     global _conn
     if _conn:
@@ -238,7 +275,20 @@ async def close_db() -> None:
 # Row -> Model helper (delegated to _base.py)
 # ---------------------------------------------------------------------------
 
-_row_to_profile = row_to_profile
+
+def _row_to_profile(row: aiosqlite.Row) -> ConnectionProfile:
+    """Wrap :func:`row_to_profile` to decrypt the password column on read.
+
+    Legacy rows (no ``enc:v1:`` prefix) round-trip unchanged thanks to
+    :func:`decrypt_password`'s migration-compat branch. The startup
+    encryption migration eventually rewrites them.
+    """
+    profile = row_to_profile(row)
+    if profile.password:
+        profile = profile.model_copy(update={"password": decrypt_password(profile.password)})
+    return profile
+
+
 _row_to_workspace = row_to_workspace
 
 
@@ -270,6 +320,10 @@ async def get_connection(conn_id: str) -> ConnectionProfile | None:
 
 async def create_connection(conn: ConnectionProfile) -> None:
     db_conn = _get_conn()
+    # Encrypt the password column before it touches the disk. Empty / None
+    # passwords (anonymous binds in CE) round-trip as the empty string —
+    # ``encrypt_password`` handles the falsy-input case.
+    stored_password = encrypt_password(conn.password) if conn.password else conn.password
     try:
         await db_conn.execute(
             """INSERT INTO connections (id, name, hosts, port, cluster_name, username, password,
@@ -282,7 +336,7 @@ async def create_connection(conn: ConnectionProfile) -> None:
                 conn.port,
                 conn.clusterName,
                 conn.username,
-                conn.password,
+                stored_password,
                 conn.color,
                 conn.note,
                 json.dumps(conn.labels),
@@ -298,16 +352,30 @@ async def create_connection(conn: ConnectionProfile) -> None:
 
 
 async def update_connection(conn_id: str, data: dict) -> ConnectionProfile | None:
+    """Atomic read-modify-write under a BEGIN IMMEDIATE write lock.
+
+    Mirrors :func:`update_workspace` and the Postgres ``SELECT ... FOR
+    UPDATE`` invariant: the SELECT and UPDATE must run inside the same
+    transaction so a concurrent writer cannot overwrite our merged
+    result with stale data (lost-update race).
+    """
     db_conn = _get_conn()
-    async with db_conn.execute("SELECT * FROM connections WHERE id = ?", (conn_id,)) as cursor:
-        row = await cursor.fetchone()
-    if not row:
-        return None
-
-    existing = _row_to_profile(row)
-    updated = build_merged_profile(existing, data, conn_id)
-
+    await db_conn.execute("BEGIN IMMEDIATE")
     try:
+        async with db_conn.execute("SELECT * FROM connections WHERE id = ?", (conn_id,)) as cursor:
+            row = await cursor.fetchone()
+        if not row:
+            await db_conn.rollback()
+            return None
+
+        existing = _row_to_profile(row)
+        updated = build_merged_profile(existing, data, conn_id)
+
+        # Re-encrypt the merged password before storing. ``existing.password``
+        # was decrypted by ``_row_to_profile``, so the merged result is
+        # plaintext regardless of whether the caller supplied a new
+        # password — we always encrypt on write.
+        stored_password = encrypt_password(updated.password) if updated.password else updated.password
         await db_conn.execute(
             """UPDATE connections
                    SET name = ?, hosts = ?, port = ?, cluster_name = ?,
@@ -321,7 +389,7 @@ async def update_connection(conn_id: str, data: dict) -> ConnectionProfile | Non
                 updated.port,
                 updated.clusterName,
                 updated.username,
-                updated.password,
+                stored_password,
                 updated.color,
                 updated.note,
                 json.dumps(updated.labels),

--- a/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
+++ b/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
@@ -26,8 +26,16 @@ from collections.abc import Awaitable, Callable, Iterable
 from typing import Any, cast
 
 import httpx
-from jose import JWTError, jwt
-from jose.exceptions import ExpiredSignatureError, JWTClaimsError
+import jwt
+from jwt.algorithms import ECAlgorithm, RSAAlgorithm
+from jwt.exceptions import (
+    DecodeError,
+    ExpiredSignatureError,
+    InvalidAudienceError,
+    InvalidIssuerError,
+    InvalidTokenError,
+    PyJWTError,
+)
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
@@ -62,10 +70,27 @@ _ALLOWED_ALGS: frozenset[str] = frozenset(
 # of HTTP requests against the issuer.
 _KID_MISS_BACKOFF_SECONDS: int = 30
 
-# TODO(follow-up): migrate from python-jose to PyJWT (>=2.9). python-jose is
-# unmaintained as of 2024 and has open CVE-2024-33663/4. Mitigations applied
-# here: pinned algorithm whitelist (above), strict aud/iss verification,
-# kid-miss back-off. Still, switching to a maintained library is preferred.
+
+def _public_key_from_jwk(jwk_dict: dict[str, Any]) -> Any:
+    """Convert a JWK dict to a PyJWT-compatible public-key object.
+
+    PyJWT's ``jwt.decode`` accepts ``cryptography``-native key objects
+    directly. We pick the algorithm class by JWK ``kty`` (key type) and
+    delegate to ``RSAAlgorithm.from_jwk`` / ``ECAlgorithm.from_jwk`` so
+    PyJWT does the actual parsing and validation. This deliberately
+    mirrors what the symmetric ``HMACAlgorithm.from_jwk`` would do — by
+    omitting the symmetric branch we silently refuse ``kty=oct`` keys
+    here, complementing the alg-whitelist defence-in-depth above.
+    """
+    import json as _json
+
+    kty = jwk_dict.get("kty")
+    raw = _json.dumps(jwk_dict)
+    if kty == "RSA":
+        return RSAAlgorithm.from_jwk(raw)
+    if kty == "EC":
+        return ECAlgorithm.from_jwk(raw)
+    raise _AuthError(f"Unsupported JWK key type: {kty!r}")
 
 
 class OIDCAuthMiddleware(BaseHTTPMiddleware):
@@ -98,9 +123,10 @@ class OIDCAuthMiddleware(BaseHTTPMiddleware):
         self._owns_http_client = http_client is None
 
         # JWKS cache state. ``_jwks_by_kid`` maps the JWS header ``kid`` to
-        # the raw JWK dict; jose accepts dicts directly. ``_expires_at`` is a
-        # monotonic-ish wall-clock seconds value; we use ``time.time()`` so a
-        # process restart resets the cache implicitly.
+        # the raw JWK dict; we lazily convert to a public-key object on
+        # first verification. ``_expires_at`` is a monotonic-ish wall-clock
+        # seconds value; we use ``time.time()`` so a process restart resets
+        # the cache implicitly.
         self._jwks_by_kid: dict[str, dict[str, Any]] = {}
         self._jwks_expires_at: float = 0.0
         self._jwks_lock = asyncio.Lock()
@@ -182,18 +208,18 @@ class OIDCAuthMiddleware(BaseHTTPMiddleware):
     async def _verify(self, token: str) -> dict[str, Any]:
         try:
             unverified_header = jwt.get_unverified_header(token)
-        except JWTError as exc:
+        except PyJWTError as exc:
             raise _AuthError(f"Malformed token header: {exc}") from exc
 
         kid = unverified_header.get("kid")
         if not kid:
             raise _AuthError("Token header missing 'kid'")
 
-        key = await self._key_for_kid(kid)
-        if key is None:
+        jwk_dict = await self._key_for_kid(kid)
+        if jwk_dict is None:
             raise _AuthError(f"Unknown signing key id (kid={kid!r})")
 
-        algorithm = key.get("alg") or unverified_header.get("alg")
+        algorithm = jwk_dict.get("alg") or unverified_header.get("alg")
         if not algorithm:
             raise _AuthError("Cannot determine signing algorithm")
         if algorithm not in _ALLOWED_ALGS:
@@ -202,19 +228,29 @@ class OIDCAuthMiddleware(BaseHTTPMiddleware):
             # via a tampered or rogue JWKS endpoint.
             raise _AuthError(f"Unsupported signing algorithm: {algorithm}")
 
+        public_key = _public_key_from_jwk(jwk_dict)
+
         try:
             claims = jwt.decode(
                 token,
-                key,
+                public_key,
                 algorithms=[algorithm],
                 audience=self.audience,
                 issuer=self.issuer_url,
             )
         except ExpiredSignatureError as exc:
             raise _AuthError("Token expired") from exc
-        except JWTClaimsError as exc:
-            raise _AuthError(f"Invalid claims: {exc}") from exc
-        except JWTError as exc:
+        except InvalidAudienceError as exc:
+            raise _AuthError(f"Invalid audience: {exc}") from exc
+        except InvalidIssuerError as exc:
+            raise _AuthError(f"Invalid issuer: {exc}") from exc
+        except DecodeError as exc:
+            # Signature/format failures land here — keep the message generic
+            # so we don't leak which leg of verification failed.
+            raise _AuthError(f"Invalid token: {exc}") from exc
+        except InvalidTokenError as exc:
+            # Catch-all for any other PyJWT-defined claim error
+            # (e.g. iat/nbf failures); InvalidTokenError is the umbrella.
             raise _AuthError(f"Invalid token: {exc}") from exc
         return cast(dict[str, Any], claims)
 

--- a/api/src/aerospike_cluster_manager_api/rate_limit.py
+++ b/api/src/aerospike_cluster_manager_api/rate_limit.py
@@ -1,19 +1,118 @@
+"""Rate limiter wiring.
+
+Built on top of :mod:`slowapi`. Two responsibilities live here:
+
+* ``_get_client_ip`` — derive the rate-limit bucket key from the request,
+  honouring an ``X-Forwarded-For`` chain only for hops we explicitly trust.
+* ``limiter`` — the module-global :class:`slowapi.Limiter` consumed by
+  routers. Carries a conservative default applied to every request that
+  passes through ``SlowAPIMiddleware``; long-lived endpoints (SSE) opt out
+  via ``@limiter.exempt``.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
 from slowapi import Limiter
 from starlette.requests import Request
 
 from aerospike_cluster_manager_api import config
 
 
+def _parse_trusted_proxies(entries: list[str]) -> tuple[list[ipaddress.IPv4Network | ipaddress.IPv6Network], set[str]]:
+    """Split TRUSTED_PROXIES entries into (CIDR networks, exact-match strings).
+
+    Bare IP literals are kept on the exact-match side so the membership
+    check stays a hash lookup. Anything that ``ip_network`` accepts as a
+    CIDR (e.g. ``10.0.0.0/8``, ``2001:db8::/32``) is parsed into a network.
+    Garbage entries are silently skipped — config validation belongs in
+    :mod:`config`, not here.
+    """
+    networks: list[ipaddress.IPv4Network | ipaddress.IPv6Network] = []
+    literals: set[str] = set()
+    for raw in entries:
+        if not raw:
+            continue
+        if "/" in raw:
+            try:
+                networks.append(ipaddress.ip_network(raw, strict=False))
+            except ValueError:
+                continue
+        else:
+            literals.add(raw)
+    return networks, literals
+
+
+def _is_trusted(addr: str, networks, literals: set[str]) -> bool:
+    """Return True iff ``addr`` matches a trusted literal or CIDR."""
+    if addr in literals:
+        return True
+    if not networks:
+        return False
+    try:
+        ip = ipaddress.ip_address(addr)
+    except ValueError:
+        return False
+    return any(ip in net for net in networks)
+
+
 def _get_client_ip(request: Request) -> str:
-    """Extract client IP, respecting X-Forwarded-For only from trusted proxies."""
+    """Extract the client IP for rate-limit bucketing.
+
+    Algorithm:
+
+    1. Read ``request.client.host`` as the immediate peer.
+    2. If no ``X-Forwarded-For`` header, return the peer.
+    3. Walk the XFF chain right-to-left, dropping hops we trust
+       (TRUSTED_PROXIES — exact IPs or CIDR ranges). Return the first
+       untrusted hop encountered. This is the leftmost untrusted entry,
+       which matches the standard reverse-proxy convention and resists
+       client-spoofed prefixes.
+    4. If every XFF hop is trusted (request entirely inside the proxy
+       fleet), return the immediate peer.
+
+    Rationale: the previous implementation took the *rightmost* XFF
+    entry, which is the address of the last trusted proxy and collapses
+    every external caller into a single bucket. Leftmost-untrusted
+    spreads the bucket across real clients while still ignoring spoofed
+    headers prepended by the caller themselves.
+    """
     client_host = request.client.host if request.client else "127.0.0.1"
 
-    if config.TRUSTED_PROXIES and client_host in config.TRUSTED_PROXIES:
-        forwarded_for = request.headers.get("X-Forwarded-For")
-        if forwarded_for:
-            return forwarded_for.split(",")[-1].strip()
+    forwarded_for = request.headers.get("X-Forwarded-For")
+    if not forwarded_for:
+        return client_host
 
+    networks, literals = _parse_trusted_proxies(config.TRUSTED_PROXIES)
+    # Empty trust list → don't believe XFF at all; the immediate peer is
+    # the only datum we can trust. This also keeps the default-deploy
+    # behaviour (operator hasn't configured any proxies) safe.
+    if not networks and not literals:
+        return client_host
+
+    # Only honour XFF when the immediate peer is itself a trusted proxy.
+    # Otherwise the caller is talking to us directly and could have
+    # forged any header they like.
+    if not _is_trusted(client_host, networks, literals):
+        return client_host
+
+    hops = [h.strip() for h in forwarded_for.split(",") if h.strip()]
+    # Walk right→left, peel off trusted hops, take the first untrusted.
+    for hop in reversed(hops):
+        if not _is_trusted(hop, networks, literals):
+            return hop
+
+    # Every hop was trusted — fall back to the immediate peer.
     return client_host
 
 
-limiter = Limiter(key_func=_get_client_ip)
+# Conservative global default: 60 requests/minute/IP. Picked low enough
+# that an unauthenticated bot scraping the API can't trivially DoS the
+# data plane, but high enough that an interactive UI session (which
+# typically issues a handful of requests per user action) never bumps
+# into it. Mutation routes layer stricter limits on top via
+# ``@limiter.limit(...)`` decorators.
+DEFAULT_LIMITS = ["60/minute"]
+
+limiter = Limiter(key_func=_get_client_ip, default_limits=DEFAULT_LIMITS)

--- a/api/src/aerospike_cluster_manager_api/routers/events.py
+++ b/api/src/aerospike_cluster_manager_api/routers/events.py
@@ -19,6 +19,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from aerospike_cluster_manager_api import config
 from aerospike_cluster_manager_api.events.broker import broker
+from aerospike_cluster_manager_api.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +63,12 @@ async def _event_generator(
     "Use the `types` parameter to filter events (comma-separated).",
     response_model=None,
 )
+# SSE streams are long-lived (one HTTP request held open for minutes/hours).
+# The global default rate limit would let only the first connection through
+# and 429 every reconnect attempt for the rest of the window — exempt the
+# stream so the broker's own ``SSE_MAX_CONNECTIONS`` cap (HTTP 429 with
+# detail "Too many SSE connections") owns the throttling decision.
+@limiter.exempt
 async def event_stream(
     request: Request,
     types: str | None = Query(None, description="Comma-separated event types to subscribe to"),

--- a/api/src/aerospike_cluster_manager_api/secrets_crypto.py
+++ b/api/src/aerospike_cluster_manager_api/secrets_crypto.py
@@ -1,0 +1,208 @@
+"""At-rest encryption for sensitive connection-profile fields.
+
+Encrypts ``connections.password`` (and any other future opt-in field) with
+``cryptography.fernet.Fernet`` so a leaked DB image / SQLite file / Postgres
+backup does not directly hand attackers downstream Aerospike credentials.
+
+Threat model
+============
+
+* In-scope: passive disclosure of the database file or backup. An attacker
+  who can read ``connections.db`` (or the equivalent Postgres dump) cannot
+  recover the plaintext password without also obtaining ``ACM_PASSWORD_KEK``.
+* Out-of-scope: a privileged process attacker who can read the live API
+  process memory or env vars. Once the API is running with the KEK
+  loaded, plaintext passwords are recoverable in-memory by definition;
+  Fernet is at-rest encryption, not a vault.
+
+KEK provisioning
+================
+
+The Key Encryption Key is provisioned via ``ACM_PASSWORD_KEK`` (44-char
+urlsafe base64, the canonical Fernet key shape). The module enforces
+the env-or-explicit-opt-in policy at import time:
+
+* ``ACM_PASSWORD_KEK`` set, valid → use it.
+* ``ACM_PASSWORD_KEK`` unset, ``ACM_ALLOW_EPHEMERAL_KEK=true`` → emit a
+  loud warning and generate a process-local ephemeral key. Existing rows
+  written under a previous ephemeral key become unreadable on restart;
+  this is documented as dev-only.
+* ``ACM_PASSWORD_KEK`` unset, no opt-in → ``RuntimeError`` at import time
+  with a copy-pasteable command for generating a key. The intent is to
+  fail loudly during deploys rather than silently downgrade to plaintext.
+
+Ciphertext format
+=================
+
+We prefix Fernet output with ``enc:v1:`` so the read path can distinguish
+already-encrypted values from legacy plaintext during migration. The ``v1``
+discriminator leaves room for a future re-key path (``enc:v2:``) without a
+schema change.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from cryptography.fernet import Fernet, InvalidToken
+
+logger = logging.getLogger(__name__)
+
+# Versioned prefix on Fernet ciphertext so the read path can distinguish
+# ``enc:v1:<token>`` (encrypt result, current schema) from a legacy plaintext
+# password row written before this module landed. ``decrypt_password`` returns
+# unprefixed input verbatim, which is the migration-compat read path.
+_PREFIX_V1 = "enc:v1:"
+
+
+class _CryptoState:
+    """Module-level state holder. Kept in a class so tests can monkey-patch
+    the singleton without rewriting every consumer."""
+
+    fernet: Fernet | None = None
+    is_ephemeral: bool = False
+
+
+_state = _CryptoState()
+
+
+def _bool_env(name: str) -> bool:
+    raw = os.getenv(name)
+    if raw is None:
+        return False
+    return raw.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _build_fernet() -> tuple[Fernet, bool]:
+    """Resolve the KEK from env and return ``(Fernet, is_ephemeral)``.
+
+    Raises ``RuntimeError`` when the env is unset and the operator has not
+    explicitly opted into the ephemeral key path. The error message includes
+    the canonical command for generating a key so the deploy fix is
+    obvious from the log line alone.
+    """
+    raw = os.getenv("ACM_PASSWORD_KEK", "").strip()
+    if raw:
+        try:
+            return Fernet(raw.encode("utf-8")), False
+        except (ValueError, TypeError) as exc:
+            raise RuntimeError(
+                "ACM_PASSWORD_KEK is set but is not a valid Fernet key. "
+                "Generate one with: "
+                "python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'"
+            ) from exc
+    if _bool_env("ACM_ALLOW_EPHEMERAL_KEK"):
+        # Explicit dev opt-in. The key lives in process memory only; rows
+        # written under it become unreadable on the next restart. We log
+        # at WARNING (not INFO) so this never gets quietly tolerated in
+        # operator dashboards.
+        ephemeral = Fernet.generate_key()
+        logger.warning(
+            "ACM_PASSWORD_KEK is unset and ACM_ALLOW_EPHEMERAL_KEK=true; "
+            "generating a process-local ephemeral key. Stored connection "
+            "passwords will become UNREADABLE on the next restart. "
+            "DO NOT use this mode in production."
+        )
+        return Fernet(ephemeral), True
+    raise RuntimeError(
+        "ACM_PASSWORD_KEK is required for at-rest encryption of stored "
+        "connection passwords. Generate one with: "
+        "python -c 'from cryptography.fernet import Fernet; "
+        "print(Fernet.generate_key().decode())' "
+        "and export it as ACM_PASSWORD_KEK. "
+        "For dev-only ephemeral mode set ACM_ALLOW_EPHEMERAL_KEK=true."
+    )
+
+
+def _get_fernet() -> Fernet:
+    """Return the cached Fernet instance, building it on first use.
+
+    Lazy build so the module can be imported by code paths that don't touch
+    the connection table (tests of unrelated modules) without forcing every
+    consumer to set ACM_PASSWORD_KEK. The first call to ``encrypt_password``
+    or ``decrypt_password`` is the load-bearing one.
+    """
+    if _state.fernet is None:
+        _state.fernet, _state.is_ephemeral = _build_fernet()
+    return _state.fernet
+
+
+def reset_for_tests() -> None:
+    """Clear cached Fernet so the next call re-resolves env. Tests only."""
+    _state.fernet = None
+    _state.is_ephemeral = False
+
+
+def is_ephemeral() -> bool:
+    """Return True when the active Fernet was provisioned from an ephemeral
+    in-memory key (i.e. ``ACM_ALLOW_EPHEMERAL_KEK=true`` path).
+
+    Used by ``main.py`` startup logging to surface the dev-only mode when
+    operators audit what KEK source is in effect.
+    """
+    if _state.fernet is None:
+        # Force resolution so callers don't see a misleading False before
+        # the first encrypt/decrypt.
+        _get_fernet()
+    return _state.is_ephemeral
+
+
+def encrypt_password(plaintext: str) -> str:
+    """Encrypt ``plaintext`` with the active KEK.
+
+    Empty / ``None`` is the operator's signal that no password is set on the
+    connection (Aerospike supports anonymous binds in CE) — we pass it
+    through verbatim so that intent round-trips through the DB. Callers
+    should normalise to an empty string before calling, but we accept
+    ``None`` defensively.
+    """
+    if not plaintext:
+        return ""
+    fernet = _get_fernet()
+    token = fernet.encrypt(plaintext.encode("utf-8")).decode("ascii")
+    return _PREFIX_V1 + token
+
+
+def decrypt_password(stored: str | None) -> str | None:
+    """Decrypt a value previously produced by :func:`encrypt_password`.
+
+    Migration compatibility: if the stored value lacks the ``enc:v1:``
+    prefix it is returned verbatim. This lets the API keep serving rows
+    that were written before the encryption migration ran. The startup
+    migration in ``db/__init__.py`` rewrites those rows on the next boot
+    so the legacy branch only executes during the rollover window.
+
+    Empty strings and ``None`` are passed through (no password set).
+    """
+    if stored is None or stored == "":
+        return stored
+    if not stored.startswith(_PREFIX_V1):
+        # Legacy plaintext row — caller will see the original password.
+        # Migration is responsible for rewriting these eventually.
+        return stored
+    fernet = _get_fernet()
+    token = stored[len(_PREFIX_V1) :]
+    try:
+        return fernet.decrypt(token.encode("ascii")).decode("utf-8")
+    except InvalidToken as exc:
+        # The KEK has changed (or the row was written under a different
+        # ephemeral key). Surface a deterministic error so the API can
+        # 500 instead of silently returning a corrupted password.
+        raise RuntimeError(
+            "Failed to decrypt stored connection password: KEK mismatch. "
+            "If you recently rotated ACM_PASSWORD_KEK, you must re-encrypt "
+            "the password column with the new key (or restore the previous "
+            "key). For ephemeral-mode dev environments this is expected "
+            "after a restart — recreate the connection profile."
+        ) from exc
+
+
+def is_encrypted(stored: str | None) -> bool:
+    """Return True when ``stored`` carries the ``enc:v1:`` ciphertext marker.
+
+    Used by the startup migration to skip already-encrypted rows. Treats
+    ``None`` and the empty string as "no password" — neither needs
+    encryption.
+    """
+    return bool(stored) and stored.startswith(_PREFIX_V1)

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -2,12 +2,35 @@
 
 from __future__ import annotations
 
+import os
 from datetime import UTC, datetime
 from unittest.mock import patch
 
 import pytest
+from cryptography.fernet import Fernet
 
 from aerospike_cluster_manager_api.models.connection import ConnectionProfile
+
+
+def _ensure_kek() -> None:
+    """Provision a deterministic Fernet key for the entire test session.
+
+    The at-rest encryption module enforces ACM_PASSWORD_KEK presence on
+    first use. Tests that don't directly exercise crypto still trip the
+    check via init_db's password migration; setting a fixed key here
+    keeps every fixture deterministic across pytest runs without forcing
+    each test to opt into ephemeral mode.
+    """
+    if not os.environ.get("ACM_PASSWORD_KEK"):
+        os.environ["ACM_PASSWORD_KEK"] = Fernet.generate_key().decode("ascii")
+    # Re-resolve so a previous test that monkey-patched the singleton
+    # doesn't leak state into the next one.
+    from aerospike_cluster_manager_api import secrets_crypto
+
+    secrets_crypto.reset_for_tests()
+
+
+_ensure_kek()
 
 
 @pytest.fixture()

--- a/api/tests/test_oidc_auth.py
+++ b/api/tests/test_oidc_auth.py
@@ -14,14 +14,13 @@ import uuid
 from collections.abc import Iterable
 
 import httpx
+import jwt as pyjwt
 import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi import FastAPI, Request
 from fastapi.responses import PlainTextResponse
 from httpx import ASGITransport, AsyncClient
-from jose import jwt as jose_jwt
-from jose.backends.cryptography_backend import CryptographyRSAKey
-from jose.constants import ALGORITHMS
+from jwt.algorithms import RSAAlgorithm
 
 from aerospike_cluster_manager_api.middleware.oidc_auth import OIDCAuthMiddleware
 
@@ -36,9 +35,14 @@ AUDIENCE = "acko-api"
 
 
 def _rsa_keypair() -> tuple[rsa.RSAPrivateKey, dict]:
-    """Return (private_key, jwk_public). ``kid`` is a stable random uuid."""
+    """Return (private_key, jwk_public). ``kid`` is a stable random uuid.
+
+    PyJWT's ``RSAAlgorithm.to_jwk`` returns a JSON string by default; we ask
+    for a dict and then graft on Keycloak-style ``kid``/``alg``/``use`` fields
+    so the resulting JWK is byte-compatible with what the IdP would emit.
+    """
     priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    pub_jwk = CryptographyRSAKey(priv.public_key(), ALGORITHMS.RS256).to_dict()
+    pub_jwk = RSAAlgorithm.to_jwk(priv.public_key(), as_dict=True)
     pub_jwk["kid"] = uuid.uuid4().hex
     pub_jwk["alg"] = "RS256"
     pub_jwk["use"] = "sig"
@@ -67,8 +71,7 @@ def _sign(
         claims["realm_access"] = {"roles": list(realm_roles)}
     if extra_claims:
         claims.update(extra_claims)
-    priv_jwk = CryptographyRSAKey(private_key, ALGORITHMS.RS256).to_dict()
-    return jose_jwt.encode(claims, priv_jwk, algorithm="RS256", headers={"kid": kid})
+    return pyjwt.encode(claims, private_key, algorithm="RS256", headers={"kid": kid})
 
 
 # ---------------------------------------------------------------------------

--- a/api/tests/test_secrets_crypto.py
+++ b/api/tests/test_secrets_crypto.py
@@ -1,0 +1,280 @@
+"""Unit tests for :mod:`aerospike_cluster_manager_api.secrets_crypto`.
+
+Covers KEK provisioning policy (env-required, ephemeral opt-in),
+``enc:v1:`` ciphertext shape, migration round-trip via the SQLite backend,
+and KEK-mismatch failure surface.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+import pytest
+from cryptography.fernet import Fernet
+
+from aerospike_cluster_manager_api import db, secrets_crypto
+from aerospike_cluster_manager_api.models.connection import ConnectionProfile
+
+
+@pytest.fixture(autouse=True)
+def _restore_secrets_state():
+    """Reset the crypto singleton around each test so env mutations
+    in one test never leak into another."""
+    yield
+    secrets_crypto.reset_for_tests()
+
+
+def test_encrypt_round_trip():
+    plaintext = "supersecret-aerospike-password"
+    blob = secrets_crypto.encrypt_password(plaintext)
+    assert blob.startswith("enc:v1:"), blob
+    assert plaintext not in blob, "plaintext leaked into ciphertext envelope"
+    assert secrets_crypto.decrypt_password(blob) == plaintext
+
+
+def test_empty_password_passes_through():
+    assert secrets_crypto.encrypt_password("") == ""
+    assert secrets_crypto.decrypt_password(None) is None
+    assert secrets_crypto.decrypt_password("") == ""
+
+
+def test_legacy_plaintext_round_trip():
+    """A row written before the migration (no ``enc:v1:`` prefix) must be
+    returned verbatim — that's the migration-compat read path."""
+    assert secrets_crypto.decrypt_password("plain-old-password") == "plain-old-password"
+    assert secrets_crypto.is_encrypted("plain-old-password") is False
+    assert secrets_crypto.is_encrypted(secrets_crypto.encrypt_password("x")) is True
+
+
+def test_missing_kek_without_opt_in_raises(monkeypatch):
+    monkeypatch.delenv("ACM_PASSWORD_KEK", raising=False)
+    monkeypatch.delenv("ACM_ALLOW_EPHEMERAL_KEK", raising=False)
+    secrets_crypto.reset_for_tests()
+    with pytest.raises(RuntimeError) as excinfo:
+        secrets_crypto.encrypt_password("anything")
+    msg = str(excinfo.value)
+    assert "ACM_PASSWORD_KEK" in msg
+    assert "Fernet.generate_key" in msg
+
+
+def test_missing_kek_with_ephemeral_opt_in_emits_warning(monkeypatch):
+    """Loud warning must fire so this never gets quietly tolerated in prod.
+
+    The package logger has ``propagate=False`` set by ``setup_logging`` at
+    import time, so pytest's ``caplog`` fixture (which attaches to the
+    root logger) doesn't see the record. Attach a temporary handler
+    directly to the target logger instead.
+    """
+    import io
+    import logging as _logging
+
+    monkeypatch.delenv("ACM_PASSWORD_KEK", raising=False)
+    monkeypatch.setenv("ACM_ALLOW_EPHEMERAL_KEK", "true")
+    secrets_crypto.reset_for_tests()
+
+    buf = io.StringIO()
+    handler = _logging.StreamHandler(buf)
+    handler.setLevel(_logging.WARNING)
+    handler.setFormatter(_logging.Formatter("%(levelname)s %(message)s"))
+    target = _logging.getLogger("aerospike_cluster_manager_api.secrets_crypto")
+    target.addHandler(handler)
+    try:
+        blob = secrets_crypto.encrypt_password("hello")
+    finally:
+        target.removeHandler(handler)
+
+    assert blob.startswith("enc:v1:")
+    assert secrets_crypto.is_ephemeral() is True
+    output = buf.getvalue()
+    assert "ephemeral key" in output.lower(), output
+
+
+def test_invalid_kek_raises_with_remediation(monkeypatch):
+    monkeypatch.setenv("ACM_PASSWORD_KEK", "not-a-fernet-key")
+    secrets_crypto.reset_for_tests()
+    with pytest.raises(RuntimeError) as excinfo:
+        secrets_crypto.encrypt_password("anything")
+    msg = str(excinfo.value)
+    assert "Fernet.generate_key" in msg
+
+
+def test_kek_mismatch_on_decrypt(monkeypatch):
+    """A row encrypted under KEK A must fail loudly when read under KEK B
+    rather than silently returning corrupted plaintext."""
+    monkeypatch.setenv("ACM_PASSWORD_KEK", Fernet.generate_key().decode("ascii"))
+    secrets_crypto.reset_for_tests()
+    blob = secrets_crypto.encrypt_password("rotation-test")
+    monkeypatch.setenv("ACM_PASSWORD_KEK", Fernet.generate_key().decode("ascii"))
+    secrets_crypto.reset_for_tests()
+    with pytest.raises(RuntimeError) as excinfo:
+        secrets_crypto.decrypt_password(blob)
+    assert "KEK mismatch" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# DB-layer integration — verify ciphertext lands on disk and is decrypted
+# transparently on read.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_password_persisted_as_ciphertext(tmp_path):
+    """The raw ``connections.password`` column must contain the ``enc:v1:``
+    envelope, never plaintext, after a successful create."""
+    db_path = str(tmp_path / "encrypt_test.db")
+    with (
+        patch("aerospike_cluster_manager_api.config.ENABLE_POSTGRES", False),
+        patch("aerospike_cluster_manager_api.config.SQLITE_PATH", db_path),
+    ):
+        await db.init_db()
+        try:
+            now = datetime.now(UTC).isoformat()
+            conn = ConnectionProfile(
+                id="conn-encrypted",
+                name="encrypted",
+                hosts=["localhost"],
+                port=3000,
+                username="admin",
+                password="hunter2",
+                color="#0097D3",
+                createdAt=now,
+                updatedAt=now,
+            )
+            await db.create_connection(conn)
+
+            # Round-trip through the public API decrypts.
+            retrieved = await db.get_connection("conn-encrypted")
+            assert retrieved is not None
+            assert retrieved.password == "hunter2"
+
+            # On-disk shape: the raw column must be ciphertext, not plaintext.
+            import aiosqlite
+
+            async with (
+                aiosqlite.connect(db_path) as raw,
+                raw.execute("SELECT password FROM connections WHERE id = ?", ("conn-encrypted",)) as cursor,
+            ):
+                row = await cursor.fetchone()
+            assert row is not None
+            stored = row[0]
+            assert stored.startswith("enc:v1:")
+            assert "hunter2" not in stored
+        finally:
+            await db.close_db()
+
+
+@pytest.mark.asyncio
+async def test_legacy_plaintext_row_migrated_on_init(tmp_path):
+    """A connection row written with a plaintext password must be rewritten
+    in-place on the next ``init_db()`` call. Idempotent: a second init
+    must not double-encrypt or otherwise corrupt the row."""
+    import aiosqlite
+
+    db_path = str(tmp_path / "legacy.db")
+    # Hand-write a legacy row, bypassing the encryption layer.
+    async with aiosqlite.connect(db_path) as raw:
+        await raw.execute(
+            """CREATE TABLE connections (
+                id TEXT PRIMARY KEY, name TEXT, hosts TEXT, port INTEGER,
+                cluster_name TEXT, username TEXT, password TEXT,
+                color TEXT, note TEXT, labels TEXT, workspace_id TEXT,
+                created_at TEXT, updated_at TEXT
+            )"""
+        )
+        now = datetime.now(UTC).isoformat()
+        await raw.execute(
+            """INSERT INTO connections (id, name, hosts, port, color, password,
+                                        created_at, updated_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                "conn-legacy",
+                "legacy",
+                '["localhost"]',
+                3000,
+                "#0097D3",
+                "legacy-plain-pw",
+                now,
+                now,
+            ),
+        )
+        await raw.commit()
+
+    with (
+        patch("aerospike_cluster_manager_api.config.ENABLE_POSTGRES", False),
+        patch("aerospike_cluster_manager_api.config.SQLITE_PATH", db_path),
+    ):
+        await db.init_db()
+        try:
+            retrieved = await db.get_connection("conn-legacy")
+            assert retrieved is not None
+            assert retrieved.password == "legacy-plain-pw"
+
+            # The on-disk column should now be ciphertext.
+            async with (
+                aiosqlite.connect(db_path) as raw,
+                raw.execute("SELECT password FROM connections WHERE id = ?", ("conn-legacy",)) as cursor,
+            ):
+                row = await cursor.fetchone()
+            assert row is not None
+            assert row[0].startswith("enc:v1:")
+            first_blob = row[0]
+        finally:
+            await db.close_db()
+
+    # Re-init: idempotent. Same blob must remain (we don't re-encrypt
+    # already-versioned rows, otherwise a process bouncing in a loop
+    # would burn through Fernet's 64-byte nonce space for no benefit).
+    with (
+        patch("aerospike_cluster_manager_api.config.ENABLE_POSTGRES", False),
+        patch("aerospike_cluster_manager_api.config.SQLITE_PATH", db_path),
+    ):
+        await db.init_db()
+        try:
+            async with (
+                aiosqlite.connect(db_path) as raw,
+                raw.execute("SELECT password FROM connections WHERE id = ?", ("conn-legacy",)) as cursor,
+            ):
+                row = await cursor.fetchone()
+            assert row is not None
+            assert row[0] == first_blob
+        finally:
+            await db.close_db()
+
+
+@pytest.mark.asyncio
+async def test_init_db_succeeds_in_ephemeral_mode_without_explicit_kek(tmp_path, monkeypatch):
+    """When ACM_PASSWORD_KEK is unset and ACM_ALLOW_EPHEMERAL_KEK=true, the
+    API must still come up. The encryption migration runs against an
+    ephemeral key — legacy rows get rewritten and become unreadable on
+    the next restart, which is the documented dev-mode trade-off."""
+    monkeypatch.delenv("ACM_PASSWORD_KEK", raising=False)
+    monkeypatch.setenv("ACM_ALLOW_EPHEMERAL_KEK", "true")
+    secrets_crypto.reset_for_tests()
+
+    db_path = str(tmp_path / "ephemeral.db")
+    with (
+        patch("aerospike_cluster_manager_api.config.ENABLE_POSTGRES", False),
+        patch("aerospike_cluster_manager_api.config.SQLITE_PATH", db_path),
+    ):
+        await db.init_db()
+        try:
+            # Sanity: round-trip a brand-new row.
+            now = datetime.now(UTC).isoformat()
+            await db.create_connection(
+                ConnectionProfile(
+                    id="conn-ephemeral",
+                    name="eph",
+                    hosts=["localhost"],
+                    port=3000,
+                    password="ephemeral-pw",
+                    color="#0097D3",
+                    createdAt=now,
+                    updatedAt=now,
+                )
+            )
+            got = await db.get_connection("conn-ephemeral")
+            assert got is not None
+            assert got.password == "ephemeral-pw"
+        finally:
+            await db.close_db()

--- a/api/tests/test_security_headers.py
+++ b/api/tests/test_security_headers.py
@@ -160,3 +160,52 @@ def test_get_client_ip_no_xff_from_trusted():
     with patch("aerospike_cluster_manager_api.config.TRUSTED_PROXIES", ["10.0.0.1"]):
         req = _FakeRequest("10.0.0.1")
         assert _get_client_ip(req) == "10.0.0.1"
+
+
+def test_get_client_ip_picks_leftmost_untrusted_in_chain():
+    """Multi-hop chain: peel trusted hops from the right and stop at the first
+    untrusted entry. Picking the rightmost (the previous behaviour) would
+    collapse every external caller into the bucket of the last reverse proxy
+    and defeat the purpose of per-IP rate limiting.
+    """
+    with patch("aerospike_cluster_manager_api.config.TRUSTED_PROXIES", ["10.0.0.1", "10.0.0.2"]):
+        req = _FakeRequest("10.0.0.1", forwarded_for="203.0.113.50, 10.0.0.2, 10.0.0.1")
+        assert _get_client_ip(req) == "203.0.113.50"
+
+
+def test_get_client_ip_supports_cidr_trusted_proxies():
+    """TRUSTED_PROXIES accepts CIDR ranges (the docstring claim)."""
+    with patch("aerospike_cluster_manager_api.config.TRUSTED_PROXIES", ["10.0.0.0/24"]):
+        # peer is inside the /24 — the XFF chain should be honoured.
+        req = _FakeRequest("10.0.0.42", forwarded_for="203.0.113.50, 10.0.0.5")
+        assert _get_client_ip(req) == "203.0.113.50"
+
+
+def test_get_client_ip_all_hops_trusted_falls_back_to_peer():
+    """Chain entirely inside the trusted proxy fleet — fall back to peer."""
+    with patch("aerospike_cluster_manager_api.config.TRUSTED_PROXIES", ["10.0.0.0/8"]):
+        req = _FakeRequest("10.0.0.1", forwarded_for="10.1.2.3, 10.2.3.4")
+        assert _get_client_ip(req) == "10.0.0.1"
+
+
+# ---------------------------------------------------------------------------
+# Global default rate limit
+# ---------------------------------------------------------------------------
+
+
+def test_limiter_carries_global_default_limits():
+    """The shared Limiter instance must declare a default the SlowAPIMiddleware
+    can apply to every route. Without this, mutation routes that forget to
+    decorate themselves are unrate-limited and the SSE-exempt opt-out has
+    nothing to opt out of.
+    """
+    from aerospike_cluster_manager_api.rate_limit import DEFAULT_LIMITS, limiter
+
+    # slowapi exposes default_limits as a list of LimitGroup objects; assert
+    # at least one group is registered and the documented "60/minute" string
+    # is present in the module-level constant we feed to the Limiter.
+    assert DEFAULT_LIMITS, "DEFAULT_LIMITS must not be empty"
+    assert any("/minute" in entry or "/second" in entry for entry in DEFAULT_LIMITS)
+    # The Limiter's internal _default_limits is the runtime source of truth;
+    # accessing the protected attribute here is a deliberate test-of-glue.
+    assert limiter._default_limits, "Limiter must be constructed with default_limits"

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -19,6 +19,7 @@ dependencies = [
     { name = "aerospike-py", extra = ["otel"] },
     { name = "aiosqlite" },
     { name = "asyncpg" },
+    { name = "cryptography" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "kubernetes" },
@@ -29,7 +30,7 @@ dependencies = [
     { name = "opentelemetry-instrumentation-fastapi" },
     { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-sdk" },
-    { name = "python-jose", extra = ["cryptography"] },
+    { name = "pyjwt", extra = ["crypto"] },
     { name = "python-json-logger" },
     { name = "pyyaml" },
     { name = "slowapi" },
@@ -54,6 +55,7 @@ requires-dist = [
     { name = "aerospike-py", extras = ["otel"], specifier = ">=0.6.4" },
     { name = "aiosqlite", specifier = ">=0.21.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
+    { name = "cryptography", specifier = ">=42" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "kubernetes", specifier = ">=31.0.0" },
@@ -64,7 +66,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-fastapi", specifier = ">=0.51b0" },
     { name = "opentelemetry-instrumentation-logging", specifier = ">=0.51b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.30.0" },
-    { name = "python-jose", extras = ["cryptography"], specifier = ">=3.3,<4" },
+    { name = "pyjwt", extras = ["crypto"], specifier = ">=2.9" },
     { name = "python-json-logger", specifier = ">=3.0.0" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
@@ -468,18 +470,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6dd0d6b095c4e1f32d0be54c2a4b250032d717647bab/durationpy-0.10.tar.gz", hash = "sha256:1fa6893409a6e739c9c72334fc65cca1f355dbdd93405d30f726deb5bde42fba", size = 3335, upload-time = "2025-05-17T13:52:37.26Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.19.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/25/ca/8de7744cb3bc966c85430ca2d0fcaeea872507c6a4cf6e007f7fe269ed9d/ecdsa-0.19.2.tar.gz", hash = "sha256:62635b0ac1ca2e027f82122b5b81cb706edc38cd91c63dda28e4f3455a2bf930", size = 202432, upload-time = "2026-03-26T09:58:17.675Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/51/79/119091c98e2bf49e24ed9f3ae69f816d715d2904aefa6a2baa039a2ba0b0/ecdsa-0.19.2-py2.py3-none-any.whl", hash = "sha256:840f5dc5e375c68f36c1a7a5b9caad28f95daa65185c9253c0c08dd952bb7399", size = 150818, upload-time = "2026-03-26T09:58:15.808Z" },
 ]
 
 [[package]]
@@ -1037,15 +1027,6 @@ wheels = [
 ]
 
 [[package]]
-name = "pyasn1"
-version = "0.6.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
-]
-
-[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1236,25 +1217,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-jose"
-version = "3.5.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "ecdsa" },
-    { name = "pyasn1" },
-    { name = "rsa" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c6/77/3a1c9039db7124eb039772b935f2244fbb73fc8ee65b9acf2375da1c07bf/python_jose-3.5.0.tar.gz", hash = "sha256:fb4eaa44dbeb1c26dcc69e4bd7ec54a1cb8dd64d3b4d81ef08d90ff453f2b01b", size = 92726, upload-time = "2025-05-28T17:31:54.288Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/c3/0bd11992072e6a1c513b16500a5d07f91a24017c5909b02c72c62d7ad024/python_jose-3.5.0-py2.py3-none-any.whl", hash = "sha256:abd1202f23d34dfad2c3d28cb8617b90acf34132c7afd60abd0b0b7d3cb55771", size = 34624, upload-time = "2025-05-28T17:31:52.802Z" },
-]
-
-[package.optional-dependencies]
-cryptography = [
-    { name = "cryptography" },
-]
-
-[[package]]
 name = "python-json-logger"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1426,18 +1388,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
     { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
     { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
-]
-
-[[package]]
-name = "rsa"
-version = "4.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyasn1" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/da/8a/22b7beea3ee0d44b1916c0c1cb0ee3af23b700b6da9f04991899d0c555d4/rsa-4.9.1.tar.gz", hash = "sha256:e7bdbfdb5497da4c07dfd35530e1a902659db6ff241e39d9953cad06ebd0ae75", size = 29034, upload-time = "2025-04-16T09:51:18.218Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/8d/0133e4eb4beed9e425d9a98ed6e081a55d195481b7632472be1af08d2f6b/rsa-4.9.1-py3-none-any.whl", hash = "sha256:68635866661c6836b8d39430f97a996acbd61bfa49406748ea243539fe239762", size = 34696, upload-time = "2025-04-16T09:51:17.142Z" },
 ]
 
 [[package]]

--- a/compose-pg.yaml
+++ b/compose-pg.yaml
@@ -23,7 +23,10 @@ services:
       - postgres-data:/var/lib/postgresql/data
     restart: unless-stopped
 
-  aerospike-cluster-manager:
+  # Override the API service from compose.yaml (split into -api / -web in #?)
+  # so the Postgres backend is reached from the FastAPI process. The web
+  # container has no DB awareness and does not need these vars.
+  aerospike-cluster-manager-api:
     environment:
       - ENABLE_POSTGRES=true
       - DATABASE_URL=postgresql://aerospike:aerospike@postgres:5432/aerospike_manager

--- a/compose.yaml
+++ b/compose.yaml
@@ -130,6 +130,36 @@ services:
       - AEROSPIKE_HOST=${AEROSPIKE_HOST:-aerospike-node-1}
       - AEROSPIKE_PORT=${AEROSPIKE_PORT:-3000}
       - SQLITE_PATH=/app/data/connections.db
+      # ── OIDC (off by default) ─────────────────────────────────────
+      - OIDC_ENABLED=${OIDC_ENABLED:-false}
+      - OIDC_ISSUER_URL=${OIDC_ISSUER_URL:-}
+      - OIDC_AUDIENCE=${OIDC_AUDIENCE:-acko-api}
+      - OIDC_REQUIRED_ROLES=${OIDC_REQUIRED_ROLES:-}
+      - OIDC_JWKS_CACHE_TTL=${OIDC_JWKS_CACHE_TTL:-10m}
+      - OIDC_EXCLUDE_PATHS=${OIDC_EXCLUDE_PATHS:-/api/health,/api/openapi.json,/api/docs}
+      - ACM_OIDC_OWNER_CLAIM=${ACM_OIDC_OWNER_CLAIM:-sub}
+      # ── MCP (off by default) ──────────────────────────────────────
+      - ACM_MCP_ENABLED=${ACM_MCP_ENABLED:-false}
+      - ACM_MCP_PATH=${ACM_MCP_PATH:-/mcp}
+      - ACM_MCP_TOKEN=${ACM_MCP_TOKEN:-}
+      - ACM_MCP_ACCESS_PROFILE=${ACM_MCP_ACCESS_PROFILE:-read_only}
+      - ACM_MCP_ALLOW_ANONYMOUS=${ACM_MCP_ALLOW_ANONYMOUS:-false}
+      # ── Kubernetes management (off by default) ────────────────────
+      - K8S_MANAGEMENT_ENABLED=${K8S_MANAGEMENT_ENABLED:-false}
+      - K8S_VERIFY_SSL=${K8S_VERIFY_SSL:-true}
+      - K8S_API_TIMEOUT=${K8S_API_TIMEOUT:-10}
+      - K8S_LOG_TIMEOUT=${K8S_LOG_TIMEOUT:-30}
+      - K8S_CA_FILE=${K8S_CA_FILE:-}
+      # ── Security headers / SSE ────────────────────────────────────
+      - ENABLE_HSTS=${ENABLE_HSTS:-false}
+      - CSP_ENABLED=${CSP_ENABLED:-true}
+      - CSP_REPORT_URI=${CSP_REPORT_URI:-}
+      - SSE_ENABLED=${SSE_ENABLED:-true}
+      - SSE_HEARTBEAT_INTERVAL=${SSE_HEARTBEAT_INTERVAL:-15}
+      - SSE_MAX_CONNECTIONS=${SSE_MAX_CONNECTIONS:-50}
+      # ── Logging ───────────────────────────────────────────────────
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+      - LOG_FORMAT=${LOG_FORMAT:-text}
     volumes:
       - app-data:/app/data
     healthcheck:

--- a/ui/src/app/(main)/acko/templates/page.tsx
+++ b/ui/src/app/(main)/acko/templates/page.tsx
@@ -65,7 +65,9 @@ export default function AckoTemplatesPage() {
           >
             Refresh
           </Button>
-          <Button variant="primary">New template</Button>
+          <Button variant="primary" disabled title="Coming soon">
+            New template
+          </Button>
         </div>
       </header>
 

--- a/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
@@ -20,7 +20,7 @@ import { mapApiError } from "@/lib/api/error-mapping"
 import { logFetchError } from "@/lib/api/log"
 import type { AerospikeRole, AerospikeUser } from "@/lib/types/admin"
 import { RiShieldKeyholeLine } from "@remixicon/react"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 
 type PageProps = { params: { clusterId: string } }
 
@@ -40,6 +40,7 @@ export default function AdminPage({ params }: PageProps) {
   const [securityDisabled, setSecurityDisabled] = useState(false)
   const [createUserOpen, setCreateUserOpen] = useState(false)
   const [createRoleOpen, setCreateRoleOpen] = useState(false)
+  const [userFilter, setUserFilter] = useState("")
 
   const load = useCallback(async () => {
     setUsersState((s) => ({ ...s, loading: true, error: null }))
@@ -100,6 +101,8 @@ export default function AdminPage({ params }: PageProps) {
           <UsersSection
             state={usersState}
             onCreate={() => setCreateUserOpen(true)}
+            filter={userFilter}
+            onFilterChange={setUserFilter}
           />
           <RolesSection
             state={rolesState}
@@ -163,10 +166,25 @@ function SecurityDisabledState() {
 function UsersSection({
   state,
   onCreate,
+  filter,
+  onFilterChange,
 }: {
   state: LoadState<AerospikeUser[]>
   onCreate: () => void
+  filter: string
+  onFilterChange: (value: string) => void
 }) {
+  const filtered = useMemo(() => {
+    if (!state.data) return null
+    const q = filter.trim().toLowerCase()
+    if (!q) return state.data
+    return state.data.filter(
+      (u) =>
+        u.username.toLowerCase().includes(q) ||
+        u.roles.some((r) => r.toLowerCase().includes(q)),
+    )
+  }, [state.data, filter])
+
   return (
     <section className="flex flex-col gap-3">
       <div className="flex items-end justify-between">
@@ -176,6 +194,8 @@ function UsersSection({
         <div className="flex gap-2">
           <Input
             type="search"
+            value={filter}
+            onChange={(e) => onFilterChange(e.target.value)}
             placeholder="Filter users..."
             className="sm:w-60"
           />
@@ -213,8 +233,8 @@ function UsersSection({
             <TableBody>
               {state.loading ? (
                 <SkeletonRows cols={6} rows={3} />
-              ) : state.data && state.data.length > 0 ? (
-                state.data.map((u) => (
+              ) : filtered && filtered.length > 0 ? (
+                filtered.map((u) => (
                   <TableRow key={u.username}>
                     <TableCell>
                       <span className="font-mono font-semibold text-gray-900 dark:text-gray-50">
@@ -240,7 +260,12 @@ function UsersSection({
                       {u.connections ?? 0}
                     </TableCell>
                     <TableCell className="text-right">
-                      <Button variant="ghost" className="h-7 px-2 text-xs">
+                      <Button
+                        variant="ghost"
+                        disabled
+                        title="Edit coming soon"
+                        className="h-7 px-2 text-xs"
+                      >
                         Edit
                       </Button>
                     </TableCell>
@@ -252,7 +277,9 @@ function UsersSection({
                     colSpan={6}
                     className="py-6 text-center text-sm text-gray-500"
                   >
-                    No users.
+                    {state.data && state.data.length > 0
+                      ? "No users match the filter."
+                      : "No users."}
                   </TableCell>
                 </TableRow>
               )}
@@ -329,7 +356,12 @@ function RolesSection({
                       )}
                     </TableCell>
                     <TableCell className="text-right">
-                      <Button variant="ghost" className="h-7 px-2 text-xs">
+                      <Button
+                        variant="ghost"
+                        disabled
+                        title="Edit coming soon"
+                        className="h-7 px-2 text-xs"
+                      >
                         Edit
                       </Button>
                     </TableCell>

--- a/ui/src/app/(main)/clusters/[clusterId]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/page.tsx
@@ -64,7 +64,13 @@ export default function ClusterOverview({ params }: PageProps) {
           >
             Refresh
           </Button>
-          <Button variant="primary">Open in AQL</Button>
+          <Button
+            variant="primary"
+            disabled
+            title="Use the dedicated terminal page"
+          >
+            Open in AQL
+          </Button>
         </div>
       </header>
 
@@ -93,8 +99,12 @@ export default function ClusterOverview({ params }: PageProps) {
               </p>
             </div>
             <div className="flex gap-2">
-              <Button variant="secondary">View CR</Button>
-              <Button variant="secondary">Events</Button>
+              <Button variant="secondary" disabled title="Coming soon">
+                View CR
+              </Button>
+              <Button variant="secondary" disabled title="Coming soon">
+                Events
+              </Button>
             </div>
           </div>
           <dl className="grid grid-cols-2 gap-4 sm:grid-cols-4">

--- a/ui/src/app/(main)/clusters/[clusterId]/secondary-indexes/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/secondary-indexes/page.tsx
@@ -3,6 +3,7 @@
 import { Badge } from "@/components/Badge"
 import { Button } from "@/components/Button"
 import { Card } from "@/components/Card"
+import { CreateIndexDialog } from "@/components/dialogs/CreateIndexDialog"
 import { ErrorBanner } from "@/components/ErrorBanner"
 import { Input } from "@/components/Input"
 import {
@@ -37,6 +38,7 @@ export default function SecondaryIndexesPage({ params }: PageProps) {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [filter, setFilter] = useState("")
+  const [createOpen, setCreateOpen] = useState(false)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -98,9 +100,20 @@ export default function SecondaryIndexesPage({ params }: PageProps) {
           >
             Refresh
           </Button>
-          <Button variant="primary">Create index</Button>
+          <Button variant="primary" onClick={() => setCreateOpen(true)}>
+            Create index
+          </Button>
         </div>
       </header>
+
+      <CreateIndexDialog
+        open={createOpen}
+        onOpenChange={setCreateOpen}
+        connId={params.clusterId}
+        onSuccess={() => {
+          void load()
+        }}
+      />
 
       {error && (
         <ErrorBanner

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
@@ -180,9 +180,17 @@ function draftToBin(draft: string, kind: BinKind): BinValue {
 
 const TTL_NEVER_SENTINEL = 4_294_967_295
 
+// TTL semantics:
+//   -1                    → "never expire" (record stays forever)
+//    0                    → "keep current ttl" (only meaningful at write time;
+//                            on read this means "no expiry was set", i.e. keep
+//                            namespace default — render as "keep")
+//    TTL_NEVER_SENTINEL   → server's wire representation of "never" on the read path
+//    > 0                  → seconds remaining until expiry
 function formatTtl(ttl: number | undefined): string {
   if (ttl === undefined) return "—"
-  if (ttl === -1 || ttl === 0 || ttl === TTL_NEVER_SENTINEL) return "never"
+  if (ttl === -1 || ttl === TTL_NEVER_SENTINEL) return "never"
+  if (ttl === 0) return "keep"
   if (ttl >= 86400)
     return `${Math.floor(ttl / 86400)}d ${Math.floor((ttl % 86400) / 3600)}h`
   if (ttl >= 3600)
@@ -320,12 +328,19 @@ export default function RecordDetailPage({ params }: PageProps) {
     if (!record) return
     setDrafts(buildInitialDraft(record))
     const ttl = record.meta.ttl
-    // When the record is set to "never expire", start with 0 (= keep TTL) so we don't force a new TTL on save.
-    setTtlDraft(
-      ttl === undefined || ttl === -1 || ttl === TTL_NEVER_SENTINEL
-        ? "-1"
-        : String(ttl),
-    )
+    // Editor seeding:
+    //   -1 / sentinel → "-1" (record is set to never expire — preserve)
+    //   0             → "" (means "keep current TTL on save"; show empty so the
+    //                       placeholder explains the rules and the user can opt in)
+    //   undefined     → "" (no TTL info — same default behaviour as 0)
+    //   > 0           → echo the remaining seconds
+    if (ttl === -1 || ttl === TTL_NEVER_SENTINEL) {
+      setTtlDraft("-1")
+    } else if (ttl === undefined || ttl === 0) {
+      setTtlDraft("")
+    } else {
+      setTtlDraft(String(ttl))
+    }
     setBinErrors({})
     setIsEditing(true)
   }

--- a/ui/src/app/(main)/clusters/[clusterId]/udfs/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/udfs/page.tsx
@@ -3,6 +3,7 @@
 import { Badge } from "@/components/Badge"
 import { Button } from "@/components/Button"
 import { Card } from "@/components/Card"
+import { RegisterUdfDialog } from "@/components/dialogs/RegisterUdfDialog"
 import { ErrorBanner } from "@/components/ErrorBanner"
 import { Input } from "@/components/Input"
 import {
@@ -27,6 +28,7 @@ export default function UdfsPage({ params }: PageProps) {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [filter, setFilter] = useState("")
+  const [registerOpen, setRegisterOpen] = useState(false)
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -82,9 +84,20 @@ export default function UdfsPage({ params }: PageProps) {
           >
             Refresh
           </Button>
-          <Button variant="primary">Register UDF</Button>
+          <Button variant="primary" onClick={() => setRegisterOpen(true)}>
+            Register UDF
+          </Button>
         </div>
       </header>
+
+      <RegisterUdfDialog
+        open={registerOpen}
+        onOpenChange={setRegisterOpen}
+        connId={params.clusterId}
+        onSuccess={() => {
+          void load()
+        }}
+      />
 
       {error && (
         <ErrorBanner

--- a/ui/src/components/clusters/AddressCopyCell.tsx
+++ b/ui/src/components/clusters/AddressCopyCell.tsx
@@ -59,6 +59,20 @@ export function AddressCopyCell({
   className,
 }: AddressCopyCellProps) {
   const [status, setStatus] = React.useState<CopyStatus>("idle")
+  // Tracks the most recent feedback-reset timer so rapid double-clicks don't
+  // race a stale callback into resetting the status, and so the timer is
+  // canceled if the cell unmounts mid-feedback (otherwise React warns about
+  // setState on an unmounted component).
+  const resetTimerRef = React.useRef<number | null>(null)
+
+  React.useEffect(() => {
+    return () => {
+      if (resetTimerRef.current !== null) {
+        window.clearTimeout(resetTimerRef.current)
+        resetTimerRef.current = null
+      }
+    }
+  }, [])
 
   if (hosts.length === 0) {
     return (
@@ -80,9 +94,17 @@ export function AddressCopyCell({
     event.stopPropagation()
     const ok = await copyText(seedList)
     setStatus(ok ? "copied" : "error")
+    // Cancel any in-flight reset before scheduling a new one so the feedback
+    // window doesn't get cut short by the previous click's pending timer.
+    if (resetTimerRef.current !== null) {
+      window.clearTimeout(resetTimerRef.current)
+    }
     // Hold the feedback long enough for a glance — the previous 1.5s window
     // was too short for the change to register reliably (#319 follow-up).
-    window.setTimeout(() => setStatus("idle"), 2500)
+    resetTimerRef.current = window.setTimeout(() => {
+      setStatus("idle")
+      resetTimerRef.current = null
+    }, 2500)
   }
 
   const tooltipContent =

--- a/ui/src/components/clusters/ClusterCard.tsx
+++ b/ui/src/components/clusters/ClusterCard.tsx
@@ -25,15 +25,31 @@ export function ClusterCard({
   const hasCustomLabels =
     Object.keys(row.labels).filter((k) => k !== ENV_LABEL_KEY).length > 0
 
-  const cardInner = (
+  // To keep the whole card clickable while still allowing nested interactive
+  // elements (the Edit button and the AddressCopyCell copy button), we render
+  // the navigation as an absolutely-positioned anchor *behind* the interactive
+  // controls (`relative` card + `absolute inset-0` link with `z-0`). All
+  // interactive children opt in with `relative z-10`. This avoids the invalid
+  // `<a><button></a>` nesting that the previous implementation produced.
+  return (
     <Card
       className={cx(
-        "flex h-full flex-col gap-3 transition",
+        "relative flex h-full flex-col gap-3 transition",
         row.connId &&
           "hover:border-indigo-300 hover:shadow-sm dark:hover:border-indigo-700",
       )}
     >
-      <div className="flex items-start gap-3">
+      {row.connId && (
+        <Link
+          href={clusterSections.overview(row.connId)}
+          aria-label={`Open ${row.displayName}`}
+          className={cx(
+            "absolute inset-0 z-0 rounded-md focus-visible:outline-none",
+            focusRing,
+          )}
+        />
+      )}
+      <div className="relative z-10 flex items-start gap-3">
         <span
           aria-hidden="true"
           className="mt-1 h-6 w-1 shrink-0 rounded-sm"
@@ -80,17 +96,21 @@ export function ClusterCard({
       </div>
 
       {row.profile && hasCustomLabels && (
-        <LabelsCell labels={row.labels} hideEnv />
+        <div className="relative z-10">
+          <LabelsCell labels={row.labels} hideEnv />
+        </div>
       )}
 
-      <AddressCopyCell
-        hosts={row.hosts}
-        port={row.port}
-        fallback={row.k8sNamespace ?? "—"}
-        className="text-xs"
-      />
+      <div className="relative z-10">
+        <AddressCopyCell
+          hosts={row.hosts}
+          port={row.port}
+          fallback={row.k8sNamespace ?? "—"}
+          className="text-xs"
+        />
+      </div>
 
-      <div className="mt-auto flex items-center justify-between gap-2 border-t border-gray-200 pt-3 dark:border-gray-800">
+      <div className="relative z-10 mt-auto flex items-center justify-between gap-2 border-t border-gray-200 pt-3 dark:border-gray-800">
         <span className="text-xs text-gray-500 dark:text-gray-500">
           {row.managedBy === "ACKO" ? "ACKO" : "Manual"}
         </span>
@@ -112,16 +132,4 @@ export function ClusterCard({
       </div>
     </Card>
   )
-
-  if (row.connId) {
-    return (
-      <Link
-        href={clusterSections.overview(row.connId)}
-        className={cx("block focus-visible:outline-none", focusRing)}
-      >
-        {cardInner}
-      </Link>
-    )
-  }
-  return cardInner
 }

--- a/ui/src/components/k8s/create-cluster-wizard/StepNamespaceStorage.tsx
+++ b/ui/src/components/k8s/create-cluster-wizard/StepNamespaceStorage.tsx
@@ -12,6 +12,7 @@ import type {
   CreateK8sClusterRequest,
   StorageVolumeConfig,
 } from "@/lib/types/k8s"
+import { useEffect } from "react"
 
 interface StepNamespaceStorageProps {
   form: CreateK8sClusterRequest
@@ -46,10 +47,20 @@ export function StepNamespaceStorage({
       ? form.namespaces
       : [defaultMemoryNamespace(clusterSize, 0)]
 
-  // Ensure the form always carries at least one namespace by syncing on mount when defaulted
-  if (!form.namespaces || form.namespaces.length === 0) {
-    updateForm({ namespaces })
-  }
+  // Ensure the form always carries at least one namespace by syncing once after mount
+  // when the form was constructed without any. Calling setState during render is a
+  // React error; an effect runs after commit so the parent receives the default
+  // without re-rendering the child mid-render.
+  const needsDefault = !form.namespaces || form.namespaces.length === 0
+  useEffect(() => {
+    if (needsDefault) {
+      updateForm({ namespaces: [defaultMemoryNamespace(clusterSize, 0)] })
+    }
+    // We intentionally only depend on whether a default is needed; ``updateForm``
+    // is a stable dispatcher from the parent reducer-style pattern and including
+    // it would re-fire if the parent recreates it.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [needsDefault, clusterSize])
 
   const {
     keys: nsKeys,

--- a/ui/src/components/ui/navigation/DropdownUserProfile.tsx
+++ b/ui/src/components/ui/navigation/DropdownUserProfile.tsx
@@ -14,6 +14,8 @@ import {
   DropdownMenuSubMenuTrigger,
   DropdownMenuTrigger,
 } from "@/components/Dropdown"
+import { logout as keycloakLogout } from "@/lib/auth/keycloak"
+import { useAuthStore } from "@/stores/auth-store"
 import {
   RiArrowRightUpLine,
   RiComputerLine,
@@ -34,6 +36,7 @@ export function DropdownUserProfile({
 }: DropdownUserProfileProps) {
   const [mounted, setMounted] = React.useState(false)
   const { theme, setTheme } = useTheme()
+  const claims = useAuthStore((s) => s.claims)
   React.useEffect(() => {
     setMounted(true)
   }, [])
@@ -41,12 +44,40 @@ export function DropdownUserProfile({
   if (!mounted) {
     return null
   }
+
+  const labelText =
+    claims?.email?.trim() ||
+    claims?.preferred_username?.trim() ||
+    claims?.name?.trim() ||
+    "Local user"
+  const isAuthenticated = Boolean(claims)
+
+  const handleSignOut = async (event: Event) => {
+    // Prevent the menu's default close-on-select from racing the redirect.
+    event.preventDefault()
+    try {
+      if (isAuthenticated) {
+        await keycloakLogout()
+      } else {
+        // OIDC disabled — best we can do is clear local state and refresh.
+        useAuthStore.getState().clear()
+        if (typeof window !== "undefined") {
+          window.location.reload()
+        }
+      }
+    } catch {
+      // logout() already redirects on success; on failure, fall back to clearing
+      // local state so the next API call exits the broken session cleanly.
+      useAuthStore.getState().clear()
+    }
+  }
+
   return (
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>{children}</DropdownMenuTrigger>
         <DropdownMenuContent align={align}>
-          <DropdownMenuLabel>emma.stone@acme.com</DropdownMenuLabel>
+          <DropdownMenuLabel>{labelText}</DropdownMenuLabel>
           <DropdownMenuGroup>
             <DropdownMenuSubMenu>
               <DropdownMenuSubMenuTrigger>Theme</DropdownMenuSubMenuTrigger>
@@ -117,7 +148,13 @@ export function DropdownUserProfile({
           </DropdownMenuGroup>
           <DropdownMenuSeparator />
           <DropdownMenuGroup>
-            <DropdownMenuItem>Sign out</DropdownMenuItem>
+            <DropdownMenuItem
+              onSelect={(event) => {
+                void handleSignOut(event)
+              }}
+            >
+              Sign out
+            </DropdownMenuItem>
           </DropdownMenuGroup>
         </DropdownMenuContent>
       </DropdownMenu>

--- a/ui/src/components/ui/navigation/UserProfile.tsx
+++ b/ui/src/components/ui/navigation/UserProfile.tsx
@@ -2,11 +2,56 @@
 
 import { Button } from "@/components/Button"
 import { cx, focusRing } from "@/lib/utils"
+import { useAuthStore } from "@/stores/auth-store"
 import { RiMore2Fill } from "@remixicon/react"
 
 import { DropdownUserProfile } from "./DropdownUserProfile"
 
+/**
+ * Derive a "display name" + 1–2 char monogram for the avatar bubble.
+ *
+ * - Authenticated: prefer ``name`` → ``preferred_username`` → ``email``
+ * - Unauthenticated (OIDC disabled / not yet logged in): "Local user" / "LU"
+ *
+ * The monogram is computed from the same source as the display name to keep
+ * them in sync when one is missing.
+ */
+function deriveIdentity(): { display: string; initials: string } {
+  const claims = useAuthStore.getState().claims
+  if (!claims) {
+    return { display: "Local user", initials: "LU" }
+  }
+  const display =
+    claims.name?.trim() ||
+    claims.preferred_username?.trim() ||
+    claims.email?.trim() ||
+    "User"
+  const trimmed = display.trim()
+  const parts = trimmed.split(/\s+/).filter(Boolean)
+  let initials: string
+  if (parts.length >= 2) {
+    initials = (parts[0][0] + parts[1][0]).toUpperCase()
+  } else if (trimmed.includes("@")) {
+    // emails: take first 2 chars of the local part
+    initials = trimmed.split("@")[0].slice(0, 2).toUpperCase()
+  } else {
+    initials = trimmed.slice(0, 2).toUpperCase()
+  }
+  return { display, initials: initials || "U" }
+}
+
+function useIdentity(): { display: string; initials: string } {
+  const claims = useAuthStore((s) => s.claims)
+  if (!claims) {
+    return { display: "Local user", initials: "LU" }
+  }
+  // Re-use the pure helper but read from the current claims so React
+  // re-renders when the store changes.
+  return deriveIdentity()
+}
+
 export const UserProfileDesktop = () => {
+  const { display, initials } = useIdentity()
   return (
     <DropdownUserProfile>
       <Button
@@ -22,9 +67,9 @@ export const UserProfileDesktop = () => {
             className="flex size-8 shrink-0 items-center justify-center rounded-full border border-gray-300 bg-white text-xs text-gray-700 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-300"
             aria-hidden="true"
           >
-            ES
+            {initials}
           </span>
-          <span>Emma Stone</span>
+          <span className="truncate">{display}</span>
         </span>
         <RiMore2Fill
           className="size-4 shrink-0 text-gray-500 group-hover:text-gray-700 group-hover:dark:text-gray-400"
@@ -36,6 +81,7 @@ export const UserProfileDesktop = () => {
 }
 
 export const UserProfileMobile = () => {
+  const { initials } = useIdentity()
   return (
     <DropdownUserProfile align="end">
       <Button
@@ -49,7 +95,7 @@ export const UserProfileMobile = () => {
           className="flex size-7 shrink-0 items-center justify-center rounded-full border border-gray-300 bg-white text-xs text-gray-700 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-300"
           aria-hidden="true"
         >
-          ES
+          {initials}
         </span>
       </Button>
     </DropdownUserProfile>

--- a/ui/src/hooks/use-event-stream.ts
+++ b/ui/src/hooks/use-event-stream.ts
@@ -48,7 +48,12 @@ export function useEventStream<T = unknown>(
       sub = subscribeEvents<T>({
         types,
         onOpen: () => {
-          if (!cancelled) setConnected(true)
+          if (!cancelled) {
+            // A successful (re)open means whatever previous error we surfaced
+            // is no longer current — clear it so the consumer's banner clears.
+            setError(null)
+            setConnected(true)
+          }
         },
         onError: (err) => {
           if (cancelled) return

--- a/ui/src/lib/api/error-mapping.ts
+++ b/ui/src/lib/api/error-mapping.ts
@@ -10,14 +10,20 @@ import { ApiError } from "./client"
  *   - 403 with EE_MSG ("Security is not enabled…") → security-disabled card
  *   - 403 otherwise                                 → permission-denied
  *   - 404                                           → empty state for the resource
+ *   - 409                                           → conflict banner (record/version mismatch)
+ *   - 422                                           → validation banner, surface backend detail
  *   - 503                                           → banner + retry, do not hide page
+ *   - 504                                           → timeout banner, suggest retry
  *   - everything else                               → generic banner
  */
 export type ApiErrorKind =
   | { kind: "security-disabled"; message: string }
   | { kind: "permission-denied"; message: string }
   | { kind: "not-found"; message: string }
+  | { kind: "conflict"; message: string }
+  | { kind: "validation"; message: string }
   | { kind: "unreachable"; message: string }
+  | { kind: "timeout"; message: string }
   | { kind: "generic"; message: string }
 
 const SECURITY_DISABLED_MARKERS = ["security is not enabled", "ee_msg"] as const
@@ -37,8 +43,25 @@ export function mapApiError(err: unknown): ApiErrorKind {
         return { kind: "permission-denied", message: err.detail }
       case 404:
         return { kind: "not-found", message: err.detail }
+      case 409:
+        return {
+          kind: "conflict",
+          message: err.detail || "Conflict — record/version mismatch",
+        }
+      case 422:
+        // FastAPI validation + aerospike-py RustPanic land here. Prefer the
+        // backend detail string verbatim; only synthesize when it is empty.
+        return {
+          kind: "validation",
+          message: err.detail ? `Validation: ${err.detail}` : "Validation error",
+        }
       case 503:
         return { kind: "unreachable", message: err.detail }
+      case 504:
+        return {
+          kind: "timeout",
+          message: err.detail || "Aerospike timeout — try again",
+        }
       default:
         return { kind: "generic", message: err.detail }
     }

--- a/ui/src/lib/api/events.ts
+++ b/ui/src/lib/api/events.ts
@@ -12,6 +12,7 @@
  * Authorization header path.
  */
 
+import { refreshToken } from "@/lib/auth/keycloak"
 import { useAuthStore } from "@/stores/auth-store"
 import { useClusterSelectorStore } from "@/stores/cluster-selector-store"
 
@@ -36,19 +37,11 @@ export interface EventSubscription {
   readonly source: EventSource
 }
 
-/**
- * Subscribe to the backend SSE event stream. Returns a handle with a
- * `close()` method. Safe to call from the client only (EventSource is
- * browser-only; will throw in server components).
- */
-export function subscribeEvents<T = unknown>(
-  options: SubscribeEventsOptions<T> = {},
-): EventSubscription {
-  if (typeof window === "undefined" || typeof EventSource === "undefined") {
-    throw new Error("subscribeEvents can only be used in the browser")
-  }
-  const { types, onMessage, onError, onOpen } = options
+/** Backoff envelope for the auto-reconnect loop. */
+const RECONNECT_INITIAL_MS = 1_000
+const RECONNECT_MAX_MS = 30_000
 
+function buildStreamUrl(types?: string[]): string {
   const params = new URLSearchParams()
   if (types && types.length > 0) params.set("types", types.join(","))
 
@@ -80,9 +73,33 @@ export function subscribeEvents<T = unknown>(
 
   const qs = params.toString()
   const baseHost = active?.apiUrl?.replace(/\/+$/, "") ?? ""
-  const url = `${baseHost}${API_PREFIX}/events/stream${qs ? `?${qs}` : ""}`
+  return `${baseHost}${API_PREFIX}/events/stream${qs ? `?${qs}` : ""}`
+}
 
-  const source = new EventSource(url)
+/**
+ * Subscribe to the backend SSE event stream. Returns a handle with a
+ * `close()` method. Safe to call from the client only (EventSource is
+ * browser-only; will throw in server components).
+ *
+ * Auth-aware reconnect: when the EventSource transitions to ``CLOSED`` (the
+ * only state we can observe — ``EventSource`` does not surface HTTP status
+ * codes), we treat it as a likely 401/expired-token and try to refresh the
+ * access token before re-opening the stream. We back off exponentially
+ * (1s → 30s) on repeated failures so a permanently-broken auth doesn't melt
+ * the API into a reconnect storm.
+ */
+export function subscribeEvents<T = unknown>(
+  options: SubscribeEventsOptions<T> = {},
+): EventSubscription {
+  if (typeof window === "undefined" || typeof EventSource === "undefined") {
+    throw new Error("subscribeEvents can only be used in the browser")
+  }
+  const { types, onMessage, onError, onOpen } = options
+
+  let source: EventSource | null = null
+  let closed = false
+  let reconnectTimer: number | null = null
+  let backoffMs = RECONNECT_INITIAL_MS
 
   const messageHandler = (ev: MessageEvent) => {
     if (!onMessage) return
@@ -101,12 +118,88 @@ export function subscribeEvents<T = unknown>(
     onMessage(wrapped)
   }
 
-  source.addEventListener("message", messageHandler)
-  if (onOpen) source.addEventListener("open", onOpen)
-  if (onError) source.addEventListener("error", onError)
+  const scheduleReconnect = () => {
+    if (closed) return
+    if (reconnectTimer !== null) return
+    const delay = backoffMs
+    backoffMs = Math.min(backoffMs * 2, RECONNECT_MAX_MS)
+    reconnectTimer = window.setTimeout(() => {
+      reconnectTimer = null
+      void openConnection()
+    }, delay)
+  }
+
+  const openConnection = async () => {
+    if (closed) return
+
+    // Tear down any previous EventSource before starting a fresh one.
+    if (source) {
+      source.close()
+      source = null
+    }
+
+    const url = buildStreamUrl(types)
+    const next = new EventSource(url)
+    source = next
+
+    next.addEventListener("open", (ev) => {
+      // Successful open resets the backoff envelope.
+      backoffMs = RECONNECT_INITIAL_MS
+      onOpen?.(ev)
+    })
+
+    next.addEventListener("message", messageHandler)
+
+    next.addEventListener("error", (ev) => {
+      onError?.(ev)
+      // EventSource auto-reconnects on transient errors but stays in CLOSED
+      // when the server hard-rejected the request (e.g. 401). In that case,
+      // attempt a token refresh and re-open ourselves, otherwise leave the
+      // browser's reconnect to do its job.
+      if (next.readyState === EventSource.CLOSED) {
+        next.close()
+        if (closed) return
+        // Attempt a one-shot token refresh; on success we immediately reopen
+        // with the new token, otherwise we fall back to backoff so we don't
+        // hammer the API while auth is permanently broken.
+        void refreshToken()
+          .then((newToken) => {
+            if (closed) return
+            if (newToken) {
+              backoffMs = RECONNECT_INITIAL_MS
+              void openConnection()
+            } else {
+              scheduleReconnect()
+            }
+          })
+          .catch(() => {
+            if (!closed) scheduleReconnect()
+          })
+      }
+    })
+  }
+
+  void openConnection()
 
   return {
-    close: () => source.close(),
-    source,
+    close: () => {
+      closed = true
+      if (reconnectTimer !== null) {
+        window.clearTimeout(reconnectTimer)
+        reconnectTimer = null
+      }
+      if (source) {
+        source.close()
+      }
+    },
+    // Best-effort accessor for advanced consumers; may briefly point at a
+    // closed instance during reconnect, which is fine because we never expose
+    // it before the first open completes for new consumers.
+    get source(): EventSource {
+      if (!source) {
+        throw new Error("EventSource is not yet initialised")
+      }
+      return source
+    },
   }
 }

--- a/ui/src/lib/api/notes.ts
+++ b/ui/src/lib/api/notes.ts
@@ -29,6 +29,11 @@ const enc = encodeURIComponent
 /**
  * PUT /api/notes/sets/{conn_id}/{ns}/{set} — upsert a set note. An empty
  * ``note`` deletes the existing row (idempotent — no error when none).
+ *
+ * Backend compatibility: the API enforces ``min_length=1`` on the note body
+ * and returns 422 for an empty PUT, so when the caller passes an
+ * empty/whitespace-only note we transparently route through DELETE instead
+ * of PUT to preserve the historical "save empty == clear note" semantics.
  */
 export async function upsertSetNote(
   connId: string,
@@ -38,8 +43,8 @@ export async function upsertSetNote(
 ): Promise<SetNote | null> {
   const path = `/notes/sets/${enc(connId)}/${enc(namespace)}/${enc(setName)}`
   // The empty-note delete returns 204; non-empty returns the saved row.
-  if (!body.note) {
-    await apiPut<unknown>(path, body)
+  if (!body.note || !body.note.trim()) {
+    await deleteSetNote(connId, namespace, setName)
     return null
   }
   return apiPut<SetNote>(path, body)
@@ -77,6 +82,9 @@ export async function listSetNotes(
 /**
  * PUT /api/notes/records/{conn_id}/{ns}/{set}/{pk} — upsert a record note.
  * Empty ``note`` deletes (idempotent).
+ *
+ * Backend compatibility: see ``upsertSetNote`` — the API rejects empty bodies
+ * with 422, so empty-note saves transparently route through DELETE.
  */
 export async function upsertRecordNote(
   connId: string,
@@ -86,8 +94,8 @@ export async function upsertRecordNote(
   body: UpsertRecordNoteRequest,
 ): Promise<RecordNote | null> {
   const path = `/notes/records/${enc(connId)}/${enc(namespace)}/${enc(setName)}/${enc(pk)}`
-  if (!body.note) {
-    await apiPut<unknown>(path, body)
+  if (!body.note || !body.note.trim()) {
+    await deleteRecordNote(connId, namespace, setName, pk, body.pkType ?? "auto")
     return null
   }
   return apiPut<RecordNote>(path, body)

--- a/ui/src/lib/types/workspace.ts
+++ b/ui/src/lib/types/workspace.ts
@@ -12,6 +12,12 @@ export interface WorkspaceResponse {
   color: string
   description?: string | null
   isDefault: boolean
+  /**
+   * Sub claim of the OIDC user that owns the workspace. Mirrors
+   * ``WorkspaceResponse.ownerId`` on the backend (see
+   * ``api/src/aerospike_cluster_manager_api/models/workspace.py``).
+   */
+  ownerId: string
   createdAt: string
   updatedAt: string
 }


### PR DESCRIPTION
## Summary
Closes the DoS surface flagged in the security review. Per-route limits already shipped in Phase 1A — this PR adds the global default and fixes the XFF identity that those limits key off.

## What changed
- **`_get_client_ip`** — was returning the rightmost XFF entry, which is normally the trusted proxy IP. Every caller bucketed into one slot, defeating the limiter. Now walks the chain right-to-left peeling trusted hops and returns the first untrusted entry. Direct connections (no XFF, or peer not in `TRUSTED_PROXIES`) return `request.client.host`. CIDRs supported (e.g. `TRUSTED_PROXIES=10.0.0.0/8,192.168.0.0/16`).
- **Limiter `default_limits=["60/minute"]`** — every route without an explicit `@limiter.limit` inherits the baseline. Per-route caps from Phase 1A (records 30/min, query 30/min, admin/udfs/k8s 20/min, sample-data 10/min) override.
- **SSE exempt** — `routers/events:/stream` decorated `@limiter.exempt` so a long-lived EventSource connection isn't killed by the 60/min default on first hello.
- **tests/test_security_headers** — 4 new cases: leftmost-untrusted multi-hop, CIDR resolution, all-trusted fallback, default_limits registration.

## Stack (final)
1. phase-1a-security-acl (#321) ← `main`
2. phase-1b-api-stability (#322) ← #321
3. phase-1c-ui-fixes (#323) ← #322
4. phase-1d-config-alignment (#324) ← #323
5. phase-2a-jose-to-pyjwt (#325) ← #324
6. phase-2b-fernet-encryption (#326) ← #325
7. **This PR (Phase 2C)** ← #326

## Test plan
- [x] `cd api && uv run pytest tests/test_security_headers.py --no-header -q` — passes
- [x] e2e: 25× POST `/api/v1/k8s/clusters/.../scale` returned `200` for the first 19 requests then `429` for the rest (per-route 20/min override works on top of default)