### PR TITLE
fix(api,mcp): close cross-tenant ACL gaps + SSRF in test_connection + MCP fail-open

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -86,7 +86,11 @@ K8S_MANAGEMENT_ENABLED=false
 # OIDC_EXCLUDE_PATHS=/api/health,/api/openapi.json,/api/docs
 # OIDC claim used as workspace-owner identity. Defaults to ``sub`` (OIDC core
 # stable subject id). Switch to ``preferred_username`` only if the IdP's sub
-# is unstable across logins.
+# is unstable across logins. When the configured claim is missing or empty
+# in a caller's JWT the API logs a one-time WARNING (per missing-claim
+# case) and silently degrades the caller to SYSTEM_OWNER_ID -- which
+# DISABLES tenant isolation for that caller. Watch logs for
+# "OIDC owner claim '<x>' is missing" after rolling out a new IdP.
 # ACM_OIDC_OWNER_CLAIM=sub
 
 # ─── Security Headers ──────────────────────────────────────────────────────
@@ -135,6 +139,16 @@ K8S_MANAGEMENT_ENABLED=false
 # Call-time gate: read_only blocks the 10 mutation tools at
 # call time. full allows everything. Default is read_only.
 # ACM_MCP_ACCESS_PROFILE=read_only
+
+# ─── Connection test SSRF gate ────────────────────────────────────────────
+# /api/connections/test rejects probe requests targeting bare IP literals
+# in loopback (127.0.0.0/8, ::1) or link-local (169.254.0.0/16, includes
+# the EC2 IMDS 169.254.169.254) ranges. Without this gate an authenticated
+# caller could repurpose the endpoint as an SSRF / port-scan primitive.
+# Set to true ONLY for local dev where the API runs alongside a loopback
+# Aerospike (compose.dev.yaml). DNS hostnames are not pre-resolved here --
+# rely on egress firewall policy to backstop DNS-based bypasses.
+# ACM_CONNECTION_TEST_ALLOW_PRIVATE=false
 
 # ─── At-rest encryption (connection passwords) ────────────────────────────
 # Fernet key (44-char urlsafe base64) used to encrypt the

--- a/api/src/aerospike_cluster_manager_api/dependencies.py
+++ b/api/src/aerospike_cluster_manager_api/dependencies.py
@@ -18,6 +18,31 @@ from aerospike_cluster_manager_api.models.workspace import SYSTEM_OWNER_ID, Work
 logger = logging.getLogger(__name__)
 
 
+# P1-5: track misconfig warnings emitted at most once per process per
+# missing-claim case. Without this guard a misconfigured IdP would log a
+# WARNING on every request which buries other diagnostic noise. The set
+# is keyed on the configured claim name so changing
+# ``ACM_OIDC_OWNER_CLAIM`` mid-process re-emits.
+_WARNED_MISSING_CLAIMS: set[str] = set()
+
+
+def _warn_missing_owner_claim_once(claim_name: str) -> None:
+    """Emit a one-time WARNING when the configured OIDC owner claim is
+    missing from the JWT. Behavior stays unchanged (caller silently
+    degrades to ``SYSTEM_OWNER_ID``) -- this is purely an observability
+    hook so an operator notices a misconfigured IdP instead of silently
+    losing tenant isolation. See ``.env.example`` for tuning guidance."""
+    if claim_name in _WARNED_MISSING_CLAIMS:
+        return
+    _WARNED_MISSING_CLAIMS.add(claim_name)
+    logger.warning(
+        "OIDC owner claim '%s' is missing or empty in caller JWT; falling back to SYSTEM_OWNER_ID. "
+        "This silently downgrades caller identity and disables tenant isolation. "
+        "Verify ACM_OIDC_OWNER_CLAIM matches a claim your IdP actually emits.",
+        claim_name,
+    )
+
+
 def _resolve_caller_owner_id(request: Request) -> str:
     """Return the caller's workspace-owner identity for ACL checks.
 
@@ -53,6 +78,11 @@ def _resolve_caller_owner_id(request: Request) -> str:
         return SYSTEM_OWNER_ID
     raw = claims.get(config.ACM_OIDC_OWNER_CLAIM)
     if not isinstance(raw, str) or not raw:
+        # P1-5: surface misconfigured-IdP cases instead of silently
+        # collapsing every authenticated caller into SYSTEM_OWNER_ID.
+        # Behaviour stays the same to avoid breaking deployments that
+        # genuinely expect single-tenant fallback.
+        _warn_missing_owner_claim_once(config.ACM_OIDC_OWNER_CLAIM)
         return SYSTEM_OWNER_ID
     return raw
 

--- a/api/src/aerospike_cluster_manager_api/k8s_client.py
+++ b/api/src/aerospike_cluster_manager_api/k8s_client.py
@@ -151,6 +151,7 @@ class K8sClient:
         apply: Any,
         body: dict[str, Any],
         label: str,
+        verify: Any = None,
     ) -> dict[str, Any]:
         """Apply ``body`` as a merge-patch with optimistic concurrency.
 
@@ -159,17 +160,32 @@ class K8sClient:
         attempt now:
 
         1. Refetches the CR to learn the current ``resourceVersion``.
-        2. Embeds it in the patch body's metadata so the API server enforces
-           optimistic concurrency (returns 409 if the CR moved underneath).
-        3. On 409 ``Conflict`` retries with backoff up to ``_PATCH_MAX_ATTEMPTS``.
+        2. Optionally re-verifies the freshly-fetched CR via ``verify``
+           (e.g. workspace-label ACL) so a TOCTOU window between the
+           caller's pre-patch ACL gate and the patch apply cannot let a
+           concurrent re-stamp leak the mutation across tenants. P1-4:
+           ``verify`` callbacks raise :class:`K8sApiError` (typically
+           ``status=409`` for "ACL changed under us, abort") which is
+           propagated unwrapped so the router maps it to a stable
+           ``Conflict`` response.
+        3. Embeds the refetched ``resourceVersion`` into the patch body's
+           metadata so the API server enforces optimistic concurrency
+           (returns 409 if the CR moved underneath us between fetch and
+           apply, even if ``verify`` passed).
+        4. On 409 ``Conflict`` retries with backoff up to ``_PATCH_MAX_ATTEMPTS``.
 
