### PR TITLE
feat(api): add 3 REST endpoints required for ackoctl MCP parity (k8s pods, bin delete, set truncate)

### DIFF
--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -37,6 +37,7 @@ from aerospike_cluster_manager_api.routers import (
     query,
     records,
     sample_data,
+    sets,
     udfs,
     workspaces,
 )
@@ -525,6 +526,7 @@ _routers = [
     connections.router,
     clusters.router,
     records.router,
+    sets.router,
     notes.router,
     query.router,
     indexes.router,

--- a/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
@@ -35,6 +35,7 @@ from aerospike_cluster_manager_api.models.k8s_cluster import (
     K8sClusterEvent,
     K8sClusterListResponse,
     K8sClusterSummary,
+    K8sPodStatus,
     K8sTemplateDetail,
     K8sTemplateSummary,
     MigrationStatusResponse,
@@ -288,6 +289,33 @@ async def get_k8s_cluster(
         namespace, f"app.kubernetes.io/name=aerospike-cluster,app.kubernetes.io/instance={name}"
     )
     return extract_detail(item, pods_raw)
+
+
+@router.get(
+    "/clusters/{namespace}/{name}/pods",
+    summary="List pods of a K8s Aerospike cluster",
+)
+@_k8s_endpoint("list Kubernetes cluster pods")
+async def list_k8s_cluster_pods(
+    caller_owner_id: CallerOwnerId,
+    namespace: str = _K8S_NAMESPACE,
+    name: str = _K8S_NAME,
+) -> list[K8sPodStatus]:
+    """Return pod status for an AerospikeCluster CR.
+
+    Mirrors the pods slice of :func:`get_k8s_cluster` so ackoctl (and any
+    other API consumer) can fetch pods without paying for the full
+    ``K8sClusterDetail`` payload (operations status, conditions, full
+    spec/status). Same workspace ACL gate -- identity-404 for invisible
+    or missing clusters.
+    """
+
+    await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
+    pods_raw = await k8s_client.list_pods(
+        namespace,
+        f"app.kubernetes.io/name=aerospike-cluster,app.kubernetes.io/instance={name}",
+    )
+    return [K8sPodStatus(**p) for p in pods_raw]
 
 
 @router.get("/clusters/{namespace}/{name}/config-drift", summary="Get cluster config drift")

--- a/api/src/aerospike_cluster_manager_api/routers/records.py
+++ b/api/src/aerospike_cluster_manager_api/routers/records.py
@@ -5,7 +5,7 @@ from typing import Literal
 
 from aerospike_py import Record
 from aerospike_py.exception import RecordNotFound
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, HTTPException, Path, Query, Request
 from starlette.responses import Response
 
 from aerospike_cluster_manager_api import db
@@ -255,6 +255,59 @@ async def delete_record(
         # Idempotent: the record is already absent, which is the desired
         # post-condition of DELETE.
         pass
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return Response(status_code=204)
+
+
+@router.delete(
+    "/{conn_id}/{namespace}/{set_name}/{pk}/bins/{bin_name}",
+    status_code=204,
+    summary="Delete a bin from a record",
+    description="Remove a single bin from an existing record (sets it to nil server-side).",
+)
+@limiter.limit("30/minute")
+async def delete_record_bin(
+    request: Request,
+    client: AerospikeClient,
+    conn_id: VerifiedConnId,
+    namespace: str = Path(..., min_length=1, max_length=31),
+    set_name: str = Path(..., min_length=1, max_length=63),
+    pk: str = Path(..., min_length=1, max_length=1024),
+    bin_name: str = Path(..., min_length=1, max_length=15),
+    pk_type: Literal["auto", "string", "int", "bytes"] = Query("auto"),
+) -> Response:
+    """Remove a single bin from an existing record.
+
+    Mirrors :func:`mcp.tools.records.delete_bin` so ackoctl reaches MCP
+    parity through the REST surface. Removing the last bin causes the
+    whole record to disappear server-side — that's standard Aerospike
+    behaviour, not something this endpoint papers over.
+
+    ``pk_type`` semantics match :func:`update_record_note` and
+    :func:`delete_record_note`: ``auto`` (default) lets the heuristic
+    decide between INTEGER and STRING; pass an explicit value for
+    digit-only string keys to avoid misclassification. Unlike record
+    reads, bin delete does not fall back to the alternate type — passing
+    the wrong ``pk_type`` would silently no-op (RecordNotFound), so be
+    explicit when in doubt.
+
+    Returns 204 on success, 404 when the record (or its bin) is absent.
+    Conn id ``conn_id`` is gated by the workspace ACL via
+    :data:`VerifiedConnId`.
+    """
+    # ``conn_id`` is unused inside the body — its only job is to trigger
+    # the workspace ACL via :data:`VerifiedConnId` before the destructive
+    # call reaches the service layer. Keep the parameter present so the
+    # dependency runs.
+    _ = conn_id
+    try:
+        await records_service.delete_bin(client, namespace, set_name, pk, bin_name, pk_type)
+    except RecordNotFound as exc:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Record '{namespace}/{set_name}/{pk}' not found",
+        ) from exc
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return Response(status_code=204)

--- a/api/src/aerospike_cluster_manager_api/routers/sets.py
+++ b/api/src/aerospike_cluster_manager_api/routers/sets.py
@@ -1,0 +1,94 @@
+"""REST endpoints scoped to a single Aerospike set.
+
+Currently exposes a single destructive operation -- ``truncate``. The
+endpoint mirrors :func:`mcp.tools.records.truncate_set` so ackoctl can
+reach MCP parity through the REST surface; the MCP wrapper does not get
+deleted in this PR, but with this router in place a future PR can drop
+the MCP tool without orphaning the operation.
+
+Workspace ACL: ``VerifiedConnId`` already gates the connection by
+workspace before the body runs -- identity-404 if the caller cannot see
+the workspace. Aerospike CE has no built-in security, so workspace
+visibility is the only ACL applied.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, HTTPException, Path, Request
+from pydantic import BaseModel, Field
+
+from aerospike_cluster_manager_api.dependencies import AerospikeClient, VerifiedConnId
+from aerospike_cluster_manager_api.models.common import MessageResponse
+from aerospike_cluster_manager_api.rate_limit import limiter
+from aerospike_cluster_manager_api.services import records_service
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/sets", tags=["sets"])
+
+
+class TruncateSetRequest(BaseModel):
+    """Body for ``POST /sets/{conn_id}/{namespace}/{set_name}/truncate``.
+
+    ``beforeLut`` is the cutoff in nanoseconds since the Aerospike
+    CITRUS epoch. ``None`` (the default) means "truncate every record
+    currently in the set". A positive value targets only records whose
+    last-update-time is below the threshold.
+
+    The service layer rejects ``beforeLut <= 0`` explicitly (it would
+    otherwise be silently equivalent to a full truncate on the wire),
+    so callers that genuinely want a full truncate must omit the field
+    or pass ``null``.
+    """
+
+    before_lut: int | None = Field(
+        default=None,
+        alias="beforeLut",
+        description=("Nanosecond LUT cutoff. Omit / null to truncate every record in the set."),
+    )
+
+    model_config = {"populate_by_name": True}
+
+
+@router.post(
+    "/{conn_id}/{namespace}/{set_name}/truncate",
+    status_code=200,
+    response_model=MessageResponse,
+    summary="Truncate a set",
+    description=(
+        "Drop every record in a namespace.set (or only records with LUT below "
+        "``beforeLut`` when supplied). Destructive — gated by workspace ACL "
+        "via the verified connection."
+    ),
+)
+@limiter.limit("10/minute")
+async def truncate_set(
+    request: Request,
+    client: AerospikeClient,
+    conn_id: VerifiedConnId,
+    body: TruncateSetRequest | None = None,
+    namespace: str = Path(..., min_length=1, max_length=31),
+    set_name: str = Path(..., min_length=1, max_length=63),
+) -> MessageResponse:
+    """Truncate a set, optionally bounded by ``beforeLut``.
+
+    ``conn_id`` is unused inside the body — its sole job is to trigger
+    the :data:`VerifiedConnId` ACL gate before we reach the destructive
+    service call. Keep the parameter so FastAPI runs the dependency.
+
+    Returns a small JSON ack so the caller can distinguish a successful
+    no-op set from a server-side failure (a 204 would be ambiguous when
+    the set was already empty).
+    """
+    _ = conn_id
+    before_lut = body.before_lut if body is not None else None
+    try:
+        await records_service.truncate_set(client, namespace, set_name, before_lut=before_lut)
+    except ValueError as exc:
+        # Service rejects ``before_lut <= 0`` explicitly -- propagate as 400
+        # so the caller can fix the request rather than re-trying.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    suffix = f" up to LUT {before_lut}" if before_lut is not None else ""
+    return MessageResponse(message=f"Set '{namespace}/{set_name}' truncated{suffix}")

--- a/api/tests/test_k8s_pods_list_endpoint.py
+++ b/api/tests/test_k8s_pods_list_endpoint.py
@@ -1,0 +1,183 @@
+"""Tests for the GET /k8s/clusters/{ns}/{name}/pods endpoint.
+
+This endpoint surfaces the same data as the pods slice of
+``GET /k8s/clusters/{ns}/{name}`` but as a dedicated, lighter-weight
+response. Added so ackoctl reaches full parity with the MCP
+``get_k8s_pods`` tool.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from aerospike_cluster_manager_api.k8s_client import K8sApiError
+
+
+@asynccontextmanager
+async def _noop_lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    yield
+
+
+SAMPLE_CR: dict = {
+    "apiVersion": "acko.io/v1alpha1",
+    "kind": "AerospikeCluster",
+    "metadata": {
+        "name": "demo",
+        "namespace": "aerospike",
+    },
+    "spec": {"size": 2, "image": "aerospike/aerospike-server:7.0.0.0"},
+    "status": {"phase": "Running", "size": 2},
+}
+
+# Two pods with every camelCase field K8sPodStatus exposes set so a regression
+# that drops a field is caught. The list_pods raw dict already uses the same
+# camelCase keys -- ``k8s_service._extract_pod_fields`` is responsible for
+# producing the alignment.
+SAMPLE_PODS_RAW: list[dict] = [
+    {
+        "name": "demo-0",
+        "podIP": "10.0.0.1",
+        "hostIP": "192.168.0.10",
+        "isReady": True,
+        "phase": "Running",
+        "image": "aerospike/aerospike-server:7.0.0.0",
+        "dynamicConfigStatus": "Synced",
+        "nodeId": "BB9000000000000",
+        "rackId": 1,
+        "configHash": "abc",
+        "podSpecHash": "def",
+        "accessEndpoints": ["10.0.0.1:3000"],
+        "servicePort": 3000,
+        "podPort": 3000,
+    },
+    {
+        "name": "demo-1",
+        "podIP": "10.0.0.2",
+        "hostIP": "192.168.0.11",
+        "isReady": False,
+        "phase": "Pending",
+        "image": "aerospike/aerospike-server:7.0.0.0",
+        "rackId": 2,
+        "accessEndpoints": ["10.0.0.2:3000"],
+        "servicePort": 3000,
+        "podPort": 3000,
+    },
+]
+
+
+@pytest.fixture()
+async def client():
+    """httpx AsyncClient wired to the FastAPI app with K8S_MANAGEMENT_ENABLED=True."""
+    with patch("aerospike_cluster_manager_api.config.K8S_MANAGEMENT_ENABLED", True):
+        import aerospike_cluster_manager_api.main as main_mod
+        import aerospike_cluster_manager_api.routers.k8s_clusters as k8s_mod
+
+        importlib.reload(k8s_mod)
+        importlib.reload(main_mod)
+        test_app = main_mod.app
+
+        original_lifespan = test_app.router.lifespan_context
+        test_app.router.lifespan_context = _noop_lifespan
+        test_app.state.limiter.enabled = False
+
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+
+        test_app.state.limiter.enabled = True
+        test_app.router.lifespan_context = original_lifespan
+
+
+class TestListPodsHappyPath:
+    async def test_returns_pod_list(self, client: AsyncClient):
+        mock_get = AsyncMock(return_value=SAMPLE_CR)
+        mock_list = AsyncMock(return_value=SAMPLE_PODS_RAW)
+
+        with (
+            patch("aerospike_cluster_manager_api.routers.k8s_clusters.k8s_client.get_cluster", mock_get),
+            patch("aerospike_cluster_manager_api.routers.k8s_clusters.k8s_client.list_pods", mock_list),
+        ):
+            response = await client.get("/api/k8s/clusters/aerospike/demo/pods")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert isinstance(body, list)
+        assert len(body) == 2
+        assert body[0]["name"] == "demo-0"
+        assert body[0]["isReady"] is True
+        assert body[0]["podIP"] == "10.0.0.1"
+        assert body[0]["rackId"] == 1
+        assert body[0]["servicePort"] == 3000
+        assert body[1]["name"] == "demo-1"
+        assert body[1]["isReady"] is False
+
+    async def test_v1_route_works(self, client: AsyncClient):
+        mock_get = AsyncMock(return_value=SAMPLE_CR)
+        mock_list = AsyncMock(return_value=SAMPLE_PODS_RAW)
+
+        with (
+            patch("aerospike_cluster_manager_api.routers.k8s_clusters.k8s_client.get_cluster", mock_get),
+            patch("aerospike_cluster_manager_api.routers.k8s_clusters.k8s_client.list_pods", mock_list),
+        ):
+            response = await client.get("/api/v1/k8s/clusters/aerospike/demo/pods")
+
+        assert response.status_code == 200
+
+    async def test_label_selector_passed_through(self, client: AsyncClient):
+        """The list_pods call must use the same label selector the detail
+        endpoint uses so a pod from another workload that happens to share
+        ``app.kubernetes.io/instance`` cannot leak through."""
+        mock_get = AsyncMock(return_value=SAMPLE_CR)
+        mock_list = AsyncMock(return_value=SAMPLE_PODS_RAW)
+
+        with (
+            patch("aerospike_cluster_manager_api.routers.k8s_clusters.k8s_client.get_cluster", mock_get),
+            patch("aerospike_cluster_manager_api.routers.k8s_clusters.k8s_client.list_pods", mock_list),
+        ):
+            await client.get("/api/k8s/clusters/aerospike/demo/pods")
+
+        mock_list.assert_awaited_once_with(
+            "aerospike",
+            "app.kubernetes.io/name=aerospike-cluster,app.kubernetes.io/instance=demo",
+        )
+
+
+class TestListPodsNotFound:
+    async def test_returns_404_when_cluster_missing(self, client: AsyncClient):
+        mock_get = AsyncMock(side_effect=K8sApiError(404, "Not Found", "missing"))
+
+        with patch("aerospike_cluster_manager_api.routers.k8s_clusters.k8s_client.get_cluster", mock_get):
+            response = await client.get("/api/k8s/clusters/aerospike/missing/pods")
+
+        assert response.status_code == 404
+        assert "not found" in response.json()["detail"].lower()
+
+
+class TestListPodsK8sDisabled:
+    async def test_returns_404_when_k8s_management_disabled(self):
+        """With K8S_MANAGEMENT_ENABLED=False the entire k8s router is gone."""
+        with patch("aerospike_cluster_manager_api.config.K8S_MANAGEMENT_ENABLED", False):
+            import aerospike_cluster_manager_api.main as main_mod
+
+            importlib.reload(main_mod)
+            test_app = main_mod.app
+
+            original_lifespan = test_app.router.lifespan_context
+            test_app.router.lifespan_context = _noop_lifespan
+            test_app.state.limiter.enabled = False
+
+            transport = ASGITransport(app=test_app)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                response = await ac.get("/api/k8s/clusters/aerospike/demo/pods")
+
+            test_app.state.limiter.enabled = True
+            test_app.router.lifespan_context = original_lifespan
+
+        assert response.status_code == 404

--- a/api/tests/test_records_bin_delete_endpoint.py
+++ b/api/tests/test_records_bin_delete_endpoint.py
@@ -1,0 +1,168 @@
+"""Tests for the DELETE /records/{conn_id}/{ns}/{set}/{pk}/bins/{bin_name} endpoint.
+
+Mirrors :func:`mcp.tools.records.delete_bin` so ackoctl reaches MCP
+parity through the REST surface.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from aerospike_py.exception import RecordNotFound
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from aerospike_cluster_manager_api.main import app
+
+
+@asynccontextmanager
+async def _noop_lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    yield
+
+
+@pytest.fixture()
+async def client():
+    original_lifespan = app.router.lifespan_context
+    app.router.lifespan_context = _noop_lifespan
+
+    app.state.limiter.enabled = False
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.state.limiter.enabled = True
+    app.router.lifespan_context = original_lifespan
+
+
+class TestDeleteBinHappyPath:
+    async def test_returns_204_on_success(self, client: AsyncClient):
+        mock_client = AsyncMock()
+        mock_client.remove_bin = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            response = await client.delete(
+                "/api/records/conn-test/test/demo/user_42/bins/name",
+            )
+
+        assert response.status_code == 204
+        # Body is empty for 204; service call took the auto pk-type heuristic
+        # (string for "user_42") so the resolved key tuple is the raw string.
+        mock_client.remove_bin.assert_awaited_once()
+        call = mock_client.remove_bin.await_args
+        assert call.args[0] == ("test", "demo", "user_42")
+        assert call.args[1] == ["name"]
+
+    async def test_v1_route_works(self, client: AsyncClient):
+        mock_client = AsyncMock()
+        mock_client.remove_bin = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            response = await client.delete(
+                "/api/v1/records/conn-test/test/demo/user_42/bins/name",
+            )
+
+        assert response.status_code == 204
+
+    async def test_explicit_pk_type_int(self, client: AsyncClient):
+        """Explicit ``pk_type=int`` parses the path pk as an integer."""
+        mock_client = AsyncMock()
+        mock_client.remove_bin = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            response = await client.delete(
+                "/api/records/conn-test/test/demo/42/bins/age",
+                params={"pk_type": "int"},
+            )
+
+        assert response.status_code == 204
+        call = mock_client.remove_bin.await_args
+        assert call.args[0] == ("test", "demo", 42)
+
+
+class TestDeleteBinErrors:
+    async def test_returns_404_when_record_missing(self, client: AsyncClient):
+        mock_client = AsyncMock()
+        mock_client.remove_bin = AsyncMock(side_effect=RecordNotFound("not found"))
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            response = await client.delete(
+                "/api/records/conn-test/test/demo/missing/bins/name",
+            )
+
+        assert response.status_code == 404
+        body = response.json()
+        assert "missing" in body["detail"]
+
+    async def test_returns_404_when_conn_missing(self, client: AsyncClient):
+        """VerifiedConnId gate: unknown connection ID surfaces as 404 before
+        the service layer runs."""
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.db.get_connection",
+            AsyncMock(return_value=None),
+        ):
+            response = await client.delete(
+                "/api/records/conn-missing/test/demo/user_42/bins/name",
+            )
+
+        assert response.status_code == 404
+        assert "conn-missing" in response.json()["detail"]
+
+    async def test_invalid_pk_type_returns_422(self, client: AsyncClient):
+        """``pk_type`` is a Literal -- unrecognised values are rejected at
+        request validation."""
+        mock_client = AsyncMock()
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            response = await client.delete(
+                "/api/records/conn-test/test/demo/user_42/bins/name",
+                params={"pk_type": "garbage"},
+            )
+
+        assert response.status_code == 422

--- a/api/tests/test_sets_router.py
+++ b/api/tests/test_sets_router.py
@@ -1,0 +1,171 @@
+"""Tests for the POST /sets/{conn_id}/{ns}/{set_name}/truncate endpoint.
+
+Mirrors :func:`mcp.tools.records.truncate_set` so ackoctl reaches MCP
+parity through the REST surface.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from aerospike_cluster_manager_api.main import app
+
+
+@asynccontextmanager
+async def _noop_lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    yield
+
+
+@pytest.fixture()
+async def client():
+    original_lifespan = app.router.lifespan_context
+    app.router.lifespan_context = _noop_lifespan
+
+    app.state.limiter.enabled = False
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.state.limiter.enabled = True
+    app.router.lifespan_context = original_lifespan
+
+
+class TestTruncateSetHappyPath:
+    async def test_returns_200_with_message_when_body_omitted(self, client: AsyncClient):
+        """No body means ``before_lut=None`` -- full truncate."""
+        mock_client = AsyncMock()
+        mock_client.truncate = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            response = await client.post(
+                "/api/sets/conn-test/test/demo/truncate",
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "truncated" in body["message"].lower()
+        # Service forwards ``nanos=0`` when before_lut is None (truncate-all).
+        mock_client.truncate.assert_awaited_once_with("test", "demo", 0)
+
+    async def test_returns_200_with_explicit_null_before_lut(self, client: AsyncClient):
+        """``beforeLut: null`` in body must behave like omitted body."""
+        mock_client = AsyncMock()
+        mock_client.truncate = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            response = await client.post(
+                "/api/sets/conn-test/test/demo/truncate",
+                json={"beforeLut": None},
+            )
+
+        assert response.status_code == 200
+        mock_client.truncate.assert_awaited_once_with("test", "demo", 0)
+
+    async def test_before_lut_is_forwarded_when_supplied(self, client: AsyncClient):
+        mock_client = AsyncMock()
+        mock_client.truncate = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            response = await client.post(
+                "/api/sets/conn-test/test/demo/truncate",
+                json={"beforeLut": 1_700_000_000_000_000_000},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert "1700000000000000000" in body["message"]
+        mock_client.truncate.assert_awaited_once_with("test", "demo", 1_700_000_000_000_000_000)
+
+    async def test_v1_route_works(self, client: AsyncClient):
+        mock_client = AsyncMock()
+        mock_client.truncate = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            response = await client.post(
+                "/api/v1/sets/conn-test/test/demo/truncate",
+            )
+
+        assert response.status_code == 200
+
+
+class TestTruncateSetErrors:
+    async def test_returns_400_on_non_positive_before_lut(self, client: AsyncClient):
+        """Service layer rejects ``before_lut=0`` (collision with truncate-all)
+        and ``before_lut<0``. Surface as 400 so the caller can fix the request."""
+        mock_client = AsyncMock()
+        mock_client.truncate = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            response = await client.post(
+                "/api/sets/conn-test/test/demo/truncate",
+                json={"beforeLut": 0},
+            )
+
+        assert response.status_code == 400
+        # Service never reached -- the wrong cutoff would otherwise silently
+        # become a truncate-all.
+        mock_client.truncate.assert_not_awaited()
+
+    async def test_returns_404_when_conn_missing(self, client: AsyncClient):
+        """VerifiedConnId gate runs first -- unknown connection surfaces as 404
+        before the destructive truncate fires."""
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.db.get_connection",
+            AsyncMock(return_value=None),
+        ):
+            response = await client.post(
+                "/api/sets/conn-missing/test/demo/truncate",
+            )
+
+        assert response.status_code == 404
+        assert "conn-missing" in response.json()["detail"]


### PR DESCRIPTION
## Motivation

Closes the last gap in ackoctl's REST surface so the MCP server can be
retired in a separate PR without orphaning three operations.

ackoctl currently shells out to MCP tools for three things that have no
REST equivalent:

1. `get_k8s_pods` -- listing pods of an AerospikeCluster CR.
2. `delete_bin` -- removing a single bin from a record.
3. `truncate_set` -- dropping every record (or LUT-cutoff slice) in a set.

This PR exposes each of those as a first-class REST endpoint, reusing
the same service-layer functions the MCP tools already wrap. The MCP
tools themselves stay in place -- a follow-up PR removes them after
ackoctl is wired to the new endpoints.

Related: ackoctl#5 (ackoctl side MCP parity tracking issue).

## Endpoints

### 1. `GET /api/v1/k8s/clusters/{namespace}/{name}/pods`

* Response: `list[K8sPodStatus]` (existing Pydantic model reused, no
  schema churn -- `K8sPodStatus` is already emitted as a slice of
  `K8sClusterDetail`).
* ACL: `_assert_caller_owns_k8s_cluster` (identity-404 for invisible
  workspaces, identical to the rest of the K8s surface).
* Errors: 404 when the cluster doesn't exist or the caller can't see it.
* Mirrors `mcp.tools.k8s.get_k8s_pods`.

Lives alongside the existing `GET /clusters/{namespace}/{name}` detail
endpoint; uses the same `list_pods` label selector
(`app.kubernetes.io/name=aerospike-cluster,app.kubernetes.io/instance={name}`).

### 2. `DELETE /api/v1/records/{conn_id}/{namespace}/{set_name}/{pk}/bins/{bin_name}`

* Query: `pk_type=auto|string|int|bytes` (default `auto`); semantics
  match `delete_record_note` / `update_record_note`.
* Response: 204 No Content on success.
* Errors: 404 when the record / bin doesn't exist, 400 on unparseable
  `pk` for an explicit `pk_type`, 422 on invalid `pk_type`.
* ACL: `VerifiedConnId` (workspace ACL on the underlying connection).
* Mirrors `mcp.tools.records.delete_bin`.

Notes:

* `delete_bin` does not fall back to the alternate particle type even
  in `auto` mode -- same rule the REST `delete_record` already follows
  to avoid silent no-ops on the wrong particle type.
* Removing the last bin causes the whole record to disappear server
  side (standard Aerospike behaviour, not papered over here).

### 3. `POST /api/v1/sets/{conn_id}/{namespace}/{set_name}/truncate`

* New router file `routers/sets.py` -- sets is a distinct noun, no
  existing module fit.
* Body: `{"beforeLut": int | null}` (alias of `before_lut`). Omitted or
  `null` means truncate-all; positive integer caps by LUT (nanoseconds
  since CITRUS epoch).
* Response: `MessageResponse` (`{"message": "..."}`).
* Errors: 400 when `beforeLut <= 0` (service rejects it explicitly to
  avoid the silent-truncate-all footgun), 404 on unknown `conn_id`.
* ACL: `VerifiedConnId`.
* Rate-limited at 10/minute (lower than other write endpoints because
  truncate is unbounded blast radius).
* Mirrors `mcp.tools.records.truncate_set`.

## Test plan

`uv run pytest tests/` -- all 1025 tests pass (17 new).

- [x] **k8s pods list:** happy path, v1 path, label selector forwarded,
  404 on missing cluster, 404 when K8S_MANAGEMENT_ENABLED=False.
- [x] **bin delete:** happy path (auto pk_type), v1 path, explicit
  `pk_type=int`, 404 on missing record, 404 on missing connection
  (VerifiedConnId gate), 422 on invalid `pk_type` value.
- [x] **set truncate:** happy path with no body, explicit `beforeLut:null`,
  `beforeLut` positive value forwarded to `client.truncate`, v1 path,
  400 on `beforeLut=0`, 404 on missing connection.

Manual checks:

- [x] `uv run ruff check src tests` -- all checks passed.
- [x] `uv run ruff format src tests` -- clean.
- [x] `app.openapi()` includes all three new operations at both
  `/api` and `/api/v1`.

## Non-goals

- Does **not** delete any MCP code (`mcp/tools/k8s.py` `get_k8s_pods`,
  `mcp/tools/records.py` `delete_bin` / `truncate_set` stay in place).
  Removing MCP is a separate PR after ackoctl is wired to these new
  endpoints and parity is verified end-to-end.
- Does **not** touch auth middleware, the K8s management feature flag,
  or anything outside the three feature areas.

## Concurrent PR note

Another agent is independently adding `POST /clusters/{conn_id}/info`
on branch `feat/cluster-info-rest`. Different files; the only
expected merge-time conflict is on `CHANGELOG.md`, which this PR did
not touch (the repo has no CHANGELOG file yet, so no conflict
materializes here).