### PR TITLE
fix(ui): error/loading boundaries + crash-safe decoding + wizard workspace sync

### DIFF
--- a/ui/src/app/(main)/clusters/[clusterId]/error.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/error.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import { Button } from "@/components/Button"
+import { Card } from "@/components/Card"
+import Link from "next/link"
+import { useEffect } from "react"
+
+interface ErrorProps {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+export default function ClusterError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    // eslint-disable-next-line no-console
+    console.error("cluster route error:", error)
+  }, [error])
+
+  const isDev = process.env.NODE_ENV !== "production"
+
+  return (
+    <main className="flex flex-col gap-6">
+      <Card className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <span className="text-xs font-medium uppercase tracking-wider text-red-600 dark:text-red-400">
+            Cluster error
+          </span>
+          <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-50">
+            Failed to load this cluster
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-500">
+            The cluster page hit an unexpected error. Try again, or return to
+            the clusters list to pick a different one.
+          </p>
+        </div>
+
+        {isDev && error?.message && (
+          <pre className="overflow-x-auto rounded border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
+            {error.message}
+            {error.digest ? `\n\ndigest: ${error.digest}` : ""}
+          </pre>
+        )}
+
+        <div className="flex gap-2">
+          <Button variant="primary" onClick={reset}>
+            Try again
+          </Button>
+          <Button variant="secondary" asChild>
+            <Link href="/clusters">Back to clusters</Link>
+          </Button>
+        </div>
+      </Card>
+    </main>
+  )
+}

