### PR TITLE
fix(api): list_connections leaks cross-tenant rows when workspace_id omitted

### DIFF
--- a/api/src/aerospike_cluster_manager_api/services/connections_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/connections_service.py
@@ -121,6 +121,15 @@ async def list_connections(
     if workspace_id is not None:
         await _assert_workspace_visible(workspace_id, caller_owner_id)
     profiles = await db.get_all_connections(workspace_id)
+
+    if caller_owner_id is not None and workspace_id is None:
+        try:
+            workspaces = await db.get_all_workspaces()
+        except db.DBNotInitialized:
+            workspaces = []
+        visible_ws_ids = {ws.id for ws in workspaces if ws.ownerId == caller_owner_id or ws.ownerId == SYSTEM_OWNER_ID}
+        profiles = [p for p in profiles if (p.workspaceId or DEFAULT_WORKSPACE_ID) in visible_ws_ids]
+
     return [ConnectionProfileResponse.from_profile(p) for p in profiles]
 
 

--- a/api/tests/test_connections_service.py
+++ b/api/tests/test_connections_service.py
@@ -91,6 +91,36 @@ class TestListConnections:
         assert all(item.workspaceId == "ws-team-svc" for item in ws_team)
         assert len(ws_team) >= 1
 
+    async def test_caller_filter_hides_other_owner_workspaces(self, init_test_db):
+        from datetime import UTC, datetime
+
+        from aerospike_cluster_manager_api import db
+        from aerospike_cluster_manager_api.models.workspace import Workspace
+
+        now = datetime.now(UTC).isoformat()
+        await db.create_workspace(
+            Workspace(id="ws-alice", name="alice", color="#111111", ownerId="alice", createdAt=now, updatedAt=now)
+        )
+        await db.create_workspace(
+            Workspace(id="ws-bob", name="bob", color="#222222", ownerId="bob", createdAt=now, updatedAt=now)
+        )
+        await connections_service.create_connection(
+            _create_payload(name="alice-conn", workspaceId="ws-alice"), caller_owner_id="alice"
+        )
+        await connections_service.create_connection(
+            _create_payload(name="bob-conn", workspaceId="ws-bob"), caller_owner_id="bob"
+        )
+
+        alice_view = await connections_service.list_connections(workspace_id=None, caller_owner_id="alice")
+        bob_view = await connections_service.list_connections(workspace_id=None, caller_owner_id="bob")
+
+        alice_names = {c.name for c in alice_view}
+        bob_names = {c.name for c in bob_view}
+        assert "alice-conn" in alice_names
+        assert "bob-conn" not in alice_names
+        assert "bob-conn" in bob_names
+        assert "alice-conn" not in bob_names
+
 
 # ---------------------------------------------------------------------------
 # create_connection


### PR DESCRIPTION
## Summary
Discovered during the OIDC e2e on origin/main (after #321/#328-#332 merged): bob authenticates against the realm and calls `GET /api/v1/connections` with no `workspaceId` filter, and alice's connection profile comes back in the list.

The Phase 1A ACL covered every single-id endpoint and `?workspaceId=`-scoped list, but the no-filter list path called `db.get_all_connections(None)` directly and skipped visibility. The UI populates the cluster picker with the unscoped list, so this leaks across tenants without any specific user action.

## What changed
- **`services/connections_service.list_connections`** — when `caller_owner_id` is provided and `workspace_id` is `None`, load workspaces and intersect the result with `{ws.id : ws.ownerId == caller or ws.ownerId == 'system'}`. `caller_owner_id=None` (legacy / OIDC-disabled) keeps the previous behavior, matching the convention used by `_assert_workspace_visible`.
- **`tests/test_connections_service`** — regression test: alice and bob each create a connection in their own workspace; calling `list_connections(workspace_id=None, caller_owner_id="alice")` returns only alice's, and the inverse for bob.

## Test plan
- [x] `cd api && uv run pytest --no-header -q` — 982 passed (+1 regression case)
- [x] e2e (Keycloak realm `acko`, alice + bob): `GET /api/v1/connections` as bob no longer returns alice's profile (verified after this fix is loaded)

## Impact
- Multi-tenant deployments using OIDC and the unscoped list are protected.
- Single-tenant / OIDC-disabled deployments (`caller_owner_id is None`) are unaffected.