-        ``body`` is not mutated — a deep copy is taken before the
+        ``body`` is not mutated -- a deep copy is taken before the
         ``metadata.resourceVersion`` injection so callers that reuse the
         patch dict (e.g. tests) keep their original input.
         """
         last_err: K8sApiError | None = None
         for attempt in range(_PATCH_MAX_ATTEMPTS):
             current = fetch()
+            if verify is not None:
+                # Raise inside ``verify`` aborts the patch loop without
+                # consuming the retry budget -- a label mismatch is not a
+                # transient API-server flake but a real ACL violation.
+                verify(current)
             rv = (current.get("metadata", {}) or {}).get("resourceVersion")
             payload = copy.deepcopy(body)
             if rv:
@@ -410,13 +426,51 @@ class K8sClient:
         logger.debug("_create_cluster_sync(namespace=%s)", namespace)
         return self._create_custom_object_sync(PLURAL, namespace, body)
 
-    def _patch_cluster_sync(self, namespace: str, name: str, body: dict[str, Any]) -> dict[str, Any]:
-        logger.debug("_patch_cluster_sync(namespace=%s, name=%s)", namespace, name)
+    def _patch_cluster_sync(
+        self,
+        namespace: str,
+        name: str,
+        body: dict[str, Any],
+        *,
+        expected_workspace_id: str | None = None,
+    ) -> dict[str, Any]:
+        logger.debug(
+            "_patch_cluster_sync(namespace=%s, name=%s, expected_workspace_id=%s)",
+            namespace,
+            name,
+            expected_workspace_id,
+        )
+
+        verify = None
+        if expected_workspace_id is not None:
+            workspace_label = "acm.aerospike.com/workspace"
+
+            def _assert_label_unchanged(current: dict[str, Any]) -> None:
+                # P1-4: re-verify the workspace label hasn't drifted under
+                # us between the caller's pre-patch ACL check and the
+                # actual apply. If a concurrent writer re-stamped the CR
+                # with a different workspace, abort with 409 so the caller
+                # treats it as a normal optimistic-concurrency failure.
+                labels = (current.get("metadata", {}) or {}).get("labels") or {}
+                actual = labels.get(workspace_label)
+                if actual != expected_workspace_id:
+                    raise K8sApiError(
+                        status=409,
+                        reason="Conflict",
+                        message=(
+                            f"Workspace label on cluster {namespace}/{name} changed "
+                            "between ACL check and patch; refusing to apply."
+                        ),
+                    )
+
+            verify = _assert_label_unchanged
+
         return self._patch_with_resource_version(
             fetch=lambda: self._get_custom_object_sync(PLURAL, namespace, name),
             apply=lambda payload: self._patch_custom_object_sync(PLURAL, namespace, name, payload),
             body=body,
             label=f"cluster {namespace}/{name}",
+            verify=verify,
         )
 
     def _delete_cluster_sync(self, namespace: str, name: str) -> dict[str, Any]:
@@ -738,8 +792,29 @@ class K8sClient:
     async def create_cluster(self, namespace: str, body: dict[str, Any]) -> dict[str, Any]:
         return await asyncio.to_thread(self._create_cluster_sync, namespace, body)
 
-    async def patch_cluster(self, namespace: str, name: str, body: dict[str, Any]) -> dict[str, Any]:
-        return await asyncio.to_thread(self._patch_cluster_sync, namespace, name, body)
+    async def patch_cluster(
+        self,
+        namespace: str,
+        name: str,
+        body: dict[str, Any],
+        *,
+        expected_workspace_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Patch an AerospikeCluster CR with optimistic concurrency.
+
+        ``expected_workspace_id`` (P1-4) is the workspace label the
+        caller verified before invoking patch. When supplied, each
+        retry's refetch re-asserts the label is still that value -- a
+        concurrent re-stamp aborts with 409 ``Conflict`` instead of
+        applying the mutation under another tenant's label.
+        """
+        return await asyncio.to_thread(
+            self._patch_cluster_sync,
+            namespace,
+            name,
+            body,
+            expected_workspace_id=expected_workspace_id,
+        )
 
     async def delete_cluster(self, namespace: str, name: str) -> dict[str, Any]:
         return await asyncio.to_thread(self._delete_cluster_sync, namespace, name)

--- a/api/src/aerospike_cluster_manager_api/mcp/registry.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/registry.py
@@ -44,6 +44,7 @@ done at the call site rather than at registration time.
 from __future__ import annotations
 
 import inspect
+import logging
 import typing
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -57,6 +58,30 @@ from aerospike_cluster_manager_api.mcp import user_context as _user_context_mod
 from aerospike_cluster_manager_api.mcp.access_profile import WRITE_TOOLS, AccessProfile, is_blocked
 from aerospike_cluster_manager_api.mcp.errors import MCPToolError, map_aerospike_errors
 from aerospike_cluster_manager_api.models.workspace import SYSTEM_OWNER_ID
+
+logger = logging.getLogger(__name__)
+
+
+# P1-5: track misconfig warnings emitted at most once per process per
+# missing-claim case. Without this guard a misconfigured IdP would log
+# a WARNING on every MCP tool invocation. Mirror the REST helper in
+# ``dependencies._warn_missing_owner_claim_once``.
+_WARNED_MISSING_CLAIMS: set[str] = set()
+
+
+def _warn_missing_owner_claim_once(claim_name: str) -> None:
+    """Emit a one-time WARNING when the configured OIDC owner claim is
+    missing from the MCP caller's JWT. Behavior unchanged (caller
+    silently degrades to permissive workspace access)."""
+    if claim_name in _WARNED_MISSING_CLAIMS:
+        return
+    _WARNED_MISSING_CLAIMS.add(claim_name)
+    logger.warning(
+        "MCP: OIDC owner claim '%s' is missing or empty in caller JWT; workspace gate is bypassed for this caller. "
+        "This silently downgrades caller identity and disables tenant isolation. "
+        "Verify ACM_OIDC_OWNER_CLAIM matches a claim your IdP actually emits.",
+        claim_name,
+    )
 
 
 @dataclass(frozen=True)
