### PR TITLE
feat(api): add POST /clusters/{conn_id}/info REST endpoint

### DIFF
--- a/api/src/aerospike_cluster_manager_api/models/cluster.py
+++ b/api/src/aerospike_cluster_manager_api/models/cluster.py
@@ -58,3 +58,49 @@ class CreateNamespaceRequest(BaseModel):
     name: str = Field(min_length=1, pattern=r"^[a-zA-Z0-9_-]{1,63}$")
     memorySize: int = Field(default=1_073_741_824, ge=1_000_000)  # min 1 MB
     replicationFactor: int = Field(default=2, ge=1, le=8)
+
+
+class ExecuteInfoRequest(BaseModel):
+    """Request body for ``POST /clusters/{conn_id}/info``.
+
+    Mirrors the MCP ``execute_info`` / ``execute_info_on_node`` /
+    ``execute_info_read_only`` tools so ackoctl can ship ``ackoctl info``
+    without a separate MCP transport.
+
+    Semantics:
+      * ``node`` unset  → fan out via ``info_all`` to every node.
+      * ``node`` set    → target the named node only.
+      * ``readOnly``    → when ``True`` (default), every command's leading
+        verb must be on :data:`info_verbs.READ_ONLY_INFO_VERBS`.
+        Whitelist violations short-circuit with HTTP 400 *before* any
+        wire round-trip.
+    """
+
+    commands: list[str] = Field(min_length=1)
+    node: str | None = None
+    readOnly: bool = True
+
+
+class InfoCommandResult(BaseModel):
+    """Per-command (per-node) result row in ``ExecuteInfoResponse``."""
+
+    command: str
+    # Node BB id. Empty string when a read-only fan-out couldn't
+    # attribute a specific node (every node returned an error).
+    node: str = ""
+    # Raw asinfo response string. Empty when the call errored.
+    output: str = ""
+    # Per-node error message; ``None`` when this row succeeded. Surfaces
+    # partial failures across the fan-out (e.g. one node returned an
+    # error while others succeeded) without dropping the successful rows.
+    error: str | None = None
+
+
+class ExecuteInfoResponse(BaseModel):
+    """Aggregated result of ``POST /clusters/{conn_id}/info``.
+
+    ``results`` is flattened across commands x nodes: a fan-out call
+    over 2 commands and 3 nodes yields 6 rows.
+    """
+
+    results: list[InfoCommandResult]

--- a/api/src/aerospike_cluster_manager_api/routers/clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/clusters.py
@@ -5,15 +5,20 @@ import logging
 from fastapi import APIRouter, HTTPException
 
 from aerospike_cluster_manager_api.dependencies import AerospikeClient, VerifiedConnId
+from aerospike_cluster_manager_api.info_verbs import InfoVerbNotAllowed, assert_read_only
 from aerospike_cluster_manager_api.models.cluster import (
     ClusterInfo,
     CreateNamespaceRequest,
+    ExecuteInfoRequest,
+    ExecuteInfoResponse,
+    InfoCommandResult,
 )
 from aerospike_cluster_manager_api.models.common import MessageResponse
 from aerospike_cluster_manager_api.services import clusters_service
 from aerospike_cluster_manager_api.services.clusters_service import (
     NamespaceConfigError,
     NamespaceNotFoundError,
+    NodeNotFoundError,
 )
 
 logger = logging.getLogger(__name__)
@@ -66,3 +71,111 @@ async def configure_namespace(body: CreateNamespaceRequest, client: AerospikeCli
             detail=f"Namespace '{exc.namespace}' configuration was rejected by the cluster",
         ) from exc
     return MessageResponse(message=message)
