### PR TITLE
fix(ui,dev): production log secret-leak + hydration race + SSE error-state cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,6 +41,16 @@ CORS_ORIGINS=http://localhost:3000,http://localhost:3100
 # ENABLE_POSTGRES=false
 # DATABASE_URL=postgresql://aerospike:aerospike@localhost:5432/aerospike_manager
 
+# compose.dev.yaml provisions a local Postgres bound to 127.0.0.1:5432.
+# POSTGRES_PASSWORD is REQUIRED (no default) — `podman compose -f
+# compose.dev.yaml up` will refuse to start until it is set. POSTGRES_USER
+# and POSTGRES_DB fall back to "aerospike" / "aerospike_manager".
+# Do NOT remove the 127.0.0.1 prefix on the port mapping without first
+# changing the password from any well-known dev value.
+# POSTGRES_USER=aerospike
+# POSTGRES_PASSWORD=
+# POSTGRES_DB=aerospike_manager
+
 # Connection pool (PostgreSQL only).
 # DB_POOL_MIN_SIZE=2
 # DB_POOL_MAX_SIZE=10

--- a/compose.dev.yaml
+++ b/compose.dev.yaml
@@ -1,16 +1,24 @@
 services:
   # ── PostgreSQL ───────────────────────────────────────────────────────
+  # SECURITY: bound to 127.0.0.1 only. Do not expose this port on a LAN
+  # without first replacing the password — POSTGRES_PASSWORD must be set
+  # in the shell or .env (no default). Set POSTGRES_USER / POSTGRES_DB to
+  # override the defaults below.
   postgres:
     container_name: postgres
     image: postgres:17-alpine
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     environment:
-      POSTGRES_USER: aerospike
-      POSTGRES_PASSWORD: aerospike
-      POSTGRES_DB: aerospike_manager
+      POSTGRES_USER: ${POSTGRES_USER:-aerospike}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD must be set (see .env.example)}
+      POSTGRES_DB: ${POSTGRES_DB:-aerospike_manager}
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U aerospike -d aerospike_manager"]
+      test:
+        [
+          "CMD-SHELL",
+          "pg_isready -U ${POSTGRES_USER:-aerospike} -d ${POSTGRES_DB:-aerospike_manager}",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/ui/src/hooks/use-event-stream.ts
+++ b/ui/src/hooks/use-event-stream.ts
@@ -77,6 +77,11 @@ export function useEventStream<T = unknown>(
       cancelled = true
       sub?.close()
       setConnected(false)
+      // Clear the last error/event so consumers that flip `enabled` back to
+      // false don't render a stale "stream broken" banner. A fresh subscribe
+      // will repopulate these on the next open.
+      setError(null)
+      setLastEvent(null)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- typesKey captures the intent
   }, [enabled, typesKey])

--- a/ui/src/hooks/use-stable-list-keys.ts
+++ b/ui/src/hooks/use-stable-list-keys.ts
@@ -1,6 +1,6 @@
 "use client"
 
-import { useRef } from "react"
+import { useMemo, useRef } from "react"
 
 /**
  * Maintains a parallel array of stable React keys for an externally
@@ -14,24 +14,48 @@ import { useRef } from "react"
  * and uncontrolled DOM state to leak from a removed entry into the
  * surviving entry that takes its slot.
  */
