### PR TITLE
fix(ui): close fetch race + state retry gaps

### DIFF
--- a/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
@@ -46,30 +46,54 @@ export default function AdminPage({ params }: PageProps) {
     setUsersState((s) => ({ ...s, loading: true, error: null }))
     setRolesState((s) => ({ ...s, loading: true, error: null }))
     setSecurityDisabled(false)
-    try {
-      const [users, roles] = await Promise.all([
-        listUsers(params.clusterId),
-        listRoles(params.clusterId),
-      ])
-      setUsersState({ data: users, loading: false, error: null })
-      setRolesState({ data: roles, loading: false, error: null })
-    } catch (err) {
-      logFetchError("admin", err)
-      const mapped = mapApiError(err)
-      // Admin endpoints refuse access either because security is off (CE
-      // default) or the connecting user lacks ACL — both surface as the
-      // same explanatory card here.
-      if (
-        mapped.kind === "security-disabled" ||
-        mapped.kind === "permission-denied"
-      ) {
-        setSecurityDisabled(true)
-        setUsersState({ data: null, loading: false, error: null })
-        setRolesState({ data: null, loading: false, error: null })
-        return
-      }
-      setUsersState({ data: null, loading: false, error: mapped.message })
-      setRolesState({ data: null, loading: false, error: mapped.message })
+
+    // allSettled lets a partial success render — e.g. listUsers may succeed
+    // while listRoles 5xxs from a transient asinfo timeout. The previous
+    // Promise.all dropped the successful side too. The "security disabled"
+    // / "permission denied" UX still wins iff *both* sides report it,
+    // since CE refuses both endpoints when security is off — a single-side
+    // 403 (e.g. read-only role) should surface as a per-section error.
+    const [usersRes, rolesRes] = await Promise.allSettled([
+      listUsers(params.clusterId),
+      listRoles(params.clusterId),
+    ])
+
+    const isAclGate = (err: unknown) => {
+      const k = mapApiError(err).kind
+      return k === "security-disabled" || k === "permission-denied"
+    }
+    if (
+      usersRes.status === "rejected" &&
+      rolesRes.status === "rejected" &&
+      isAclGate(usersRes.reason) &&
+      isAclGate(rolesRes.reason)
+    ) {
+      logFetchError("admin", usersRes.reason)
+      setSecurityDisabled(true)
+      setUsersState({ data: null, loading: false, error: null })
+      setRolesState({ data: null, loading: false, error: null })
+      return
+    }
+
+    if (usersRes.status === "fulfilled") {
+      setUsersState({ data: usersRes.value, loading: false, error: null })
+    } else {
+      logFetchError("admin-users", usersRes.reason)
+      setUsersState({
+        data: null,
+        loading: false,
+        error: mapApiError(usersRes.reason).message,
+      })
+    }
+    if (rolesRes.status === "fulfilled") {
+      setRolesState({ data: rolesRes.value, loading: false, error: null })
+    } else {
+      logFetchError("admin-roles", rolesRes.reason)
+      setRolesState({
+        data: null,
+        loading: false,
+        error: mapApiError(rolesRes.reason).message,
+      })
     }
   }, [params.clusterId])
 

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
@@ -43,7 +43,7 @@ import { cx } from "@/lib/utils"
 import { RiRefreshLine, RiTimerLine } from "@remixicon/react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 type PageProps = {
   params: { clusterId: string; namespace: string; set: string }
@@ -197,8 +197,16 @@ export default function RecordBrowserPage({ params }: PageProps) {
     }
   }, [reloadSetNote])
 
+  // Sequence ref guards against fast successive fetches (page-size flips,
+  // double-click on Apply, set switch mid-fetch) — older promises that
+  // resolve after a newer one would otherwise overwrite the latest result.
+  // filterRecords doesn't accept an AbortSignal, so we discard stale
+  // resolutions instead of cancelling the in-flight request.
+  const fetchSeqRef = useRef(0)
+
   const runFetch = useCallback(
     async (target: FilterDraft, size: number) => {
+      const seq = ++fetchSeqRef.current
       setLoading(true)
       setError(null)
       try {
@@ -212,6 +220,7 @@ export default function RecordBrowserPage({ params }: PageProps) {
           pkMatchMode: target.pkMatchMode,
           filters: filters ?? null,
         })
+        if (seq !== fetchSeqRef.current) return
         setRecords(resp.records)
         setMeta({
           total: resp.total,
@@ -219,10 +228,11 @@ export default function RecordBrowserPage({ params }: PageProps) {
           executionTimeMs: resp.executionTimeMs,
         })
       } catch (err) {
+        if (seq !== fetchSeqRef.current) return
         logFetchError("records", err)
         setError(mapApiError(err).message)
       } finally {
-        setLoading(false)
+        if (seq === fetchSeqRef.current) setLoading(false)
       }
     },
     [params.clusterId, params.namespace, params.set],

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
@@ -500,7 +500,7 @@ export default function RecordBrowserPage({ params }: PageProps) {
                         // primary-key column; the detail route requires a pk
                         // path segment, so we render an inert digest stub
                         // instead of a broken empty-string link.
-                        <span className="italic text-gray-400 text-xs">
+                        <span className="text-xs italic text-gray-400">
                           digest:{r.key.digest?.slice(0, 8) ?? ""}…
                         </span>
                       )}

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
@@ -483,17 +483,27 @@ export default function RecordBrowserPage({ params }: PageProps) {
                         "sticky left-0 z-10 bg-white font-mono text-xs dark:bg-[#090E1A]",
                       )}
                     >
