### PR TITLE
docs: drop legacy LOG_HANDLERS / dictConfig refs + sanitize vendor-internal mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Related targets: `make kind-up/down/status`, `make acko-install/uninstall/verify
 - **AQL Terminal** — Web-based AQL command execution
 - **Prometheus Metrics** — Cluster metrics export
 - **OpenTelemetry Observability** — Traces, metrics, and logs via standard OTel SDK env vars; HTTP server, asyncpg, and aerospike-py spans auto-emit. See [docs/observability.md](docs/observability.md).
-- **Structured stdout logs ready for OTel Collector** — JSON output with `request_id` / `otelTraceID` / `otelSpanID` correlation fields. Optional rotating-file mirror (`LOG_FILE_PATH`) lets a pod-internal sidecar tail logs on a shared `emptyDir` and forward them via OTLP to an external OpenTelemetry Collector for vendor-specific routing (NELO, Datadog, Loki, Elasticsearch, ...). See [docs/logging.md](docs/logging.md).
+- **Structured stdout logs ready for OTel Collector** — JSON output with `request_id` / `otelTraceID` / `otelSpanID` correlation fields. Optional rotating-file mirror (`LOG_FILE_PATH`) lets a pod-internal sidecar tail logs on a shared `emptyDir` and forward them via OTLP to an external OpenTelemetry Collector for vendor-specific routing (Datadog, Loki, Elasticsearch, Sentry, ...). See [docs/logging.md](docs/logging.md).
 - **Sample Data Generator** — Generate deterministic sample records with optional indexes and UDFs
 - **K8s Cluster Management** — Full lifecycle management of Aerospike clusters on Kubernetes (see below)
   - ACL/Security configuration with role and user management via wizard

--- a/api/src/aerospike_cluster_manager_api/logging_config.py
+++ b/api/src/aerospike_cluster_manager_api/logging_config.py
@@ -4,15 +4,13 @@ A single stdout handler with either text or JSON output (selected by
 ``LOG_FORMAT``), plus an optional rotating file mirror.
 
 External log routing — PII redaction, sampling, vendor-specific exporters
-(NELO, Datadog, Loki, Elasticsearch, ...) — is the responsibility of an
+(Datadog, Loki, Elasticsearch, Sentry, ...) — is the responsibility of an
 OpenTelemetry Collector that receives this process's stdout (or tails the
-``LOG_FILE_PATH`` rotating file via a pod-internal sidecar). The OTel
-Collector spec already covers every transform-pipeline use case that
-earlier ACM releases implemented with pluggable in-process handlers, so
-that hook (``LOG_HANDLERS`` / ``LOGGING_CONFIG_FILE`` /
-``aerospike_cluster_manager.log_handlers`` entry-point group) was removed.
+``LOG_FILE_PATH`` rotating file via a pod-internal sidecar). Any transform
+pipeline lives in the Collector configuration, so operators swap backends
+from helm values alone without touching the application image.
 
-Two layered modes remain:
+Two modes:
 
 1. ``LOG_FILE_PATH`` is set
    Attach a ``RotatingFileHandler`` *in addition to* stdout so a pod-
@@ -30,11 +28,8 @@ Two layered modes remain:
    for OTel correlation when the LoggingInstrumentor has patched the
    LogRecord factory.
 
-For the in-process SDK pattern that earlier releases supported via
-``LOG_HANDLERS``, deploy an OTel Collector with the appropriate
-processor pipeline (``attributes/redact``, ``probabilistic_sampler``,
-``transform`` for fixed fields) and exporter for the vendor backend.
-See docs/logging.md for the full migration guide.
+See docs/logging.md for OTel Collector deployment shapes and an
+example fluent-bit sidecar configuration.
 """
 
 from __future__ import annotations

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -46,9 +46,8 @@ if config.K8S_MANAGEMENT_ENABLED:
     from aerospike_cluster_manager_api.routers import k8s_clusters
 
 # OTel must initialize BEFORE setup_logging so LoggingInstrumentor can patch
-# the LogRecord factory before the first log line is emitted. Both calls are
-# no-ops when their respective env vars are at their defaults
-# (OTEL_SDK_DISABLED=true / LOG_HANDLERS empty / LOGGING_CONFIG_FILE empty).
+# the LogRecord factory before the first log line is emitted. setup_observability
+# is a no-op when OTEL_SDK_DISABLED=true.
 setup_observability()
 setup_logging(config.LOG_LEVEL, config.LOG_FORMAT)
 logger = logging.getLogger(__name__)

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -5,15 +5,11 @@ configuration emits a single stdout handler with either text or JSON
 output (selected by ``LOG_FORMAT``).
 
 External log routing — PII redaction, sampling, field enrichment,
-vendor-specific exporters (NELO, Datadog, Loki, Elasticsearch, ...) —
+vendor-specific exporters (Datadog, Loki, Elasticsearch, Sentry, ...) —
 is delegated to an **OpenTelemetry Collector** that receives this
-process's logs. The ACM image deliberately does not embed in-process
-SDK handlers anymore: any pipeline you would have implemented inside
-Python (`attributes/redact`, per-record sampling, fixed-field injection,
-tenant-aware fan-out) is already covered by OTel Collector
-processors/exporters, and centralizing it there avoids per-vendor
-Python wrappers and lets operators swap backends from helm values
-alone.
+process's logs. Any transform pipeline lives in the Collector
+configuration, so operators swap backends from helm values alone
+without touching the application image.
 
 ## Architecture
 
@@ -28,8 +24,8 @@ alone.
                                                                  |
                                                 +----------------+----------------+
                                                 v                                 v
-                                         Loki / Elastic /                 NELO / Datadog /
-                                         Tempo / Sentry                   sentry-otel-bridge
+                                         Loki / Elastic /                  Datadog / Sentry /
+                                         Tempo / Sentry                    your-vendor-bridge
 ```
 
 The OTel Collector itself is **not** deployed by the ACKO helm chart —
