### PR TITLE
fix(api): event-collector ns, truncate semantics, race / ReDoS / CORS guards

### DIFF
--- a/api/src/aerospike_cluster_manager_api/client_manager.py
+++ b/api/src/aerospike_cluster_manager_api/client_manager.py
@@ -150,6 +150,15 @@ class ClientManager:
         An MCP session evicts only its own slot, so disconnect from one
         session leaves other sessions' (and the REST path's) cached
         clients intact -- the core invariant of #303.
+
+        Race-safety: ``client.close()`` runs *while still holding* the
+        per-key lock so a concurrent ``get_client()`` cannot start
+        building a fresh AsyncClient against a soon-to-be-closed
+        underlying connection. The lock entry itself is intentionally
+        left in ``_conn_locks`` -- it gets cleaned up wholesale in
+        :meth:`close_all` and :meth:`close_session`. Popping it here
+        without the global lock + before the close completed was the
+        original race.
         """
         key = self._key(conn_id)
         conn_lock = await self._get_conn_lock(key)
@@ -159,8 +168,6 @@ class ClientManager:
             # session is the conservative choice since the underlying
             # cluster info doesn't depend on which MCP session asked.
             info_cache.invalidate_connection(conn_id)
-            async with self._global_lock:
-                self._conn_locks.pop(key, None)
             if client is not None:
                 with (
                     _tracer.start_as_current_span(

--- a/api/src/aerospike_cluster_manager_api/events/collector.py
+++ b/api/src/aerospike_cluster_manager_api/events/collector.py
@@ -175,8 +175,12 @@ class EventCollector:
                 clusters, _ = await k8s_client.list_clusters()
                 span.set_attribute("asm.collect.clusters", len(clusters))
                 for cluster in clusters:
-                    ns = cluster.get("namespace", "")
-                    name = cluster.get("name", "")
+                    metadata = cluster.get("metadata", {}) or {}
+                    ns = metadata.get("namespace", "") or ""
+                    name = metadata.get("name", "") or ""
+                    if not ns or not name:
+                        logger.debug("Skipping cluster with missing metadata.namespace/name: %r", metadata)
+                        continue
                     try:
                         detail = await k8s_client.get_cluster(ns, name)
                         await broker.publish(

--- a/api/src/aerospike_cluster_manager_api/expression_builder.py
+++ b/api/src/aerospike_cluster_manager_api/expression_builder.py
@@ -25,12 +25,41 @@ class InvalidPkPatternError(ValueError):
     """Raised when a user-supplied PK regex/prefix pattern is malformed."""
 
 
+# Hard cap on user-supplied regex length. 256 is comfortably above any
+# legitimate PK / bin pattern we've seen, well below the size at which
+# pathological backtracking becomes feasible.
+_MAX_REGEX_PATTERN_LENGTH = 256
+
+# Heuristic detector for the classic "evil regex" shapes that drive
+# catastrophic backtracking in Python's ``re`` engine: a quantifier
+# wrapped in a quantified group, e.g. ``(a+)+``, ``(a*)*``, ``(a?)+``,
+# ``(.+)+`` etc. We can't catch every pathological pattern this way, but
+# the structural majority of accidental ReDoS payloads land on this
+# shape and the rejection is cheap.
+_REDOS_NESTED_QUANTIFIER_RE = re.compile(r"\([^()]*[+*?][^()]*\)\s*[+*?{]")
+
+
 def _validate_pattern(pattern: str) -> None:
     """Catch the common syntactic regex errors (unbalanced brackets / parens,
     dangling quantifiers) before the pattern reaches the server. Python's
     regex grammar is more permissive than POSIX in places, but rejecting
     the structural majority on the API side beats letting the user see an
