### PR TITLE
feat(api)!: stdout-only logging + LOG_FILE_PATH for OTel Collector sidecar (#362)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,25 +146,16 @@ K8S_MANAGEMENT_ENABLED=false
 # LOG_LEVEL=INFO
 # LOG_FORMAT=text   # "text" (human-readable) or "json" (structured)
 #
-# Comma-separated list of pluggable logging-handler specs, applied in addition
-# to the default stdout handler. Each spec is either "module.path:ClassName"
-# or an entry-point name registered under "aerospike_cluster_manager.log_handlers".
-# Each handler is constructed with no arguments and is expected to read its own
-# configuration from the environment. A failing handler is logged and skipped.
-# See docs/logging.md for examples (Loki, Datadog, in-house NELO SDK, etc.).
-# LOG_HANDLERS=
+# External log routing (redaction, sampling, vendor exporters) is handled
+# downstream by an OpenTelemetry Collector that receives this process's
+# stdout — directly via a node-level DaemonSet, or via a pod-internal
+# sidecar that tails the rotating file at LOG_FILE_PATH. See docs/logging.md
+# for the recommended deployment shape.
 #
-# Path to a YAML/JSON file consumed by logging.config.dictConfig. When set,
-# this takes full ownership of logging — LOG_LEVEL / LOG_FORMAT / LOG_HANDLERS /
-# LOG_FILE_PATH are ignored. Use as an escape hatch when the LOG_HANDLERS
-# factory pattern is too restrictive.
-# LOGGING_CONFIG_FILE=
-#
-# Mirror logs to a rotating file in addition to stdout. Intended for sidecar
-# log shippers (fluent-bit, vector, promtail, ...) that tail a file on a
-# shared volume — avoids the per-container-runtime quirks of kubectl-logs
-# scraping. Failure to open the file falls back to stdout-only and emits a
-# stderr warning; the pod does not crash.
+# Mirror logs to a rotating file in addition to stdout. Required when using
+# a pod-internal sidecar that forwards to OTel Collector (the sidecar tails
+# the file on a shared emptyDir volume). Failure to open the file falls
+# back to stdout-only and emits a stderr warning; the pod does not crash.
 # LOG_FILE_PATH=
 # LOG_FILE_MAX_BYTES=52428800     # 50 MiB per file
 # LOG_FILE_BACKUP_COUNT=3         # keep 3 rotated copies

--- a/.env.example
+++ b/.env.example
@@ -145,3 +145,26 @@ K8S_MANAGEMENT_ENABLED=false
 # ─── Logging ───────────────────────────────────────────────────────────────
 # LOG_LEVEL=INFO
 # LOG_FORMAT=text   # "text" (human-readable) or "json" (structured)
+#
+# Comma-separated list of pluggable logging-handler specs, applied in addition
+# to the default stdout handler. Each spec is either "module.path:ClassName"
+# or an entry-point name registered under "aerospike_cluster_manager.log_handlers".
+# Each handler is constructed with no arguments and is expected to read its own
+# configuration from the environment. A failing handler is logged and skipped.
+# See docs/logging.md for examples (Loki, Datadog, in-house NELO SDK, etc.).
+# LOG_HANDLERS=
+#
+# Path to a YAML/JSON file consumed by logging.config.dictConfig. When set,
+# this takes full ownership of logging — LOG_LEVEL / LOG_FORMAT / LOG_HANDLERS /
+# LOG_FILE_PATH are ignored. Use as an escape hatch when the LOG_HANDLERS
+# factory pattern is too restrictive.
+# LOGGING_CONFIG_FILE=
+#
+# Mirror logs to a rotating file in addition to stdout. Intended for sidecar
+# log shippers (fluent-bit, vector, promtail, ...) that tail a file on a
+# shared volume — avoids the per-container-runtime quirks of kubectl-logs
+# scraping. Failure to open the file falls back to stdout-only and emits a
+# stderr warning; the pod does not crash.
+# LOG_FILE_PATH=
+# LOG_FILE_MAX_BYTES=52428800     # 50 MiB per file
+# LOG_FILE_BACKUP_COUNT=3         # keep 3 rotated copies

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Related targets: `make kind-up/down/status`, `make acko-install/uninstall/verify
 - **AQL Terminal** — Web-based AQL command execution
 - **Prometheus Metrics** — Cluster metrics export
 - **OpenTelemetry Observability** — Traces, metrics, and logs via standard OTel SDK env vars; HTTP server, asyncpg, and aerospike-py spans auto-emit. See [docs/observability.md](docs/observability.md).
-- **Pluggable Logging Handlers** — Forward logs to NELO, Datadog, Loki, or any ``logging.Handler`` via ``LOG_HANDLERS=module:Class`` (or entry-point alias) without forking the image. See [docs/logging.md](docs/logging.md).
+- **Structured stdout logs ready for OTel Collector** — JSON output with `request_id` / `otelTraceID` / `otelSpanID` correlation fields. Optional rotating-file mirror (`LOG_FILE_PATH`) lets a pod-internal sidecar tail logs on a shared `emptyDir` and forward them via OTLP to an external OpenTelemetry Collector for vendor-specific routing (NELO, Datadog, Loki, Elasticsearch, ...). See [docs/logging.md](docs/logging.md).
 - **Sample Data Generator** — Generate deterministic sample records with optional indexes and UDFs
 - **K8s Cluster Management** — Full lifecycle management of Aerospike clusters on Kubernetes (see below)
   - ACL/Security configuration with role and user management via wizard
@@ -843,10 +843,8 @@ All environment variables with their defaults and descriptions. See `api/src/aer
 | Variable | Default | Description |
 |---|---|---|
 | `LOG_LEVEL` | `INFO` | API log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-| `LOG_FORMAT` | `text` | Log output format: `text` for local dev, `json` for structured container logging |
-| `LOG_HANDLERS` | _(empty)_ | Comma-separated handler specs (`module:Class` or entry-point name) attached in addition to stdout. See [docs/logging.md](docs/logging.md). |
-| `LOGGING_CONFIG_FILE` | _(empty)_ | Path to a YAML/JSON `dictConfig` file. Takes full ownership of logging when set. |
-| `LOG_FILE_PATH` | _(empty)_ | When set, mirror logs to a rotating file in addition to stdout. Designed for sidecar log shippers tailing a shared `emptyDir`. |
+| `LOG_FORMAT` | `text` | Log output format: `text` for local dev, `json` for structured container logging (recommended when shipping to an OTel Collector) |
+| `LOG_FILE_PATH` | _(empty)_ | When set, mirror logs to a rotating file in addition to stdout. Designed for a pod-internal sidecar that tails the file and forwards records via OTLP to an external OTel Collector. See [docs/logging.md](docs/logging.md). |
 | `LOG_FILE_MAX_BYTES` | `52428800` | Per-file size cap (bytes) for `LOG_FILE_PATH` rotation. Default 50 MiB. |
 | `LOG_FILE_BACKUP_COUNT` | `3` | Number of rotated backups kept on disk. |
 

--- a/README.md
+++ b/README.md
@@ -844,6 +844,11 @@ All environment variables with their defaults and descriptions. See `api/src/aer
 |---|---|---|
 | `LOG_LEVEL` | `INFO` | API log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
 | `LOG_FORMAT` | `text` | Log output format: `text` for local dev, `json` for structured container logging |
+| `LOG_HANDLERS` | _(empty)_ | Comma-separated handler specs (`module:Class` or entry-point name) attached in addition to stdout. See [docs/logging.md](docs/logging.md). |
+| `LOGGING_CONFIG_FILE` | _(empty)_ | Path to a YAML/JSON `dictConfig` file. Takes full ownership of logging when set. |
+| `LOG_FILE_PATH` | _(empty)_ | When set, mirror logs to a rotating file in addition to stdout. Designed for sidecar log shippers tailing a shared `emptyDir`. |
+| `LOG_FILE_MAX_BYTES` | `52428800` | Per-file size cap (bytes) for `LOG_FILE_PATH` rotation. Default 50 MiB. |
+| `LOG_FILE_BACKUP_COUNT` | `3` | Number of rotated backups kept on disk. |
 
 ## Production Deployment
 

--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -139,22 +139,6 @@ CM_SSE_BROADCAST_PER_CONNECTION: bool = os.getenv("CM_SSE_BROADCAST_PER_CONNECTI
 OTEL_ENABLED: bool = os.getenv("OTEL_SDK_DISABLED", "true").lower() not in ("true", "1", "yes")
 
 # ---------------------------------------------------------------------------
-# Pluggable log handlers
-# ---------------------------------------------------------------------------
-# Comma-separated list of "module:Class" specs (or entry-point names registered
-# under the "aerospike_cluster_manager.log_handlers" group). Each handler is
-# instantiated with no arguments and is expected to self-configure from its own
-# environment variables (e.g. pynelo's NELO_HOST / NELO_PROJECT_TOKEN). Failure
-# to load a single handler is logged and skipped — it does not abort startup or
-# remove other handlers.
-LOG_HANDLERS: str = os.getenv("LOG_HANDLERS", "")
-
-# When set, the file at this path is loaded as a YAML/JSON dictConfig and given
-# full control over logging configuration. LOG_LEVEL / LOG_FORMAT / LOG_HANDLERS
-# are ignored in this mode — the dictConfig is authoritative.
-LOGGING_CONFIG_FILE: str = os.getenv("LOGGING_CONFIG_FILE", "")
-
-# ---------------------------------------------------------------------------
 # At-rest encryption for stored connection passwords
 # ---------------------------------------------------------------------------
 # Fernet key used by ``secrets_crypto.encrypt_password`` to wrap the

--- a/api/src/aerospike_cluster_manager_api/logging_config.py
+++ b/api/src/aerospike_cluster_manager_api/logging_config.py
@@ -148,7 +148,12 @@ def _setup_default_logging(level: str, formatter: logging.Formatter) -> None:
     # Clear existing handlers before attaching a new one. Repeated calls
     # (test fixtures, uvicorn --reload) would otherwise accumulate handlers
     # with mismatched filter coverage and produce duplicate log lines.
+    # Close before remove so any RotatingFileHandler attached on a previous
+    # setup_logging() call releases its file descriptor immediately rather
+    # than waiting for GC — important on Windows / under pytest where the
+    # next tmp_path cleanup races against the leaked fd.
     for h in list(root.handlers):
+        h.close()
         root.removeHandler(h)
     root.setLevel(log_level)
     root.addHandler(handler)
@@ -174,12 +179,13 @@ def _attach_file_mirror(path: str, formatter: logging.Formatter) -> None:
         return
     try:
         target = Path(path)
-        if target.parent:
-            # parents=True creates missing intermediates; exist_ok=True keeps
-            # this idempotent across pod restarts. mkdir on a path whose
-            # parent already exists as a regular file raises NotADirectoryError
-            # (OSError subclass) and is reported via the except branch below.
-            target.parent.mkdir(parents=True, exist_ok=True)
+        # parents=True creates missing intermediates; exist_ok=True keeps
+        # this idempotent across pod restarts. mkdir on a path whose
+        # parent already exists as a regular file raises NotADirectoryError
+        # (OSError subclass) and is reported via the except branch below.
+        # Bare filenames have parent == Path(".") which is always present,
+        # so an explicit truthy guard would never short-circuit anyway.
+        target.parent.mkdir(parents=True, exist_ok=True)
         max_bytes = _get_int_env("LOG_FILE_MAX_BYTES", _DEFAULT_LOG_FILE_MAX_BYTES)
         backup_count = _get_int_env("LOG_FILE_BACKUP_COUNT", _DEFAULT_LOG_FILE_BACKUP_COUNT)
         # delay=False forces the file to be opened during setup so a bad

--- a/api/src/aerospike_cluster_manager_api/logging_config.py
+++ b/api/src/aerospike_cluster_manager_api/logging_config.py
@@ -1,58 +1,52 @@
 """Logging configuration for the application.
 
-Three layered modes:
+A single stdout handler with either text or JSON output (selected by
+``LOG_FORMAT``), plus an optional rotating file mirror.
 
-1. ``LOGGING_CONFIG_FILE`` is set
-   The file is loaded as YAML/JSON and applied verbatim via
-   :func:`logging.config.dictConfig`. The user owns every formatter, handler,
-   filter, and logger. ``LOG_LEVEL`` / ``LOG_FORMAT`` / ``LOG_HANDLERS`` /
-   ``LOG_FILE_PATH`` are ignored. Use this when you need full programmatic
-   control (third-party handlers with non-trivial constructors, complex
-   routing, etc.).
+External log routing — PII redaction, sampling, vendor-specific exporters
+(NELO, Datadog, Loki, Elasticsearch, ...) — is the responsibility of an
+OpenTelemetry Collector that receives this process's stdout (or tails the
+``LOG_FILE_PATH`` rotating file via a pod-internal sidecar). The OTel
+Collector spec already covers every transform-pipeline use case that
+earlier ACM releases implemented with pluggable in-process handlers, so
+that hook (``LOG_HANDLERS`` / ``LOGGING_CONFIG_FILE`` /
+``aerospike_cluster_manager.log_handlers`` entry-point group) was removed.
 
-2. ``LOG_HANDLERS`` is set (and ``LOGGING_CONFIG_FILE`` is not)
-   The default stdout handler is configured first, then each spec in
-   ``LOG_HANDLERS`` is resolved and attached. A spec is either
-   ``module.path:ClassName`` or an entry-point name registered under
-   ``aerospike_cluster_manager.log_handlers``. Each handler is constructed
-   with no arguments and is expected to read its own configuration from the
-   environment (e.g. ``pynelo``'s ``NELO_HOST`` / ``NELO_PROJECT_TOKEN``).
-   A failure to load one handler is logged and skipped — it does not abort
-   startup or remove other handlers.
+Two layered modes remain:
 
-3. Neither is set
-   Default behaviour preserved: a single stdout handler with a text or JSON
-   formatter (selected by ``LOG_FORMAT``), the existing ``RequestIDFilter``
-   for X-Request-ID propagation, and ``otelTraceID`` / ``otelSpanID`` fields
-   for OTel correlation when the logging instrumentor has patched the
+1. ``LOG_FILE_PATH`` is set
+   Attach a ``RotatingFileHandler`` *in addition to* stdout so a pod-
+   internal sidecar (fluent-bit, vector, promtail, ...) sharing an
+   ``emptyDir`` volume can tail the file and forward records to an
+   external OTel Collector OTLP endpoint. Rotation policy is controlled
+   by ``LOG_FILE_MAX_BYTES`` (default 50 MiB) and ``LOG_FILE_BACKUP_COUNT``
+   (default 3). Failure to open the file (parent dir unwritable, etc.)
+   is reported to stderr and the application falls back to stdout-only
+   logging instead of failing startup.
+
+2. Default
+   A single stdout handler with the existing ``RequestIDFilter`` for
+   X-Request-ID propagation and ``otelTraceID`` / ``otelSpanID`` fields
+   for OTel correlation when the LoggingInstrumentor has patched the
    LogRecord factory.
 
-In modes 2 and 3, setting ``LOG_FILE_PATH`` additionally attaches a rotating
-file handler so a logging sidecar (fluent-bit, vector, promtail, ...) sharing
-an ``emptyDir`` volume can tail logs without scraping ``kubectl logs``. The
-rotation policy is controlled by ``LOG_FILE_MAX_BYTES`` (default 50 MiB) and
-``LOG_FILE_BACKUP_COUNT`` (default 3). Failure to open the file (parent dir
-unwritable, etc.) is reported to stderr and the application falls back to
-stdout-only logging instead of failing startup.
+For the in-process SDK pattern that earlier releases supported via
+``LOG_HANDLERS``, deploy an OTel Collector with the appropriate
+processor pipeline (``attributes/redact``, ``probabilistic_sampler``,
+``transform`` for fixed fields) and exporter for the vendor backend.
+See docs/logging.md for the full migration guide.
 """
 
 from __future__ import annotations
 
-import importlib
 import logging
-import logging.config
 import logging.handlers
 import os
 import sys
-from importlib.metadata import entry_points
 from pathlib import Path
-from typing import Any
-
-import yaml
 
 from aerospike_cluster_manager_api.middleware.trace_id import RequestIDFilter
 
-ENTRY_POINT_GROUP = "aerospike_cluster_manager.log_handlers"
 _LOGGER_NAME = "aerospike_cluster_manager_api"
 
 # Rotation defaults applied when LOG_FILE_PATH is set but the size / backup-
@@ -65,48 +59,17 @@ _DEFAULT_LOG_FILE_BACKUP_COUNT = 3
 
 
 def setup_logging(level: str = "INFO", log_format: str = "text") -> None:
-    """Configure structured logging for the application.
+    """Configure stdout (and optional file-mirror) logging.
 
     Args:
         level: Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL).
-        log_format: Output format — "text" for human-readable, "json" for structured JSON.
+        log_format: Output format — "text" for human-readable, "json" for
+            structured JSON. Pick "json" when shipping to an OTel Collector
+            with a JSON parser.
     """
-    config_file = os.getenv("LOGGING_CONFIG_FILE", "").strip()
-    if config_file:
-        _apply_dictconfig_file(config_file)
-        return
-
     formatter = _build_formatter(log_format)
     _setup_default_logging(level, formatter)
     _attach_file_mirror(os.getenv("LOG_FILE_PATH", ""), formatter)
-    _attach_extra_handlers(os.getenv("LOG_HANDLERS", ""))
-
-
-# ---------------------------------------------------------------------------
-# Mode 1: external dictConfig file
-# ---------------------------------------------------------------------------
-
-
-def _apply_dictconfig_file(path: str) -> None:
-    p = Path(path)
-    if not p.exists():
-        # fail-fast: silently falling back to defaults would make the
-        # misconfiguration nearly impossible to debug ("why are my logs not
-        # going to NELO?"). Crashing on startup forces the operator to fix
-        # the path or unset the env var.
-        raise FileNotFoundError(f"LOGGING_CONFIG_FILE not found: {path}")
-    with p.open() as f:
-        cfg: Any = yaml.safe_load(f)
-    if not isinstance(cfg, dict):
-        raise ValueError(
-            f"LOGGING_CONFIG_FILE must contain a dictConfig mapping at the top level, got {type(cfg).__name__}"
-        )
-    logging.config.dictConfig(cfg)
-
-
-# ---------------------------------------------------------------------------
-# Mode 2 + 3: default stdout handler + optional plugin handlers
-# ---------------------------------------------------------------------------
 
 
 def _build_formatter(log_format: str) -> logging.Formatter:
@@ -163,11 +126,12 @@ def _setup_default_logging(level: str, formatter: logging.Formatter) -> None:
 def _attach_file_mirror(path: str, formatter: logging.Formatter) -> None:
     """Mirror logs to a rotating file when ``LOG_FILE_PATH`` is set.
 
-    Intended for sidecar log shippers that tail a file on a shared ``emptyDir``
-    volume — kubectl-logs scraping is the alternative but it forces operators
-    to also configure container-runtime log paths, which is brittle across
-    Docker, containerd, and CRI-O. The file handler reuses the same formatter
-    as stdout so the on-disk format matches what ``kubectl logs`` shows.
+    Intended for a pod-internal sidecar log shipper (fluent-bit / vector /
+    promtail / ...) that tails a file on a shared ``emptyDir`` volume and
+    forwards records via OTLP to an external OTel Collector. ``kubectl logs``
+    scraping is the alternative but requires the sidecar (or a node-level
+    DaemonSet) to know the container-runtime's per-host log path, which is
+    brittle across Docker, containerd, and CRI-O.
 
     Failures are non-fatal: an unwritable directory or insufficient
     permissions emit a warning to stderr (logging is not yet usable for its
@@ -231,56 +195,3 @@ def _get_int_env(name: str, default: int) -> int:
         )
         return default
     return value
-
-
-def _attach_extra_handlers(spec: str) -> None:
-    spec = spec.strip()
-    if not spec:
-        return
-    root = logging.getLogger(_LOGGER_NAME)
-    self_logger = logging.getLogger(__name__)
-    discovered = _load_entry_points()
-    for raw in (s.strip() for s in spec.split(",") if s.strip()):
-        try:
-            handler_cls = _resolve_handler(raw, discovered)
-            instance = handler_cls()
-        except Exception as e:
-            # Per-handler isolation: one failed plugin must not silently disable
-            # the rest or abort startup. Visible at INFO logs since attached
-            # handlers are also reported there.
-            self_logger.error("failed to attach log handler %r: %s", raw, e)
-            continue
-        # The default stdout handler attaches RequestIDFilter to itself; we
-        # also attach it to plugin handlers so they get a populated
-        # `request_id` field without each one having to opt in.
-        instance.addFilter(RequestIDFilter())
-        root.addHandler(instance)
-        self_logger.info("attached log handler: %s", raw)
-
-
-def _load_entry_points() -> dict[str, type[logging.Handler]]:
-    out: dict[str, type[logging.Handler]] = {}
-    try:
-        eps = entry_points(group=ENTRY_POINT_GROUP)
-    except Exception:
-        return out
-    for ep in eps:
-        try:
-            out[ep.name] = ep.load()
-        except Exception as e:
-            logging.getLogger(__name__).error("entry-point %s load failed: %s", ep.name, e)
-    return out
-
-
-def _resolve_handler(spec: str, ep_cache: dict[str, type[logging.Handler]]) -> type[logging.Handler]:
-    if ":" in spec:
-        mod_name, _, cls_name = spec.partition(":")
-        if not mod_name or not cls_name:
-            raise ValueError(f"invalid 'module:Class' spec: {spec!r}")
-        mod = importlib.import_module(mod_name)
-        return getattr(mod, cls_name)
-    if spec in ep_cache:
-        return ep_cache[spec]
-    raise ValueError(
-        f"unknown handler {spec!r}: not a 'module:Class' spec and not in entry-points group {ENTRY_POINT_GROUP!r}"
-    )

--- a/api/src/aerospike_cluster_manager_api/logging_config.py
+++ b/api/src/aerospike_cluster_manager_api/logging_config.py
@@ -5,9 +5,10 @@ Three layered modes:
 1. ``LOGGING_CONFIG_FILE`` is set
    The file is loaded as YAML/JSON and applied verbatim via
    :func:`logging.config.dictConfig`. The user owns every formatter, handler,
-   filter, and logger. ``LOG_LEVEL`` / ``LOG_FORMAT`` / ``LOG_HANDLERS`` are
-   ignored. Use this when you need full programmatic control (third-party
-   handlers with non-trivial constructors, complex routing, etc.).
+   filter, and logger. ``LOG_LEVEL`` / ``LOG_FORMAT`` / ``LOG_HANDLERS`` /
+   ``LOG_FILE_PATH`` are ignored. Use this when you need full programmatic
+   control (third-party handlers with non-trivial constructors, complex
+   routing, etc.).
 
 2. ``LOG_HANDLERS`` is set (and ``LOGGING_CONFIG_FILE`` is not)
    The default stdout handler is configured first, then each spec in
@@ -25,6 +26,14 @@ Three layered modes:
    for X-Request-ID propagation, and ``otelTraceID`` / ``otelSpanID`` fields
    for OTel correlation when the logging instrumentor has patched the
    LogRecord factory.
+
+In modes 2 and 3, setting ``LOG_FILE_PATH`` additionally attaches a rotating
+file handler so a logging sidecar (fluent-bit, vector, promtail, ...) sharing
+an ``emptyDir`` volume can tail logs without scraping ``kubectl logs``. The
+rotation policy is controlled by ``LOG_FILE_MAX_BYTES`` (default 50 MiB) and
+``LOG_FILE_BACKUP_COUNT`` (default 3). Failure to open the file (parent dir
+unwritable, etc.) is reported to stderr and the application falls back to
+stdout-only logging instead of failing startup.
 """
 
 from __future__ import annotations
@@ -32,6 +41,7 @@ from __future__ import annotations
 import importlib
 import logging
 import logging.config
+import logging.handlers
 import os
 import sys
 from importlib.metadata import entry_points
@@ -44,6 +54,14 @@ from aerospike_cluster_manager_api.middleware.trace_id import RequestIDFilter
 
 ENTRY_POINT_GROUP = "aerospike_cluster_manager.log_handlers"
 _LOGGER_NAME = "aerospike_cluster_manager_api"
+
+# Rotation defaults applied when LOG_FILE_PATH is set but the size / backup-
+# count knobs are not. 50 MiB * 3 keeps disk usage bounded to ~200 MiB while
+# leaving enough history that an emptyDir-tail sidecar that briefly stalls
+# (image pull during pod restart, etc.) doesn't lose records on the next
+# rotation.
+_DEFAULT_LOG_FILE_MAX_BYTES = 50 * 1024 * 1024
+_DEFAULT_LOG_FILE_BACKUP_COUNT = 3
 
 
 def setup_logging(level: str = "INFO", log_format: str = "text") -> None:
@@ -58,7 +76,9 @@ def setup_logging(level: str = "INFO", log_format: str = "text") -> None:
         _apply_dictconfig_file(config_file)
         return
 
-    _setup_default_logging(level, log_format)
+    formatter = _build_formatter(log_format)
+    _setup_default_logging(level, formatter)
+    _attach_file_mirror(os.getenv("LOG_FILE_PATH", ""), formatter)
     _attach_extra_handlers(os.getenv("LOG_HANDLERS", ""))
 
 
@@ -89,9 +109,7 @@ def _apply_dictconfig_file(path: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _setup_default_logging(level: str, log_format: str) -> None:
-    log_level = getattr(logging, level.upper(), logging.INFO)
-
+def _build_formatter(log_format: str) -> logging.Formatter:
     if log_format == "json":
         from pythonjsonlogger.json import JsonFormatter
 
@@ -99,7 +117,7 @@ def _setup_default_logging(level: str, log_format: str) -> None:
         # LoggingInstrumentor (see observability.setup_observability). When OTel
         # is disabled, they are absent from the record — the `defaults` arg
         # keeps the JSON output stable instead of raising KeyError.
-        formatter: logging.Formatter = JsonFormatter(
+        return JsonFormatter(
             fmt="%(asctime)s %(levelname)s %(name)s %(request_id)s %(otelTraceID)s %(otelSpanID)s %(message)s",
             datefmt="%Y-%m-%dT%H:%M:%S",
             rename_fields={
@@ -111,11 +129,14 @@ def _setup_default_logging(level: str, log_format: str) -> None:
             },
             defaults={"request_id": "-", "otelTraceID": "0", "otelSpanID": "0"},
         )
-    else:
-        formatter = logging.Formatter(
-            fmt="%(asctime)s %(levelname)-8s [%(name)s] %(message)s",
-            datefmt="%Y-%m-%d %H:%M:%S",
-        )
+    return logging.Formatter(
+        fmt="%(asctime)s %(levelname)-8s [%(name)s] %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+
+
+def _setup_default_logging(level: str, formatter: logging.Formatter) -> None:
+    log_level = getattr(logging, level.upper(), logging.INFO)
 
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(formatter)
@@ -132,6 +153,78 @@ def _setup_default_logging(level: str, log_format: str) -> None:
     root.setLevel(log_level)
     root.addHandler(handler)
     root.propagate = False
+
+
+def _attach_file_mirror(path: str, formatter: logging.Formatter) -> None:
+    """Mirror logs to a rotating file when ``LOG_FILE_PATH`` is set.
+
+    Intended for sidecar log shippers that tail a file on a shared ``emptyDir``
+    volume — kubectl-logs scraping is the alternative but it forces operators
+    to also configure container-runtime log paths, which is brittle across
+    Docker, containerd, and CRI-O. The file handler reuses the same formatter
+    as stdout so the on-disk format matches what ``kubectl logs`` shows.
+
+    Failures are non-fatal: an unwritable directory or insufficient
+    permissions emit a warning to stderr (logging is not yet usable for its
+    own errors at this point) and the application keeps stdout-only logging
+    so the pod still starts.
+    """
+    path = path.strip()
+    if not path:
+        return
+    try:
+        target = Path(path)
+        if target.parent:
+            # parents=True creates missing intermediates; exist_ok=True keeps
+            # this idempotent across pod restarts. mkdir on a path whose
+            # parent already exists as a regular file raises NotADirectoryError
+            # (OSError subclass) and is reported via the except branch below.
+            target.parent.mkdir(parents=True, exist_ok=True)
+        max_bytes = _get_int_env("LOG_FILE_MAX_BYTES", _DEFAULT_LOG_FILE_MAX_BYTES)
+        backup_count = _get_int_env("LOG_FILE_BACKUP_COUNT", _DEFAULT_LOG_FILE_BACKUP_COUNT)
+        # delay=False forces the file to be opened during setup so a bad
+        # path/permission surfaces immediately as an OSError that we can log
+        # and recover from, rather than failing later at the first log emit.
+        handler = logging.handlers.RotatingFileHandler(
+            filename=str(target),
+            maxBytes=max_bytes,
+            backupCount=backup_count,
+            encoding="utf-8",
+            delay=False,
+        )
+    except OSError as e:
+        # Don't crash the pod just because the operator typo'd LOG_FILE_PATH.
+        # logging isn't fully wired for our own diagnostics yet, so write the
+        # warning straight to stderr — kubectl logs will still surface it.
+        print(
+            f"WARNING: LOG_FILE_PATH={path!r} could not be opened ({e}); continuing with stdout-only logging",
+            file=sys.stderr,
+        )
+        return
+    handler.setFormatter(formatter)
+    handler.addFilter(RequestIDFilter())
+    logging.getLogger(_LOGGER_NAME).addHandler(handler)
+
+
+def _get_int_env(name: str, default: int) -> int:
+    raw = os.getenv(name, "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        print(
+            f"WARNING: {name}={raw!r} is not an integer; falling back to default {default}",
+            file=sys.stderr,
+        )
+        return default
+    if value <= 0:
+        print(
+            f"WARNING: {name}={value} must be positive; falling back to default {default}",
+            file=sys.stderr,
+        )
+        return default
+    return value
 
 
 def _attach_extra_handlers(spec: str) -> None:

--- a/api/tests/test_logging_config.py
+++ b/api/tests/test_logging_config.py
@@ -1,4 +1,4 @@
-"""Tests for the pluggable logging config (LOG_HANDLERS / LOGGING_CONFIG_FILE / LOG_FILE_PATH / entry-points)."""
+"""Tests for the stdout (+ optional file mirror) logging config."""
 
 from __future__ import annotations
 
@@ -6,8 +6,6 @@ import logging
 import logging.handlers
 import sys
 from pathlib import Path
-from typing import ClassVar
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -38,32 +36,32 @@ def restore_root_logger():
 
 
 # ---------------------------------------------------------------------------
-# Default mode (no env vars set)
+# Default stdout-only mode
 # ---------------------------------------------------------------------------
 
 
 def test_setup_logging_default_text(monkeypatch):
-    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
-    monkeypatch.delenv("LOG_HANDLERS", raising=False)
+    monkeypatch.delenv("LOG_FILE_PATH", raising=False)
     logging_config.setup_logging("INFO", "text")
     root = logging.getLogger(ROOT_LOGGER_NAME)
     assert root.level == logging.INFO
     assert len(root.handlers) == 1
-    assert isinstance(root.handlers[0], logging.StreamHandler)
+    stream_handlers = [h for h in root.handlers if isinstance(h, logging.StreamHandler)]
+    assert len(stream_handlers) == 1
+    assert stream_handlers[0].stream is sys.stdout
 
 
 def test_setup_logging_default_json(monkeypatch):
-    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
-    monkeypatch.delenv("LOG_HANDLERS", raising=False)
+    monkeypatch.delenv("LOG_FILE_PATH", raising=False)
     logging_config.setup_logging("DEBUG", "json")
     root = logging.getLogger(ROOT_LOGGER_NAME)
     assert root.level == logging.DEBUG
+    assert len(root.handlers) == 1
 
 
 def test_setup_logging_clears_existing_handlers(monkeypatch):
     """Repeated calls must replace handlers, not accumulate them."""
-    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
-    monkeypatch.delenv("LOG_HANDLERS", raising=False)
+    monkeypatch.delenv("LOG_FILE_PATH", raising=False)
     logging_config.setup_logging("INFO", "text")
     logging_config.setup_logging("INFO", "text")
     root = logging.getLogger(ROOT_LOGGER_NAME)
@@ -71,140 +69,11 @@ def test_setup_logging_clears_existing_handlers(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# LOG_HANDLERS module:Class spec
-# ---------------------------------------------------------------------------
-
-
-class _FakeHandler(logging.Handler):
-    """A minimal Handler with a no-arg constructor used by LOG_HANDLERS tests."""
-
-    instances: ClassVar[list[_FakeHandler]] = []  # type: ignore[name-defined]
-
-    def __init__(self) -> None:
-        super().__init__()
-        type(self).instances.append(self)
-
-    def emit(self, record: logging.LogRecord) -> None:  # pragma: no cover - not exercised
-        pass
-
-
-def _install_fake_handler_module(monkeypatch):
-    """Make `_fake_handler_pkg:_FakeHandler` resolvable as a module path."""
-    mod = type(sys)("_fake_handler_pkg")
-    mod._FakeHandler = _FakeHandler  # type: ignore[attr-defined]
-    monkeypatch.setitem(sys.modules, "_fake_handler_pkg", mod)
-
-
-def test_log_handlers_module_class_spec(monkeypatch):
-    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
-    monkeypatch.setenv("LOG_HANDLERS", "_fake_handler_pkg:_FakeHandler")
-    _install_fake_handler_module(monkeypatch)
-    _FakeHandler.instances.clear()
-    logging_config.setup_logging("INFO", "text")
-    assert len(_FakeHandler.instances) == 1
-    root = logging.getLogger(ROOT_LOGGER_NAME)
-    assert _FakeHandler.instances[0] in root.handlers
-
-
-def test_log_handlers_invalid_spec_does_not_abort_startup(monkeypatch):
-    """A bad spec must logger.error + skip; the good handler in the same list must still load."""
-    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
-    monkeypatch.setenv("LOG_HANDLERS", "no_such_module:NotAClass,_fake_handler_pkg:_FakeHandler")
-    _install_fake_handler_module(monkeypatch)
-    _FakeHandler.instances.clear()
-
-    # setup_logging sets propagate=False on the application root logger so
-    # caplog (which attaches to stdlib root) cannot see records emitted from
-    # `aerospike_cluster_manager_api.logging_config`. Attach our own
-    # capture handler directly to that logger instead.
-    captured: list[logging.LogRecord] = []
-
-    class _CaptureHandler(logging.Handler):
-        def emit(self, record: logging.LogRecord) -> None:
-            captured.append(record)
-
-    capture = _CaptureHandler(level=logging.ERROR)
-    plugin_logger = logging.getLogger("aerospike_cluster_manager_api.logging_config")
-    plugin_logger.addHandler(capture)
-    try:
-        logging_config.setup_logging("INFO", "text")
-    finally:
-        plugin_logger.removeHandler(capture)
-
-    # The good handler still attached
-    assert len(_FakeHandler.instances) == 1
-    # The bad spec produced an error log
-    assert any("failed to attach log handler" in r.getMessage() for r in captured)
-
-
-def test_log_handlers_empty_string(monkeypatch):
-    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
-    monkeypatch.setenv("LOG_HANDLERS", "  ")
-    logging_config.setup_logging("INFO", "text")
-    root = logging.getLogger(ROOT_LOGGER_NAME)
-    # Only the default stdout handler
-    assert len(root.handlers) == 1
-
-
-def test_resolve_handler_invalid_module_class_format():
-    with pytest.raises(ValueError, match="invalid 'module:Class' spec"):
-        logging_config._resolve_handler(":NoModule", {})
-
-
-# ---------------------------------------------------------------------------
-# Entry-point name spec
-# ---------------------------------------------------------------------------
-
-
-def test_log_handlers_entry_point_name(monkeypatch):
-    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
-    monkeypatch.setenv("LOG_HANDLERS", "myhandler")
-    _FakeHandler.instances.clear()
-
-    fake_ep = MagicMock()
-    fake_ep.name = "myhandler"
-    fake_ep.load.return_value = _FakeHandler
-
-    monkeypatch.setattr(
-        logging_config,
-        "entry_points",
-        lambda group: [fake_ep] if group == logging_config.ENTRY_POINT_GROUP else [],
-    )
-
-    logging_config.setup_logging("INFO", "text")
-    assert len(_FakeHandler.instances) == 1
-
-
-def test_log_handlers_unknown_name_logs_error(monkeypatch):
-    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
-    monkeypatch.setenv("LOG_HANDLERS", "ghost")
-    monkeypatch.setattr(logging_config, "entry_points", lambda group: [])
-
-    captured: list[logging.LogRecord] = []
-
-    class _CaptureHandler(logging.Handler):
-        def emit(self, record: logging.LogRecord) -> None:
-            captured.append(record)
-
-    cap = _CaptureHandler(level=logging.ERROR)
-    plugin_logger = logging.getLogger("aerospike_cluster_manager_api.logging_config")
-    plugin_logger.addHandler(cap)
-    try:
-        logging_config.setup_logging("INFO", "text")
-    finally:
-        plugin_logger.removeHandler(cap)
-
-    assert any("ghost" in r.getMessage() for r in captured)
-
-
-# ---------------------------------------------------------------------------
-# LOG_FILE_PATH (rotating file mirror for sidecar tailing)
+# LOG_FILE_PATH (rotating file mirror for pod-internal sidecar)
 # ---------------------------------------------------------------------------
 
 
 def test_log_file_path_attaches_rotating_file_handler(tmp_path: Path, monkeypatch):
-    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
-    monkeypatch.delenv("LOG_HANDLERS", raising=False)
     log_file = tmp_path / "logs" / "acm-api.log"
     monkeypatch.setenv("LOG_FILE_PATH", str(log_file))
 
@@ -224,8 +93,6 @@ def test_log_file_path_attaches_rotating_file_handler(tmp_path: Path, monkeypatc
 
 
 def test_log_file_path_respects_rotation_overrides(tmp_path: Path, monkeypatch):
-    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
-    monkeypatch.delenv("LOG_HANDLERS", raising=False)
     log_file = tmp_path / "acm.log"
     monkeypatch.setenv("LOG_FILE_PATH", str(log_file))
     monkeypatch.setenv("LOG_FILE_MAX_BYTES", "12345")
@@ -241,8 +108,6 @@ def test_log_file_path_respects_rotation_overrides(tmp_path: Path, monkeypatch):
 
 def test_log_file_path_invalid_rotation_falls_back_to_default(tmp_path: Path, monkeypatch):
     """Bad LOG_FILE_MAX_BYTES must not crash startup — fall back to default."""
-    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
-    monkeypatch.delenv("LOG_HANDLERS", raising=False)
     log_file = tmp_path / "acm.log"
     monkeypatch.setenv("LOG_FILE_PATH", str(log_file))
     monkeypatch.setenv("LOG_FILE_MAX_BYTES", "not-an-int")
@@ -257,8 +122,6 @@ def test_log_file_path_invalid_rotation_falls_back_to_default(tmp_path: Path, mo
 
 
 def test_log_file_path_unwritable_directory_does_not_abort(tmp_path: Path, monkeypatch, capsys):
-    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
-    monkeypatch.delenv("LOG_HANDLERS", raising=False)
     # Use a path under tmp_path with a parent component that is an existing
     # *file* — Path.mkdir raises NotADirectoryError, which is an OSError.
     blocker = tmp_path / "blocker"
@@ -279,8 +142,6 @@ def test_log_file_path_unwritable_directory_does_not_abort(tmp_path: Path, monke
 
 
 def test_log_file_path_empty_is_noop(monkeypatch):
-    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
-    monkeypatch.delenv("LOG_HANDLERS", raising=False)
     monkeypatch.setenv("LOG_FILE_PATH", "  ")
 
     logging_config.setup_logging("INFO", "text")
@@ -292,8 +153,6 @@ def test_log_file_path_empty_is_noop(monkeypatch):
 
 def test_log_file_path_double_call_does_not_accumulate_handlers(tmp_path: Path, monkeypatch):
     """uvicorn --reload / repeated setup_logging() must not leak file descriptors."""
-    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
-    monkeypatch.delenv("LOG_HANDLERS", raising=False)
     log_file = tmp_path / "acm.log"
     monkeypatch.setenv("LOG_FILE_PATH", str(log_file))
 
@@ -311,82 +170,3 @@ def test_log_file_path_double_call_does_not_accumulate_handlers(tmp_path: Path, 
         assert prior not in root.handlers
         if isinstance(prior, logging.handlers.RotatingFileHandler):
             assert prior.stream is None
-
-
-def test_log_file_path_ignored_when_logging_config_file_set(tmp_path: Path, monkeypatch):
-    """LOGGING_CONFIG_FILE takes full ownership; LOG_FILE_PATH must not double-attach."""
-    cfg_path = tmp_path / "logging.yaml"
-    cfg_path.write_text(
-        """
-version: 1
-disable_existing_loggers: false
-handlers:
-  console:
-    class: logging.StreamHandler
-loggers:
-  aerospike_cluster_manager_api:
-    level: INFO
-    handlers: [console]
-    propagate: false
-""".strip()
-    )
-    monkeypatch.setenv("LOGGING_CONFIG_FILE", str(cfg_path))
-    monkeypatch.setenv("LOG_FILE_PATH", str(tmp_path / "should-not-exist.log"))
-
-    logging_config.setup_logging("INFO", "text")
-
-    root = logging.getLogger(ROOT_LOGGER_NAME)
-    file_handlers = [h for h in root.handlers if isinstance(h, logging.handlers.RotatingFileHandler)]
-    assert file_handlers == []
-    assert not (tmp_path / "should-not-exist.log").exists()
-
-
-# ---------------------------------------------------------------------------
-# LOGGING_CONFIG_FILE
-# ---------------------------------------------------------------------------
-
-
-def test_logging_config_file_takes_precedence(tmp_path: Path, monkeypatch):
-    cfg_path = tmp_path / "logging.yaml"
-    cfg_path.write_text(
-        """
-version: 1
-disable_existing_loggers: false
-handlers:
-  console:
-    class: logging.StreamHandler
-    level: WARNING
-loggers:
-  aerospike_cluster_manager_api:
-    level: WARNING
-    handlers: [console]
-    propagate: false
-""".strip()
-    )
-
-    monkeypatch.setenv("LOGGING_CONFIG_FILE", str(cfg_path))
-    # LOG_HANDLERS must be ignored when a config file is set
-    monkeypatch.setenv("LOG_HANDLERS", "_fake_handler_pkg:_FakeHandler")
-    _install_fake_handler_module(monkeypatch)
-    _FakeHandler.instances.clear()
-
-    logging_config.setup_logging("INFO", "text")
-
-    root = logging.getLogger(ROOT_LOGGER_NAME)
-    assert root.level == logging.WARNING
-    # The fake handler from LOG_HANDLERS must NOT have been attached
-    assert _FakeHandler.instances == []
-
-
-def test_logging_config_file_missing_raises(monkeypatch):
-    monkeypatch.setenv("LOGGING_CONFIG_FILE", "/nonexistent/path/logging.yaml")
-    with pytest.raises(FileNotFoundError):
-        logging_config.setup_logging("INFO", "text")
-
-
-def test_logging_config_file_non_dict_raises(tmp_path: Path, monkeypatch):
-    bad = tmp_path / "logging.yaml"
-    bad.write_text("- this is a list, not a mapping\n")
-    monkeypatch.setenv("LOGGING_CONFIG_FILE", str(bad))
-    with pytest.raises(ValueError, match="dictConfig mapping"):
-        logging_config.setup_logging("INFO", "text")

--- a/api/tests/test_logging_config.py
+++ b/api/tests/test_logging_config.py
@@ -24,7 +24,12 @@ def restore_root_logger():
     saved_handlers = list(root.handlers)
     saved_propagate = root.propagate
     yield
+    # close() before removeHandler() so RotatingFileHandler instances release
+    # their file descriptors immediately — otherwise the leaked fd races
+    # tmp_path cleanup (PermissionError on Windows; silent inode pin on Linux).
     for h in list(root.handlers):
+        if h not in saved_handlers:
+            h.close()
         root.removeHandler(h)
     for h in saved_handlers:
         root.addHandler(h)
@@ -283,6 +288,29 @@ def test_log_file_path_empty_is_noop(monkeypatch):
     root = logging.getLogger(ROOT_LOGGER_NAME)
     file_handlers = [h for h in root.handlers if isinstance(h, logging.handlers.RotatingFileHandler)]
     assert file_handlers == []
+
+
+def test_log_file_path_double_call_does_not_accumulate_handlers(tmp_path: Path, monkeypatch):
+    """uvicorn --reload / repeated setup_logging() must not leak file descriptors."""
+    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
+    monkeypatch.delenv("LOG_HANDLERS", raising=False)
+    log_file = tmp_path / "acm.log"
+    monkeypatch.setenv("LOG_FILE_PATH", str(log_file))
+
+    logging_config.setup_logging("INFO", "text")
+    first_pass_handlers = list(logging.getLogger(ROOT_LOGGER_NAME).handlers)
+    logging_config.setup_logging("INFO", "text")
+
+    root = logging.getLogger(ROOT_LOGGER_NAME)
+    file_handlers = [h for h in root.handlers if isinstance(h, logging.handlers.RotatingFileHandler)]
+    # Exactly one RotatingFileHandler — the one from the second call.
+    assert len(file_handlers) == 1
+    # And the prior handler is closed (no leaked fd). RotatingFileHandler.close
+    # sets ``self.stream`` to None.
+    for prior in first_pass_handlers:
+        assert prior not in root.handlers
+        if isinstance(prior, logging.handlers.RotatingFileHandler):
+            assert prior.stream is None
 
 
 def test_log_file_path_ignored_when_logging_config_file_set(tmp_path: Path, monkeypatch):

--- a/api/tests/test_logging_config.py
+++ b/api/tests/test_logging_config.py
@@ -1,8 +1,9 @@
-"""Tests for the pluggable logging config (LOG_HANDLERS / LOGGING_CONFIG_FILE / entry-points)."""
+"""Tests for the pluggable logging config (LOG_HANDLERS / LOGGING_CONFIG_FILE / LOG_FILE_PATH / entry-points)."""
 
 from __future__ import annotations
 
 import logging
+import logging.handlers
 import sys
 from pathlib import Path
 from typing import ClassVar
@@ -189,6 +190,127 @@ def test_log_handlers_unknown_name_logs_error(monkeypatch):
         plugin_logger.removeHandler(cap)
 
     assert any("ghost" in r.getMessage() for r in captured)
+
+
+# ---------------------------------------------------------------------------
+# LOG_FILE_PATH (rotating file mirror for sidecar tailing)
+# ---------------------------------------------------------------------------
+
+
+def test_log_file_path_attaches_rotating_file_handler(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
+    monkeypatch.delenv("LOG_HANDLERS", raising=False)
+    log_file = tmp_path / "logs" / "acm-api.log"
+    monkeypatch.setenv("LOG_FILE_PATH", str(log_file))
+
+    logging_config.setup_logging("INFO", "text")
+
+    root = logging.getLogger(ROOT_LOGGER_NAME)
+    file_handlers = [h for h in root.handlers if isinstance(h, logging.handlers.RotatingFileHandler)]
+    assert len(file_handlers) == 1
+    fh = file_handlers[0]
+    # parent dir was created on demand
+    assert log_file.parent.exists()
+    # records actually land in the file
+    logging.getLogger(ROOT_LOGGER_NAME).info("hello-file-mirror")
+    fh.flush()
+    fh.close()
+    assert "hello-file-mirror" in log_file.read_text(encoding="utf-8")
+
+
+def test_log_file_path_respects_rotation_overrides(tmp_path: Path, monkeypatch):
+    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
+    monkeypatch.delenv("LOG_HANDLERS", raising=False)
+    log_file = tmp_path / "acm.log"
+    monkeypatch.setenv("LOG_FILE_PATH", str(log_file))
+    monkeypatch.setenv("LOG_FILE_MAX_BYTES", "12345")
+    monkeypatch.setenv("LOG_FILE_BACKUP_COUNT", "7")
+
+    logging_config.setup_logging("INFO", "text")
+
+    root = logging.getLogger(ROOT_LOGGER_NAME)
+    fh = next(h for h in root.handlers if isinstance(h, logging.handlers.RotatingFileHandler))
+    assert fh.maxBytes == 12345
+    assert fh.backupCount == 7
+
+
+def test_log_file_path_invalid_rotation_falls_back_to_default(tmp_path: Path, monkeypatch):
+    """Bad LOG_FILE_MAX_BYTES must not crash startup — fall back to default."""
+    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
+    monkeypatch.delenv("LOG_HANDLERS", raising=False)
+    log_file = tmp_path / "acm.log"
+    monkeypatch.setenv("LOG_FILE_PATH", str(log_file))
+    monkeypatch.setenv("LOG_FILE_MAX_BYTES", "not-an-int")
+    monkeypatch.setenv("LOG_FILE_BACKUP_COUNT", "-3")
+
+    logging_config.setup_logging("INFO", "text")
+
+    root = logging.getLogger(ROOT_LOGGER_NAME)
+    fh = next(h for h in root.handlers if isinstance(h, logging.handlers.RotatingFileHandler))
+    assert fh.maxBytes == logging_config._DEFAULT_LOG_FILE_MAX_BYTES
+    assert fh.backupCount == logging_config._DEFAULT_LOG_FILE_BACKUP_COUNT
+
+
+def test_log_file_path_unwritable_directory_does_not_abort(tmp_path: Path, monkeypatch, capsys):
+    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
+    monkeypatch.delenv("LOG_HANDLERS", raising=False)
+    # Use a path under tmp_path with a parent component that is an existing
+    # *file* — Path.mkdir raises NotADirectoryError, which is an OSError.
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory")
+    bad_path = blocker / "acm.log"
+    monkeypatch.setenv("LOG_FILE_PATH", str(bad_path))
+
+    logging_config.setup_logging("INFO", "text")
+
+    root = logging.getLogger(ROOT_LOGGER_NAME)
+    file_handlers = [h for h in root.handlers if isinstance(h, logging.handlers.RotatingFileHandler)]
+    # stdout-only fallback, no file handler attached
+    assert file_handlers == []
+    # And a stderr warning explaining why
+    err = capsys.readouterr().err
+    assert "LOG_FILE_PATH" in err
+    assert "stdout-only" in err
+
+
+def test_log_file_path_empty_is_noop(monkeypatch):
+    monkeypatch.delenv("LOGGING_CONFIG_FILE", raising=False)
+    monkeypatch.delenv("LOG_HANDLERS", raising=False)
+    monkeypatch.setenv("LOG_FILE_PATH", "  ")
+
+    logging_config.setup_logging("INFO", "text")
+
+    root = logging.getLogger(ROOT_LOGGER_NAME)
+    file_handlers = [h for h in root.handlers if isinstance(h, logging.handlers.RotatingFileHandler)]
+    assert file_handlers == []
+
+
+def test_log_file_path_ignored_when_logging_config_file_set(tmp_path: Path, monkeypatch):
+    """LOGGING_CONFIG_FILE takes full ownership; LOG_FILE_PATH must not double-attach."""
+    cfg_path = tmp_path / "logging.yaml"
+    cfg_path.write_text(
+        """
+version: 1
+disable_existing_loggers: false
+handlers:
+  console:
+    class: logging.StreamHandler
+loggers:
+  aerospike_cluster_manager_api:
+    level: INFO
+    handlers: [console]
+    propagate: false
+""".strip()
+    )
+    monkeypatch.setenv("LOGGING_CONFIG_FILE", str(cfg_path))
+    monkeypatch.setenv("LOG_FILE_PATH", str(tmp_path / "should-not-exist.log"))
+
+    logging_config.setup_logging("INFO", "text")
+
+    root = logging.getLogger(ROOT_LOGGER_NAME)
+    file_handlers = [h for h in root.handlers if isinstance(h, logging.handlers.RotatingFileHandler)]
+    assert file_handlers == []
+    assert not (tmp_path / "should-not-exist.log").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -4,217 +4,145 @@ The API server uses Python's standard ``logging`` module. The default
 configuration emits a single stdout handler with either text or JSON
 output (selected by ``LOG_FORMAT``).
 
-When that is not enough, two extension points are provided so you can
-forward logs to NELO, Datadog, Loki, Sentry, or any other system without
-forking the image.
+External log routing — PII redaction, sampling, field enrichment,
+vendor-specific exporters (NELO, Datadog, Loki, Elasticsearch, ...) —
+is delegated to an **OpenTelemetry Collector** that receives this
+process's logs. The ACM image deliberately does not embed in-process
+SDK handlers anymore: any pipeline you would have implemented inside
+Python (`attributes/redact`, per-record sampling, fixed-field injection,
+tenant-aware fan-out) is already covered by OTel Collector
+processors/exporters, and centralizing it there avoids per-vendor
+Python wrappers and lets operators swap backends from helm values
+alone.
+
+## Architecture
+
+```
++----------------+         +------------------+         +-----------------+
+| ACM api        | stdout  | pod-internal     |  OTLP   | OTel Collector  |
+| (stdout +      | + file  | sidecar          | -----> | (cluster /      |
+| LOG_FILE_PATH) | ------> | (fluent-bit /    |         | namespace,      |
+|                |         | vector / ...)    |         | NOT inside this |
++----------------+         +------------------+         | helm chart)     |
+                                                        +-----------------+
+                                                                 |
+                                                +----------------+----------------+
+                                                v                                 v
+                                         Loki / Elastic /                 NELO / Datadog /
+                                         Tempo / Sentry                   sentry-otel-bridge
+```
+
+The OTel Collector itself is **not** deployed by the ACKO helm chart —
+the assumption is that the cluster already has one (a DaemonSet for
+node-level, a Deployment for namespace-level, or one per-namespace
+when isolation matters). The chart only opt-in deploys the **sidecar
+that forwards to it**.
 
 ## Modes
 
-There are three configuration modes, selected by environment variables:
+Two modes:
 
-1. **Default** — neither ``LOGGING_CONFIG_FILE`` nor ``LOG_HANDLERS`` is
-   set. A single stdout handler (text or JSON) with the existing
-   ``RequestIDFilter`` and OpenTelemetry trace/span ID injection.
+1. **Default — stdout only**
+   A single ``StreamHandler(sys.stdout)`` with the existing
+   ``RequestIDFilter`` and OpenTelemetry trace/span ID injection. Pick
+   this when a node-level OTel Collector DaemonSet scrapes container
+   logs (e.g. via the Collector's ``filelog`` receiver against
+   ``/var/log/containers/*.log``).
 
-2. **LOG_HANDLERS** — comma-separated list of handler specs.  Each spec
-   is either a ``module.path:ClassName`` (importlib import) or an
-   entry-point name registered under the
-   ``aerospike_cluster_manager.log_handlers`` group. Each handler is
-   constructed with **no arguments** and is expected to read its own
-   configuration from environment variables. The default stdout handler
-   stays attached; ``LOG_HANDLERS`` adds to it.
+2. **Stdout + rotating file mirror — ``LOG_FILE_PATH``**
+   Attach a ``RotatingFileHandler`` so a pod-internal sidecar sharing
+   an ``emptyDir`` volume can tail the file and forward records via
+   OTLP. Rotation is size-based: ``LOG_FILE_MAX_BYTES`` (default 50
+   MiB) and ``LOG_FILE_BACKUP_COUNT`` (default 3). Failure to open the
+   file (parent dir unwritable, etc.) is reported to stderr and the
+   application falls back to stdout-only logging instead of failing
+   startup.
 
-3. **LOGGING_CONFIG_FILE** — path to a YAML/JSON dictConfig file.
-   The file is loaded as-is via ``logging.config.dictConfig`` and given
-   full control over every formatter, handler, filter, and logger.
-   ``LOG_HANDLERS``, ``LOG_LEVEL``, ``LOG_FORMAT``, and ``LOG_FILE_PATH``
-   are ignored in this mode.
+When ``LOG_FORMAT=json``, both stdout and the rotating file emit JSON
+records with the same schema. OTel Collector's ``filelog`` receiver
+parses them via the ``json_parser`` operator.
 
-Across modes 1 and 2, setting ``LOG_FILE_PATH`` additionally attaches a
-``RotatingFileHandler`` that mirrors records to a file. This is the
-recommended pairing with a logging sidecar (fluent-bit, vector, promtail)
-that tails a shared ``emptyDir`` volume — see Example C below.
+## Example — fluent-bit OTLP forwarder sidecar (helm)
 
-## Example A — NELO via LOG_HANDLERS
-
-[``pynelo``](https://github.com/naver/pynelo) is a logging.Handler that
-configures itself from ``NELO_HOST`` / ``NELO_PORT`` /
-``NELO_PROJECT_NAME`` / ``NELO_PROJECT_TOKEN`` environment variables, so
-no Python wrapping is needed.
-
-helm values:
+The ACKO chart's default values for the logging sidecar do exactly this
+pattern. The relevant knobs:
 
 ```yaml
 ui:
-  api:
-    extraPipPackages:
-      - "pynelo>=1.0.0"
-    logging:
-      handlers: "pynelo:AsyncNeloHandler"
-    extraEnv:
-      - name: NELO_HOST
-        value: nelo-collector.svc.cluster.local
-      - name: NELO_PORT
-        value: "10006"
-      - name: NELO_PROJECT_NAME
-        value: ad-ai-aerospike
-    extraEnvFrom:
-      - secretRef:
-          name: nelo-token
-```
-
-Verify by looking for the attach line in pod logs:
-
-```
-kubectl logs -n <ns> deploy/<release>-aerospike-ce-kubernetes-operator-ui-api -c api \
-  | grep "attached log handler"
-# attached log handler: pynelo:AsyncNeloHandler
-```
-
-## Example B — Datadog via dictConfig
-
-Building a custom image once is more reliable than ``extraPipPackages``
-when you need to install non-Python build dependencies or run in an
-airgap cluster.
-
-``Dockerfile``:
-
-```dockerfile
-FROM ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-api:latest
-RUN pip install ddtrace
-```
-
-helm values:
-
-```yaml
-ui:
-  api:
-    image:
-      repository: my-registry.example.com/asm-api-with-datadog
-      tag: latest
-    logging:
-      dictConfig:
-        version: 1
-        disable_existing_loggers: false
-        formatters:
-          json:
-            "()": pythonjsonlogger.json.JsonFormatter
-            fmt: "%(asctime)s %(levelname)s %(name)s %(message)s %(otelTraceID)s %(otelSpanID)s"
-        handlers:
-          console:
-            class: logging.StreamHandler
-            formatter: json
-        loggers:
-          aerospike_cluster_manager_api:
-            level: INFO
-            handlers: [console]
-            propagate: false
-```
-
-The chart writes the dictConfig payload into a ConfigMap, mounts it at
-``/etc/asm/logging.yaml``, and sets ``LOGGING_CONFIG_FILE`` to that
-path.  Pod restart applies the new config.
-
-## Example C — Sidecar log shipper via ``LOG_FILE_PATH``
-
-When the operator wants to forward logs through a generic agent
-(fluent-bit, vector, promtail) instead of an in-process SDK, the sidecar
-needs a stable file to tail. The ACM API writes records to
-``LOG_FILE_PATH`` in addition to stdout — the sidecar mounts the same
-``emptyDir`` volume and runs ``tail -F`` (or its equivalent).
-
-helm values:
-
-```yaml
-ui:
+  env:
+    logFormat: "json"           # recommended for downstream parsing
   api:
     logging:
-      # Both knobs are wired up by the ACKO helm chart — see ACKO's
-      # values.yaml for the chart-side defaults. Setting fileMirror
-      # also auto-mounts the shared emptyDir at /var/log/acm.
       fileMirror:
-        enabled: true
-        path: /var/log/acm/api.log
-        maxBytes: 52428800   # 50 MiB
-        backupCount: 3
+        enabled: true           # writes /var/log/acm/api.log on a shared emptyDir
       sidecar:
-        enabled: true
-        image: cr.fluentbit.io/fluent/fluent-bit:3.2
-        # configFile is rendered into a ConfigMap and mounted at
-        # /fluent-bit/etc/fluent-bit.conf inside the sidecar.
-        configFile: |
-          [SERVICE]
-              Flush 1
-          [INPUT]
-              Name tail
-              Path /var/log/acm/*.log
-              Refresh_Interval 5
-          [OUTPUT]
-              Name stdout
-              Match *
+        enabled: true           # fluent-bit container, mounts the same emptyDir read-only
+        otlp:
+          endpoint: "otel-collector.observability.svc.cluster.local:4317"
+          # headers: "x-tenant=acm,authorization=Bearer ..."
 ```
 
-Equivalent raw env (bare ACM image, no helm):
+The chart pre-bakes a fluent-bit config that:
 
-```bash
-LOG_FILE_PATH=/var/log/acm/api.log
-LOG_FILE_MAX_BYTES=52428800
-LOG_FILE_BACKUP_COUNT=3
-LOG_FORMAT=json   # recommended so the sidecar can parse fields directly
-```
+- tails ``LOG_FILE_PATH`` with the ``tail`` input + ``json_parser``
+- forwards records to ``otlp.endpoint`` via the ``opentelemetry`` output
+- propagates ``otlp.headers`` as OTLP HTTP/gRPC metadata
 
-Why a file and not ``kubectl logs``? Container-runtime log paths
-(``/var/log/containers/...``) differ across Docker, containerd, and
-CRI-O, and the sidecar would need elevated privileges to read them.
-A shared ``emptyDir`` works the same way on every runtime and stays
-inside the pod's security boundary.
+Operators who need a different shipper (vector, promtail, vendor agent)
+can override ``sidecar.image`` and ``sidecar.config.content`` — the
+schema is documented in the ACKO chart's ``values.yaml``.
 
-If ``LOG_FILE_PATH`` is unwritable (parent directory missing
-permissions, etc.) the API logs a single warning to stderr and falls
-back to stdout-only — the pod still starts so the operator can
-investigate via ``kubectl logs``.
+## Migrating from pre-0.X.0 ``LOG_HANDLERS`` / ``LOGGING_CONFIG_FILE``
 
-## Registering an entry-point alias (third-party packages)
+Earlier ACM releases shipped two in-process extension hooks:
 
-A package that wants to be addressable by a short name in
-``LOG_HANDLERS`` can declare:
+- ``LOG_HANDLERS=module:Class`` (or entry-point name registered under
+  ``aerospike_cluster_manager.log_handlers``) — attached additional
+  ``logging.Handler`` instances such as ``pynelo.AsyncNeloHandler``.
+- ``LOGGING_CONFIG_FILE`` — path to a YAML/JSON ``dictConfig`` file
+  given full ownership of the logging pipeline.
 
-```toml
-# pyproject.toml of the third-party package
-[project.entry-points."aerospike_cluster_manager.log_handlers"]
-nelo = "pynelo:AsyncNeloHandler"
-```
+Both hooks were removed in this release. Each prior use case maps to an
+OTel Collector primitive:
 
-Then ``LOG_HANDLERS=nelo`` works identically to
-``LOG_HANDLERS=pynelo:AsyncNeloHandler``.
+| Old pattern | OTel Collector equivalent |
+|---|---|
+| Vendor SDK handler (NELO, Datadog, ...) | Run the vendor exporter (or an OTLP→vendor bridge) on the cluster's Collector. ACM stays vendor-neutral. |
+| Per-record PII redaction inside the handler | Pipeline with the `attributes` / `redaction` / `transform` processor. |
+| Sampling inside the handler (`error 100% / info 1%`) | `probabilistic_sampler` or `tail_sampling` processor. |
+| Fixed extra fields (`service`, `env`, `tenant`) | `resource` / `attributes` processor; or set OTel SDK resource attributes via env. |
+| Multi-sink fan-out (stdout + vendor) | Multiple exporters on the same Collector pipeline. |
+| Full ``dictConfig`` for routing/level overrides | Collector ``service.pipelines.logs`` configuration. |
+
+If a use case truly cannot be expressed in the Collector (extremely
+high-cardinality per-record context that has to be derived inside the
+application process), file an issue with the specific transform you
+need — we will reconsider, but the bar for re-introducing in-process
+hooks is high because each one becomes a per-vendor Python dependency
+that complicates the airgap and dependency-pin story.
 
 ## OpenTelemetry trace correlation
 
 When OpenTelemetry is enabled (see ``observability.md``), the
 ``opentelemetry-instrumentation-logging`` library injects
 ``otelTraceID`` and ``otelSpanID`` attributes onto every ``LogRecord``.
-The default JSON formatter renames these to ``trace_id`` /``span_id`` in
-the output, and any third-party handler that serializes
-``LogRecord.__dict__`` (like ``pynelo``) will forward them automatically.
-No additional configuration required.
+The default JSON formatter renames these to ``trace_id`` / ``span_id``
+in the output. Downstream Collector pipelines forward them as OTel log
+attributes so logs are linkable to spans in the same backend without
+any extra configuration.
 
 ## Constraints to be aware of
 
-- Each plugin handler is constructed with **no arguments** (``cls()``).
-  Wrap your handler in a no-arg adaptor if its constructor needs
-  positional arguments.
-- A failure to load one handler is logged at ``ERROR`` level on
-  ``aerospike_cluster_manager_api.logging_config`` and skipped.  Other
-  handlers in the list keep loading.  Missing module / missing
-  entry-point / constructor exception all behave the same way.
-- ``LOGGING_CONFIG_FILE`` failure (file missing, top-level not a
-  mapping) raises and aborts startup. Falling back to defaults silently
-  would make the misconfiguration impossible to debug.
-- ``extraPipPackages`` in the helm chart runs ``pip install --target``
-  in an init container. This requires PyPI egress from the cluster.
-  In airgap environments, build a custom image instead (see Example B).
 - ``LOG_FILE_PATH`` rotation uses Python's stdlib
-  ``RotatingFileHandler`` — size-based, not time-based. Default 50 MiB
-  per file, 3 backups. Tune via ``LOG_FILE_MAX_BYTES`` /
-  ``LOG_FILE_BACKUP_COUNT`` or supply a full ``LOGGING_CONFIG_FILE`` if
-  you need a different rotation policy (e.g. ``TimedRotatingFileHandler``).
+  ``RotatingFileHandler`` — size-based, not time-based. Tune via
+  ``LOG_FILE_MAX_BYTES`` / ``LOG_FILE_BACKUP_COUNT``. For
+  time-based rotation, point the sidecar at the Collector and let
+  the Collector's batch/queue settings govern flush cadence instead.
+- The file path must live on a volume the sidecar also mounts. The
+  ACKO chart wires this via a shared ``emptyDir`` automatically when
+  ``ui.api.logging.fileMirror.enabled=true`` and
+  ``ui.api.logging.sidecar.enabled=true``.
+- Sidecar without ``fileMirror`` is rejected at ``helm install`` time
+  — the sidecar would otherwise have nothing to tail. Either enable
+  both, or skip the sidecar and rely on a node-level DaemonSet OTel
+  Collector scraping ``/var/log/containers/*.log``.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -27,8 +27,13 @@ There are three configuration modes, selected by environment variables:
 3. **LOGGING_CONFIG_FILE** — path to a YAML/JSON dictConfig file.
    The file is loaded as-is via ``logging.config.dictConfig`` and given
    full control over every formatter, handler, filter, and logger.
-   ``LOG_HANDLERS`` and ``LOG_LEVEL`` / ``LOG_FORMAT`` are ignored in
-   this mode.
+   ``LOG_HANDLERS``, ``LOG_LEVEL``, ``LOG_FORMAT``, and ``LOG_FILE_PATH``
+   are ignored in this mode.
+
+Across modes 1 and 2, setting ``LOG_FILE_PATH`` additionally attaches a
+``RotatingFileHandler`` that mirrors records to a file. This is the
+recommended pairing with a logging sidecar (fluent-bit, vector, promtail)
+that tails a shared ``emptyDir`` volume — see Example C below.
 
 ## Example A — NELO via LOG_HANDLERS
 
@@ -110,6 +115,65 @@ The chart writes the dictConfig payload into a ConfigMap, mounts it at
 ``/etc/asm/logging.yaml``, and sets ``LOGGING_CONFIG_FILE`` to that
 path.  Pod restart applies the new config.
 
+## Example C — Sidecar log shipper via ``LOG_FILE_PATH``
+
+When the operator wants to forward logs through a generic agent
+(fluent-bit, vector, promtail) instead of an in-process SDK, the sidecar
+needs a stable file to tail. The ACM API writes records to
+``LOG_FILE_PATH`` in addition to stdout — the sidecar mounts the same
+``emptyDir`` volume and runs ``tail -F`` (or its equivalent).
+
+helm values:
+
+```yaml
+ui:
+  api:
+    logging:
+      # Both knobs are wired up by the ACKO helm chart — see ACKO's
+      # values.yaml for the chart-side defaults. Setting fileMirror
+      # also auto-mounts the shared emptyDir at /var/log/acm.
+      fileMirror:
+        enabled: true
+        path: /var/log/acm/api.log
+        maxBytes: 52428800   # 50 MiB
+        backupCount: 3
+      sidecar:
+        enabled: true
+        image: cr.fluentbit.io/fluent/fluent-bit:3.2
+        # configFile is rendered into a ConfigMap and mounted at
+        # /fluent-bit/etc/fluent-bit.conf inside the sidecar.
+        configFile: |
+          [SERVICE]
+              Flush 1
+          [INPUT]
+              Name tail
+              Path /var/log/acm/*.log
+              Refresh_Interval 5
+          [OUTPUT]
+              Name stdout
+              Match *
+```
+
+Equivalent raw env (bare ACM image, no helm):
+
+```bash
+LOG_FILE_PATH=/var/log/acm/api.log
+LOG_FILE_MAX_BYTES=52428800
+LOG_FILE_BACKUP_COUNT=3
+LOG_FORMAT=json   # recommended so the sidecar can parse fields directly
+```
+
+Why a file and not ``kubectl logs``? Container-runtime log paths
+(``/var/log/containers/...``) differ across Docker, containerd, and
+CRI-O, and the sidecar would need elevated privileges to read them.
+A shared ``emptyDir`` works the same way on every runtime and stays
+inside the pod's security boundary.
+
+If ``LOG_FILE_PATH`` is unwritable (parent directory missing
+permissions, etc.) the API logs a single warning to stderr and falls
+back to stdout-only — the pod still starts so the operator can
+investigate via ``kubectl logs``.
+
 ## Registering an entry-point alias (third-party packages)
 
 A package that wants to be addressable by a short name in
@@ -149,3 +213,8 @@ No additional configuration required.
 - ``extraPipPackages`` in the helm chart runs ``pip install --target``
   in an init container. This requires PyPI egress from the cluster.
   In airgap environments, build a custom image instead (see Example B).
+- ``LOG_FILE_PATH`` rotation uses Python's stdlib
+  ``RotatingFileHandler`` — size-based, not time-based. Default 50 MiB
+  per file, 3 backups. Tune via ``LOG_FILE_MAX_BYTES`` /
+  ``LOG_FILE_BACKUP_COUNT`` or supply a full ``LOGGING_CONFIG_FILE`` if
+  you need a different rotation policy (e.g. ``TimedRotatingFileHandler``).


### PR DESCRIPTION
## Summary

Closes #362.

**Direction change (BREAKING)**: the in-process Python logging extension hooks (`LOG_HANDLERS` / `LOGGING_CONFIG_FILE` / `aerospike_cluster_manager.log_handlers` entry-point group) are removed. External log routing — PII redaction, sampling, fixed-field enrichment, vendor-specific exporters — is delegated to an **external OpenTelemetry Collector** that receives this process's logs via either:

1. A **node-level DaemonSet** scraping container logs (`/var/log/containers/*.log`), or
2. A **pod-internal sidecar** (fluent-bit / vector / promtail) that tails `LOG_FILE_PATH` on a shared `emptyDir` volume and forwards records via OTLP.

The companion ACKO chart change (PR aerospike-ce-kubernetes-operator#269) wires option 2 with a fluent-bit OTLP-forwarder sidecar. The OTel Collector itself is **not** embedded in the chart — it is assumed to exist elsewhere in the cluster, so operators can route a single OTel pipeline for many workloads.

### Kept and tightened

- `LOG_LEVEL` / `LOG_FORMAT` — unchanged.
- `LOG_FILE_PATH` / `LOG_FILE_MAX_BYTES` / `LOG_FILE_BACKUP_COUNT` — kept as the sidecar enabler. Rotating file on a shared `emptyDir`, fd-leak-safe across `setup_logging()` re-entries (uvicorn `--reload`, test fixtures).
- `request_id` / `otelTraceID` / `otelSpanID` correlation in stdout JSON via `LoggingInstrumentor` (unchanged).

### Removed

- `LOG_HANDLERS` env var and all per-handler load/attach code.
- `LOGGING_CONFIG_FILE` env var and the `yaml.safe_load` + `dictConfig` path.
- `aerospike_cluster_manager.log_handlers` entry-point discovery.
- Tests covering the above (10 tests deleted).

### Migration matrix

| Old pattern | OTel Collector equivalent |
|---|---|
| Direct attach of a vendor SDK handler | Run the vendor exporter (or an OTLP→vendor bridge) on the cluster's Collector.|Direct attach of a vendor SDK handler | Run the vendor exporter (or an OTLP→vendor bridge) on the cluster's Collector. |
| Per-record PII redaction inside the handler | `attributes` / `redaction` / `transform` processor. |
| Sampling (error 100% / info 1%) inside the handler | `probabilistic_sampler` / `tail_sampling` processor. |
| Fixed extra fields (`service`, `env`, `tenant`) | `resource` / `attributes` processor; or OTel SDK resource attributes via env. |
| Multi-sink fan-out | Multiple exporters on the same Collector pipeline. |
| `LOGGING_CONFIG_FILE` for full pipeline ownership | Collector `service.pipelines.logs` configuration. |

Full migration guide in `docs/logging.md`.

## Why this direction

- One centralized OTel Collector pipeline beats per-vendor Python wrappers.
- Vendor swap is now a helm values change, not a code/airgap event (no `extraPipPackages`, no fork).
- Removes the per-handler `pip install` blast-radius and the init-container path that came with it.
- Aligns ACM with the broader OTel adoption already in place (`LoggingInstrumentor` / `FastAPIInstrumentor` are kept; only the *vendor-specific in-process exporters* are gone).

## Test plan

- [x] `uv run pytest tests/test_logging_config.py` — 10 tests pass (default text/json, repeated-call idempotence, `LOG_FILE_PATH` attach / rotation overrides / invalid rotation / unwritable parent / empty no-op / double-call no fd leak).
- [x] `uv run ruff check` / `ruff format --check` — clean.
- [ ] Smoke: container start with `LOG_FILE_PATH=/var/log/acm/api.log`, fluent-bit sidecar tailing → OTel Collector → backend. Covered by the ACKO PR validation.

## Versioning

`feat!` Conventional Commit triggers a MAJOR bump. Per workspace policy MAJOR is gated on explicit user approval — confirmed in PR discussion. Auto-release should be paused; release tag will be cut manually after both PRs land.
