### PR TITLE
fix(ui): SSR crash, error UX, and security hardening

### DIFF
--- a/api/src/aerospike_cluster_manager_api/rate_limit.py
+++ b/api/src/aerospike_cluster_manager_api/rate_limit.py
@@ -115,4 +115,4 @@ def _get_client_ip(request: Request) -> str:
 # ``@limiter.limit(...)`` decorators.
 DEFAULT_LIMITS = ["60/minute"]
 
-limiter = Limiter(key_func=_get_client_ip, default_limits=DEFAULT_LIMITS)
+limiter = Limiter(key_func=_get_client_ip, default_limits=DEFAULT_LIMITS)  # type: ignore[arg-type]  # slowapi default_limits accepts list[str]; pyright strict-checks against alias

--- a/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
@@ -154,7 +154,7 @@ function SecurityDisabledState() {
       <a
         href="https://aerospike.com/docs/server/operations/configure/security"
         target="_blank"
-        rel="noreferrer"
+        rel="noopener noreferrer"
         className="text-xs font-medium text-indigo-600 hover:underline dark:text-indigo-400"
       >
         See Aerospike security docs →

--- a/ui/src/app/(main)/clusters/page.tsx
+++ b/ui/src/app/(main)/clusters/page.tsx
@@ -11,6 +11,7 @@ import { EditConnectionDialog } from "@/components/dialogs/EditConnectionDialog"
 import { useConnections } from "@/hooks/use-connections"
 import { useK8sClusters } from "@/hooks/use-k8s-clusters"
 import type { ConnectionProfileResponse } from "@/lib/types/connection"
+import { bumpConnectionsRev } from "@/stores/data-revision-store"
 import { useUiStore } from "@/stores/ui-store"
 import Link from "next/link"
 import { useMemo, useState } from "react"
@@ -42,6 +43,11 @@ export default function ClustersPage() {
   const combinedError = conn.error ?? k8s.error
 
   const handleConnectionUpserted = () => {
+    // Bump the connections revision so every other ``useConnections``
+    // subscriber (sidebar, dropdowns, …) refreshes too. Without this the
+    // sidebar shows stale data after add/edit even though this page itself
+    // refetches.
+    bumpConnectionsRev()
     conn.refetch()
   }
 

--- a/ui/src/components/DatePicker.tsx
+++ b/ui/src/components/DatePicker.tsx
@@ -113,7 +113,8 @@ const TimeInput = React.forwardRef<HTMLDivElement, TimeInputProps>(
       () => innerRef?.current,
     )
 
-    const locale = window !== undefined ? window.navigator.language : "en-US"
+    const locale =
+      typeof window !== "undefined" ? window.navigator.language : "en-US"
 
     const state = useTimeFieldState({
       hourCycle: hourCycle,

--- a/ui/src/components/k8s/create-cluster-wizard/CreateClusterWizard.tsx
+++ b/ui/src/components/k8s/create-cluster-wizard/CreateClusterWizard.tsx
@@ -220,6 +220,7 @@ export function CreateClusterWizard() {
     string | null
   >(null)
   const [templateLoading, setTemplateLoading] = useState(false)
+  const [templateError, setTemplateError] = useState<string | null>(null)
 
   const [namespacesList, setNamespacesList] = useState<string[]>([])
   const [submitting, setSubmitting] = useState(false)
@@ -273,11 +274,18 @@ export function CreateClusterWizard() {
   const handleSelectTemplate = async (name: string) => {
     setSelectedTemplateName(name)
     setTemplateLoading(true)
+    setTemplateError(null)
     try {
       const detail = await getK8sTemplate(name)
       const spec = (detail as { spec?: Record<string, unknown> }).spec ?? {}
       const updates = buildFormUpdatesFromTemplate(spec, name)
       setForm((prev) => ({ ...prev, ...updates }))
+    } catch (err) {
+      // Surface load failure to the user instead of silently leaving the
+      // template selector with stale state. Mirrors `submitError` styling.
+      const message =
+        err instanceof Error ? err.message : "Failed to load template"
+      setTemplateError(`Failed to load template "${name}": ${message}`)
     } finally {
       setTemplateLoading(false)
     }
@@ -451,6 +459,11 @@ export function CreateClusterWizard() {
       {stepError && (
         <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-800 dark:border-amber-900/50 dark:bg-amber-950/40 dark:text-amber-200">
           {stepError}
+        </div>
+      )}
+      {templateError && (
+        <div className="rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
+          {templateError}
         </div>
       )}
       {submitError && (

--- a/ui/src/lib/api/error-mapping.ts
+++ b/ui/src/lib/api/error-mapping.ts
@@ -53,7 +53,9 @@ export function mapApiError(err: unknown): ApiErrorKind {
         // backend detail string verbatim; only synthesize when it is empty.
         return {
           kind: "validation",
-          message: err.detail ? `Validation: ${err.detail}` : "Validation error",
+          message: err.detail
+            ? `Validation: ${err.detail}`
+            : "Validation error",
         }
       case 503:
         return { kind: "unreachable", message: err.detail }

--- a/ui/src/lib/api/events.ts
+++ b/ui/src/lib/api/events.ts
@@ -69,7 +69,21 @@ function buildStreamUrl(types?: string[]): string {
     null
   if (active) params.set("cluster", active.id)
   const token = useAuthStore.getState().accessToken
-  if (token) params.set("access_token", token)
+  if (token) {
+    // TODO(ADR-0040 follow-up): replace with per-stream signed nonce or
+    // cookie-based auth so the token does not appear in the URL. EventSource
+    // does not support custom headers in stock browsers, so this remains the
+    // workaround until the broker grows a dedicated handshake endpoint.
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "[events.ts] access_token is being sent in the SSE URL query " +
+          "string. Ensure the ingress masks `access_token` from access logs. " +
+          "Tracking: ADR-0040 follow-up.",
+      )
+    }
+    params.set("access_token", token)
+  }
 
   const qs = params.toString()
   const baseHost = active?.apiUrl?.replace(/\/+$/, "") ?? ""

--- a/ui/src/lib/api/notes.ts
+++ b/ui/src/lib/api/notes.ts
@@ -95,7 +95,13 @@ export async function upsertRecordNote(
 ): Promise<RecordNote | null> {
   const path = `/notes/records/${enc(connId)}/${enc(namespace)}/${enc(setName)}/${enc(pk)}`
   if (!body.note || !body.note.trim()) {
-    await deleteRecordNote(connId, namespace, setName, pk, body.pkType ?? "auto")
+    await deleteRecordNote(
+      connId,
+      namespace,
+      setName,
+      pk,
+      body.pkType ?? "auto",
+    )
     return null
   }
   return apiPut<RecordNote>(path, body)


### PR DESCRIPTION
## Summary
Five UI bugs from the 2026-05-09 audit. Most urgent: a guaranteed SSR crash in `DatePicker.tsx` from a malformed `window !== undefined` check.

## Issues Addressed
1. **CRITICAL** `DatePicker.tsx` SSR crash - `window !== undefined` is wrong; correct form is `typeof window !== "undefined"`
2. **HIGH** JWT in SSE URL query param - dev-mode warning until proper follow-up (ADR-0040)
3. **HIGH** Template load errors silently swallowed in cluster wizard
4. **HIGH** External link missing `noopener` (only `noreferrer`)
5. **MEDIUM** Sidebar stale after connection add/edit (missing `bumpConnectionsRev`)

## Follow-ups
- Replace JWT-in-URL with cookie or signed-nonce auth for SSE (ADR-0040)

## Test Plan
- [ ] `npx tsc --noEmit`
- [ ] Manual: visit page with TimeInput in production build (catch SSR)
- [ ] Manual: open create-cluster wizard, force template fetch failure, see error
- [ ] Manual: add a connection, sidebar reflects immediately