### PR TITLE
fix(api): close cross-tenant data leaks in K8s endpoints and SSE collector

### DIFF
--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -120,6 +120,18 @@ SSE_ENABLED: bool = os.getenv("SSE_ENABLED", "true").lower() in ("true", "1", "y
 SSE_HEARTBEAT_INTERVAL: int = _get_int("SSE_HEARTBEAT_INTERVAL", 15)  # seconds between heartbeat pings
 SSE_MAX_CONNECTIONS: int = _get_int("SSE_MAX_CONNECTIONS", 50)  # max concurrent SSE subscribers
 
+# CM_SSE_BROADCAST_PER_CONNECTION gates the per-connection broadcast loops in
+# ``events.collector`` (cluster.metrics, connection.health, k8s.cluster.*).
+# Default ``false`` because the broker has no per-subscriber owner filter --
+# emitting tenant-A connection metrics to tenant-B subscribers leaks data.
+# Operators of single-tenant deployments can opt back in by setting this to
+# true. Tracked as follow-up to ADR-0040 (per-subscriber filtering).
+CM_SSE_BROADCAST_PER_CONNECTION: bool = os.getenv("CM_SSE_BROADCAST_PER_CONNECTION", "false").lower() in (
+    "true",
+    "1",
+    "yes",
+)
+
 # ---------------------------------------------------------------------------
 # OpenTelemetry — exporter/sampler/resource configuration goes through OTel
 # SDK standard env vars (OTEL_EXPORTER_OTLP_*, OTEL_TRACES_SAMPLER, ...). The

--- a/api/src/aerospike_cluster_manager_api/dependencies.py
+++ b/api/src/aerospike_cluster_manager_api/dependencies.py
@@ -105,10 +105,29 @@ async def _get_verified_connection(
     return conn_id
 
 
-async def _get_verified_workspace(workspace_id: str = Path()) -> str:
-    """Verify that a workspace exists (path parameter) and return its id."""
-    ws = await db.get_workspace(workspace_id)
+async def _get_verified_workspace(
+    workspace_id: str = Path(),
+    caller_owner_id: str = Depends(_resolve_caller_owner_id),
+) -> str:
+    """Verify that a workspace exists and the caller can see it.
+
+    Default-deny ACL gate -- mirrors the rule used by
+    :func:`services.workspaces_service.get_workspace`. Returns the
+    workspace id when ``ownerId == caller_owner_id`` or the workspace is
+    system-shared (``ownerId == SYSTEM_OWNER_ID``). Raises 404
+    (identity-404, not 403) for missing rows and for rows the caller
+    cannot see, matching the wire shape used elsewhere so id enumeration
+    is impossible.
+    """
+    try:
+        ws = await db.get_workspace(workspace_id)
+    except db.DBNotInitialized:
+        # Unit-test paths that skip the workspace DB keep the legacy
+        # path-validation-only behaviour.
+        return workspace_id
     if not ws:
+        raise HTTPException(status_code=404, detail=f"Workspace '{workspace_id}' not found")
+    if ws.ownerId != caller_owner_id and ws.ownerId != SYSTEM_OWNER_ID:
         raise HTTPException(status_code=404, detail=f"Workspace '{workspace_id}' not found")
     return workspace_id
 

--- a/api/src/aerospike_cluster_manager_api/events/collector.py
+++ b/api/src/aerospike_cluster_manager_api/events/collector.py
@@ -59,10 +59,18 @@ class EventCollector:
             except asyncio.CancelledError:
                 return
             except Exception:
-                logger.debug("Metrics collection error", exc_info=True)
+                logger.warning("Metrics collection error", exc_info=True)
             await asyncio.sleep(METRICS_INTERVAL_S)
 
     async def _publish_metrics(self) -> None:
+        # The broker has no per-subscriber owner filter, so a per-connection
+        # broadcast loop leaks tenant-A metrics to tenant-B SSE subscribers.
+        # Disabled by default; single-tenant deployments can opt back in via
+        # ``CM_SSE_BROADCAST_PER_CONNECTION=true``. Frontends should poll
+        # ``/clusters/{id}`` for metrics until ADR-0040 follow-up lands a
+        # broker-level filtering primitive.
+        if not config.CM_SSE_BROADCAST_PER_CONNECTION:
+            return
         if broker.subscriber_count == 0:
             return
         connections = await db.get_all_connections()
@@ -83,7 +91,7 @@ class EventCollector:
                         }
                     )
                 except Exception:
-                    logger.debug("Failed to collect metrics for connection '%s'", conn.id, exc_info=True)
+                    logger.warning("Failed to collect metrics for connection '%s'", conn.id, exc_info=True)
 
     # ------------------------------------------------------------------
     # Connection health loop
@@ -96,10 +104,16 @@ class EventCollector:
             except asyncio.CancelledError:
                 return
             except Exception:
-                logger.debug("Health collection error", exc_info=True)
+                logger.warning("Health collection error", exc_info=True)
             await asyncio.sleep(HEALTH_INTERVAL_S)
 
     async def _publish_health(self) -> None:
+        # See ``_publish_metrics``: same multi-tenant leak. Gated off by
+        # default until ADR-0040 follow-up gives the broker per-subscriber
+        # filtering. Per-connection health is also exposed at
+        # ``GET /api/clusters/{id}/health`` for poll-based UIs.
+        if not config.CM_SSE_BROADCAST_PER_CONNECTION:
+            return
         if broker.subscriber_count == 0:
             return
         from aerospike_cluster_manager_api.constants import INFO_BUILD, INFO_EDITION, INFO_NAMESPACES
@@ -159,10 +173,16 @@ class EventCollector:
             except asyncio.CancelledError:
                 return
             except Exception:
-                logger.debug("K8s collection error", exc_info=True)
+                logger.warning("K8s collection error", exc_info=True)
             await asyncio.sleep(K8S_INTERVAL_S)
 
     async def _publish_k8s(self) -> None:
+        # See ``_publish_metrics``: per-cluster events (k8s.cluster.detail /
+        # events / health) bypass the workspace ACL when broadcast to all
+        # SSE subscribers. Gated off by default until per-subscriber filter
+        # lands.
+        if not config.CM_SSE_BROADCAST_PER_CONNECTION:
+            return
         if broker.subscriber_count == 0:
             return
         with _tracer.start_as_current_span(
@@ -192,7 +212,7 @@ class EventCollector:
                             }
                         )
                     except Exception:
-                        logger.debug("Failed to collect K8s detail for %s/%s", ns, name, exc_info=True)
+                        logger.warning("Failed to collect K8s detail for %s/%s", ns, name, exc_info=True)
 
                     try:
                         field_selector = f"involvedObject.name={name},involvedObject.kind=AerospikeCluster"
@@ -206,7 +226,7 @@ class EventCollector:
                             }
                         )
                     except Exception:
-                        logger.debug("Failed to collect K8s events for %s/%s", ns, name, exc_info=True)
+                        logger.warning("Failed to collect K8s events for %s/%s", ns, name, exc_info=True)
 
                     try:
                         from aerospike_cluster_manager_api.routers.k8s_clusters import extract_health
@@ -222,9 +242,9 @@ class EventCollector:
                             }
                         )
                     except Exception:
-                        logger.debug("Failed to collect K8s health for %s/%s", ns, name, exc_info=True)
+                        logger.warning("Failed to collect K8s health for %s/%s", ns, name, exc_info=True)
             except Exception:
-                logger.debug("K8s collection cycle failed", exc_info=True)
+                logger.warning("K8s collection cycle failed", exc_info=True)
 
 
 collector = EventCollector()