+
+/**
+ * Generate a stable id. Prefers `crypto.randomUUID` where available; falls
+ * back to a base36 random string for non-secure-context / older browsers
+ * that ship `crypto` without `randomUUID` (these keys never travel beyond
+ * React reconciliation, so cryptographic strength is not required).
+ */
+const newId = (): string => {
+  const c: { randomUUID?: () => string } | undefined = (
+    globalThis as { crypto?: { randomUUID?: () => string } }
+  ).crypto
+  return c?.randomUUID?.() ?? `id-${Math.random().toString(36).slice(2)}`
+}
+
 export function useStableListKeys(currentLength: number) {
   const keysRef = useRef<string[]>([])
 
-  // Defensive realignment if the source array changes outside the
-  // notify* helpers (e.g., form prefill on first render, async fill).
-  while (keysRef.current.length < currentLength) {
-    keysRef.current.push(crypto.randomUUID())
-  }
-  if (keysRef.current.length > currentLength) {
-    keysRef.current = keysRef.current.slice(0, currentLength)
-  }
+  // Realign via useMemo keyed on currentLength so the work runs only when
+  // the source list actually grows/shrinks (not on every render). Doing the
+  // realignment unconditionally inside the render body — as the previous
+  // implementation did — pushes new ids into the ref on every pass; under
+  // React StrictMode's double-invoke that means the ids generated during
+  // the first render are different from the ones generated during the
+  // second, and every keyed child re-mounts at commit time.
+  const keys = useMemo(() => {
+    if (keysRef.current.length === currentLength) return keysRef.current
+    if (keysRef.current.length < currentLength) {
+      const next = [...keysRef.current]
+      while (next.length < currentLength) next.push(newId())
+      keysRef.current = next
+    } else {
+      keysRef.current = keysRef.current.slice(0, currentLength)
+    }
+    return keysRef.current
+  }, [currentLength])
 
   const notifyAdd = () => {
-    keysRef.current = [...keysRef.current, crypto.randomUUID()]
+    keysRef.current = [...keysRef.current, newId()]
   }
   const notifyRemove = (i: number) => {
     keysRef.current = keysRef.current.filter((_, idx) => idx !== i)
   }
 
-  return { keys: keysRef.current, notifyAdd, notifyRemove }
+  return { keys, notifyAdd, notifyRemove }
 }

--- a/ui/src/lib/api/client.ts
+++ b/ui/src/lib/api/client.ts
@@ -20,7 +20,10 @@
  */
 
 import { useAuthStore } from "@/stores/auth-store"
-import { getActiveApiUrl } from "@/stores/cluster-selector-store"
+import {
+  getActiveApiUrl,
+  getHydrationPromise,
+} from "@/stores/cluster-selector-store"
 
 export const API_PREFIX = "/api"
 export const DEFAULT_TIMEOUT_MS = 30_000