+
+
+@router.post(
+    "/{conn_id}/info",
+    response_model=ExecuteInfoResponse,
+    summary="Execute asinfo commands",
+    description=(
+        "Run one or more asinfo commands against a cluster. "
+        "Mirrors the MCP execute_info / execute_info_on_node / "
+        "execute_info_read_only contracts so ackoctl can drive raw asinfo "
+        "diagnostics over the REST surface. "
+        "When readOnly=true (default), each command's leading verb is "
+        "validated against the read-only whitelist BEFORE any wire "
+        "round-trip — a single bad verb fails the entire call with 400."
+    ),
+)
+async def execute_info(
+    body: ExecuteInfoRequest,
+    client: AerospikeClient,
+    conn_id: VerifiedConnId,
+) -> ExecuteInfoResponse:
+    """Run asinfo commands per the ExecuteInfoRequest semantics."""
+    # When readOnly is on, fail-fast on the FIRST non-whitelisted verb so
+    # a bad verb never reaches the wire. Pydantic already enforces
+    # commands non-empty.
+    if body.readOnly:
+        for cmd in body.commands:
+            try:
+                assert_read_only(cmd)
+            except InfoVerbNotAllowed as exc:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(f"command '{exc.verb}' not in read-only whitelist; pass readOnly=false to allow"),
+                ) from exc
+
+    results: list[InfoCommandResult] = []
+    target_node = body.node or None
+
+    for cmd in body.commands:
+        if target_node is not None and body.readOnly:
+            # Single-node read-only: whitelist already enforced above;
+            # service still re-validates as a defense-in-depth.
+            try:
+                node, response = await clusters_service.execute_info_read_only(client, cmd, target_node)
+            except NodeNotFoundError as exc:
+                results.append(
+                    InfoCommandResult(
+                        command=cmd,
+                        node=target_node,
+                        output="",
+                        error=str(exc),
+                    )
+                )
+                continue
+            results.append(InfoCommandResult(command=cmd, node=node, output=response))
+
+        elif target_node is not None and not body.readOnly:
+            # Single-node, no whitelist gate.
+            try:
+                response = await clusters_service.execute_info_on_node(client, cmd, target_node)
+            except NodeNotFoundError as exc:
+                results.append(
+                    InfoCommandResult(
+                        command=cmd,
+                        node=target_node,
+                        output="",
+                        error=str(exc),
+                    )
+                )
+                continue
+            results.append(InfoCommandResult(command=cmd, node=target_node, output=response))
+
+        else:
+            # Fan-out across every node (readOnly applies only to the
+            # upfront verb check — per-node results are returned verbatim).
+            node_results = await clusters_service.execute_info(client, cmd)
+            if not node_results:
+                # No node responded at all — emit a single attribution-less
+                # row so the caller still sees a result for this command.
+                results.append(
+                    InfoCommandResult(
+                        command=cmd,
+                        node="",
+                        output="",
+                        error="no nodes responded",
+                    )
+                )
+                continue
+            for r in node_results:
+                # aerospike_py.InfoNodeResult is a NamedTuple
+                # (node_name, error_code, response). Unpack positionally to
+                # tolerate both the real NamedTuple and the plain-tuple
+                # shape used by unit-test mocks.
+                node_name, error_code, response_str = r[0], r[1], r[2]
+                err_msg: str | None = None
+                # Non-zero / truthy error_code indicates a per-node failure.
+                if error_code:
+                    err_msg = f"asinfo error_code={error_code}"
+                results.append(
+                    InfoCommandResult(
+                        command=cmd,
+                        node=node_name,
+                        output=response_str,
+                        error=err_msg,
+                    )
+                )
+
+    return ExecuteInfoResponse(results=results)

