### PR TITLE
feat(mcp): ACM_MCP_ALLOWED_HOSTS to widen DNS rebinding allow-list

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -149,6 +149,20 @@ K8S_MANAGEMENT_ENABLED=false
 # Call-time gate: read_only blocks the 10 mutation tools at
 # call time. full allows everything. Default is read_only.
 # ACM_MCP_ACCESS_PROFILE=read_only
+# DNS rebinding protection — Host/Origin allow-list for the streamable-HTTP
+# transport. The MCP SDK auto-enables a guard that whitelists only
+# `127.0.0.1:*`, `localhost:*`, `[::1]:*` when the transport host falls
+# back to its default. That breaks deployments where /mcp is reached
+# through an ingress / LoadBalancer with a public hostname (HTTP 421
+# Invalid Host header).
+#
+# Set this to a comma-separated list of extra Host values your operators
+# expect MCP clients to use. Loopback entries are merged in automatically
+# so in-pod debugging (kubectl exec ... curl localhost:8000/mcp) keeps
+# working. Both `host` and `host:*` wildcard-port forms are accepted.
+#
+# Empty (default) keeps the SDK auto-default behavior — loopback only.
+# ACM_MCP_ALLOWED_HOSTS=aerospike-api.example.com,aerospike-api.example.com:*
 
 # ─── Connection test SSRF gate ────────────────────────────────────────────
 # /api/connections/test rejects probe requests targeting bare IP literals

--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -269,6 +269,4 @@ ACM_MCP_ALLOW_ANONYMOUS: bool = _get_bool("ACM_MCP_ALLOW_ANONYMOUS", False)
 # When the list is empty (default) we preserve the SDK auto-default behavior —
 # only loopback hosts are allowed. This matches what users got before this knob
 # existed and avoids silently widening the trust boundary on upgrade.
-ACM_MCP_ALLOWED_HOSTS: list[str] = [
-    h.strip() for h in os.getenv("ACM_MCP_ALLOWED_HOSTS", "").split(",") if h.strip()
-]
+ACM_MCP_ALLOWED_HOSTS: list[str] = [h.strip() for h in os.getenv("ACM_MCP_ALLOWED_HOSTS", "").split(",") if h.strip()]