-                      <Link
-                        href={clusterSections.record(
-                          params.clusterId,
-                          params.namespace,
-                          params.set,
-                          encodeURIComponent(r.key.pk ?? ""),
-                        )}
-                        className="text-indigo-600 hover:underline dark:text-indigo-400"
-                      >
-                        {r.key.pk}
-                      </Link>
+                      {r.key.pk != null ? (
+                        <Link
+                          href={clusterSections.record(
+                            params.clusterId,
+                            params.namespace,
+                            params.set,
+                            encodeURIComponent(r.key.pk),
+                          )}
+                          className="text-indigo-600 hover:underline dark:text-indigo-400"
+                        >
+                          {r.key.pk}
+                        </Link>
+                      ) : (
+                        // digest-only records (sendKey=false on write) have no
+                        // primary-key column; the detail route requires a pk
+                        // path segment, so we render an inert digest stub
+                        // instead of a broken empty-string link.
+                        <span className="italic text-gray-400 text-xs">
+                          digest:{r.key.digest?.slice(0, 8) ?? ""}…
+                        </span>
+                      )}
                     </TableCell>
                     <TableCell className="text-right font-mono text-xs tabular-nums">
                       {r.meta.generation}
@@ -505,22 +515,33 @@ export default function RecordBrowserPage({ params }: PageProps) {
                       <TableCell key={b}>{renderBin(r.bins[b], b)}</TableCell>
                     ))}
                     <TableCell className="text-right">
-                      <Button
-                        variant="ghost"
-                        className="h-7 px-2 text-xs"
-                        asChild
-                      >
-                        <Link
-                          href={clusterSections.record(
-                            params.clusterId,
-                            params.namespace,
-                            params.set,
-                            encodeURIComponent(r.key.pk ?? ""),
-                          )}
+                      {r.key.pk != null ? (
+                        <Button
+                          variant="ghost"
+                          className="h-7 px-2 text-xs"
+                          asChild
+                        >
+                          <Link
+                            href={clusterSections.record(
+                              params.clusterId,
+                              params.namespace,
+                              params.set,
+                              encodeURIComponent(r.key.pk),
+                            )}
+                          >
+                            Open
+                          </Link>
+                        </Button>
+                      ) : (
+                        <Button
+                          variant="ghost"
+                          disabled
+                          title="Digest-only records cannot be opened by primary key"
+                          className="h-7 px-2 text-xs"
                         >
                           Open
-                        </Link>
-                      </Button>
+                        </Button>
+                      )}
                     </TableCell>
                   </TableRow>
                 ))

--- a/ui/src/hooks/use-connections.ts
+++ b/ui/src/hooks/use-connections.ts
@@ -10,7 +10,7 @@
 
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 import { listConnections } from "@/lib/api/connections"
 import { logFetchError } from "@/lib/api/log"