--- a/api/tests/test_clusters_router_info.py
+++ b/api/tests/test_clusters_router_info.py
@@ -1,0 +1,386 @@
+"""Integration tests for ``POST /clusters/{conn_id}/info``.
+
+Drives the FastAPI surface end-to-end (httpx ASGITransport) so the test
+covers wiring + body validation + service composition. The matching
+service-layer unit tests for the underlying ``execute_info`` /
+``execute_info_on_node`` / ``execute_info_read_only`` primitives live in
+``test_clusters_service.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from aerospike_cluster_manager_api.main import app
+from aerospike_cluster_manager_api.services.info_cache import info_cache
+
+
+def _info_all_result(name: str, resp: str, err: int | None = None) -> tuple[str, int | None, str]:
+    """Mirror ``aerospike_py.types.InfoNodeResult`` tuple shape used by ``info_all``."""
+    return (name, err, resp)
+
+
+def _make_mock_client() -> AsyncMock:
+    """Build a mock AsyncClient with distinct per-node responses.
+
+    Distinct ``node_marker_X`` payloads ensure tests that filter on
+    ``node`` actually exercise the filter — identical payloads would
+    let a "returns first result" bug pass silently.
+    """
+    mock = AsyncMock()
+    mock.get_node_names = Mock(return_value=["BB9020011AC4202", "BB9020012AC4202"])
+    mock.is_connected.return_value = True
+
+    def info_all_side_effect(cmd: str):
+        if cmd == "build":
+            return [
+                _info_all_result("BB9020011AC4202", "8.1.0.0"),
+                _info_all_result("BB9020012AC4202", "8.1.0.0"),
+            ]
+        if cmd == "version":
+            return [
+                _info_all_result("BB9020011AC4202", "8.1.0.0"),
+                _info_all_result("BB9020012AC4202", "8.1.0.0"),
+            ]
+        if cmd == "namespaces":
+            return [
+                _info_all_result("BB9020011AC4202", "test;bar"),
+                _info_all_result("BB9020012AC4202", "test;bar"),
+            ]
+        if cmd == "statistics":
+            return [
+                _info_all_result("BB9020011AC4202", "node1_marker;cluster_size=2"),
+                _info_all_result("BB9020012AC4202", "node2_marker;cluster_size=2"),
+            ]
+        return []
+
+    mock.info_all.side_effect = info_all_side_effect
+    return mock
+
+
+@asynccontextmanager
+async def _noop_lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    yield
+
+
+@pytest.fixture()
+async def client(init_test_db):
+    original_lifespan = app.router.lifespan_context
+    app.router.lifespan_context = _noop_lifespan
+    app.state.limiter.enabled = False
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.state.limiter.enabled = True
+    app.router.lifespan_context = original_lifespan
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    info_cache.clear()
+    yield
+    info_cache.clear()
+
+
+class TestExecuteInfoSingleNodeReadOnly:
+    """``node`` set + readOnly=true — exercises execute_info_read_only path."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_response_per_command(self, client: AsyncClient, sample_connection):
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={
+                    "commands": ["build", "namespaces"],
+                    "node": "BB9020011AC4202",
+                    "readOnly": True,
+                },
+            )
+
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        results = data["results"]
+        assert len(results) == 2
+
+        by_cmd = {r["command"]: r for r in results}
+        assert by_cmd["build"]["node"] == "BB9020011AC4202"
+        assert by_cmd["build"]["output"] == "8.1.0.0"
+        assert by_cmd["build"]["error"] is None
+
+        assert by_cmd["namespaces"]["node"] == "BB9020011AC4202"
+        assert by_cmd["namespaces"]["output"] == "test;bar"
+        assert by_cmd["namespaces"]["error"] is None
+
+    @pytest.mark.asyncio
+    async def test_unknown_node_yields_error_row(self, client: AsyncClient, sample_connection):
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={
+                    "commands": ["build"],
+                    "node": "ghost-node",
+                    "readOnly": True,
+                },
+            )
+
+        # Per-node failure is reported per-row, not as an overall HTTP error.
+        assert resp.status_code == 200, resp.text
+        row = resp.json()["results"][0]
+        assert row["command"] == "build"
+        assert row["node"] == "ghost-node"
+        assert row["output"] == ""
+        assert row["error"] is not None
+
+
+class TestExecuteInfoWhitelistRejection:
+    """readOnly=true gate must reject ANY non-whitelisted command up-front."""
+
+    @pytest.mark.asyncio
+    async def test_set_config_rejected_with_400(self, client: AsyncClient, sample_connection):
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={
+                    "commands": ["set-config:context=service;migrate-threads=2"],
+                    "readOnly": True,
+                },
+            )
+
+        assert resp.status_code == 400, resp.text
+        detail = resp.json()["detail"]
+        assert "set-config" in detail
+        assert "read-only whitelist" in detail
+        assert "readOnly=false" in detail
+        # Wire was NOT touched — fail-fast before any info_all call.
+        mock_as_client.info_all.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_one_bad_verb_fails_the_whole_batch(self, client: AsyncClient, sample_connection):
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={
+                    "commands": ["build", "recluster:"],  # second is mutation
+                    "readOnly": True,
+                },
+            )
+
+        assert resp.status_code == 400, resp.text
+        assert "recluster" in resp.json()["detail"]
+        # Even the first (valid) command must not run — atomic batch rejection.
+        mock_as_client.info_all.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_readonly_false_allows_unwhitelisted_verb(self, client: AsyncClient, sample_connection):
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+        # Simulate set-config response
+        mock_as_client.info_all.side_effect = lambda cmd: [
+            _info_all_result("BB9020011AC4202", "ok"),
+            _info_all_result("BB9020012AC4202", "ok"),
+        ]
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={
+                    "commands": ["set-config:context=service;migrate-threads=2"],
+                    "readOnly": False,
+                },
+            )
+
+        assert resp.status_code == 200, resp.text
+        # Fan-out: two nodes -> two rows.
+        rows = resp.json()["results"]
+        assert len(rows) == 2
+        assert all(r["output"] == "ok" for r in rows)
+        assert all(r["error"] is None for r in rows)
+
+
+class TestExecuteInfoFanOut:
+    """Node omitted -> fan-out via execute_info / info_all."""
+
+    @pytest.mark.asyncio
+    async def test_fan_out_returns_one_row_per_node(self, client: AsyncClient, sample_connection):
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={
+                    "commands": ["statistics"],
+                    "readOnly": True,
+                },
+            )
+
+        assert resp.status_code == 200, resp.text
+        rows = resp.json()["results"]
+        # Two nodes -> two rows for the single command.
+        assert len(rows) == 2
+        node_outputs = {r["node"]: r["output"] for r in rows}
+        assert "node1_marker" in node_outputs["BB9020011AC4202"]
+        assert "node2_marker" in node_outputs["BB9020012AC4202"]
+        assert all(r["error"] is None for r in rows)
+
+    @pytest.mark.asyncio
+    async def test_fan_out_marks_per_node_errors(self, client: AsyncClient, sample_connection):
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+        # node1 errors, node2 succeeds — verify partial-failure surfacing.
+        mock_as_client.info_all.side_effect = lambda cmd: [
+            _info_all_result("BB9020011AC4202", "", err=1),
+            _info_all_result("BB9020012AC4202", "ok", err=None),
+        ]
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={
+                    "commands": ["build"],
+                    "readOnly": True,
+                },
+            )
+
+        assert resp.status_code == 200, resp.text
+        rows = {r["node"]: r for r in resp.json()["results"]}
+        assert rows["BB9020011AC4202"]["error"] is not None
+        assert rows["BB9020012AC4202"]["error"] is None
+        assert rows["BB9020012AC4202"]["output"] == "ok"
+
+    @pytest.mark.asyncio
+    async def test_multiple_commands_fan_out(self, client: AsyncClient, sample_connection):
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={
+                    "commands": ["build", "version"],
+                    "readOnly": True,
+                },
+            )
+
+        assert resp.status_code == 200, resp.text
+        rows = resp.json()["results"]
+        # 2 commands x 2 nodes = 4 rows
+        assert len(rows) == 4
+        by_cmd: dict[str, list[dict]] = {}
+        for r in rows:
+            by_cmd.setdefault(r["command"], []).append(r)
+        assert set(by_cmd) == {"build", "version"}
+        assert len(by_cmd["build"]) == 2
+        assert len(by_cmd["version"]) == 2
+
+
+class TestExecuteInfoConnNotFound:
+    @pytest.mark.asyncio
+    async def test_unknown_conn_id_returns_404(self, client: AsyncClient, init_test_db):
+        # No connection persisted -> dependency raises 404 before reaching the handler.
+        resp = await client.post(
+            "/api/v1/clusters/conn-does-not-exist/info",
+            json={"commands": ["build"], "readOnly": True},
+        )
+        assert resp.status_code == 404, resp.text
+        assert "conn-does-not-exist" in resp.json()["detail"]
+
+
+class TestExecuteInfoValidation:
+    @pytest.mark.asyncio
+    async def test_empty_commands_rejected(self, client: AsyncClient, sample_connection):
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            # Even with a valid conn, an empty commands list should fail Pydantic
+            # validation (422) — drives ackoctl to error-out client-side.
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={"commands": [], "readOnly": True},
+            )
+        assert resp.status_code == 422, resp.text
+
+    @pytest.mark.asyncio
+    async def test_legacy_api_prefix_also_works(self, client: AsyncClient, sample_connection):
+        # Mirror the /api ↔ /api/v1 duality wired in main.py — clients on
+        # the unversioned path must still reach the new endpoint.
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/clusters/{sample_connection.id}/info",
+                json={"commands": ["build"], "readOnly": True},
+            )
+
+        assert resp.status_code == 200, resp.text
+        assert len(resp.json()["results"]) == 2  # fan-out across 2 nodes