--- a/ui/src/app/(main)/clusters/[clusterId]/secondary-indexes/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/secondary-indexes/page.tsx
@@ -166,16 +166,15 @@ export default function SecondaryIndexesPage({ params }: PageProps) {
                 Object.entries(grouped).map(([ns, rows]) => (
                   <Fragment key={ns}>
                     <TableRow>
-                      <TableHeaderCell
-                        scope="colgroup"
+                      <TableCell
                         colSpan={6}
                         className="bg-gray-50 py-2 pl-4 font-mono sm:pl-6 dark:bg-gray-900"
                       >
-                        {ns}
+                        <span role="rowheader">{ns}</span>
                         <span className="ml-2 font-sans font-medium text-gray-500 dark:text-gray-400">
                           {rows.length}
                         </span>
-                      </TableHeaderCell>
+                      </TableCell>
                     </TableRow>
                     {rows.map((r) => {
                       const s = stateBadge[r.state]

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
@@ -243,12 +243,20 @@ function buildInitialDraft(record: AerospikeRecord): BinDraft[] {
   })
 }
 
+const safeDecode = (s: string): string | null => {
+  try {
+    return decodeURIComponent(s)
+  } catch {
+    return null
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 export default function RecordDetailPage({ params }: PageProps) {
   const router = useRouter()
-  const pk = decodeURIComponent(params.key)
+  const pk = safeDecode(params.key)
 
   const [record, setRecord] = useState<AerospikeRecord | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -262,6 +270,7 @@ export default function RecordDetailPage({ params }: PageProps) {
   const [saving, setSaving] = useState(false)
 
   const loadRecord = (signal?: { cancelled: boolean }) => {
+    if (pk === null) return Promise.resolve()
     setIsLoading(true)
     setError(null)
     return getRecordDetail(params.clusterId, {
@@ -292,6 +301,10 @@ export default function RecordDetailPage({ params }: PageProps) {
   const loadSignalRef = useRef<{ cancelled: boolean }>({ cancelled: false })
 
   useEffect(() => {
+    if (pk === null) {
+      setIsLoading(false)
+      return
+    }
     const signal = { cancelled: false }
     loadSignalRef.current = signal
     loadRecord(signal)
@@ -302,7 +315,7 @@ export default function RecordDetailPage({ params }: PageProps) {
   }, [params.clusterId, params.namespace, params.set, pk])
 
   const handleDelete = async () => {
-    if (!record) return
+    if (!record || pk === null) return
     if (!window.confirm(`Delete record '${pk}'?`)) return
     setDeleting(true)
     try {
@@ -376,7 +389,7 @@ export default function RecordDetailPage({ params }: PageProps) {
   }
 
   const handleSave = async () => {
-    if (!record) return
+    if (!record || pk === null) return
     setError(null)
 
     // Validate bin names
@@ -452,6 +465,40 @@ export default function RecordDetailPage({ params }: PageProps) {
     () => Object.keys(binErrors).length > 0,
     [binErrors],
   )
+
+  if (pk === null) {
+    return (
+      <main className="flex flex-col gap-6">
+        <nav
+          aria-label="Breadcrumb"
+          className="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-500"
+        >
+          <Link
+            href={clusterSections.sets(params.clusterId)}
+            className="hover:text-gray-900 dark:hover:text-gray-50"
+          >
+            Sets
+          </Link>
+          <span aria-hidden="true">/</span>
+          <Link
+            href={clusterSections.set(
+              params.clusterId,
+              params.namespace,
+              params.set,
+            )}
+            className="hover:text-gray-900 dark:hover:text-gray-50"
+          >
+            <span className="font-mono">
+              {params.namespace}.{params.set}
+            </span>
+          </Link>
+        </nav>
+        <Card className="py-10 text-center text-sm text-gray-500 dark:text-gray-500">
+          Invalid record key.
+        </Card>
+      </main>
+    )
+  }
 
   return (
     <main className="flex flex-col gap-6">

--- a/ui/src/app/(main)/error.tsx
+++ b/ui/src/app/(main)/error.tsx
@@ -1,0 +1,53 @@
+"use client"
+
+import { Button } from "@/components/Button"
+import { Card } from "@/components/Card"
+import { useEffect } from "react"
+
+interface ErrorProps {
+  error: Error & { digest?: string }
+  reset: () => void
+}
+
+export default function MainError({ error, reset }: ErrorProps) {
+  useEffect(() => {
+    // Surface the error in the browser console for diagnosis. Next.js logs
+    // its own stack trace server-side already.
+    // eslint-disable-next-line no-console
+    console.error("(main) route error:", error)
+  }, [error])
+
+  const isDev = process.env.NODE_ENV !== "production"
+
+  return (
+    <main className="flex flex-col gap-6">
+      <Card className="flex flex-col gap-4">
+        <div className="flex flex-col gap-1">
+          <span className="text-xs font-medium uppercase tracking-wider text-red-600 dark:text-red-400">
+            Error
+          </span>
+          <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-50">
+            Something went wrong
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-500">
+            An unexpected error occurred while rendering this page. You can try
+            again, or navigate elsewhere using the sidebar.
+          </p>
+        </div>
+
+        {isDev && error?.message && (
+          <pre className="overflow-x-auto rounded border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
+            {error.message}
+            {error.digest ? `\n\ndigest: ${error.digest}` : ""}
+          </pre>
+        )}
+
+        <div className="flex gap-2">
+          <Button variant="primary" onClick={reset}>
+            Try again
+          </Button>
+        </div>
+      </Card>
+    </main>
+  )
+}

--- a/ui/src/app/(main)/loading.tsx
+++ b/ui/src/app/(main)/loading.tsx
@@ -1,0 +1,39 @@
+import { Card } from "@/components/Card"
+
+// Route-level loading skeleton. Rendered by Next.js automatically while the
+// matching segment is suspending (e.g. server components fetching data).
+export default function MainLoading() {
+  return (
+    <main className="flex flex-col gap-6">
+      <span role="status" aria-live="polite" className="sr-only">
+        Loading…
+      </span>
+
+      <div className="flex flex-col gap-2">
+        <div className="h-3 w-24 animate-pulse rounded bg-gray-200 dark:bg-gray-800" />
+        <div className="h-6 w-64 animate-pulse rounded bg-gray-200 dark:bg-gray-800" />
+      </div>
+
+      <Card className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="flex flex-col gap-2">
+            <div className="h-3 w-16 animate-pulse rounded bg-gray-200 dark:bg-gray-800" />
+            <div className="h-4 w-24 animate-pulse rounded bg-gray-200 dark:bg-gray-800" />
+          </div>
+        ))}
+      </Card>
+
+      <Card className="p-0">
+        <div className="flex flex-col divide-y divide-gray-200 dark:divide-gray-800">
+          {[0, 1, 2, 3].map((i) => (
+            <div key={i} className="flex items-center gap-3 px-5 py-3">
+              <div className="h-4 w-40 animate-pulse rounded bg-gray-200 dark:bg-gray-800" />
+              <div className="h-4 w-24 animate-pulse rounded bg-gray-100 dark:bg-gray-900" />
+              <div className="h-4 flex-1 animate-pulse rounded bg-gray-100 dark:bg-gray-900" />
+            </div>
+          ))}
+        </div>
+      </Card>
+    </main>
+  )
+}

--- a/ui/src/components/browser/RecordFilters.tsx
+++ b/ui/src/components/browser/RecordFilters.tsx
@@ -602,6 +602,15 @@ function ConditionEditor({
     if (needsValue) inputRef.current?.focus()
   }, [needsValue])
 
+  // Resync local input state when the underlying condition changes from the
+  // outside (operator switch, parent reset, etc.). Without this, switching
+  // operator from e.g. "between" back to "equals" would keep the stale
+  // first-value/second-value strings in the inputs.
+  useEffect(() => {
+    setVal(condition.value != null ? String(condition.value) : "")
+    setVal2(condition.value2 != null ? String(condition.value2) : "")
+  }, [condition.value, condition.value2, condition.operator])
+
   const commit = useCallback(() => {
     const updates: Partial<Omit<FilterDraftCondition, "id">> = {}
     if (needsValue) {

--- a/ui/src/components/k8s/create-cluster-wizard/CreateClusterWizard.tsx
+++ b/ui/src/components/k8s/create-cluster-wizard/CreateClusterWizard.tsx
@@ -216,6 +216,19 @@ export function CreateClusterWizard() {
     workspaceId: currentWorkspaceId,
   }))
 
+  // The form snapshot above only captures the workspace at mount time.
+  // If the user switches workspace via the sidebar dropdown while the wizard
+  // is open, keep the form's workspaceId in sync so the review step shows the
+  // correct value. handleCreate also re-reads from the store at submit to
+  // protect against any last-millisecond divergence.
+  useEffect(() => {
+    setForm((prev) =>
+      prev.workspaceId === currentWorkspaceId
+        ? prev
+        : { ...prev, workspaceId: currentWorkspaceId },
+    )
+  }, [currentWorkspaceId])
+
   const [templates, setTemplates] = useState<K8sTemplateSummary[]>([])
   const [selectedTemplateName, setSelectedTemplateName] = useState<
     string | null
@@ -376,7 +389,11 @@ export function CreateClusterWizard() {
     setSubmitError(null)
     setSubmitting(true)
     try {
-      const payload = cleanupPayload(form)
+      // Re-read the live workspace at submit time. The form's workspaceId is
+      // captured once on mount; reading from the store here protects against
+      // a stale snapshot if the user switched workspace mid-flow.
+      const liveWorkspaceId = useUiStore.getState().currentWorkspaceId
+      const payload = cleanupPayload({ ...form, workspaceId: liveWorkspaceId })
       await createK8sCluster(payload)
       // The operator path also auto-creates a connection profile under the
       // chosen workspace; refresh consumers (sidebar, dropdowns) so the new

--- a/ui/src/components/ui/navigation/Sidebar.tsx
+++ b/ui/src/components/ui/navigation/Sidebar.tsx
@@ -145,6 +145,21 @@ export function Sidebar() {
     isActive(`/clusters/${c.id}`),
   )?.id
 
+  // Controlled accordion: defaultValue only applies on mount, so navigating
+  // between clusters via the URL would leave the accordion stuck on whatever
+  // cluster was active at first render. Track the open cluster in state and
+  // resync whenever the active cluster (derived from pathname) changes, while
+  // still allowing the user to manually toggle a cluster open/closed.
+  const [openCluster, setOpenCluster] = useState<string>(expandedCluster ?? "")
+  useEffect(() => {
+    if (expandedCluster && expandedCluster !== openCluster) {
+      setOpenCluster(expandedCluster)
+    }
+    // openCluster intentionally omitted: we only force-sync when the active
+    // cluster changes, not on every manual toggle.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [expandedCluster])
+
   const loading = conn.isLoading || k8s.isLoading
 
   return (
@@ -170,7 +185,8 @@ export function Sidebar() {
                 <Accordion
                   type="single"
                   collapsible
-                  defaultValue={expandedCluster}
+                  value={openCluster}
+                  onValueChange={setOpenCluster}
                   className="flex flex-col gap-0.5"
                 >
                   {clusterList.map((c) => (


### PR DESCRIPTION
## Summary

Six P1 UI fixes that prevent route crashes, fix stale state, and clean up invalid HTML.

- **P1-1 crash-safe record key decoding** — `decodeURIComponent(params.key)` ran at the top of the record detail component and crashed the route with `URIError` for any malformed URL (e.g. `%E0%A4%A`). With no error.tsx covering the route, the user got Next.js's default crash page. Adds a `safeDecode` helper and an "Invalid record key" empty-state Card so navigation still works.
- **P1-2 error.tsx + loading.tsx boundaries** — App Router previously had zero `error.tsx`/`loading.tsx`. Adds:
  - `app/(main)/error.tsx` — top-level boundary with reset, dev-only `error.message`.
  - `app/(main)/clusters/[clusterId]/error.tsx` — cluster-scoped, with "Back to clusters" link.
  - `app/(main)/loading.tsx` — skeleton mirroring typical page shape.
- **P1-3 wizard workspaceId sync** — `useState(() => ({ ..., workspaceId: currentWorkspaceId }))` snapshotted workspace once at mount; switching workspace via the sidebar dropdown left the wizard submitting against the original. Added an effect that mirrors `currentWorkspaceId` into the form, plus a defensive `useUiStore.getState()` re-read at submit time inside `handleCreate`.
- **P1-4 Sidebar Accordion controlled** — `defaultValue={expandedCluster}` only applied at mount, so navigating to a different cluster left the accordion stuck. Switched to a controlled Accordion (`value` + `onValueChange`) that resyncs whenever the active cluster changes while still letting the user toggle manually.
- **P1-5 ConditionEditor stale local state** — `val`/`val2` `useState` was only seeded once, so changing the operator or having the parent reset the condition kept the previous strings in the inputs and re-committed them. Added a `useEffect` keyed on `[condition.value, condition.value2, condition.operator]` that resyncs.
- **P1-6 valid HTML in secondary-indexes** — `<TableHeaderCell scope="colgroup">` rendered inside `<TableBody>` is invalid (`th` in `tbody`) and produced hydration warnings. Replaced with a `<TableCell colSpan={6}>` wrapping a `<span role="rowheader">` for the namespace label, preserving the existing visual styling.

## Test plan

- [x] `npm run lint` — clean, 0 warnings.
- [x] `npm run type-check` — clean.
- [x] `npm run build` — production build succeeds for all 12 routes (no SSR-breaking changes).
- [x] `npm run format:check` — all files pass Prettier.
- [x] Vitest run for `secondary-indexes/page.test.tsx` (closest existing test to a touched file): 4/4 pass.
- [ ] Manual: navigate to `/clusters/<id>/sets/<ns>/<set>/records/%E0%A4%A` — see "Invalid record key" empty-state Card with breadcrumb back to set list (no crash).
- [ ] Manual: open `/clusters/new`, advance to step 2, switch workspace via sidebar dropdown, return to wizard — confirm review step shows the new workspace and the created cluster lands in the right one.
- [ ] Manual: navigate between two clusters in the sidebar — confirm the cluster accordion follows the active cluster instead of staying pinned to the first.
- [ ] Manual: in record-browser filters, switch operator from `between` to `equals` — confirm the inputs reset, no leaked second-value string.