### PR TITLE
fix(local-dev): use ui.api.enabled / ui.web.enabled instead of nonexistent ui.enabled

### DIFF
--- a/scripts/local-dev/acko-install.sh
+++ b/scripts/local-dev/acko-install.sh
@@ -93,9 +93,12 @@ if [[ -n "${ACKO_FULLNAME_OVERRIDE}" ]]; then
 fi
 
 if [[ "${ACKO_UI_ENABLED}" == "true" ]]; then
-  _helm_args+=(--set "ui.enabled=true")
+  # The chart toggles UI api/web independently via ui.api.enabled and
+  # ui.web.enabled; there is no top-level ui.enabled key. Set both so the
+  # rendered manifests are deterministic regardless of chart defaults.
+  _helm_args+=(--set "ui.api.enabled=true" --set "ui.web.enabled=true")
   if [[ "${ACKO_UI_LOCAL_BUILD}" == "true" ]]; then
-    log "UI mode: ui.enabled=true with locally-built images (tag: ${ACKO_UI_IMAGE_TAG}, pullPolicy=Never)"
+    log "UI mode: ui.api/web enabled with locally-built images (tag: ${ACKO_UI_IMAGE_TAG}, pullPolicy=Never)"
     _helm_args+=(
       --set "ui.api.image.repository=${ACKO_UI_API_IMAGE}"
       --set "ui.api.image.tag=${ACKO_UI_IMAGE_TAG}"
@@ -105,10 +108,14 @@ if [[ "${ACKO_UI_ENABLED}" == "true" ]]; then
       --set "ui.web.image.pullPolicy=Never"
     )
   else
-    log "UI mode: ui.enabled=true with chart-default images (ghcr.io, tag: latest)"
+    log "UI mode: ui.api/web enabled with chart-default images (ghcr.io, tag: latest)"
   fi
 else
-  _helm_args+=(--set "ui.enabled=false")
+  # Disable BOTH UI deployments. Previously this only set ui.enabled=false,
+  # which is not a chart key and silently fell through to the chart's
+  # default (api.enabled=true, web.enabled=true) — the UI pods then
+  # deployed, hit ImagePullBackOff on ghcr.io, and helm --wait timed out.
+  _helm_args+=(--set "ui.api.enabled=false" --set "ui.web.enabled=false")
 fi
 
 log "helm upgrade --install ${ACKO_RELEASE} ${ACKO_CHART_PATH}"


### PR DESCRIPTION
## What

scripts/local-dev/acko-install.sh sets `--set ui.enabled=false` (and `=true`) to toggle the ACKO UI deployments. The chart has no such key — `ui.enabled` is silently ignored.

## Why it matters

The chart's `values.yaml` has `ui.api.enabled` and `ui.web.enabled` independent toggles, defaulting to `true`. The script's "UI disabled" path fell through to the chart defaults, so:

1. `helm upgrade --install acko ... --wait --timeout=600s` rendered the UI api/web Deployments
2. Pods stayed in `ImagePullBackOff` (chart defaults pull `ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-{api,web}:latest`, which is not pre-loaded in kind)
3. After 10 minutes the helm command rolled back and exited non-zero
4. The operator deployment was still up but the release was not recorded in `helm list`
5. Re-running `make acko-install` then complained the release didn't exist, while orphan ValidatingWebhookConfigurations referencing the now-missing webhook service blocked any subsequent `kubectl apply -f aerospikecluster.yaml`

## Fix

Set the two real keys explicitly, in both the on and off branches. Idempotent on subsequent runs.

## How I found it

Local end-to-end smoke (kind + ACKO + cluster-manager + ackoctl). Worked around by running `helm install acko ... --set ui.api.enabled=false --set ui.web.enabled=false`; this PR brings the script in line.