### PR DESCRIPTION
## Summary

Adds `POST /clusters/{conn_id}/info` — a REST passthrough for raw `asinfo` commands so [ackoctl](https://github.com/aerospike-ce-ecosystem/ackoctl) can ship `ackoctl info` without depending on the MCP transport.

Closes #354.

## Motivation

Cluster-manager already has:

- `clusters_service.execute_info` / `execute_info_on_node` / `execute_info_read_only` — production-tested service-layer wrappers around `aerospike-py`'s info protocol.
- `info_verbs.READ_ONLY_INFO_VERBS` — single source of truth for the read-only whitelist.
- MCP exposure of the above via `mcp/tools/info_commands.py`.

…but no REST surface. ackoctl reaches cluster-manager only over `/api/v1/*`, so it cannot ship `ackoctl info` until this gap is closed. The MCP tooling stays in place; a follow-up PR will retire it once ackoctl is shipping the REST path.

## Endpoint contract

```
POST /api/v1/clusters/{conn_id}/info

body: {
  "commands": ["build", "namespaces", ...],   # required, non-empty
  "node": "BB9020011AC4202"?,                  # optional
  "readOnly": true                             # default
}

response: {
  "results": [
    { "command": "build", "node": "BB9020011AC4202", "output": "8.1.0.0", "error": null },
    ...
  ]
}
```

Semantics mirror the MCP tool wrappers verbatim:

| `node` | `readOnly` | Backing service call |
|--------|------------|----------------------|
| set    | `true`     | `execute_info_read_only(client, cmd, node)` |
| set    | `false`    | `execute_info_on_node(client, cmd, node)` |
| unset  | `true`     | upfront whitelist gate, then `execute_info` fan-out |
| unset  | `false`    | `execute_info` fan-out |

Whitelist violations are atomic for the batch: one bad verb in `commands` fails the entire call with HTTP 400 before any wire round-trip.

`VerifiedConnId` dependency injection inherits the workspace ACL exactly like `GET /clusters/{conn_id}`.

## Files

- `api/src/aerospike_cluster_manager_api/models/cluster.py` — new `ExecuteInfoRequest`, `InfoCommandResult`, `ExecuteInfoResponse` Pydantic models.
- `api/src/aerospike_cluster_manager_api/routers/clusters.py` — new POST handler.
- `api/tests/test_clusters_router_info.py` — 11 integration tests via httpx ASGITransport.

## Non-goals

- No MCP removal in this PR — that lands separately after ackoctl ships `info`.
- No new asinfo capabilities — only mirrors what the service layer already exposes.
- No changes to K8s, security middleware, or other unrelated surfaces.

## Test plan

- [x] `uv run pytest tests/test_clusters_router_info.py` — 11/11 pass.
- [x] `uv run pytest` — full suite (1019 tests) green.
- [x] `uv run ruff check src tests` — clean.
- [x] `uv run ruff format --check src tests` — clean.
- [x] `uv run pyright` on the changed files — 0 errors / 0 warnings.
- [x] OpenAPI generation verified: endpoint appears at both `/api/v1/clusters/{conn_id}/info` and `/api/clusters/{conn_id}/info`; `ExecuteInfoRequest`, `InfoCommandResult`, `ExecuteInfoResponse` schemas registered in `components.schemas`.
- [ ] Manual smoke against a live cluster (kind + ackoctl), to be done as part of the ackoctl `info` PR.