### PR TITLE
feat(mcp): ACM_MCP_ALLOWED_ORIGINS for non-derivable Origin shapes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -163,6 +163,14 @@ K8S_MANAGEMENT_ENABLED=false
 #
 # Empty (default) keeps the SDK auto-default behavior — loopback only.
 # ACM_MCP_ALLOWED_HOSTS=aerospike-api.example.com,aerospike-api.example.com:*
+# Browser-style Origin allow-list. Set this when the public Origin form
+# differs from Host — non-standard port, CDN / proxy rewriting,
+# strict-scheme (https-only) deployments. When empty (default), we derive
+# `http://<host>` + `https://<host>` from ACM_MCP_ALLOWED_HOSTS for each
+# bare hostname; the auto-derivation skips `host:*` wildcard-port entries
+# (they would over-grant on the origin axis). Loopback origins are merged
+# in automatically.
+# ACM_MCP_ALLOWED_ORIGINS=https://app.example.com:8443,https://acm.cdn-domain.com
 
 # ─── Connection test SSRF gate ────────────────────────────────────────────
 # /api/connections/test rejects probe requests targeting bare IP literals

--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -270,3 +270,27 @@ ACM_MCP_ALLOW_ANONYMOUS: bool = _get_bool("ACM_MCP_ALLOW_ANONYMOUS", False)
 # only loopback hosts are allowed. This matches what users got before this knob
 # existed and avoids silently widening the trust boundary on upgrade.
 ACM_MCP_ALLOWED_HOSTS: list[str] = [h.strip() for h in os.getenv("ACM_MCP_ALLOWED_HOSTS", "").split(",") if h.strip()]
+
+# Origin allow-list for the streamable-HTTP transport. Browser-style clients
+# send an ``Origin`` header on cross-origin requests; SDK's
+# :class:`TransportSecurityMiddleware` matches it against this list.
+#
+# When empty (default), :func:`mcp.server.server.build_mcp_app` derives
+# ``http://<host>`` + ``https://<host>`` entries from ``ACM_MCP_ALLOWED_HOSTS``.
+# That works for plain ingress URLs (``aerospike-api.example.com`` →
+# ``http://aerospike-api.example.com`` + ``https://...``) and is what you want
+# in the common case.
+#
+# Set this env explicitly when the public Origin form differs from Host — e.g.::
+#
+#   * non-standard port:     ACM_MCP_ALLOWED_ORIGINS=https://app.example.com:8443
+#   * CDN / proxy rewriting: ACM_MCP_ALLOWED_ORIGINS=https://acm.cdn-domain.com
+#   * strict-scheme:         ACM_MCP_ALLOWED_ORIGINS=https://aerospike-api.example.com
+#                            (only https — no http auto-derivation)
+#
+# Localhost loopback origins (``http://127.0.0.1:*``, ``http://localhost:*``,
+# ``http://[::1]:*``) are merged in automatically — explicit operator entries
+# never need to repeat them.
+ACM_MCP_ALLOWED_ORIGINS: list[str] = [
+    o.strip() for o in os.getenv("ACM_MCP_ALLOWED_ORIGINS", "").split(",") if o.strip()
+]

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -558,7 +558,10 @@ app.include_router(api_router)
 if config.ACM_MCP_ENABLED:
     from aerospike_cluster_manager_api.mcp.server import CanonicalMCPMount, build_mcp_app, streamable_http_asgi
 
-    _mcp_app = build_mcp_app(allowed_hosts=config.ACM_MCP_ALLOWED_HOSTS)
+    _mcp_app = build_mcp_app(
+        allowed_hosts=config.ACM_MCP_ALLOWED_HOSTS,
+        allowed_origins=config.ACM_MCP_ALLOWED_ORIGINS,
+    )
     # ``CanonicalMCPMount`` replaces ``app.mount(...)`` because the default
     # Starlette ``Mount`` regex (``^/mcp/(?P<path>.*)$``) does not match
     # the bare ``/mcp`` URL — the parent Router then falls into the

--- a/api/src/aerospike_cluster_manager_api/mcp/server.py
+++ b/api/src/aerospike_cluster_manager_api/mcp/server.py
@@ -88,34 +88,57 @@ class CanonicalMCPMount(BaseRoute):
         await self.app(scope, receive, send)
 
 