@@ -164,9 +189,12 @@ async def _assert_workspace_owns_arg(
     # empty claim degrades to SYSTEM_OWNER_ID -- same rule
     # ``dependencies._resolve_caller_owner_id`` applies for REST
     # callers, so misconfigured IdPs cannot lock callers out of the
-    # default workspace.
+    # default workspace. P1-5: emit a one-time WARNING so a
+    # misconfigured IdP is loudly visible (set guard prevents log
+    # spam).
     raw = claims.get(config.ACM_OIDC_OWNER_CLAIM)
     if not isinstance(raw, str) or not raw:
+        _warn_missing_owner_claim_once(config.ACM_OIDC_OWNER_CLAIM)
         return
     caller_owner_id = raw
 

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/connections.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/connections.py
@@ -116,7 +116,7 @@ async def create_connection(
 @tool(category="connection", mutation=False)
 async def get_connection(conn_id: str) -> dict[str, Any]:
     """Fetch a connection profile by id."""
-    result = await connections_service.get_connection(conn_id)
+    result = await connections_service.get_connection(conn_id, _resolve_mcp_caller_owner_id())
     return result.model_dump()
 
 

--- a/api/src/aerospike_cluster_manager_api/mcp/tools/k8s.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/tools/k8s.py
@@ -191,9 +191,22 @@ async def _assert_caller_owns_cluster(namespace: str, name: str) -> None:
     try:
         ws = await db.get_workspace(workspace_id)
     except db.DBNotInitialized:
+        # Workspace metaDB is not configured -- preserve the legacy
+        # single-tenant fallback used by unit-test paths that exercise
+        # the K8s tools in isolation. Mirrors the REST permissive leg
+        # in :func:`routers.k8s_clusters._is_workspace_visible`.
         return
     if ws is None:
-        return
+        # Orphan label: the workspace the CR was stamped against has
+        # been deleted. Pre-fix the MCP tool returned silently, leaving
+        # the cluster accessible to every caller. Mirror the REST gate
+        # (``_is_workspace_visible`` returns False -> 404) and surface
+        # an identity-not_found so the caller cannot enumerate
+        # orphaned-label clusters across tenants.
+        raise MCPToolError(
+            f"Cluster '{namespace}/{name}' not found",
+            code="not_found",
+        )
     if ws.ownerId == caller_owner_id or ws.ownerId == SYSTEM_OWNER_ID:
         return
     raise MCPToolError(
@@ -366,7 +379,15 @@ async def scale_k8s_cluster(
     previous_size = int(current.get("spec", {}).get("size", 0) or 0)
 
     patch = {"spec": {"size": size}}
-    result = await k8s_client.patch_cluster(namespace, name, patch)
+    # P1-4: pass the workspace label observed during the ACL gate so the
+    # patch loop aborts if a concurrent writer re-stamps the CR with a
+    # different label between the gate and the apply (TOCTOU).
+    result = await k8s_client.patch_cluster(
+        namespace,
+        name,
+        patch,
+        expected_workspace_id=_cr_workspace_id(current),
+    )
     new_size = int(result.get("spec", {}).get("size", size) or size)
 
     # Use a non-aliased camelCase form directly so the response matches the

--- a/api/src/aerospike_cluster_manager_api/models/k8s/template.py
+++ b/api/src/aerospike_cluster_manager_api/models/k8s/template.py
@@ -56,6 +56,17 @@ class CreateK8sTemplateRequest(BaseModel):
     model_config = {"populate_by_name": True}
 
     name: str = Field(min_length=1, max_length=63, pattern=r"^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$")
+    workspace_id: str | None = Field(
+        default=None,
+        alias="workspaceId",
+        description=(
+            "Workspace to stamp on the template via the "
+            "``acm.aerospike.com/workspace`` label. Defaults to the caller's "
+            "default workspace at the router layer when omitted. Without "
+            "this stamp, templates remain unlabelled and visible to every "
+            "authenticated caller (legacy single-tenant fallback)."
+        ),
+    )
     image: str | None = Field(default=None, pattern=r"^[a-z0-9]([a-z0-9._/-]*[a-z0-9])?:[a-zA-Z0-9._-]+$")
     size: int | None = Field(default=None, ge=1, le=8)
     resources: ResourceConfig | None = None

--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -66,16 +66,23 @@ async def create_connection(
 
 
 @router.get("/{conn_id}", summary="Get connection", description="Retrieve a single connection profile by its ID.")
-async def get_connection(conn_id: str = Depends(_get_verified_connection)) -> ConnectionProfileResponse:
+async def get_connection(
+    caller_owner_id: CallerOwnerId,
+    conn_id: str = Depends(_get_verified_connection),
+) -> ConnectionProfileResponse:
     """Retrieve a single connection profile by its ID.
 
     The dependency enforces the workspace ACL: the caller must own the
     connection's workspace (or the row must live in the shared
     ``SYSTEM_OWNER_ID`` workspace). Cross-tenant probes 404 to keep the
     wire shape identical to the missing-row case.
+
+    ``caller_owner_id`` is also threaded into the service-layer call as
+    defense-in-depth (P1-2) so a future refactor that bypasses
+    ``_get_verified_connection`` still hits the ACL.
     """
     try:
-        return await connections_service.get_connection(conn_id)
+        return await connections_service.get_connection(conn_id, caller_owner_id)
     except ConnectionNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
@@ -213,10 +220,32 @@ def _disconnected_health(error: str, error_type: str) -> Response:
     description="Test connectivity to an Aerospike cluster without saving the profile.",
 )
 @limiter.limit("5/minute")
-async def test_connection(request: Request, body: TestConnectionRequest) -> dict[str, bool | str]:
-    """Test connectivity to an Aerospike cluster without saving the profile."""
+async def test_connection(
+    request: Request,
+    body: TestConnectionRequest,
+    caller_owner_id: CallerOwnerId,
+) -> dict[str, bool | str]:
+    """Test connectivity to an Aerospike cluster without saving the profile.
+
+    Failure messages are normalised to a generic ``"connection failed"``
+    string so the REST surface does not leak host/port or driver
+    internals to the caller. The original exception text is preserved in
+    the structured operator log alongside the caller identity so an SRE
+    debugging a flapping cluster still has the underlying error.
+    """
     result = await connections_service.test_connection(body)
-    return {"success": result.success, "message": result.message}
+    if not result.success:
+        # Mirror the MCP-side hardening (mcp/tools/connections.py:~265):
+        # generic wire response, structured operator log with detail.
+        logger.warning(
+            "REST test_connection failure: caller_owner_id=%s hosts=%s port=%s detail=%s",
+            caller_owner_id,
+            body.hosts,
+            body.port,
+            result.message,
+        )
+        return {"success": False, "message": "connection failed"}
+    return {"success": True, "message": result.message}
 
 
 @router.delete(

--- a/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
@@ -467,7 +467,7 @@ async def force_reconcile_k8s_cluster(
 ) -> K8sClusterSummary:
     """Add a force-reconcile annotation to trigger the operator to re-reconcile."""
 
-    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
+    cr = await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     patch: dict[str, Any] = {
         "metadata": {
             "annotations": {
@@ -475,7 +475,7 @@ async def force_reconcile_k8s_cluster(
             }
         }
     }
-    result = await k8s_client.patch_cluster(namespace, name, patch)
+    result = await k8s_client.patch_cluster(namespace, name, patch, expected_workspace_id=_cr_workspace_id(cr))
     return extract_summary(result)
 
 
@@ -493,7 +493,7 @@ async def reset_circuit_breaker(
     name: str = _K8S_NAME,
 ) -> dict[str, str]:
     """Reset the circuit breaker by patching status counters and annotating the CR."""
-    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
+    cr = await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     # 1. Reset status subresource (clear error state)
     await k8s_client.patch_cluster_status(
         namespace,
@@ -511,7 +511,7 @@ async def reset_circuit_breaker(
             }
         }
     }
-    await k8s_client.patch_cluster(namespace, name, patch)
+    await k8s_client.patch_cluster(namespace, name, patch, expected_workspace_id=_cr_workspace_id(cr))
     return {"message": "Circuit breaker reset triggered", "namespace": namespace, "name": name}
 
 
@@ -558,6 +558,14 @@ async def import_k8s_cluster(
             status_code=404,
             detail=f"Workspace '{cr_workspace_id}' not found",
         )
+    # P1-3: stamp the caller's default workspace label when the imported
+    # CR has none. Without this fix, an import landed unlabelled and was
+    # therefore visible to every authenticated caller (matching the
+    # pre-#307 system-shared bucket). Mirrors the create_k8s_cluster
+    # pattern at routers/k8s_clusters.py:~603.
+    if cr_workspace_id is None:
+        labels = cr.setdefault("metadata", {}).setdefault("labels", {})
+        labels[_WORKSPACE_LABEL] = DEFAULT_WORKSPACE_ID
 
     existing_namespaces = await k8s_client.list_namespaces()
     if cr_namespace not in existing_namespaces:
@@ -667,9 +675,9 @@ async def update_k8s_cluster(
     if not has_update_fields(body):
         raise HTTPException(status_code=400, detail="At least one field must be provided")
 
-    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
+    cr = await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     patch = build_update_patch(body)
-    result = await k8s_client.patch_cluster(namespace, name, patch)
+    result = await k8s_client.patch_cluster(namespace, name, patch, expected_workspace_id=_cr_workspace_id(cr))
     return extract_summary(result)
 
 
@@ -723,9 +731,9 @@ async def scale_k8s_cluster(
     name: str = _K8S_NAME,
 ) -> K8sClusterSummary:
 
-    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
+    cr = await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     patch = {"spec": {"size": body.size}}
-    result = await k8s_client.patch_cluster(namespace, name, patch)
+    result = await k8s_client.patch_cluster(namespace, name, patch, expected_workspace_id=_cr_workspace_id(cr))
     return extract_summary(result)
 
 
@@ -744,9 +752,9 @@ async def update_node_blocklist(
 ) -> K8sClusterSummary:
     """Patch spec.k8sNodeBlockList on the AerospikeCluster CR."""
 
-    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
+    cr = await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     patch: dict[str, Any] = {"spec": {"k8sNodeBlockList": body.node_names}}
-    result = await k8s_client.patch_cluster(namespace, name, patch)
+    result = await k8s_client.patch_cluster(namespace, name, patch, expected_workspace_id=_cr_workspace_id(cr))
     return extract_summary(result)
 
 
@@ -906,18 +914,16 @@ async def list_k8s_secrets(caller_owner_id: CallerOwnerId, namespace: str = "aer
 async def _assert_template_visible(name: str, caller_owner_id: str, *, for_mutation: bool = False) -> dict[str, Any]:
     """Default-deny ACL gate for template reads / mutations.
 
-    Templates with no ``acm.aerospike.com/workspace`` label are treated as
-    system-shared (visible to every authenticated caller) so legacy CRs
-    created before workspace labelling stay reachable. Labelled CRs are
-    visible only to the workspace owner (or ``SYSTEM_OWNER_ID``). Returns
-    the CR dict when visible; raises 404 otherwise (identity-404 to
-    prevent enumeration).
+    Templates with no ``acm.aerospike.com/workspace`` label are surfaced
+    ONLY to the system caller -- legacy/pre-labelling rows stay reachable
+    for migration but never leak across tenants. Labelled CRs are visible
+    to the workspace owner (or ``SYSTEM_OWNER_ID``). Returns the CR dict
+    when visible; raises 404 otherwise (identity-404 to prevent
+    enumeration).
 
-    Unlabelled (system-shared) templates are readable by all but cannot be
-    mutated; setting ``for_mutation=True`` therefore rejects them with the
-    same identity-404 used elsewhere. This prevents cross-tenant mutation
-    while a follow-up PR threads ``workspace`` through the template create
-    path so newly created templates are always labelled.
+    With newly-created templates always carrying a workspace label
+    (post-#307 fix), the only unlabelled rows in production are pre-fix
+    legacy fixtures; system-only access is the safe default.
     """
     try:
         item = await k8s_client.get_template(name)
@@ -927,9 +933,15 @@ async def _assert_template_visible(name: str, caller_owner_id: str, *, for_mutat
         raise _map_k8s_error(e) from e
     workspace_id = _cr_workspace_id(item)
     if workspace_id is None:
-        if for_mutation:
-            raise HTTPException(status_code=404, detail=f"Template '{name}' not found")
-        return item
+        # Unlabelled: only the system caller may read or mutate.
+        # ``for_mutation`` is kept on the signature so existing call
+        # sites stay explicit, but the visibility rule is now the same
+        # for both paths -- the pre-fix gap let any caller mutate
+        # unlabelled templates iff they had created one (round-tripping
+        # the create-without-label bug).
+        if caller_owner_id == SYSTEM_OWNER_ID:
+            return item
+        raise HTTPException(status_code=404, detail=f"Template '{name}' not found")
     if not await _is_workspace_visible(workspace_id, caller_owner_id):
         raise HTTPException(status_code=404, detail=f"Template '{name}' not found")
     return item
@@ -940,13 +952,25 @@ async def _assert_template_visible(name: str, caller_owner_id: str, *, for_mutat
 async def list_k8s_templates(caller_owner_id: CallerOwnerId) -> list[K8sTemplateSummary]:
 
     items = await k8s_client.list_templates()
-    # Filter labelled templates by workspace visibility. Templates without a
-    # workspace label are treated as system-shared (legacy compatibility).
+    # Filter labelled templates by workspace visibility. Unlabelled
+    # templates are surfaced ONLY to the system caller -- legacy/pre-#307
+    # rows stay reachable for migration but no tenant can read another
+    # tenant's untagged templates. The pre-fix behaviour returned
+    # unlabelled templates to every caller, which leaked another tenant's
+    # untagged template metadata.
     workspace_ids: set[str] = {ws_id for item in items if (ws_id := _cr_workspace_id(item)) is not None}
     visible_workspaces: dict[str, bool] = {
         ws_id: await _is_workspace_visible(ws_id, caller_owner_id) for ws_id in workspace_ids
     }
-    items = [item for item in items if (ws := _cr_workspace_id(item)) is None or visible_workspaces.get(ws, False)]
+    is_system_caller = caller_owner_id == SYSTEM_OWNER_ID
+
+    def _template_visible(item: dict[str, Any]) -> bool:
+        ws = _cr_workspace_id(item)
+        if ws is None:
+            return is_system_caller
+        return visible_workspaces.get(ws, False)
+
+    items = [item for item in items if _template_visible(item)]
     return [extract_template_summary(item) for item in items]
 
 
@@ -976,12 +1000,27 @@ async def create_k8s_template(
     caller_owner_id: CallerOwnerId,
 ) -> K8sTemplateSummary:
 
-    # Templates have no workspace_id field on the request model today -- they
-    # remain system-shared until a future PR threads workspace through
-    # CreateK8sTemplateRequest. Still require an authenticated caller (the
-    # ``caller_owner_id`` dependency would not run otherwise) so anonymous
-    # template mutations are impossible once OIDC is enabled.
+    # Resolve the target workspace -- explicit body field wins, otherwise
+    # fall back to the caller's default workspace bucket so the new CR
+    # gets stamped with a label and the ACL gates (list / mutate) work
+    # downstream. Pre-fix the body had no field at all and the CR was
+    # created unlabelled -- visible to every authenticated caller and
+    # write-locked because ``_assert_template_visible(for_mutation=True)``
+    # rejected unlabelled rows (#P0-2).
+    if body.workspace_id is not None and not await _is_workspace_visible(body.workspace_id, caller_owner_id):
+        raise HTTPException(
+            status_code=404,
+            detail=f"Workspace '{body.workspace_id}' not found",
+        )
+    target_workspace_id = body.workspace_id or DEFAULT_WORKSPACE_ID
+
     cr = build_template_cr(body)
+    # Stamp the workspace label so subsequent ACL gates can recognise the
+    # template's tenant -- mirrors the create_k8s_cluster pattern at
+    # routers/k8s_clusters.py:~603. Always labels (even for the default
+    # bucket) so list/get/mutate gates can apply uniform rules.
+    labels = cr.setdefault("metadata", {}).setdefault("labels", {})
+    labels[_WORKSPACE_LABEL] = target_workspace_id
     result = await k8s_client.create_template(cr)
     return extract_template_summary(result)
 
@@ -1078,9 +1117,9 @@ async def resync_k8s_cluster_template(
     name: str = _K8S_NAME,
 ) -> K8sClusterSummary:
 
-    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
+    cr = await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     patch: dict[str, Any] = {"metadata": {"annotations": {"acko.io/resync-template": "true"}}}
-    result = await k8s_client.patch_cluster(namespace, name, patch)
+    result = await k8s_client.patch_cluster(namespace, name, patch, expected_workspace_id=_cr_workspace_id(cr))
     return extract_summary(result)
 
 
@@ -1175,13 +1214,13 @@ async def trigger_k8s_cluster_operation(
     name: str = _K8S_NAME,
 ) -> K8sClusterSummary:
 
-    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
+    cr = await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     op_id = body.id or f"ui-{uuid.uuid4().hex[:8]}"
     operation: dict[str, Any] = {"kind": body.kind, "id": op_id}
     if body.pod_list:
         operation["podList"] = body.pod_list
     patch: dict[str, Any] = {"spec": {"operations": [operation]}}
-    result = await k8s_client.patch_cluster(namespace, name, patch)
+    result = await k8s_client.patch_cluster(namespace, name, patch, expected_workspace_id=_cr_workspace_id(cr))
     return extract_summary(result)
 
 
@@ -1198,7 +1237,7 @@ async def clear_k8s_cluster_operations(
     name: str = _K8S_NAME,
 ) -> K8sClusterSummary:
     """Clear spec.operations to unblock a stuck cluster."""
-    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
+    cr = await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
     patch: dict[str, Any] = {"spec": {"operations": []}}
-    result = await k8s_client.patch_cluster(namespace, name, patch)
+    result = await k8s_client.patch_cluster(namespace, name, patch, expected_workspace_id=_cr_workspace_id(cr))
     return extract_summary(result)

--- a/api/src/aerospike_cluster_manager_api/services/connections_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/connections_service.py
@@ -16,7 +16,9 @@ exceptions defined here, which the router translates to HTTP status codes.
 from __future__ import annotations
 
 import contextlib
+import ipaddress
 import logging
+import os
 import uuid
 from datetime import UTC, datetime
 from typing import Any, NamedTuple
@@ -55,6 +57,22 @@ class ConnectionNotFoundError(LookupError):
         self.conn_id = conn_id
 
 
+class BlockedConnectionTargetError(ValueError):
+    """Raised when a test_connection target points at a denied address.
+
+    Default-deny SSRF gate: loopback, link-local (especially the EC2 IMDS
+    169.254.169.254), and IPv6 ``::1`` are rejected before any network
+    syscall so the API cannot be repurposed as an internal port scanner
+    or a metadata-service exfil channel. Operators can override the
+    default-deny via ``ACM_CONNECTION_TEST_ALLOW_PRIVATE=true`` for dev
+    deployments where the API and Aerospike share a host.
+    """
+
+    def __init__(self, host: str) -> None:
+        super().__init__(f"Connection target '{host}' is not allowed")
+        self.host = host
+
+
 class WorkspaceNotFoundError(LookupError):
     """Raised when a referenced workspace does not exist."""
 
@@ -85,6 +103,56 @@ class TestConnectionResult(NamedTuple):
 # ---------------------------------------------------------------------------
 # Service entry points
 # ---------------------------------------------------------------------------
+
+
+_ALLOW_PRIVATE_TARGETS_ENV = "ACM_CONNECTION_TEST_ALLOW_PRIVATE"
+
+
+def _allow_private_targets() -> bool:
+    """Return True when operators have opted into private-range targets.
+
+    Read live (not snapshotted) so test fixtures can flip the env var via
+    monkeypatch. The default is False -- production deployments default-
+    deny loopback / link-local to keep the test_connection API from
+    being repurposed as an internal port scanner or IMDS exfil channel.
+    """
+    return os.environ.get(_ALLOW_PRIVATE_TARGETS_ENV, "false").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _is_blocked_target(host: str) -> bool:
+    """Return True iff ``host`` resolves to a denied IP literal.
+
+    Blocks loopback (``127.0.0.0/8``, ``::1``) and link-local IPv4
+    (``169.254.0.0/16`` -- includes the EC2 IMDS ``169.254.169.254``) so
+    the test-connection endpoint cannot be turned into an SSRF probe by
+    an authenticated caller. Hostnames that are not bare IP literals are
+    *not* blocked here -- the underlying Aerospike client resolves DNS
+    natively and re-checking after resolve would race with TOCTOU. The
+    contract is: literal-IP rejection is the cheap first line; deeper
+    network-policy enforcement (egress firewall) is expected to backstop
+    DNS-based bypasses.
+
+    The ``ACM_CONNECTION_TEST_ALLOW_PRIVATE`` env var disables the gate
+    for dev deployments where the API and Aerospike share a host (the
+    compose.dev.yaml workflow exercises this routinely).
+    """
+    if _allow_private_targets():
+        return False
+    candidate = host.strip()
+    if not candidate:
+        return False
+    # IPv6 literals may arrive bracketed (`[::1]`); strip before parsing.
+    if candidate.startswith("[") and candidate.endswith("]"):
+        candidate = candidate[1:-1]
+    try:
+        ip = ipaddress.ip_address(candidate)
+    except ValueError:
+        # Not a bare IP literal -- let it through; DNS-based abuse is
+        # explicitly out of scope per the docstring rationale.
+        return False
+    if ip.is_loopback:
+        return True
+    return bool(ip.is_link_local)
 
 
 async def _assert_workspace_visible(workspace_id: str, caller_owner_id: str | None) -> None:
@@ -133,13 +201,39 @@ async def list_connections(
     return [ConnectionProfileResponse.from_profile(p) for p in profiles]
 
 
-async def get_connection(conn_id: str) -> ConnectionProfileResponse:
-    """Return the connection profile with id ``conn_id``.
+async def get_connection(conn_id: str, caller_owner_id: str) -> ConnectionProfileResponse:
+    """Return the connection profile with id ``conn_id`` if visible to caller.
 
-    Raises ``ConnectionNotFoundError`` if no such profile exists.
+    Raises ``ConnectionNotFoundError`` when the row does not exist *or*
+    when it exists but the caller does not own the underlying workspace
+    (and the workspace is not the SYSTEM-shared bucket). Identity-404
+    so id enumeration cannot distinguish "missing" from "exists but not
+    yours".
+
+    ``caller_owner_id`` is mandatory -- previously this service entry
+    had no ACL plumbed through and relied on every caller (REST + MCP)
+    to gate beforehand. That made it a regression trap: any future
+    caller forgetting the gate would silently expose cross-tenant
+    connections. Threading the parameter through forces the contract.
     """
     conn = await db.get_connection(conn_id)
     if not conn:
+        raise ConnectionNotFoundError(conn_id)
+    workspace_id = getattr(conn, "workspaceId", None)
+    if workspace_id is None:
+        # Legacy / dict-fixture connection with no workspace association.
+        # Treat as system-shared so the pre-#307 wire shape is preserved.
+        return ConnectionProfileResponse.from_profile(conn)
+    try:
+        workspace = await db.get_workspace(workspace_id)
+    except db.DBNotInitialized:
+        # Unit-test paths that don't drive the workspace DB keep the
+        # legacy permissive behaviour -- matches the dependency-layer
+        # convention in :func:`dependencies._get_verified_connection`.
+        return ConnectionProfileResponse.from_profile(conn)
+    if workspace is None:
+        raise ConnectionNotFoundError(conn_id)
+    if workspace.ownerId != caller_owner_id and workspace.ownerId != SYSTEM_OWNER_ID:
         raise ConnectionNotFoundError(conn_id)
     return ConnectionProfileResponse.from_profile(conn)
 
@@ -218,10 +312,35 @@ async def delete_connection(conn_id: str) -> None:
 async def test_connection(req: TestConnectionRequest) -> TestConnectionResult:
     """Probe Aerospike connectivity without persisting a profile.
 
-    Returns a :class:`TestConnectionResult`. Never raises — any error is
+    Returns a :class:`TestConnectionResult`. Never raises -- any error is
     captured and surfaced as ``success=False`` so HTTP/MCP wrappers can
     forward the wire shape unchanged.
+
+    SSRF gate: targets that resolve to loopback / link-local literals
+    (including the EC2 IMDS ``169.254.169.254``) are rejected before any
+    network syscall fires. The blocked path returns the same
+    ``success=False`` shape as a real connection failure so a probing
+    caller cannot distinguish "blocked" from "unreachable" by the wire
+    response alone -- the discriminator is operator-only via the
+    structured log.
     """
+    # Default-deny SSRF gate. Apply once at the top, before any network
+    # syscall, so an attacker cannot use this surface to enumerate
+    # internal listeners (Redis on 127.0.0.1, IMDS on 169.254.169.254,
+    # cloud SQL proxies on the host loopback). The check is cheap (pure
+    # ip parsing) and keyed on bare IP literals -- DNS hostnames are
+    # outside the gate; egress firewalls are expected to backstop those.
+    for host_str in req.hosts:
+        host_only, _ = parse_host_port(host_str, req.port)
+        if _is_blocked_target(host_only):
+            logger.warning(
+                "Test connection blocked: target=%s reason=loopback_or_link_local",
+                host_str,
+            )
+            return TestConnectionResult(
+                success=False,
+                message="connection failed",
+            )
     try:
         hosts = [parse_host_port(h, req.port) for h in req.hosts]
 

--- a/api/src/aerospike_cluster_manager_api/services/workspaces_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/workspaces_service.py
@@ -95,6 +95,25 @@ def _is_visible_to(ws: Workspace, caller_owner_id: str) -> bool:
     return ws.ownerId == caller_owner_id or ws.ownerId == SYSTEM_OWNER_ID
 
 
+def _is_owned_by(ws: Workspace, caller_owner_id: str) -> bool:
+    """Return True iff ``caller_owner_id`` may **mutate** ``ws``.
+
+    Stricter than :func:`_is_visible_to`: SYSTEM-owned workspaces (the
+    built-in default, ``ws-default``) can only be mutated by the system
+    caller itself. Without this check any authenticated caller could
+    rename or recolor ``ws-default`` because the visibility rule lets
+    every authenticated caller read SYSTEM rows. The earlier
+    pre-fix behaviour gated update/delete on visibility, so any tenant
+    could mutate the shared default.
+
+    The system caller (``caller_owner_id == SYSTEM_OWNER_ID``) keeps the
+    legacy permissive path -- anonymous deployments and the
+    single-tenant fallback both resolve to SYSTEM_OWNER_ID and should
+    still be able to manage every workspace.
+    """
+    return ws.ownerId == caller_owner_id
+
+
 # ---------------------------------------------------------------------------
 # Service entry points
 # ---------------------------------------------------------------------------
@@ -154,10 +173,17 @@ async def update_workspace(
 
     Raises :class:`WorkspaceNotFoundError` when the workspace does not
     exist or is invisible to the caller — same wire shape so id
-    enumeration is impossible.
+    enumeration is impossible. Mutations require strict ownership
+    (:func:`_is_owned_by`); visibility alone is not enough or any tenant
+    could rename / recolor SYSTEM-owned rows like ``ws-default``.
     """
     ws = await db.get_workspace(workspace_id)
     if ws is None or not _is_visible_to(ws, caller_owner_id):
+        raise WorkspaceNotFoundError(workspace_id)
+    if not _is_owned_by(ws, caller_owner_id):
+        # Visible to the caller (e.g. SYSTEM-shared default) but not
+        # owned -- refuse the mutation. Use the same identity-404 wire
+        # shape as the visibility miss to avoid leaking ownership info.
         raise WorkspaceNotFoundError(workspace_id)
 
     update_data = payload.model_dump(exclude_unset=True, by_alias=False)
@@ -186,6 +212,11 @@ async def delete_workspace(workspace_id: str, caller_owner_id: str) -> None:
     """
     ws = await db.get_workspace(workspace_id)
     if ws is None or not _is_visible_to(ws, caller_owner_id):
+        raise WorkspaceNotFoundError(workspace_id)
+    if not _is_owned_by(ws, caller_owner_id):
+        # Same default-deny rule update_workspace uses: visible (e.g.
+        # SYSTEM-shared) but not owned by the caller is treated as a
+        # 404 to avoid leaking the existence of the SYSTEM bucket.
         raise WorkspaceNotFoundError(workspace_id)
     if ws.isDefault or ws.id == DEFAULT_WORKSPACE_ID:
         raise WorkspaceIsDefaultError(workspace_id)

--- a/api/tests/test_connections_router.py
+++ b/api/tests/test_connections_router.py
@@ -312,7 +312,13 @@ class TestTestConnection:
         assert body["message"] == "Connected successfully"
 
     async def test_failure(self, client: AsyncClient):
-        """Test connection endpoint when connection fails."""
+        """Test connection endpoint when connection fails.
+
+        Failure messages are normalised to a generic ``"connection
+        failed"`` so the REST surface does not leak driver internals
+        (P1-1 hardening); the original detail lives in the operator
+        log only.
+        """
         with patch(
             "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
             side_effect=Exception("Connection refused"),
@@ -325,7 +331,9 @@ class TestTestConnection:
         assert response.status_code == 200
         body = response.json()
         assert body["success"] is False
-        assert "Connection refused" in body["message"]
+        assert body["message"] == "connection failed"
+        # The original detail must NOT leak through.
+        assert "Connection refused" not in body["message"]
 
     async def test_not_connected(self, client: AsyncClient):
         """Test connection endpoint when client connects but is_connected returns False."""
@@ -346,7 +354,9 @@ class TestTestConnection:
         assert response.status_code == 200
         body = response.json()
         assert body["success"] is False
-        assert "Failed to connect" in body["message"]
+        # P1-1: REST returns the normalised generic message; the original
+        # ("Failed to connect") only appears in the operator log.
+        assert body["message"] == "connection failed"
 
     async def test_with_credentials(self, client: AsyncClient):
         """Test connection endpoint passes credentials correctly."""
@@ -375,6 +385,95 @@ class TestTestConnection:
         call_args = mock_cls.call_args[0][0]
         assert call_args["user"] == "admin"
         assert call_args["password"] == "secret"
+
+
+class TestConnectionSSRF:
+    """P1-1 regression: test_connection rejects loopback / link-local
+    targets without making any network call."""
+
+    async def test_imds_target_rejected_without_network_call(self, client: AsyncClient):
+        """169.254.169.254 (EC2 IMDS) must be blocked by the SSRF gate
+        before the Aerospike client is even constructed."""
+        with patch(
+            "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
+        ) as mock_cls:
+            response = await client.post(
+                "/api/connections/test",
+                json={"hosts": ["169.254.169.254"], "port": 80},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["success"] is False
+        # No network call must have happened.
+        mock_cls.assert_not_called()
+
+    async def test_loopback_ipv4_rejected(self, client: AsyncClient):
+        with patch(
+            "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
+        ) as mock_cls:
+            response = await client.post(
+                "/api/connections/test",
+                json={"hosts": ["127.0.0.1"], "port": 3000},
+            )
+        assert response.status_code == 200
+        assert response.json()["success"] is False
+        mock_cls.assert_not_called()
+
+    async def test_loopback_ipv6_rejected(self, client: AsyncClient):
+        with patch(
+            "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
+        ) as mock_cls:
+            response = await client.post(
+                "/api/connections/test",
+                json={"hosts": ["[::1]"], "port": 3000},
+            )
+        assert response.status_code == 200
+        assert response.json()["success"] is False
+        mock_cls.assert_not_called()
+
+    async def test_loopback_allowed_when_env_override_set(self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch):
+        """``ACM_CONNECTION_TEST_ALLOW_PRIVATE=true`` lets dev deployments
+        target the loopback Aerospike running alongside the API."""
+        monkeypatch.setenv("ACM_CONNECTION_TEST_ALLOW_PRIVATE", "true")
+
+        mock_client = AsyncMock()
+        mock_client.connect = AsyncMock()
+        mock_client.is_connected = lambda: True
+        mock_client.close = AsyncMock()
+
+        with patch(
+            "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
+            return_value=mock_client,
+        ) as mock_cls:
+            response = await client.post(
+                "/api/connections/test",
+                json={"hosts": ["127.0.0.1"], "port": 3000},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+        mock_cls.assert_called_once()
+
+    async def test_dns_hostname_not_blocked(self, client: AsyncClient):
+        """Hostnames are not pre-resolved here -- the gate is bare-IP
+        only. Egress firewalls back-stop DNS-based bypasses."""
+        mock_client = AsyncMock()
+        mock_client.connect = AsyncMock()
+        mock_client.is_connected = lambda: True
+        mock_client.close = AsyncMock()
+
+        with patch(
+            "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
+            return_value=mock_client,
+        ) as mock_cls:
+            response = await client.post(
+                "/api/connections/test",
+                json={"hosts": ["example.com"], "port": 3000},
+            )
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+        mock_cls.assert_called_once()
 
 
 class TestCrossOwnerWorkspaceAccess:

--- a/api/tests/test_connections_service.py
+++ b/api/tests/test_connections_service.py
@@ -146,7 +146,7 @@ class TestCreateConnection:
 
     async def test_persisted_can_be_retrieved(self, init_test_db):
         created = await connections_service.create_connection(_create_payload())
-        fetched = await connections_service.get_connection(created.id)
+        fetched = await connections_service.get_connection(created.id, "system")
         assert fetched.id == created.id
         assert fetched.name == created.name
 
@@ -159,13 +159,31 @@ class TestCreateConnection:
 class TestGetConnection:
     async def test_returns_existing(self, init_test_db):
         created = await connections_service.create_connection(_create_payload())
-        result = await connections_service.get_connection(created.id)
+        result = await connections_service.get_connection(created.id, "system")
         assert isinstance(result, ConnectionProfileResponse)
         assert result.id == created.id
 
     async def test_missing_raises(self, init_test_db):
         with pytest.raises(ConnectionNotFoundError):
-            await connections_service.get_connection("conn-nonexistent")
+            await connections_service.get_connection("conn-nonexistent", "system")
+
+    async def test_cross_owner_returns_not_found(self, init_test_db):
+        """P1-2 regression: get_connection now requires caller_owner_id and
+        rejects cross-tenant probes with the same wire shape as missing."""
+        from datetime import UTC, datetime
+
+        from aerospike_cluster_manager_api import db
+        from aerospike_cluster_manager_api.models.workspace import Workspace
+
+        now = datetime.now(UTC).isoformat()
+        await db.create_workspace(
+            Workspace(id="ws-alice", name="alice", color="#111111", ownerId="alice", createdAt=now, updatedAt=now)
+        )
+        created = await connections_service.create_connection(
+            _create_payload(name="alice-only", workspaceId="ws-alice"), caller_owner_id="alice"
+        )
+        with pytest.raises(ConnectionNotFoundError):
+            await connections_service.get_connection(created.id, caller_owner_id="bob")
 
 
 # ---------------------------------------------------------------------------
@@ -206,7 +224,7 @@ class TestDeleteConnection:
         created = await connections_service.create_connection(_create_payload())
         await connections_service.delete_connection(created.id)
         with pytest.raises(ConnectionNotFoundError):
-            await connections_service.get_connection(created.id)
+            await connections_service.get_connection(created.id, "system")
 
     async def test_idempotent_for_missing(self, init_test_db):
         # Delete twice — second call must not raise (idempotent).

--- a/api/tests/test_workspaces_service.py
+++ b/api/tests/test_workspaces_service.py
@@ -129,6 +129,33 @@ class TestUpdateWorkspace:
         with pytest.raises(WorkspaceNotFoundError):
             await workspaces_service.update_workspace(created.id, UpdateWorkspaceRequest(name="hijacked"), OWNER_B)
 
+    async def test_non_system_caller_cannot_update_system_workspace(self, init_test_db):
+        """Regression: visibility != ownership.
+
+        ``ws-default`` is owned by ``SYSTEM_OWNER_ID`` and visible to every
+        authenticated caller. Before the fix, any tenant could rename or
+        recolor it because update_workspace gated on visibility alone.
+        """
+        with pytest.raises(WorkspaceNotFoundError):
+            await workspaces_service.update_workspace(
+                DEFAULT_WORKSPACE_ID,
+                UpdateWorkspaceRequest(name="hijacked-default"),
+                OWNER_A,
+            )
+        # The default must be intact afterwards.
+        fetched = await workspaces_service.get_workspace(DEFAULT_WORKSPACE_ID, OWNER_A)
+        assert fetched.name != "hijacked-default"
+
+    async def test_system_caller_can_update_system_workspace(self, init_test_db):
+        """SYSTEM caller (anonymous / single-tenant fallback) keeps the
+        legacy permissive path so ``ws-default`` stays manageable."""
+        result = await workspaces_service.update_workspace(
+            DEFAULT_WORKSPACE_ID,
+            UpdateWorkspaceRequest(name="System Renamed"),
+            SYSTEM_OWNER_ID,
+        )
+        assert result.name == "System Renamed"
+
     async def test_owner_id_in_db_layer_not_mutated(self, init_test_db):
         """Defense-in-depth: even when a stale ``ownerId`` key reaches the
         DB merge helper, ``build_merged_workspace`` holds the field
@@ -162,8 +189,44 @@ class TestDeleteWorkspace:
             await workspaces_service.delete_workspace(created.id, OWNER_B)
 
     async def test_default_rejected(self, init_test_db):
-        with pytest.raises(WorkspaceIsDefaultError):
+        # The non-system caller is now blocked by the ownership gate before
+        # the "is default" guard fires (visibility allows the read, but
+        # SYSTEM ownership rejects the mutation). Both surface the same
+        # identity-404 wire shape.
+        with pytest.raises(WorkspaceNotFoundError):
             await workspaces_service.delete_workspace(DEFAULT_WORKSPACE_ID, OWNER_A)
+        # The system caller still hits the dedicated default-protection
+        # error, preserving the legacy 400 response on the router.
+        with pytest.raises(WorkspaceIsDefaultError):
+            await workspaces_service.delete_workspace(DEFAULT_WORKSPACE_ID, SYSTEM_OWNER_ID)
+
+    async def test_non_system_caller_cannot_delete_system_workspace(self, init_test_db):
+        """Regression for P0-1: only the system caller can delete a
+        SYSTEM-owned workspace. Prior to the fix, visibility alone gated
+        the delete path so any tenant could attempt it (and the only
+        thing stopping ``ws-default`` deletion was the dedicated
+        ``WorkspaceIsDefaultError`` guard, which doesn't fire on
+        non-default SYSTEM rows)."""
+        # Seed a non-default SYSTEM-owned workspace via the DB to mimic a
+        # legacy/pre-migration row.
+        from aerospike_cluster_manager_api.models.workspace import Workspace
+
+        now = datetime.now(UTC).isoformat()
+        await db.create_workspace(
+            Workspace(
+                id="ws-system-extra",
+                name="system-extra",
+                color="#ABCDEF",
+                ownerId=SYSTEM_OWNER_ID,
+                createdAt=now,
+                updatedAt=now,
+            )
+        )
+        with pytest.raises(WorkspaceNotFoundError):
+            await workspaces_service.delete_workspace("ws-system-extra", OWNER_A)
+        # Still present.
+        ws = await db.get_workspace("ws-system-extra")
+        assert ws is not None
 
     async def test_with_connections_rejected(self, init_test_db):
         created = await workspaces_service.create_workspace(_create_payload(), OWNER_A)


### PR DESCRIPTION
## Summary

Closes 3 P0 multi-tenant ACL bugs and 5 P1 hardening issues identified by a comprehensive review of the API surface.

### P0
- **services/workspaces_service.py** — Any tenant could rename/delete the SYSTEM-shared default workspace via update/delete endpoints. Now requires strict ownership for mutations; visibility unchanged.
- **routers/k8s_clusters.py + models/k8s/template.py** — K8s templates created without workspace label were both visible to all tenants and unmodifiable by anyone (404). Templates now stamp workspace label on create/import; list endpoint gates unlabelled rows on system caller.
- **mcp/tools/k8s.py** — MCP K8s ACL gate fail-open when workspace was deleted. Now mirrors REST behaviour.

### P1
- **services/connections_service.py + routers/connections.py + mcp/tools/connections.py** — test_connection now denies loopback and link-local (169.254/16, ::1), returns generic message via REST. Server-side detail still logged with caller_owner_id.
- **services/connections_service.py** — Service-level get_connection now requires caller_owner_id (no more regression-trap signature).
- **routers/k8s_clusters.py + k8s_client.py** — Patch flows re-verify workspace label on each optimistic-concurrency refetch (TOCTOU window closed).
- **mcp/registry.py + dependencies.py** — Missing OIDC owner claim now warns once per process instead of silently downgrading the caller to SYSTEM_OWNER_ID.
- **routers/k8s_clusters.py** — import_k8s_cluster now stamps workspace label when input has none (was silently shared with all tenants).

## Test plan
- [x] ruff check + format + pyright pass (0 errors)
- [x] pytest tests/ all green — 991 passed (added regression tests for SYSTEM workspace mutation, template ACL, SSRF block, get_connection ACL)
- [ ] manual: with OIDC enabled, two tenants cannot see/mutate each other's templates
- [ ] manual: link-local test_connection rejected without making network call