--- a/api/src/aerospike_cluster_manager_api/rate_limit.py
+++ b/api/src/aerospike_cluster_manager_api/rate_limit.py
@@ -115,4 +115,4 @@ def _get_client_ip(request: Request) -> str:
 # ``@limiter.limit(...)`` decorators.
 DEFAULT_LIMITS = ["60/minute"]
 
-limiter = Limiter(key_func=_get_client_ip, default_limits=DEFAULT_LIMITS)
+limiter = Limiter(key_func=_get_client_ip, default_limits=DEFAULT_LIMITS)  # type: ignore[arg-type]  # slowapi default_limits accepts list[str]; pyright strict-checks against alias

--- a/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
@@ -230,7 +230,21 @@ async def list_k8s_clusters(
         visible_workspaces[ws_id] = await _is_workspace_visible(ws_id, caller_owner_id)
     items = [item for item in items if (ws := _cr_workspace_id(item)) is None or visible_workspaces.get(ws, False)]
 
+    # Build the connection-id correlation table from connections visible to the
+    # caller only. Without this filter, a tenant would receive another tenant's
+    # connectionId on a CR that happens to share a name/host -- a cross-tenant
+    # data leak. Mirrors the visibility rule used by
+    # ``services/connections_service.list_connections``.
     connections = await db.get_all_connections()
+    try:
+        all_workspaces = await db.get_all_workspaces()
+    except db.DBNotInitialized:
+        all_workspaces = []
+    visible_ws_ids = {
+        ws.id for ws in all_workspaces if ws.ownerId == caller_owner_id or ws.ownerId == SYSTEM_OWNER_ID
+    }
+    if all_workspaces:
+        connections = [c for c in connections if (c.workspaceId or DEFAULT_WORKSPACE_ID) in visible_ws_ids]
     conn_by_host: dict[str, str] = {}
     conn_by_name: dict[str, str] = {}
     for conn in connections:
@@ -678,6 +692,17 @@ async def delete_k8s_cluster(
         service_host = f"{name}.{namespace}.svc.cluster.local"
         for conn in all_conns:
             if conn.name == k8s_prefix or service_host in conn.hosts:
+                # Gate on workspace visibility so we never delete another
+                # tenant's connection profile that happens to share a
+                # hostname/name with the cluster being torn down.
+                conn_ws = conn.workspaceId or DEFAULT_WORKSPACE_ID
+                if not await _is_workspace_visible(conn_ws, caller_owner_id):
+                    logger.info(
+                        "Skipping connection cleanup for %s (workspace %s not visible to caller)",
+                        conn.id,
+                        conn_ws,
+                    )
+                    continue
                 await db.delete_connection(conn.id)
                 await client_manager.close_client(conn.id)
                 logger.info("Cleaned up auto-connect profile %s for deleted cluster %s/%s", conn.id, namespace, name)
@@ -808,31 +833,68 @@ async def delete_k8s_cluster_hpa(
 # ---------------------------------------------------------------------------
 
 
+async def _visible_cluster_namespaces(caller_owner_id: str) -> set[str]:
+    """Return the K8s namespaces hosting an AerospikeCluster the caller can see.
+
+    Used to bound infrastructure-level lookups (secrets) to namespaces the
+    caller has any cluster footprint in. Namespaces without a labelled CR
+    (legacy / system-shared) remain reachable.
+    """
+    items, _ = await k8s_client.list_clusters(limit=200)
+    workspace_ids: set[str] = {ws_id for item in items if (ws_id := _cr_workspace_id(item)) is not None}
+    visible_workspaces: dict[str, bool] = {
+        ws_id: await _is_workspace_visible(ws_id, caller_owner_id) for ws_id in workspace_ids
+    }
+    namespaces: set[str] = set()
+    for item in items:
+        ws_id = _cr_workspace_id(item)
+        if ws_id is None or visible_workspaces.get(ws_id, False):
+            ns = (item.get("metadata", {}) or {}).get("namespace")
+            if ns:
+                namespaces.add(ns)
+    return namespaces
+
+
 @router.get("/namespaces", summary="List Kubernetes namespaces")
 @_k8s_endpoint("list Kubernetes namespaces")
-async def list_k8s_namespaces() -> list[str]:
-
+async def list_k8s_namespaces(caller_owner_id: CallerOwnerId) -> list[str]:
+    # Namespaces are infrastructure-level metadata: returned cluster-wide so
+    # users can pick one when creating a new cluster. The ``caller_owner_id``
+    # dependency still requires an authenticated caller.
+    _ = caller_owner_id
     return await k8s_client.list_namespaces()
 
 
 @router.get("/nodes", summary="List Kubernetes nodes with zone info")
 @_k8s_endpoint("list Kubernetes nodes")
-async def list_k8s_nodes() -> list[dict[str, Any]]:
-
+async def list_k8s_nodes(caller_owner_id: CallerOwnerId) -> list[dict[str, Any]]:
+    # Nodes are cluster-level infrastructure -- enumerated for placement
+    # planning. Authenticated callers only.
+    _ = caller_owner_id
     return await k8s_client.list_nodes()
 
 
 @router.get("/storageclasses", summary="List Kubernetes storage classes")
 @_k8s_endpoint("list Kubernetes storage classes")
-async def list_k8s_storage_classes() -> list[str]:
-
+async def list_k8s_storage_classes(caller_owner_id: CallerOwnerId) -> list[str]:
+    # Storage classes are cluster-level infrastructure metadata.
+    # Authenticated callers only.
+    _ = caller_owner_id
     return await k8s_client.list_storage_classes()
 
 
 @router.get("/secrets", summary="List K8s Secrets in a namespace")
 @_k8s_endpoint("list Kubernetes secrets")
-async def list_k8s_secrets(namespace: str = "aerospike") -> list[str]:
-
+async def list_k8s_secrets(caller_owner_id: CallerOwnerId, namespace: str = "aerospike") -> list[str]:
+    # Secrets are sensitive: only return them for namespaces the caller has
+    # at least one visible AerospikeCluster CR in. Namespaces with no
+    # labelled CR (legacy / system-shared) remain reachable so existing
+    # single-tenant deployments keep working.
+    visible = await _visible_cluster_namespaces(caller_owner_id)
+    if visible and namespace not in visible:
+        # Identity-404 (empty list) so callers cannot enumerate other
+        # tenants' namespaces.
+        return []
     return await k8s_client.list_secrets(namespace)
 
 
@@ -841,21 +903,53 @@ async def list_k8s_secrets(namespace: str = "aerospike") -> list[str]:
 # ---------------------------------------------------------------------------
 
 
+async def _assert_template_visible(name: str, caller_owner_id: str) -> dict[str, Any]:
+    """Default-deny ACL gate for template mutations / get.
+
+    Templates with no ``acm.aerospike.com/workspace`` label are treated as
+    system-shared (visible to every authenticated caller) so legacy CRs
+    created before workspace labelling stay reachable. Labelled CRs are
+    visible only to the workspace owner (or ``SYSTEM_OWNER_ID``). Returns
+    the CR dict when visible; raises 404 otherwise (identity-404 to
+    prevent enumeration).
+    """
+    try:
+        item = await k8s_client.get_template(name)
+    except K8sApiError as e:
+        if e.status == 404:
+            raise HTTPException(status_code=404, detail=f"Template '{name}' not found") from e
+        raise _map_k8s_error(e) from e
+    workspace_id = _cr_workspace_id(item)
+    if workspace_id is None:
+        return item
+    if not await _is_workspace_visible(workspace_id, caller_owner_id):
+        raise HTTPException(status_code=404, detail=f"Template '{name}' not found")
+    return item
+
+
 @router.get("/templates", summary="List K8s AerospikeClusterTemplates")
 @_k8s_endpoint("list Kubernetes templates")
-async def list_k8s_templates() -> list[K8sTemplateSummary]:
+async def list_k8s_templates(caller_owner_id: CallerOwnerId) -> list[K8sTemplateSummary]:
 
     items = await k8s_client.list_templates()
+    # Filter labelled templates by workspace visibility. Templates without a
+    # workspace label are treated as system-shared (legacy compatibility).
+    workspace_ids: set[str] = {ws_id for item in items if (ws_id := _cr_workspace_id(item)) is not None}
+    visible_workspaces: dict[str, bool] = {
+        ws_id: await _is_workspace_visible(ws_id, caller_owner_id) for ws_id in workspace_ids
+    }
+    items = [item for item in items if (ws := _cr_workspace_id(item)) is None or visible_workspaces.get(ws, False)]
     return [extract_template_summary(item) for item in items]
 
 
 @router.get("/templates/{name}", summary="Get K8s AerospikeClusterTemplate detail")
 @_k8s_endpoint("get Kubernetes template")
 async def get_k8s_template(
+    caller_owner_id: CallerOwnerId,
     name: str = _K8S_NAME,
 ) -> K8sTemplateDetail:
 
-    item = await k8s_client.get_template(name)
+    item = await _assert_template_visible(name, caller_owner_id)
     metadata = item.get("metadata", {})
     return K8sTemplateDetail(
         name=metadata.get("name", ""),
@@ -868,8 +962,17 @@ async def get_k8s_template(
 @router.post("/templates", status_code=201, summary="Create K8s AerospikeClusterTemplate")
 @limiter.limit("20/minute")
 @_k8s_endpoint("create Kubernetes template")
-async def create_k8s_template(request: Request, body: CreateK8sTemplateRequest) -> K8sTemplateSummary:
+async def create_k8s_template(
+    request: Request,
+    body: CreateK8sTemplateRequest,
+    caller_owner_id: CallerOwnerId,
+) -> K8sTemplateSummary:
 
+    # Templates have no workspace_id field on the request model today -- they
+    # remain system-shared until a future PR threads workspace through
+    # CreateK8sTemplateRequest. Still require an authenticated caller (the
+    # ``caller_owner_id`` dependency would not run otherwise) so anonymous
+    # template mutations are impossible once OIDC is enabled.
     cr = build_template_cr(body)
     result = await k8s_client.create_template(cr)
     return extract_template_summary(result)
@@ -881,9 +984,11 @@ async def create_k8s_template(request: Request, body: CreateK8sTemplateRequest) 
 async def update_k8s_template(
     request: Request,
     body: UpdateK8sTemplateRequest,
+    caller_owner_id: CallerOwnerId,
     name: str = _K8S_NAME,
 ) -> K8sTemplateSummary:
 
+    await _assert_template_visible(name, caller_owner_id)
     patch = build_template_update_patch(body)
     if not patch.get("spec"):
         raise HTTPException(status_code=400, detail="No fields to update")
@@ -896,8 +1001,11 @@ async def update_k8s_template(
 @_k8s_endpoint("delete Kubernetes template")
 async def delete_k8s_template(
     request: Request,
+    caller_owner_id: CallerOwnerId,
     name: str = _K8S_NAME,
 ) -> DeleteResponse:
+
+    await _assert_template_visible(name, caller_owner_id)
 
     # Fetch all clusters (unpaginated) to check for template references
     all_clusters: list[dict[str, Any]] = []

--- a/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
@@ -903,9 +903,7 @@ async def list_k8s_secrets(caller_owner_id: CallerOwnerId, namespace: str = "aer
 # ---------------------------------------------------------------------------
 
 
-async def _assert_template_visible(
-    name: str, caller_owner_id: str, *, for_mutation: bool = False
-) -> dict[str, Any]:
+async def _assert_template_visible(name: str, caller_owner_id: str, *, for_mutation: bool = False) -> dict[str, Any]:
     """Default-deny ACL gate for template reads / mutations.
 
     Templates with no ``acm.aerospike.com/workspace`` label are treated as

--- a/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
@@ -236,14 +236,14 @@ async def list_k8s_clusters(
     # data leak. Mirrors the visibility rule used by
     # ``services/connections_service.list_connections``.
     connections = await db.get_all_connections()
-    try:
-        all_workspaces = await db.get_all_workspaces()
-    except db.DBNotInitialized:
-        all_workspaces = []
-    visible_ws_ids = {
-        ws.id for ws in all_workspaces if ws.ownerId == caller_owner_id or ws.ownerId == SYSTEM_OWNER_ID
-    }
-    if all_workspaces:
+    if caller_owner_id is not None:
+        try:
+            all_workspaces = await db.get_all_workspaces()
+        except db.DBNotInitialized:
+            all_workspaces = []
+        visible_ws_ids = {
+            ws.id for ws in all_workspaces if ws.ownerId == caller_owner_id or ws.ownerId == SYSTEM_OWNER_ID
+        }
         connections = [c for c in connections if (c.workspaceId or DEFAULT_WORKSPACE_ID) in visible_ws_ids]
     conn_by_host: dict[str, str] = {}
     conn_by_name: dict[str, str] = {}
@@ -903,8 +903,10 @@ async def list_k8s_secrets(caller_owner_id: CallerOwnerId, namespace: str = "aer
 # ---------------------------------------------------------------------------
 
 
-async def _assert_template_visible(name: str, caller_owner_id: str) -> dict[str, Any]:
-    """Default-deny ACL gate for template mutations / get.
+async def _assert_template_visible(
+    name: str, caller_owner_id: str, *, for_mutation: bool = False
+) -> dict[str, Any]:
+    """Default-deny ACL gate for template reads / mutations.
 
     Templates with no ``acm.aerospike.com/workspace`` label are treated as
     system-shared (visible to every authenticated caller) so legacy CRs
@@ -912,6 +914,12 @@ async def _assert_template_visible(name: str, caller_owner_id: str) -> dict[str,
     visible only to the workspace owner (or ``SYSTEM_OWNER_ID``). Returns
     the CR dict when visible; raises 404 otherwise (identity-404 to
     prevent enumeration).
+
+    Unlabelled (system-shared) templates are readable by all but cannot be
+    mutated; setting ``for_mutation=True`` therefore rejects them with the
+    same identity-404 used elsewhere. This prevents cross-tenant mutation
+    while a follow-up PR threads ``workspace`` through the template create
+    path so newly created templates are always labelled.
     """
     try:
         item = await k8s_client.get_template(name)
@@ -921,6 +929,8 @@ async def _assert_template_visible(name: str, caller_owner_id: str) -> dict[str,
         raise _map_k8s_error(e) from e
     workspace_id = _cr_workspace_id(item)
     if workspace_id is None:
+        if for_mutation:
+            raise HTTPException(status_code=404, detail=f"Template '{name}' not found")
         return item
     if not await _is_workspace_visible(workspace_id, caller_owner_id):
         raise HTTPException(status_code=404, detail=f"Template '{name}' not found")
@@ -988,7 +998,7 @@ async def update_k8s_template(
     name: str = _K8S_NAME,
 ) -> K8sTemplateSummary:
 
-    await _assert_template_visible(name, caller_owner_id)
+    await _assert_template_visible(name, caller_owner_id, for_mutation=True)
     patch = build_template_update_patch(body)
     if not patch.get("spec"):
         raise HTTPException(status_code=400, detail="No fields to update")
@@ -1005,7 +1015,7 @@ async def delete_k8s_template(
     name: str = _K8S_NAME,
 ) -> DeleteResponse:
 
-    await _assert_template_visible(name, caller_owner_id)
+    await _assert_template_visible(name, caller_owner_id, for_mutation=True)
 
     # Fetch all clusters (unpaginated) to check for template references
     all_clusters: list[dict[str, Any]] = []

--- a/api/src/aerospike_cluster_manager_api/routers/notes.py
+++ b/api/src/aerospike_cluster_manager_api/routers/notes.py
@@ -56,6 +56,12 @@ async def _assert_caller_owns_connection(
     profile = await db.get_connection(conn_id)
     if profile is None:  # pragma: no cover — VerifiedConnId already checked
         raise HTTPException(status_code=404, detail=f"Connection '{conn_id}' not found")
+    if profile.workspaceId is None:
+        # Legacy / personal connection with no workspace association. Mirror
+        # the behaviour in ``dependencies._get_verified_connection`` and treat
+        # as system-shared (caller owns by default). Without this guard, a
+        # ``workspaceId=None`` row produces a spurious 404 for any caller.
+        return conn_id
     workspace = await db.get_workspace(profile.workspaceId)
     if workspace is None:
         # Workspace was deleted between the VerifiedConnId lookup and now —

--- a/ui/src/lib/api/error-mapping.ts
+++ b/ui/src/lib/api/error-mapping.ts
@@ -53,7 +53,9 @@ export function mapApiError(err: unknown): ApiErrorKind {
         // backend detail string verbatim; only synthesize when it is empty.
         return {
           kind: "validation",
-          message: err.detail ? `Validation: ${err.detail}` : "Validation error",
+          message: err.detail
+            ? `Validation: ${err.detail}`
+            : "Validation error",
         }
       case 503:
         return { kind: "unreachable", message: err.detail }

--- a/ui/src/lib/api/notes.ts
+++ b/ui/src/lib/api/notes.ts
@@ -95,7 +95,13 @@ export async function upsertRecordNote(
 ): Promise<RecordNote | null> {
   const path = `/notes/records/${enc(connId)}/${enc(namespace)}/${enc(setName)}/${enc(pk)}`
   if (!body.note || !body.note.trim()) {
-    await deleteRecordNote(connId, namespace, setName, pk, body.pkType ?? "auto")
+    await deleteRecordNote(
+      connId,
+      namespace,
+      setName,
+      pk,
+      body.pkType ?? "auto",
+    )
     return null
   }
   return apiPut<RecordNote>(path, body)


### PR DESCRIPTION
## Summary
Closes multi-tenant data leaks across the K8s router and SSE collector. Follows up #333 (the previous cross-tenant fix) by extending the same ACL discipline to all surfaces touched by background tasks and K8s templates.

## Bugs Addressed
1. **CRITICAL** `list_k8s_clusters` leaked Tenant B's connectionId to Tenant A
2. **CRITICAL** `delete_k8s_cluster` deleted Tenant B's connection profiles silently
3. **CRITICAL** SSE collector broadcast all connections' metrics/health to all subscribers
4. **HIGH** `notes.py` 404'd legitimate legacy connections (workspaceId=None case)
5. **HIGH** `_get_verified_workspace` exported without ownership gate (footgun)
6. **HIGH** Template endpoints had zero workspace ACL
7. **HIGH** `list_k8s_secrets` accepted arbitrary namespace param
8. **MEDIUM** Background-loop exceptions logged at DEBUG (invisible)

## Follow-ups
- SSE collector currently feature-flagged off by default; design proper per-subscriber filtering in the broker (tracking issue needed)
- Namespace-scoping for `list_k8s_namespaces`/`nodes`/`storage_classes` deferred — document accepted risk

## Test Plan
- [ ] Unit tests for K8s router workspace scoping
- [ ] Manual: tenant A subscribes to SSE while tenant B operates -> no cross-tenant events
- [ ] Manual: tenant A deletes a K8s cluster sharing names with tenant B's connection -> only A's connection deleted
- [ ] Manual: legacy connection (workspaceId=NULL) note CRUD works