-    empty result with no signal that their pattern was the problem."""
+    empty result with no signal that their pattern was the problem.
+
+    Also rejects patterns that exceed
+    :data:`_MAX_REGEX_PATTERN_LENGTH` or match the nested-quantifier
+    heuristic in :data:`_REDOS_NESTED_QUANTIFIER_RE` -- a coarse but
+    cheap ReDoS guard. Python's ``re`` cannot be safely interrupted
+    once compilation/matching has started, so structural rejection is
+    the only viable defence at this layer.
+    """
+    if len(pattern) > _MAX_REGEX_PATTERN_LENGTH:
+        raise InvalidPkPatternError(f"Regex pattern is too long ({len(pattern)} > {_MAX_REGEX_PATTERN_LENGTH})")
+    if _REDOS_NESTED_QUANTIFIER_RE.search(pattern):
+        raise InvalidPkPatternError(
+            "Regex pattern contains a nested quantifier shape "
+            "(e.g. (...+)+, (...*)+, (...?)+) that can trigger catastrophic backtracking"
+        )
     try:
         re.compile(pattern)
     except re.error as e:

--- a/api/src/aerospike_cluster_manager_api/k8s_client.py
+++ b/api/src/aerospike_cluster_manager_api/k8s_client.py
@@ -71,23 +71,28 @@ class K8sClient:
 
             from . import config as app_config
 
+            # Build a per-instance Configuration so we don't mutate the
+            # process-wide singleton (``client.Configuration.set_default``
+            # would leak K8S_VERIFY_SSL=false into anything else in the
+            # process that ever instantiates a kubernetes client). Start
+            # from a copy of whatever the loader populated so cluster
+            # endpoint / auth headers carry over, then layer our overrides
+            # on top.
+            configuration = client.Configuration.get_default_copy()
             if not app_config.K8S_VERIFY_SSL:
-                configuration = client.Configuration.get_default_copy()
                 configuration.verify_ssl = False
                 configuration.ssl_ca_cert = None
-                client.Configuration.set_default(configuration)
                 logger.warning("K8S_VERIFY_SSL=false — TLS certificate verification disabled")
             elif app_config.K8S_CA_FILE:
-                configuration = client.Configuration.get_default_copy()
                 configuration.verify_ssl = True
                 configuration.ssl_ca_cert = app_config.K8S_CA_FILE  # type: ignore[reportAttributeAccessIssue]
-                client.Configuration.set_default(configuration)
                 logger.info("Using custom K8s API CA bundle: %s", app_config.K8S_CA_FILE)
 
-            self._custom_api = client.CustomObjectsApi()
-            self._core_api = client.CoreV1Api()
-            self._storage_api = client.StorageV1Api()
-            self._autoscaling_api = client.AutoscalingV2Api()
+            api_client = client.ApiClient(configuration=configuration)
+            self._custom_api = client.CustomObjectsApi(api_client=api_client)
+            self._core_api = client.CoreV1Api(api_client=api_client)
+            self._storage_api = client.StorageV1Api(api_client=api_client)
+            self._autoscaling_api = client.AutoscalingV2Api(api_client=api_client)
             self._initialized = True
 
     # ------------------------------------------------------------------

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -190,10 +190,23 @@ app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)  # type: ignore[reportArgumentType]
 app.add_middleware(SlowAPIMiddleware)
 
+# CORS wildcard + credentials is unsafe -- the browser will silently drop
+# the response when both are set. Treat the dangerous combo as a
+# configuration error: log a warning and force credentials off so the
+# server starts in a recognizably-broken-but-safe state instead of
+# silently leaking a "*" origin with cookies/Authorization echoed back.
+_cors_allow_credentials = True
+if "*" in config.CORS_ORIGINS:
+    logger.warning(
+        "CORS_ORIGINS contains '*' which is incompatible with allow_credentials=True; "
+        "forcing allow_credentials=False. Set CORS_ORIGINS to an explicit list of origins to re-enable credentials."
+    )
+    _cors_allow_credentials = False
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=config.CORS_ORIGINS,
-    allow_credentials=True,
+    allow_credentials=_cors_allow_credentials,
     allow_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
     allow_headers=["Content-Type", "Authorization", "X-Request-ID"],
 )