@@ -30,17 +30,33 @@ export function useConnections(): UseConnectionsResult {
   const [isLoading, setIsLoading] = useState(true)
   const rev = useDataRevisionStore((s) => s.connectionsRev)
 
+  // Hook-level mounted guard so both the initial fetch effect AND the
+  // exposed refetch can drop late resolutions after unmount. The previous
+  // useEffect-local `cancelled` flag missed callers who triggered refetch
+  // and then navigated away before the response landed — React would then
+  // warn about setState on an unmounted component (and in strict mode, the
+  // double-mount during dev surfaced the same race more reliably).
+  const isMountedRef = useRef(true)
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
   const refetch = useCallback(async () => {
     setIsLoading(true)
     setError(null)
     try {
       const result = await listConnections()
+      if (!isMountedRef.current) return
       setData(result)
     } catch (err) {
       logFetchError("connections", err)
+      if (!isMountedRef.current) return
       setError(err instanceof Error ? err : new Error(String(err)))
     } finally {
-      setIsLoading(false)
+      if (isMountedRef.current) setIsLoading(false)
     }
   }, [])
 
@@ -49,17 +65,17 @@ export function useConnections(): UseConnectionsResult {
     ;(async () => {
       try {
         const result = await listConnections()
-        if (!cancelled) {
+        if (!cancelled && isMountedRef.current) {
           setData(result)
           setError(null)
         }
       } catch (err) {
         logFetchError("connections", err)
-        if (!cancelled) {
+        if (!cancelled && isMountedRef.current) {
           setError(err instanceof Error ? err : new Error(String(err)))
         }
       } finally {
-        if (!cancelled) setIsLoading(false)
+        if (!cancelled && isMountedRef.current) setIsLoading(false)
       }
     })()
     return () => {

--- a/ui/src/stores/cluster-selector-store.ts
+++ b/ui/src/stores/cluster-selector-store.ts
@@ -99,9 +99,13 @@ function settleHydration(): void {
 
 /**
  * Fetch the cluster registry from the static JSON mount and hydrate the store.
- * Idempotent — call from the root provider on mount. Settles
- * `getHydrationPromise()` whether the registry loads or the fetch fails so
- * apiFetch callers never block forever in legacy single-cluster mode.
+ * Idempotent on success; on failure, the cached single-flight promise is
+ * cleared so a follow-up `hydrateClusterRegistry()` call (e.g. from a retry
+ * banner) primes a fresh pending promise that future apiFetch callers can
+ * actually wait on. Without that reset, the first failure would leave a
+ * settled promise behind and apiFetch would skip waiting on the in-flight
+ * retry, racing the relative-path fallback into the same boot-time 401
+ * loop the single-flight was supposed to prevent.
  */
 export async function hydrateClusterRegistry(
   fetcher: typeof fetch = fetch,
@@ -128,9 +132,19 @@ export async function hydrateClusterRegistry(
       throw new Error(msg)
     }
     useClusterSelectorStore.getState().setRegistry(data)
-    return data
-  } finally {
     settleHydration()
+    return data
+  } catch (err) {
+    // Drain the pending promise so the next caller sees a deterministic
+    // resolved state (rather than a stuck pending one), then null out the
+    // cache so the *next* hydrateClusterRegistry call primes a brand new
+    // single-flight promise. Order matters: settle first so already-awaiting
+    // apiFetch callers unblock, then null out so the retry creates a fresh
+    // promise the next batch of callers can await.
+    settleHydration()
+    hydrationPromise = null
+    resolveHydration = null
+    throw err
   }
 }
 


### PR DESCRIPTION
## Summary

Five P1 frontend fixes carried over from the prior review. All within `ui/src/`.

- **Record browser fetch race**: `runFetch` now bumps a `fetchSeqRef` and discards stale resolutions so a slower in-flight `filterRecords` cannot overwrite a newer result (page-size flip / Apply double-click / set switch).
- **`AdminPage.load` partial success**: switched `Promise.all` -> `Promise.allSettled` so a transient roles 5xx no longer blanks out the users list. The "security disabled / permission denied" empty state still wins, but only when *both* endpoints report ACL gating.
- **Digest-only record link**: rows where `key.pk` is null/undefined now render an inert `digest:xxxxxxxx...` label and a disabled Open button instead of producing a `Link` whose href ends in an empty path segment.
- **`hydrateClusterRegistry` retry**: after a fetch failure, the cached single-flight promise is now nulled out (after settling so already-awaiting `apiFetch` callers unblock) so the next `hydrateClusterRegistry()` call primes a fresh promise that future `apiFetch` callers can wait on.
- **`useConnections.refetch` unmount guard**: hook-level `isMountedRef` gates every `setState` in both the mount/rev effect and the exposed `refetch`, eliminating the unmount-during-pending warning and the strict-mode dev double-mount race.

## Files

- `ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx`
- `ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx`
- `ui/src/stores/cluster-selector-store.ts`
- `ui/src/hooks/use-connections.ts`

## Test plan

- [x] `npm run lint` -> clean
- [x] `npm run type-check` -> clean
- [x] `npm test` -> 41/41 pass (9 files, includes existing record-browser, useConnections, cluster-selector tests)
- [x] `npm run build` -> production build succeeds, no hydration mismatch
- [ ] Manual: rapid Apply/page-size flips on the record browser; admin page with one endpoint failing; digest-only set rendering; registry-error retry