-def _build_transport_security(allowed_hosts: list[str]) -> TransportSecuritySettings | None:
+def _build_transport_security(allowed_hosts: list[str], allowed_origins: list[str]) -> TransportSecuritySettings | None:
     """Construct the streamable-HTTP transport security settings.
 
-    Returns ``None`` when ``allowed_hosts`` is empty so the SDK falls back to
-    its own auto-default (DNS rebinding protection enabled with loopback-only
+    Returns ``None`` when both lists are empty so the SDK falls back to its
+    own auto-default (DNS rebinding protection enabled with loopback-only
     allow-lists, because the transport ``host`` defaults to ``127.0.0.1``).
 
-    Returns an explicit :class:`TransportSecuritySettings` when the list is
-    non-empty, merging the operator-supplied external hostnames with the
-    loopback defaults so in-pod debugging (``kubectl exec ... curl
+    Returns an explicit :class:`TransportSecuritySettings` when either list
+    is non-empty, merging the operator-supplied entries with the loopback
+    defaults so in-pod debugging (``kubectl exec ... curl
     http://localhost:8000/mcp``) keeps working alongside the public ingress
-    hostnames. Origins are merged similarly. DNS rebinding protection itself
-    stays *on* — we widen the allow-list, never disable the guard.
+    hostnames. DNS rebinding protection itself stays *on* — we widen the
+    allow-list, never disable the guard.
+
+    Origin merge rules
+    ------------------
+
+    * ``allowed_origins`` explicitly set: operator's literal list is used as
+      the Origin allow-list (plus loopback). Nothing is auto-derived from
+      ``allowed_hosts`` — operators who care about Origin enforcement know
+      what schemes / ports they speak.
+    * ``allowed_origins`` empty and ``allowed_hosts`` set: derive
+      ``http://<host>`` and ``https://<host>`` for each bare hostname so
+      browser-style clients pointed at the public ingress continue to work
+      without operators having to re-enumerate every URL form.
+      ``host:*`` wildcard-port entries do NOT auto-generate origins —
+      ``http://host:*`` would over-grant.
     """
-    if not allowed_hosts:
+    if not allowed_hosts and not allowed_origins:
         return None