@@ -309,18 +322,35 @@ if (
         "isolated to localhost / a trusted network."
     )
 
+# Starlette ``add_middleware`` semantics: each call ``insert(0, ...)`` into
+# ``user_middleware``, then ``build_middleware_stack`` wraps them in
+# ``reversed()`` order. Net effect: the LAST ``add_middleware`` call becomes
+# the OUTERMOST layer at request time. We exploit that to land:
+#
+#   request -> MCPBearerToken -> OIDC -> MCPUserContext -> ... -> route
+#
+# i.e. MCPBearerToken runs first to handle opaque bearer tokens (it
+# stashes a sentinel ``request.state.user_claims`` on success, otherwise
+# falls through), OIDC runs next to JWT-verify and populate
+# ``request.state.user_claims`` for real, and MCPUserContextMiddleware
+# runs *after* both so it can copy the now-populated claims onto the
+# contextvar for the MCP tool registry. The order of the ``add_middleware``
+# calls below is therefore deliberately reversed from the runtime order.
 if config.ACM_MCP_ENABLED:
     # E.2 (#307): bridge ``request.state.user_claims`` into a contextvar
     # so the MCP registry's workspace gate can read the caller identity
-    # without re-threading the FastAPI ``Request``. Installed BEFORE
-    # OIDC + MCPBearerToken in the add_middleware order so it runs
-    # INNER to both at request time -- by then ``user_claims`` is
-    # populated (or correctly absent for anonymous deployments).
+    # without re-threading the FastAPI ``Request``. Added FIRST here so
+    # it ends up INNERMOST among the auth-related middlewares — it reads
+    # the claims OIDC + MCPBearer have already populated.
     from aerospike_cluster_manager_api.mcp.user_context import MCPUserContextMiddleware
 
     app.add_middleware(MCPUserContextMiddleware)
 
 if config.OIDC_ENABLED:
+    # OIDC sits in the middle of the stack: outer to MCPUserContext (so
+    # claims are populated before the bridge reads them) but inner to
+    # MCPBearerToken (so an opaque bearer token can short-circuit OIDC's
+    # JWT verifier).
     app.add_middleware(
         OIDCAuthMiddleware,
         enabled=True,
@@ -332,6 +362,9 @@ if config.OIDC_ENABLED:
     )
 
 if config.ACM_MCP_ENABLED:
+    # Added LAST among the MCP/OIDC trio so it ends up OUTERMOST and
+    # gets first crack at the request -- bearer-only callers never reach
+    # OIDC's JWT verifier.
     from aerospike_cluster_manager_api.mcp.auth import MCPBearerTokenMiddleware
 
     app.add_middleware(MCPBearerTokenMiddleware)
@@ -375,6 +408,7 @@ try:
         AdminError,
         AerospikeError,
         AerospikeTimeoutError,
+        BackpressureError,
         ClusterError,
         IndexFoundError,
         IndexNotFound,
@@ -430,6 +464,18 @@ try:
     @app.exception_handler(AerospikeTimeoutError)
     async def _timeout_error(_req: Request, exc: AerospikeTimeoutError) -> JSONResponse:
         return JSONResponse(status_code=504, content={"detail": "Operation timed out"})
+
+    @app.exception_handler(BackpressureError)
+    async def _backpressure_error(_req: Request, exc: BackpressureError) -> JSONResponse:
+        # aerospike-py backpressure: native client refused the call because
+        # its in-flight queue is full. 503 + Retry-After (seconds) matches
+        # the aerospike-py-fastapi skill contract so clients can retry with
+        # exponential backoff instead of treating it as a hard failure.
+        return JSONResponse(
+            status_code=503,
+            content={"detail": "Aerospike client is overloaded; retry after backoff"},
+            headers={"Retry-After": "1"},
+        )
 
     @app.exception_handler(ClusterError)
     async def _cluster_error(_req: Request, exc: ClusterError) -> JSONResponse:

--- a/api/src/aerospike_cluster_manager_api/services/records_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/records_service.py
@@ -323,15 +323,24 @@ async def truncate_set(
     """Truncate every record in ``namespace.set_name`` (optionally up to a LUT).
 
     ``before_lut`` is the cutoff in nanoseconds since CITRUS epoch (the
-    aerospike-py ``truncate`` API's ``nanos`` parameter). When omitted, the
-    truncate covers all records currently in the set. Pass an explicit
-    nanosecond value to truncate only records whose last-update-time is
-    below that threshold.
+    aerospike-py ``truncate`` API's ``nanos`` parameter). ``None`` means
+    "truncate everything currently in the set". A positive value targets
+    only records whose last-update-time is below that threshold.
+
+    Explicit ``before_lut=0`` is rejected: the underlying info command
+    treats ``lut=0`` as "no cutoff" (i.e. truncate-all), which would
+    silently turn a buggy caller passing literal zero into a full
+    truncation. Forcing ``ValueError`` makes the contract explicit —
+    callers that genuinely want a full truncate must pass ``None``.
 
     Internally this becomes the ``truncate-namespace:namespace=...;set=...
     [;lut=...]`` info command — aerospike-py's :meth:`AsyncClient.truncate`
     issues it for us so we don't have to format the wire string by hand.
     """
+    if before_lut is not None and before_lut <= 0:
+        raise ValueError(
+            "before_lut must be a positive nanosecond value; pass before_lut=None to truncate every record in the set"
+        )
     nanos = before_lut if before_lut is not None else 0
     await client.truncate(namespace, set_name, nanos)
 

--- a/api/tests/test_client_manager.py
+++ b/api/tests/test_client_manager.py
@@ -116,8 +116,15 @@ class TestClientManagerConcurrency:
             result_slow = await task_slow
             assert result_slow is slow_client
 
-    async def test_close_client_cleans_up_lock(self, mock_db_profile):
-        """close_client() should remove the per-connection lock entry.
+    async def test_close_client_evicts_cached_client(self, mock_db_profile):
+        """close_client() removes the cached client; the per-conn lock
+        entry is intentionally left in place.
+
+        Holding the lock across ``client.close()`` is what makes the
+        eviction race-safe (Phase 1B / B4). Popping the lock would let
+        a concurrent ``get_client()`` install a fresh lock + new client
+        while we're still closing the old one. ``close_all`` /
+        ``close_session`` clear ``_conn_locks`` wholesale.
 
         REST callers have ``session_id=None`` so the cache key is
         ``(None, conn_id)`` -- see #303 for the per-session keying
@@ -135,8 +142,9 @@ class TestClientManagerConcurrency:
             assert (None, "conn-1") in mgr._conn_locks
 
             await mgr.close_client("conn-1")
-            assert (None, "conn-1") not in mgr._conn_locks
             assert (None, "conn-1") not in mgr._clients
+            # Lock entry is intentionally retained (Phase 1B / B4).
+            assert (None, "conn-1") in mgr._conn_locks
 
 
 class TestClientManagerSessionKeying:


### PR DESCRIPTION
- events/collector: read namespace/name from metadata (was top-level, always
  empty), causing every K8s API call from the SSE loop to hit "" namespace
- services/records_service: truncate_set rejects before_lut <= 0; only None
  means "truncate all". Closes the MCP foot-gun where 0 silently truncated
- client_manager: close_client holds the per-key lock through client.close()
  to eliminate the new-client-during-close race
- expression_builder: 256-char cap and nested-quantifier rejection
  ((.+)+, (a*)+, etc.) on PK/bin regex to bound ReDoS surface
- main: BackpressureError -> 503 with Retry-After:1 (matches the
  aerospike-py-fastapi contract); CORS wildcard + allow_credentials=True
  forces allow_credentials=False with a startup warning instead of silently
  echoing untrusted origins. Middleware ordering documented in-place.
- k8s_client: per-instance Configuration passed via ApiClient(configuration=)
  so K8S_VERIFY_SSL=false no longer leaks to other K8s clients via the
  process-wide singleton.