@@ -91,35 +87,6 @@ The chart pre-bakes a fluent-bit config that:
 Operators who need a different shipper (vector, promtail, vendor agent)
 can override ``sidecar.image`` and ``sidecar.config.content`` — the
 schema is documented in the ACKO chart's ``values.yaml``.
-
-## Migrating from pre-0.X.0 ``LOG_HANDLERS`` / ``LOGGING_CONFIG_FILE``
-
-Earlier ACM releases shipped two in-process extension hooks:
-
-- ``LOG_HANDLERS=module:Class`` (or entry-point name registered under
-  ``aerospike_cluster_manager.log_handlers``) — attached additional
-  ``logging.Handler`` instances such as ``pynelo.AsyncNeloHandler``.
-- ``LOGGING_CONFIG_FILE`` — path to a YAML/JSON ``dictConfig`` file
-  given full ownership of the logging pipeline.
-
-Both hooks were removed in this release. Each prior use case maps to an
-OTel Collector primitive:
-
-| Old pattern | OTel Collector equivalent |
-|---|---|
-| Vendor SDK handler (NELO, Datadog, ...) | Run the vendor exporter (or an OTLP→vendor bridge) on the cluster's Collector. ACM stays vendor-neutral. |
-| Per-record PII redaction inside the handler | Pipeline with the `attributes` / `redaction` / `transform` processor. |
-| Sampling inside the handler (`error 100% / info 1%`) | `probabilistic_sampler` or `tail_sampling` processor. |
-| Fixed extra fields (`service`, `env`, `tenant`) | `resource` / `attributes` processor; or set OTel SDK resource attributes via env. |
-| Multi-sink fan-out (stdout + vendor) | Multiple exporters on the same Collector pipeline. |
-| Full ``dictConfig`` for routing/level overrides | Collector ``service.pipelines.logs`` configuration. |
-
-If a use case truly cannot be expressed in the Collector (extremely
-high-cardinality per-record context that has to be derived inside the
-application process), file an issue with the specific transform you
-need — we will reconsider, but the bar for re-introducing in-process
-hooks is high because each one becomes a per-vendor Python dependency
-that complicates the airgap and dependency-pin story.
 
 ## OpenTelemetry trace correlation
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -24,7 +24,7 @@ without touching the application image.
                                                                  |
                                                 +----------------+----------------+
                                                 v                                 v
-                                         Loki / Elastic /                  Datadog / Sentry /
+                                         Loki / Elastic /                  Datadog / Splunk /
                                          Tempo / Sentry                    your-vendor-bridge
 ```
 


### PR DESCRIPTION
## Summary

Two related cleanups after the OTel Collector transition (PRs #368, #270, #271).

### 1. Legacy logging-hook references

The previously removed in-process `LOG_HANDLERS` / `LOGGING_CONFIG_FILE` / `dictConfig` hooks no longer have backwards-compat or migration guidance — the project doesn't carry that maintenance.

- `docs/logging.md` — drop the "Migrating from pre-0.X.0" section and trim the intro paragraph that referenced the prior hooks.
- `api/src/aerospike_cluster_manager_api/logging_config.py` — module docstring describes the current pipeline only.
- `api/src/aerospike_cluster_manager_api/main.py` — drop the stale `LOG_HANDLERS` / `LOGGING_CONFIG_FILE` mention from the setup ordering comment.

### 2. vendor-internal references

It refers to a vendor-internal observability platform; it doesn't belong in user-facing docs or inline comments.

- `README.md`, `docs/logging.md`, `logging_config.py` docstring — replace the "Datadog, Loki, …" enumeration with vendor-neutral examples (Datadog / Loki / Elasticsearch / Sentry).
- `docs/logging.md` architecture diagram — drop the vendor-internal leg.

## Test plan

- [x] `uv run pytest tests/test_logging_config.py` — 10 tests pass.
- [x] `ruff check` / `ruff format --check` — clean.
- [x] `grep -rni "vendor-internal SDK"` in worktree returns no matches outside of `.git/`.