-    return TransportSecuritySettings(
-        enable_dns_rebinding_protection=True,
-        allowed_hosts=[*allowed_hosts, *_LOOPBACK_HOSTS],
-        allowed_origins=[
+    merged_hosts = [*allowed_hosts, *_LOOPBACK_HOSTS]
+    if allowed_origins:
+        merged_origins = [*allowed_origins, *_LOOPBACK_ORIGINS]
+    else:
+        merged_origins = [
             *[f"http://{h}" for h in allowed_hosts if not h.endswith(":*")],
             *[f"https://{h}" for h in allowed_hosts if not h.endswith(":*")],
             *_LOOPBACK_ORIGINS,
-        ],
+        ]
+    return TransportSecuritySettings(
+        enable_dns_rebinding_protection=True,
+        allowed_hosts=merged_hosts,
+        allowed_origins=merged_origins,
     )
 
 
-def build_mcp_app(*, allowed_hosts: list[str] | None = None) -> FastMCP:
+def build_mcp_app(
+    *,
+    allowed_hosts: list[str] | None = None,
+    allowed_origins: list[str] | None = None,
+) -> FastMCP:
     """Construct the ACM MCP server with all decorated tools registered.
 
     ``streamable_http_path="/"`` keeps the inner Streamable-HTTP route at
@@ -135,8 +158,19 @@ def build_mcp_app(*, allowed_hosts: list[str] | None = None) -> FastMCP:
     surface ``/mcp`` through an ingress / LoadBalancer with a public
     hostname need to widen the list here — otherwise every external
     request is rejected with HTTP 421 ``Invalid Host header``.
+
+    Origin allow-list
+    -----------------
+
+    ``allowed_origins`` is the operator-configured list of extra ``Origin``
+    header values to accept (browser-style clients send ``Origin`` on
+    cross-origin requests). When empty, the SDK / our defaults derive
+    ``http://<host>`` + ``https://<host>`` entries from ``allowed_hosts``,
+    which works for plain ingress URLs. Set it explicitly when the public
+    Origin form differs from the Host — e.g. non-standard ports, CDN /
+    proxy rewriting, or strict-scheme deployments that need only ``https``.
     """
-    transport_security = _build_transport_security(allowed_hosts or [])
+    transport_security = _build_transport_security(allowed_hosts or [], allowed_origins or [])
     mcp = FastMCP(
         "aerospike-cluster-manager",
         streamable_http_path="/",

--- a/api/tests/mcp/test_streamable_http_allowed_hosts.py
+++ b/api/tests/mcp/test_streamable_http_allowed_hosts.py
@@ -87,3 +87,45 @@ def test_multiple_external_hosts_all_merged() -> None:
     assert "aerospike-api.staging.example.com" in settings.allowed_hosts
     assert "http://aerospike-api.example.com" in settings.allowed_origins
     assert "http://aerospike-api.staging.example.com" in settings.allowed_origins
+
+
+def test_explicit_origins_replace_auto_derivation() -> None:
+    """``allowed_origins`` explicit → no auto-derivation from hosts.
+
+    Operators who set an explicit Origin allow-list usually have a reason
+    (strict-scheme deployment, non-standard port, CDN). The auto-derivation
+    would silently broaden the trust boundary, so we honor only the literal
+    list (plus loopback for in-pod debugging).
+    """
+    mcp = build_mcp_app(
+        allowed_hosts=["aerospike-api.example.com"],
+        allowed_origins=["https://aerospike-api.example.com"],
+    )
+    settings = mcp.settings.transport_security
+    assert settings is not None
+    # Operator-supplied origin is present.
+    assert "https://aerospike-api.example.com" in settings.allowed_origins
+    # Auto-derived ``http://`` form is NOT present — operator wants https only.
+    assert "http://aerospike-api.example.com" not in settings.allowed_origins
+    # Loopback origins are still merged in.
+    for origin in _LOOPBACK_ORIGINS:
+        assert origin in settings.allowed_origins
+
+
+def test_origin_only_without_host_still_engages_guard() -> None:
+    """``allowed_origins`` only (host empty) → still flips DNS rebinding on.
+
+    Edge case: operator sets origins but forgets hosts. We don't try to be
+    clever — we engage the explicit settings (with loopback hosts) so the
+    operator's origin allow-list is honored, even though the host axis is
+    loopback-only. The deployment effectively only serves ``/mcp`` to
+    in-pod clients, which is a coherent (if unusual) configuration.
+    """
+    mcp = build_mcp_app(allowed_origins=["https://cdn.example.com"])
+    settings = mcp.settings.transport_security
+    assert settings is not None
+    assert settings.enable_dns_rebinding_protection is True
+    assert set(settings.allowed_hosts) == set(_LOOPBACK_HOSTS)
+    assert "https://cdn.example.com" in settings.allowed_origins
+    for origin in _LOOPBACK_ORIGINS:
+        assert origin in settings.allowed_origins


### PR DESCRIPTION
Follow-up to #347.

## Why

#347 merged `ACM_MCP_ALLOWED_HOSTS` to widen the DNS-rebinding allow-list with operator-configured external Host values, and auto-derives `http://<host>` + `https://<host>` Origin entries for each bare hostname. That covers plain ingress URLs (`aerospike-api.example.com`), but breaks for operators whose public Origin form differs from the Host:

- **non-standard port** — `https://app.example.com:8443` cannot be auto-derived (we only emit `http://<host>` + `https://<host>` without ports)
- **CDN / proxy rewriting** — the client-visible Origin `https://acm.cdn-domain.com` is unrelated to the backend Host `aerospike-api.example.com`
- **strict-scheme** — deployment serves Origin over `https` only and wants to reject `http://aerospike-api.example.com`

Currently those operators have no way to express the Origin allow-list except by forking the helper.

## What

Add `ACM_MCP_ALLOWED_ORIGINS` (comma-separated list of Origin values) and plumb it through `build_mcp_app(allowed_origins=...)`:

- **Empty list (default)**: unchanged. We still derive `http://` + `https://` from `ACM_MCP_ALLOWED_HOSTS` for each bare hostname.
- **Non-empty list**: operator's literal list is used. Auto-derivation is SKIPPED — if you set this, you know what schemes / ports you speak. Loopback origins (`http://127.0.0.1:*`, `http://localhost:*`, `http://[::1]:*`) are still merged in so in-pod debugging keeps working.

Edge case: `ACM_MCP_ALLOWED_ORIGINS` set but `ACM_MCP_ALLOWED_HOSTS` empty — engages explicit settings (with loopback hosts only). Unusual but coherent: a deployment that only serves `/mcp` to in-pod browser flows.

## Files

| File | Change |
|---|---|
| `config.py` | `ACM_MCP_ALLOWED_ORIGINS` env parsing |
| `mcp/server.py` | `_build_transport_security(allowed_hosts, allowed_origins)` + `build_mcp_app(allowed_origins=...)` |
| `main.py` | Pass `config.ACM_MCP_ALLOWED_ORIGINS` into `build_mcp_app` |
| `.env.example` | Doc snippet |
| `tests/mcp/test_streamable_http_allowed_hosts.py` | 2 new tests (6 total) |

## Test plan

```
$ uv run pytest tests/mcp/test_streamable_http_allowed_hosts.py -v
tests/mcp/test_streamable_http_allowed_hosts.py::test_no_allowed_hosts_uses_sdk_default PASSED
tests/mcp/test_streamable_http_allowed_hosts.py::test_external_host_merged_with_loopback_defaults PASSED
tests/mcp/test_streamable_http_allowed_hosts.py::test_wildcard_port_host_does_not_generate_origin PASSED
tests/mcp/test_streamable_http_allowed_hosts.py::test_multiple_external_hosts_all_merged PASSED
tests/mcp/test_streamable_http_allowed_hosts.py::test_explicit_origins_replace_auto_derivation PASSED
tests/mcp/test_streamable_http_allowed_hosts.py::test_origin_only_without_host_still_engages_guard PASSED
6 passed
```

Refs: #347