@@ -163,6 +166,19 @@ export async function apiFetch<T>(
   path: string,
   init: ApiRequestInit = {},
 ): Promise<T> {
+  // Wait for the cluster registry to either hydrate or fail, so we resolve
+  // the base URL against the final state. Without this, requests issued
+  // during boot fall back to the relative-path origin and then the
+  // post-hydration re-fetch races a 401 the silent-refresh path can't
+  // distinguish from a real auth failure. Browser-only path: in SSR we
+  // never have a registry, so the call resolves immediately via the
+  // already-terminal "registryError unset, registry unset" branch only when
+  // a hydrate has been kicked off; otherwise apiFetch on the server falls
+  // straight through.
+  if (typeof window !== "undefined") {
+    await getHydrationPromise()
+  }
+
   const url = buildUrl(path, init.query)
   const timeoutMs = init.timeoutMs ?? DEFAULT_TIMEOUT_MS
 

--- a/ui/src/lib/api/error-mapping.ts
+++ b/ui/src/lib/api/error-mapping.ts
@@ -26,11 +26,15 @@ export type ApiErrorKind =
   | { kind: "timeout"; message: string }
   | { kind: "generic"; message: string }
 
-const SECURITY_DISABLED_MARKERS = ["security is not enabled", "ee_msg"] as const
-
+// Backend emits the exact phrase "Security is not enabled. Add a 'security
+// { }' block to aerospike.conf to manage users and roles." (see
+// api/src/aerospike_cluster_manager_api/constants.py :: EE_MSG). Anchor on
+// that phrase verbatim. The previous heuristic matched a lone `ee_msg`
+// substring, which produces false positives on legitimate 403 responses
+// like "EE_MSG: not authorized to drop role" — the user would then see
+// the security-disabled card instead of the real permission-denied error.
 function looksLikeSecurityDisabled(detail: string): boolean {
-  const lower = detail.toLowerCase()
-  return SECURITY_DISABLED_MARKERS.some((m) => lower.includes(m))
+  return detail.toLowerCase().includes("security is not enabled")
 }
 
 export function mapApiError(err: unknown): ApiErrorKind {

--- a/ui/src/lib/api/events.ts
+++ b/ui/src/lib/api/events.ts
@@ -69,11 +69,25 @@ function buildStreamUrl(types?: string[]): string {
     null
   if (active) params.set("cluster", active.id)
   const token = useAuthStore.getState().accessToken
+  const baseHost = active?.apiUrl?.replace(/\/+$/, "") ?? ""
   if (token) {
     // TODO(ADR-0040 follow-up): replace with per-stream signed nonce or
     // cookie-based auth so the token does not appear in the URL. EventSource
     // does not support custom headers in stock browsers, so this remains the
     // workaround until the broker grows a dedicated handshake endpoint.
+    //
+    // Until that lands, refuse to open the stream against a plain-http
+    // origin: the JWT would travel as cleartext in the URL and end up in
+    // every reverse-proxy access log on the path. Operators must serve the
+    // API over https before SSE+OIDC can be used.
+    if (active?.apiUrl && /^http:\/\//i.test(active.apiUrl)) {
+      throw new Error(
+        "[events.ts] refusing to open SSE stream over plain http://: " +
+          "the access_token query param would leak via access logs. " +
+          "Configure the cluster apiUrl to use https://. " +
+          "Tracking: ADR-0040 follow-up.",
+      )
+    }
     if (process.env.NODE_ENV !== "production") {
       // eslint-disable-next-line no-console
       console.warn(
@@ -86,7 +100,6 @@ function buildStreamUrl(types?: string[]): string {
   }
 
   const qs = params.toString()
-  const baseHost = active?.apiUrl?.replace(/\/+$/, "") ?? ""
   return `${baseHost}${API_PREFIX}/events/stream${qs ? `?${qs}` : ""}`
 }
 

--- a/ui/src/lib/api/log.ts
+++ b/ui/src/lib/api/log.ts
@@ -9,14 +9,29 @@ import { ApiError } from "./client"
  * downstream telemetry that hooks into console output. Extracts
  * status/detail/body from `ApiError` to keep the payload terse;
  * passes the raw error through otherwise.
+ *
+ * SECURITY: response bodies on connection-test, password-change, and
+ * OIDC-failure endpoints can echo back submitted credentials or tokens.
+ * In production we therefore log only `{ status, scope, message }` and
+ * keep the full `{ detail, body }` payload behind a NODE_ENV guard so
+ * downstream telemetry does not persist secrets.
  */
 export function logFetchError(scope: string, err: unknown): void {
   if (err instanceof ApiError) {
+    if (process.env.NODE_ENV !== "production") {
+      // eslint-disable-next-line no-console
+      console.error(`[${scope}] fetch failed`, {
+        status: err.status,
+        detail: err.detail,
+        body: err.body,
+      })
+      return
+    }
     // eslint-disable-next-line no-console
     console.error(`[${scope}] fetch failed`, {
       status: err.status,
-      detail: err.detail,
-      body: err.body,
+      scope,
+      message: err.message,
     })
     return
   }

--- a/ui/src/stores/cluster-selector-store.ts
+++ b/ui/src/stores/cluster-selector-store.ts
@@ -69,33 +69,93 @@ export const useClusterSelectorStore = create<ClusterSelectorStore>()(
 )
 
 /**
+ * Single-flight hydration promise. The first `hydrateClusterRegistry()` call
+ * primes this; every concurrent / subsequent `getHydrationPromise()` caller
+ * awaits the same promise so apiFetch never races the boot-time hydrate
+ * (otherwise the first few requests fall back to the relative-path origin
+ * before the registry lands, then the post-hydration re-fetch triggers a
+ * 401 the silent-refresh path can't distinguish from a real auth failure).
+ */
+let hydrationPromise: Promise<void> | null = null
+let resolveHydration: (() => void) | null = null
+
+function ensurePendingPromise(): Promise<void> {
+  if (hydrationPromise) return hydrationPromise
+  hydrationPromise = new Promise<void>((resolve) => {
+    resolveHydration = resolve
+  })
+  return hydrationPromise
+}
+
+function settleHydration(): void {
+  if (resolveHydration) {
+    const r = resolveHydration
+    resolveHydration = null
+    r()
+  } else if (!hydrationPromise) {
+    hydrationPromise = Promise.resolve()
+  }
+}
+
+/**
  * Fetch the cluster registry from the static JSON mount and hydrate the store.
- * Idempotent — call from the root provider on mount.
+ * Idempotent — call from the root provider on mount. Settles
+ * `getHydrationPromise()` whether the registry loads or the fetch fails so
+ * apiFetch callers never block forever in legacy single-cluster mode.
  */
 export async function hydrateClusterRegistry(
   fetcher: typeof fetch = fetch,
 ): Promise<ClusterRegistry> {
-  const res = await fetcher(REGISTRY_PATH, {
-    cache: "no-store",
-    credentials: "omit",
-  })
-  if (!res.ok) {
-    const msg = `Failed to load ${REGISTRY_PATH}: ${res.status} ${res.statusText}`
-    useClusterSelectorStore.getState().setRegistryError(msg)
-    throw new Error(msg)
+  ensurePendingPromise()
+  try {
+    const res = await fetcher(REGISTRY_PATH, {
+      cache: "no-store",
+      credentials: "omit",
+    })
+    if (!res.ok) {
+      const msg = `Failed to load ${REGISTRY_PATH}: ${res.status} ${res.statusText}`
+      useClusterSelectorStore.getState().setRegistryError(msg)
+      throw new Error(msg)
+    }
+    const data = (await res.json()) as ClusterRegistry
+    if (
+      !data ||
+      !Array.isArray(data.clusters) ||
+      typeof data.defaultClusterId !== "string"
+    ) {
+      const msg = `${REGISTRY_PATH} has invalid shape`
+      useClusterSelectorStore.getState().setRegistryError(msg)
+      throw new Error(msg)
+    }
+    useClusterSelectorStore.getState().setRegistry(data)
+    return data
+  } finally {
+    settleHydration()
   }
-  const data = (await res.json()) as ClusterRegistry
-  if (
-    !data ||
-    !Array.isArray(data.clusters) ||
-    typeof data.defaultClusterId !== "string"
-  ) {
-    const msg = `${REGISTRY_PATH} has invalid shape`
-    useClusterSelectorStore.getState().setRegistryError(msg)
-    throw new Error(msg)
-  }
-  useClusterSelectorStore.getState().setRegistry(data)
-  return data
+}
+
+/**
+ * Returns a single-flight promise that resolves once
+ * `hydrateClusterRegistry()` has settled (success OR error). If hydration
+ * has not been kicked off yet, resolves immediately so legacy single-cluster
+ * deployments — which never call `hydrateClusterRegistry` — do not deadlock.
+ *
+ * apiFetch awaits this before resolving the base URL so initial requests
+ * cannot fall back to the relative-path origin and then race the
+ * post-hydration re-fetch into a spurious 401.
+ */
+export function getHydrationPromise(): Promise<void> {
+  return hydrationPromise ?? Promise.resolve()
+}
+
+/**
+ * Test-only escape hatch: drop the cached single-flight promise so the next
+ * `hydrateClusterRegistry()` primes a fresh one. Used by unit tests that
+ * swap the store between scenarios.
+ */
+export function __resetHydrationPromiseForTests(): void {
+  hydrationPromise = null
+  resolveHydration = null
 }
 
 /**

--- a/ui/src/stores/cluster-store.ts
+++ b/ui/src/stores/cluster-store.ts
@@ -51,7 +51,9 @@ export const useClusterStore = create<ClusterStore>((set, get) => ({
 
   invalidate: (connId) => {
     const { [connId]: _removed, ...rest } = get().clusters
-    set({ clusters: rest })
+    const { [connId]: _loading, ...restLoading } = get().loadingIds
+    const { [connId]: _err, ...restErrors } = get().errors
+    set({ clusters: rest, loadingIds: restLoading, errors: restErrors })
   },
 
   reset: () => set({ clusters: {}, loadingIds: {}, errors: {} }),


### PR DESCRIPTION
## Summary

Eight correctness/security fixes across the UI lib, hooks, stores, and dev compose stack — no API or behavioural surface changes beyond what each bullet describes.

- `ui/src/lib/api/log.ts` — `logFetchError` no longer dumps `{ detail, body }` from `ApiError` to `console.error` in production builds. Connection-test, password-change, and OIDC-failure responses echo back submitted credentials/tokens; full payload is now gated behind `NODE_ENV !== 'production'` and prod logs only `{ status, scope, message }`.
- `ui/src/lib/api/events.ts` — Refuse to open the SSE stream when the active cluster `apiUrl` is `http://`. The JWT travels in the URL query string (EventSource limitation) and would land in every reverse-proxy access log on the path. Throws an explicit error directing operators to https. The dev-only warn for the https path is kept; cookie/handshake-based fix is tracked in ADR-0040 follow-up.
- `compose.dev.yaml` + `.env.example` — Bind Postgres to `127.0.0.1:5432:5432` (loopback only) and require `${POSTGRES_PASSWORD:?...}` so compose refuses to start without an explicit password instead of accepting the well-known `aerospike:aerospike` default.
- `ui/src/lib/api/client.ts` + `ui/src/stores/cluster-selector-store.ts` — Expose `getHydrationPromise()` (single-flight, primed inside `hydrateClusterRegistry`'s try/finally). `apiFetch` awaits it on the client before resolving the base URL, so requests issued during boot can no longer fall back to the relative-path origin and then race the post-hydration re-fetch into a spurious 401. Legacy single-cluster deployments resolve immediately so the path does not deadlock.
- `ui/src/hooks/use-stable-list-keys.ts` — Move the realignment loop out of the render body and into a `useMemo` keyed on `currentLength`. The previous implementation pushed `crypto.randomUUID()` into a ref during render, breaking key stability under StrictMode dev double-mount. Add a non-secure-context fallback for `crypto.randomUUID`.
- `ui/src/hooks/use-event-stream.ts` — Cleanup now also clears `error` and `lastEvent`. Previously, after `enabled` flipped from true to false, consumers saw `{ connected: false, error: lastError }` and rendered a 'stream broken' banner that no longer corresponded to a live subscription.
- `ui/src/lib/api/error-mapping.ts` — Anchor `looksLikeSecurityDisabled` on the exact backend phrase `"security is not enabled"` (from `api/.../constants.py :: EE_MSG`). The previous lone-`ee_msg` substring match produced false positives on legitimate 403s like `EE_MSG: not authorized to drop role` — users saw the security-disabled card instead of the real permission-denied banner.
- `ui/src/stores/cluster-store.ts` — `invalidate(connId)` now strips the entry from `loadingIds` and `errors` as well as `clusters`, so subsequent selectors do not render stale spinners or banners against an evicted cluster.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run type-check` clean
- [x] `npm run test -- --run` — all 41 vitest tests pass (9 files)
- [x] `npm run build` — production build succeeds, 8 routes generated
- [x] `python yaml`/`yq` parse of `compose.dev.yaml` succeeds
- [ ] Manual: trigger a 401 on the connection-test endpoint with a production build → `console.error` no longer surfaces the response body
- [ ] Manual: stop a subscribed SSE stream (`enabled` → false) → no stale 'stream broken' banner
- [ ] Manual: `podman compose -f compose.dev.yaml up` without `POSTGRES_PASSWORD` set → fails fast with a clear error
- [ ] Manual: configure a cluster with `apiUrl: http://...` and OIDC enabled → SSE subscribe throws the explicit https-required error