--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -241,3 +241,34 @@ ACM_MCP_ACCESS_PROFILE: AccessProfile = parse_profile(os.getenv("ACM_MCP_ACCESS_
 # loopback or behind a sealed-off ingress can opt back in here, but the
 # refusal is the default for a reason.
 ACM_MCP_ALLOW_ANONYMOUS: bool = _get_bool("ACM_MCP_ALLOW_ANONYMOUS", False)
+
+# DNS rebinding protection — Host/Origin header allow-list for the streamable-HTTP
+# transport.
+#
+# The MCP Python SDK (``mcp.server.lowlevel.server.streamable_http_app``)
+# auto-enables DNS rebinding protection whenever the transport ``host`` falls
+# back to its default of ``127.0.0.1`` and no explicit ``TransportSecuritySettings``
+# is supplied. Because :func:`mcp.server.server.streamable_http_asgi` calls
+# ``mcp.streamable_http_app()`` without arguments, that default kicks in and the
+# transport rejects any request whose ``Host`` header is not in
+# ``["127.0.0.1:*", "localhost:*", "[::1]:*"]`` with HTTP 421 ``Invalid Host header``.
+#
+# That is the correct default for ``mcp run`` on a developer laptop, but it
+# breaks production deployments where the API is reached through an ingress /
+# LoadBalancer / Gateway with a public hostname (e.g.
+# ``aerospike-api.example.com``). Operators set this env to a comma-separated
+# list of allowed Host values, e.g.::
+#
+#     ACM_MCP_ALLOWED_HOSTS=aerospike-api.example.com,aerospike-api.example.com:*
+#
+# Each entry is matched as-is by the SDK's :class:`TransportSecurityMiddleware`,
+# which also supports the ``host:*`` wildcard-port pattern. The localhost
+# loopback entries are merged in automatically so direct in-pod debugging
+# (``kubectl exec ... curl http://localhost:8000/mcp``) keeps working.
+#
+# When the list is empty (default) we preserve the SDK auto-default behavior —
+# only loopback hosts are allowed. This matches what users got before this knob
+# existed and avoids silently widening the trust boundary on upgrade.
+ACM_MCP_ALLOWED_HOSTS: list[str] = [
+    h.strip() for h in os.getenv("ACM_MCP_ALLOWED_HOSTS", "").split(",") if h.strip()
+]

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -558,7 +558,7 @@ app.include_router(api_router)
 if config.ACM_MCP_ENABLED:
     from aerospike_cluster_manager_api.mcp.server import CanonicalMCPMount, build_mcp_app, streamable_http_asgi
 
-    _mcp_app = build_mcp_app()
+    _mcp_app = build_mcp_app(allowed_hosts=config.ACM_MCP_ALLOWED_HOSTS)
     # ``CanonicalMCPMount`` replaces ``app.mount(...)`` because the default
     # Starlette ``Mount`` regex (``^/mcp/(?P<path>.*)$``) does not match
     # the bare ``/mcp`` URL — the parent Router then falls into the

--- a/api/src/aerospike_cluster_manager_api/mcp/server.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/server.py
@@ -8,11 +8,24 @@ registry into the FastMCP app.
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
+from mcp.server.transport_security import TransportSecuritySettings
 from starlette.routing import BaseRoute, Match
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 from aerospike_cluster_manager_api.mcp import tools  # noqa: F401  — import side-effects only
 from aerospike_cluster_manager_api.mcp.registry import register_all
+
+# SDK auto-default for the streamable-HTTP transport when ``host`` falls back to
+# ``127.0.0.1`` — see ``mcp.server.lowlevel.server.streamable_http_app``. We
+# replicate it here so the operator-configured allow-list can be MERGED with the
+# loopback entries instead of REPLACING them (which would break in-pod
+# debugging such as ``kubectl exec ... curl http://localhost:8000/mcp``).
+_LOOPBACK_HOSTS: tuple[str, ...] = ("127.0.0.1:*", "localhost:*", "[::1]:*")
+_LOOPBACK_ORIGINS: tuple[str, ...] = (
+    "http://127.0.0.1:*",
+    "http://localhost:*",
+    "http://[::1]:*",
+)
 
 
 class CanonicalMCPMount(BaseRoute):
@@ -75,7 +88,34 @@ class CanonicalMCPMount(BaseRoute):
         await self.app(scope, receive, send)
 
 
-def build_mcp_app() -> FastMCP:
+def _build_transport_security(allowed_hosts: list[str]) -> TransportSecuritySettings | None:
+    """Construct the streamable-HTTP transport security settings.
+
+    Returns ``None`` when ``allowed_hosts`` is empty so the SDK falls back to
+    its own auto-default (DNS rebinding protection enabled with loopback-only
+    allow-lists, because the transport ``host`` defaults to ``127.0.0.1``).
+
+    Returns an explicit :class:`TransportSecuritySettings` when the list is
+    non-empty, merging the operator-supplied external hostnames with the
+    loopback defaults so in-pod debugging (``kubectl exec ... curl
+    http://localhost:8000/mcp``) keeps working alongside the public ingress
+    hostnames. Origins are merged similarly. DNS rebinding protection itself
+    stays *on* — we widen the allow-list, never disable the guard.
+    """
+    if not allowed_hosts:
+        return None
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=[*allowed_hosts, *_LOOPBACK_HOSTS],
+        allowed_origins=[
+            *[f"http://{h}" for h in allowed_hosts if not h.endswith(":*")],
+            *[f"https://{h}" for h in allowed_hosts if not h.endswith(":*")],
+            *_LOOPBACK_ORIGINS,
+        ],
+    )
+
+
+def build_mcp_app(*, allowed_hosts: list[str] | None = None) -> FastMCP:
     """Construct the ACM MCP server with all decorated tools registered.
 
     ``streamable_http_path="/"`` keeps the inner Streamable-HTTP route at
@@ -83,8 +123,25 @@ def build_mcp_app() -> FastMCP:
     :class:`CanonicalMCPMount` at ``ACM_MCP_PATH`` (``/mcp`` by default)
     both ``/mcp`` and ``/mcp/<anything>`` reach the JSON-RPC transport
     without a 307 redirect.
+
+    Host allow-list
+    ---------------
+
+    ``allowed_hosts`` is the operator-configured list of extra ``Host``
+    header values to accept in addition to the SDK's loopback defaults. The
+    SDK auto-enables a DNS-rebinding guard that whitelists only
+    ``127.0.0.1:*`` / ``localhost:*`` / ``[::1]:*`` whenever the transport
+    ``host`` falls back to ``127.0.0.1``, so production deployments that
+    surface ``/mcp`` through an ingress / LoadBalancer with a public
+    hostname need to widen the list here — otherwise every external
+    request is rejected with HTTP 421 ``Invalid Host header``.
     """
-    mcp = FastMCP("aerospike-cluster-manager", streamable_http_path="/")
+    transport_security = _build_transport_security(allowed_hosts or [])
+    mcp = FastMCP(
+        "aerospike-cluster-manager",
+        streamable_http_path="/",
+        transport_security=transport_security,
+    )
     register_all(mcp)
     return mcp
 

--- a/api/tests/mcp/test_streamable_http_allowed_hosts.py
+++ b/api/tests/mcp/test_streamable_http_allowed_hosts.py
@@ -80,9 +80,7 @@ def test_wildcard_port_host_does_not_generate_origin() -> None:
 
 def test_multiple_external_hosts_all_merged() -> None:
     """Multiple operator-supplied hosts all land in the allow-list."""
-    mcp = build_mcp_app(
-        allowed_hosts=["aerospike-api.example.com", "aerospike-api.staging.example.com"]
-    )
+    mcp = build_mcp_app(allowed_hosts=["aerospike-api.example.com", "aerospike-api.staging.example.com"])
     settings = mcp.settings.transport_security
     assert settings is not None
     assert "aerospike-api.example.com" in settings.allowed_hosts

--- a/api/tests/mcp/test_streamable_http_allowed_hosts.py
+++ b/api/tests/mcp/test_streamable_http_allowed_hosts.py
@@ -1,0 +1,91 @@
+"""Unit tests for ACM_MCP_ALLOWED_HOSTS plumbing.
+
+The MCP SDK auto-enables DNS rebinding protection with a loopback-only
+allow-list (``127.0.0.1:*``, ``localhost:*``, ``[::1]:*``) whenever
+``FastMCP`` is constructed without an explicit ``transport_security`` and
+the streamable-HTTP transport ``host`` falls back to its default
+(``127.0.0.1``). That is correct for ``mcp run`` on a developer laptop,
+but it makes every production ingress hostname return HTTP 421
+``Invalid Host header``.
+
+The :func:`build_mcp_app` helper widens that allow-list with the
+operator-configured ``ACM_MCP_ALLOWED_HOSTS`` list while keeping the
+loopback entries so in-pod debugging keeps working. These tests verify
+that plumbing without booting a real HTTP server.
+"""
+
+from __future__ import annotations
+
+from aerospike_cluster_manager_api.mcp.server import (
+    _LOOPBACK_HOSTS,
+    _LOOPBACK_ORIGINS,
+    build_mcp_app,
+)
+
+
+def test_no_allowed_hosts_uses_sdk_default() -> None:
+    """No allow-list → SDK auto-fills loopback-only defaults.
+
+    We pass ``None`` to FastMCP, and the SDK's pydantic ``Settings`` model
+    materialises its ``host=127.0.0.1`` auto-default —
+    ``allowed_hosts=['127.0.0.1:*', 'localhost:*', '[::1]:*']``. External
+    hostnames are NOT silently injected: an unconfigured deployment
+    behaves exactly as the SDK does upstream.
+    """
+    mcp = build_mcp_app()
+    settings = mcp.settings.transport_security
+    assert settings is not None
+    assert settings.enable_dns_rebinding_protection is True
+    assert set(settings.allowed_hosts) == set(_LOOPBACK_HOSTS)
+    # External hosts are not silently widened.
+    assert "aerospike-api.example.com" not in settings.allowed_hosts
+
+
+def test_external_host_merged_with_loopback_defaults() -> None:
+    """Non-empty list → explicit TransportSecuritySettings on FastMCP.
+
+    The merge is additive — we never strip the loopback entries because
+    that would break ``kubectl exec ... curl http://localhost:8000/mcp``.
+    """
+    mcp = build_mcp_app(allowed_hosts=["aerospike-api.example.com"])
+    settings = mcp.settings.transport_security
+    assert settings is not None
+    assert settings.enable_dns_rebinding_protection is True
+    assert "aerospike-api.example.com" in settings.allowed_hosts
+    for host in _LOOPBACK_HOSTS:
+        assert host in settings.allowed_hosts
+    # Origin allow-list mirrors the bare-hostname entries with both schemes;
+    # loopback origins are merged in for browser-style probes against the
+    # in-pod debug port.
+    assert "http://aerospike-api.example.com" in settings.allowed_origins
+    assert "https://aerospike-api.example.com" in settings.allowed_origins
+    for origin in _LOOPBACK_ORIGINS:
+        assert origin in settings.allowed_origins
+
+
+def test_wildcard_port_host_does_not_generate_origin() -> None:
+    """``host:*`` wildcard-port entries are accepted on the Host axis only.
+
+    Generating ``http://example.com:*`` automatically would over-grant —
+    operators who need browser flows on a non-standard port can supply an
+    explicit origin allow-list in a follow-up.
+    """
+    mcp = build_mcp_app(allowed_hosts=["example.com:*"])
+    settings = mcp.settings.transport_security
+    assert settings is not None
+    assert "example.com:*" in settings.allowed_hosts
+    assert "http://example.com:*" not in settings.allowed_origins
+    assert "https://example.com:*" not in settings.allowed_origins
+
+
+def test_multiple_external_hosts_all_merged() -> None:
+    """Multiple operator-supplied hosts all land in the allow-list."""
+    mcp = build_mcp_app(
+        allowed_hosts=["aerospike-api.example.com", "aerospike-api.staging.example.com"]
+    )
+    settings = mcp.settings.transport_security
+    assert settings is not None
+    assert "aerospike-api.example.com" in settings.allowed_hosts
+    assert "aerospike-api.staging.example.com" in settings.allowed_hosts
+    assert "http://aerospike-api.example.com" in settings.allowed_origins
+    assert "http://aerospike-api.staging.example.com" in settings.allowed_origins


### PR DESCRIPTION
## Why

The MCP Python SDK ([`mcp.server.lowlevel.server.streamable_http_app`](https://github.com/modelcontextprotocol/python-sdk/blob/main/src/mcp/server/lowlevel/server.py#L579)) auto-enables a DNS-rebinding guard that whitelists only the loopback hosts (`127.0.0.1:*`, `localhost:*`, `[::1]:*`) whenever the transport `host` falls back to its default of `127.0.0.1` and no explicit `transport_security` is supplied to `FastMCP`. That's the correct default for `mcp run` on a developer laptop, but it makes every production ingress hostname return **HTTP 421 `Invalid Host header`**.

Reproduced on a Kubernetes deploy of ACM 0.23.0 — `/mcp` is reachable through a Gateway API HTTPRoute with public hostname `aerospike-api.example.com`, but every `initialize` request hits 421 even though `/api/docs` and `/api/v1/connections` are 200. `curl` against `http://localhost:8000/mcp` via `kubectl port-forward` returns the expected SSE-framed `initialize` reply. The existing test file actually flags this in its docstring (`tests/mcp/test_streamable_http_e2e.py` lines 56-58).

## What

Add `ACM_MCP_ALLOWED_HOSTS` (comma-separated list of extra Host header values) and plumb it through `build_mcp_app(allowed_hosts=...)`:

- **Empty list (default)** leaves the SDK auto-default in place — only loopback hosts are allowed. Unchanged behavior on upgrade.
- **Non-empty list** constructs an explicit `TransportSecuritySettings`, merging the operator-supplied hostnames with the loopback defaults so in-pod debugging (`kubectl exec ... curl http://localhost:8000/mcp`) keeps working alongside the public ingress. Origins are merged similarly (http + https for bare hostnames). DNS rebinding protection stays *on* — we widen the allow-list, never disable the guard.

Wildcard-port entries (`host:*`) are accepted on the Host axis but do not auto-generate `http://host:*` origins — those would over-grant; operators who need browser flows on a non-standard port can add an explicit origin allow-list in a follow-up.

## Files

| File | Change |
|---|---|
| `config.py` | `ACM_MCP_ALLOWED_HOSTS` env parsing |
| `mcp/server.py` | `_build_transport_security()` helper + `build_mcp_app(allowed_hosts=...)` |
| `main.py` | Pass `config.ACM_MCP_ALLOWED_HOSTS` into `build_mcp_app` |
| `.env.example` | Doc snippet |
| `tests/mcp/test_streamable_http_allowed_hosts.py` | 4 unit tests |

## Test plan

```
$ uv run pytest tests/mcp/test_streamable_http_allowed_hosts.py -v
tests/mcp/test_streamable_http_allowed_hosts.py::test_no_allowed_hosts_uses_sdk_default PASSED
tests/mcp/test_streamable_http_allowed_hosts.py::test_external_host_merged_with_loopback_defaults PASSED
tests/mcp/test_streamable_http_allowed_hosts.py::test_wildcard_port_host_does_not_generate_origin PASSED
tests/mcp/test_streamable_http_allowed_hosts.py::test_multiple_external_hosts_all_merged PASSED
4 passed
```

Manually verified end-to-end on a Kubernetes deploy: `Host: aerospike-api.example.com` POST `/mcp` returned 421 before this change and 200 OK + valid `serverInfo` after, with `ACM_MCP_ALLOWED_HOSTS=aerospike-api.example.com` set.