### PR TITLE
fix(api): stop leaking internal exception text in 500 responses; drop stale MCP doc-comments

### DIFF
--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -295,18 +295,23 @@ app.add_middleware(TraceIDMiddleware)
 # ---------------------------------------------------------------------------
 
 
-def _internal_error_response(message: str) -> JSONResponse:
-    """Build a 500 JSON response that surfaces requestId + the underlying error.
+def _internal_error_response() -> JSONResponse:
+    """Build a 500 JSON response that surfaces requestId for log correlation.
 
     Issues #257 and #260 specifically asked for log-correlation context in 500
     bodies. TraceIDMiddleware populates ``request_id_var`` for the duration of
     every request, so the handler can read it without a dependency on
     request.state.
+
+    The body intentionally carries only a generic message — the underlying
+    ``str(exc)`` / traceback can leak internal detail (hostnames, query
+    fragments, stack context) to API clients, so callers must log the full
+    error server-side and clients correlate via ``requestId``.
     """
     from aerospike_cluster_manager_api.middleware.trace_id import REQUEST_ID_HEADER, request_id_var
 
     request_id = request_id_var.get()
-    body: dict[str, str] = {"detail": "An internal server error occurred", "error": message}
+    body: dict[str, str] = {"detail": "An internal server error occurred", "error": "Internal server error"}
     if request_id and request_id != "-":
         body["requestId"] = request_id
     response = JSONResponse(status_code=500, content=body)
@@ -371,7 +376,7 @@ try:
                 },
             )
         logger.warning("Unrecognized ServerError: %s", msg)
-        return _internal_error_response(msg)
+        return _internal_error_response()
 
     @app.exception_handler(AerospikeTimeoutError)
     async def _timeout_error(_req: Request, exc: AerospikeTimeoutError) -> JSONResponse:
@@ -417,8 +422,8 @@ try:
 
     @app.exception_handler(AerospikeError)
     async def _aerospike_error(_req: Request, exc: AerospikeError) -> JSONResponse:
-        logger.exception("Aerospike error")
-        return _internal_error_response(str(exc))
+        logger.exception("Aerospike error: %s", exc)
+        return _internal_error_response()
 
 except ImportError:
     pass

--- a/api/src/aerospike_cluster_manager_api/models/cluster.py
+++ b/api/src/aerospike_cluster_manager_api/models/cluster.py
@@ -63,9 +63,8 @@ class CreateNamespaceRequest(BaseModel):
 class ExecuteInfoRequest(BaseModel):
     """Request body for ``POST /clusters/{conn_id}/info``.
 
-    Mirrors the MCP ``execute_info`` / ``execute_info_on_node`` /
-    ``execute_info_read_only`` tools so ackoctl can ship ``ackoctl info``
-    without a separate MCP transport.
+    Backs ``ackoctl info`` — node-scoped and read-only info execution are
+    expressed through this single REST endpoint via the fields below.
 
     Semantics:
       * ``node`` unset  → fan out via ``info_all`` to every node.

--- a/api/src/aerospike_cluster_manager_api/routers/records.py
+++ b/api/src/aerospike_cluster_manager_api/routers/records.py
@@ -279,10 +279,10 @@ async def delete_record_bin(
 ) -> Response:
     """Remove a single bin from an existing record.
 
-    Mirrors :func:`mcp.tools.records.delete_bin` so ackoctl reaches MCP
-    parity through the REST surface. Removing the last bin causes the
-    whole record to disappear server-side — that's standard Aerospike
-    behaviour, not something this endpoint papers over.
+    Exposed as ``DELETE /records/{conn_id}/{namespace}/{set_name}/{pk}/bins/{bin_name}``;
+    ackoctl drives bin deletion through this REST surface. Removing the
+    last bin causes the whole record to disappear server-side — that's
+    standard Aerospike behaviour, not something this endpoint papers over.
 
     ``pk_type`` semantics match :func:`update_record_note` and
     :func:`delete_record_note`: ``auto`` (default) lets the heuristic

--- a/api/src/aerospike_cluster_manager_api/routers/sets.py
+++ b/api/src/aerospike_cluster_manager_api/routers/sets.py
@@ -1,10 +1,8 @@
 """REST endpoints scoped to a single Aerospike set.
 
-Currently exposes a single destructive operation -- ``truncate``. The
-endpoint mirrors :func:`mcp.tools.records.truncate_set` so ackoctl can
-reach MCP parity through the REST surface; the MCP wrapper does not get
-deleted in this PR, but with this router in place a future PR can drop
-the MCP tool without orphaning the operation.
+Currently exposes a single destructive operation -- ``truncate`` via
+``POST /sets/{conn_id}/{namespace}/{set_name}/truncate``. ackoctl drives
+this set truncation through the REST surface.
 
 Workspace ACL: ``VerifiedConnId`` already gates the connection by
 workspace before the body runs -- identity-404 if the caller cannot see

--- a/api/tests/test_api_500_regressions.py
+++ b/api/tests/test_api_500_regressions.py
@@ -206,9 +206,11 @@ class TestIndexesIdempotency:
 
         assert response.status_code == 500
         body = response.json()
-        # The improved 500 handler now surfaces requestId + error message.
+        # The 500 handler surfaces requestId for log correlation but keeps the
+        # error field generic — raw exception text must not leak to clients.
         assert "requestId" in body
-        assert "real failure" in body.get("error", "")
+        assert body["error"] == "Internal server error"
+        assert "real failure" not in str(body)
 
     async def test_delete_returns_204_when_drop_raises_but_index_already_gone(
         self,
@@ -251,7 +253,7 @@ class TestIndexesIdempotency:
 
 
 class TestInternalErrorBody:
-    async def test_500_body_includes_request_id_and_error_message(self, http_client: AsyncClient):
+    async def test_500_body_includes_request_id_and_generic_error_message(self, http_client: AsyncClient):
         mock_client = AsyncMock()
         mock_client.index_integer_create = AsyncMock(side_effect=AerospikeError("boom"))
         mock_client.info_random_node = AsyncMock(return_value="")
@@ -269,5 +271,7 @@ class TestInternalErrorBody:
         body = response.json()
         assert body["detail"] == "An internal server error occurred"
         assert body["requestId"] == "abcd1234abcd1234abcd1234abcd1234"
-        assert body["error"] == "boom"
+        # error field stays generic — raw exception text ("boom") must not leak.
+        assert body["error"] == "Internal server error"
+        assert "boom" not in str(body)
         assert response.headers.get("X-Request-ID") == "abcd1234abcd1234abcd1234abcd1234"

--- a/api/tests/test_records_bin_delete_endpoint.py
+++ b/api/tests/test_records_bin_delete_endpoint.py
@@ -1,7 +1,6 @@
 """Tests for the DELETE /records/{conn_id}/{ns}/{set}/{pk}/bins/{bin_name} endpoint.
 
-Mirrors :func:`mcp.tools.records.delete_bin` so ackoctl reaches MCP
-parity through the REST surface.
+ackoctl drives bin deletion through this REST surface.
 """
 
 from __future__ import annotations

--- a/api/tests/test_sets_router.py
+++ b/api/tests/test_sets_router.py
@@ -1,7 +1,6 @@
 """Tests for the POST /sets/{conn_id}/{ns}/{set_name}/truncate endpoint.
 
-Mirrors :func:`mcp.tools.records.truncate_set` so ackoctl reaches MCP
-parity through the REST surface.
+ackoctl drives set truncation through this REST surface.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Two review-driven backend fixes for `aerospike-cluster-manager`.

### 1. Info-leak hardening — 500 responses
`_internal_error_response` previously put the raw `str(exc)` into the
client-facing JSON `error` field, leaking internal detail (hostnames,
query fragments, stack context) to API clients.

- The `error` field now carries a generic `"Internal server error"`.
- `requestId` is still included for log correlation.
- The full `str(exc)` / traceback is still logged server-side at the
  same place (`logger.warning` / `logger.exception`) — logging was not
  removed.
- `test_api_500_regressions.py` assertions updated to expect the
  generic body and to verify the raw exception text does **not** appear.

### 2. Dead-reference cleanup — stale MCP doc-comments
The MCP server was removed in #357. Doc-comments still referenced the
removed `mcp.tools.*` surface in `routers/sets.py`, `routers/records.py`,
`models/cluster.py` and two test modules. All updated to describe the
current REST surface. Comment-only changes — no functional code touched.

## Test plan

- [x] `uv run pytest tests/` — 712 passed
- [x] `uv run ruff check src tests` — clean
- [x] `uv run ruff format --check src tests` — clean