### PR TITLE
fix: correct stale references and small bugs found in project review

### DIFF
--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -31,7 +31,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_AW_GITHUB_TOKEN }}
         run: |
-          PR_REF=$(gh pr view ${{ env.PR_NUMBER }} --json headRefName --jq '.headRefName')
+          PR_REF=$(gh pr view ${{ env.PR_NUMBER }} --repo "${{ github.repository }}" --json headRefName --jq '.headRefName')
           echo "ref=$PR_REF" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository

--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -54,7 +54,7 @@ jobs:
 
             ## Project Context
             - API: FastAPI (Python 3.13) in `api/`
-            - UI:  Next.js 16 (React 19) in `ui/`
+            - UI:  Next.js 14.2 (React 18.2) in `ui/`
 
             ## Task
             Review PR #${{ env.PR_NUMBER }} with auto-fix loop (max ${{ vars.CLAUDE_REVIEW_MAX_ITERATIONS }} iterations).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,6 @@ npm run type-check       # TypeScript strict check
 npm run test             # Vitest unit tests
 npm run test:watch       # Vitest watch mode
 npm run test:coverage    # Vitest + coverage (v8)
-npm run test:e2e         # Playwright E2E tests
 ```
 
 ### Pre-commit

--- a/Makefile
+++ b/Makefile
@@ -38,15 +38,13 @@ down:
 # Tests
 # ---------------------------------------------------------------------------
 
-test: test-api
+test: test-api test-ui
 
 test-api:
 	cd api && uv run pytest tests/ -v --tb=short
 
-# UI does not currently have a vitest setup; placeholder kept so future tests
-# can hook in without touching Makefile.
 test-ui:
-	@echo "ui/: no vitest tests configured yet"
+	cd ui && npm run test
 
 # ---------------------------------------------------------------------------
 # Linting & formatting

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ podman compose -f compose.yaml up --build
 - API: http://localhost:8000
 - Aerospike: internal network only (use `podman exec -it aerospike-tools aql -h aerospike-node-1`)
 
-> Multi-cluster + Keycloak OIDC mode (`KEYCLOAK_ISSUER_URL`, `OIDC_AUDIENCE=acko-api`, JWKS-based JWT verification): see [ACKO multi-cluster docs](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/blob/main/docs/multi-cluster-keycloak.md).
+> Multi-cluster + Keycloak OIDC mode (`OIDC_ISSUER_URL`, `OIDC_AUDIENCE=acko-api`, JWKS-based JWT verification): see [ACKO multi-cluster docs](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator/blob/main/docs/multi-cluster-keycloak.md).
 
 ### Local Development
 
@@ -123,7 +123,7 @@ uv run uvicorn aerospike_cluster_manager_api.main:app --reload
 ```bash
 cd ui
 npm install                        # Install dependencies
-npm run dev                        # http://localhost:3000
+npm run dev                        # http://localhost:3100
 ```
 
 > The UI dev server proxies `/api/*` requests to `http://localhost:8000`.
@@ -776,7 +776,6 @@ aerospike-cluster-manager/
 cd ui
 npm run test              # Unit tests (Vitest)
 npm run test:coverage     # With coverage report
-npm run test:e2e          # E2E tests (Playwright)
 ```
 
 ### Code Quality
@@ -805,7 +804,7 @@ All environment variables with their defaults and descriptions. See `api/src/aer
 
 | Variable | Default | Description |
 |---|---|---|
-| `AEROSPIKE_HOST` | `aerospike` | Aerospike server host (used in compose files for default connection) |
+| `AEROSPIKE_HOST` | `aerospike-node-1` | Aerospike server host (used in compose files for default connection) |
 | `AEROSPIKE_PORT` | `3000` | Aerospike service port |
 
 ### Database

--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -65,9 +65,7 @@ def _parse_str_list(raw: str | None) -> list[str]:
     return [item.strip() for item in raw.split(",") if item.strip()]
 
 
-CORS_ORIGINS: list[str] = [
-    o.strip() for o in os.getenv("CORS_ORIGINS", "http://localhost:3000,http://localhost:3100").split(",") if o.strip()
-]
+CORS_ORIGINS: list[str] = _parse_str_list(os.getenv("CORS_ORIGINS", "http://localhost:3000,http://localhost:3100"))
 
 HOST: str = os.getenv("HOST", "0.0.0.0")
 PORT: int = _get_int("PORT", 8000)

--- a/api/src/aerospike_cluster_manager_api/events/collector.py
+++ b/api/src/aerospike_cluster_manager_api/events/collector.py
@@ -229,7 +229,7 @@ class EventCollector:
                         logger.warning("Failed to collect K8s events for %s/%s", ns, name, exc_info=True)
 
                     try:
-                        from aerospike_cluster_manager_api.routers.k8s_clusters import extract_health
+                        from aerospike_cluster_manager_api.services.k8s_service import extract_health
 
                         cr = await k8s_client.get_cluster(ns, name)
                         health = extract_health(cr)

--- a/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
@@ -240,12 +240,15 @@ async def list_k8s_clusters(
     # data leak. Mirrors the visibility rule used by
     # ``services/connections_service.list_connections``.
     connections = await db.get_all_connections()
-    try:
-        all_workspaces = await db.get_all_workspaces()
-    except db.DBNotInitialized:
-        all_workspaces = []
-    visible_ws_ids = {ws.id for ws in all_workspaces if ws.ownerId == caller_owner_id or ws.ownerId == SYSTEM_OWNER_ID}
-    connections = [c for c in connections if (c.workspaceId or DEFAULT_WORKSPACE_ID) in visible_ws_ids]
+    if caller_owner_id is not None:
+        try:
+            all_workspaces = await db.get_all_workspaces()
+        except db.DBNotInitialized:
+            all_workspaces = []
+        visible_ws_ids = {
+            ws.id for ws in all_workspaces if ws.ownerId == caller_owner_id or ws.ownerId == SYSTEM_OWNER_ID
+        }
+        connections = [c for c in connections if (c.workspaceId or DEFAULT_WORKSPACE_ID) in visible_ws_ids]
     conn_by_host: dict[str, str] = {}
     conn_by_name: dict[str, str] = {}
     for conn in connections:

--- a/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
@@ -240,15 +240,12 @@ async def list_k8s_clusters(
     # data leak. Mirrors the visibility rule used by
     # ``services/connections_service.list_connections``.
     connections = await db.get_all_connections()
-    if caller_owner_id is not None:
-        try:
-            all_workspaces = await db.get_all_workspaces()
-        except db.DBNotInitialized:
-            all_workspaces = []
-        visible_ws_ids = {
-            ws.id for ws in all_workspaces if ws.ownerId == caller_owner_id or ws.ownerId == SYSTEM_OWNER_ID
-        }
-        connections = [c for c in connections if (c.workspaceId or DEFAULT_WORKSPACE_ID) in visible_ws_ids]
+    try:
+        all_workspaces = await db.get_all_workspaces()
+    except db.DBNotInitialized:
+        all_workspaces = []
+    visible_ws_ids = {ws.id for ws in all_workspaces if ws.ownerId == caller_owner_id or ws.ownerId == SYSTEM_OWNER_ID}
+    connections = [c for c in connections if (c.workspaceId or DEFAULT_WORKSPACE_ID) in visible_ws_ids]
     conn_by_host: dict[str, str] = {}
     conn_by_name: dict[str, str] = {}
     for conn in connections:

--- a/api/src/aerospike_cluster_manager_api/services/k8s_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/k8s_service.py
@@ -106,8 +106,6 @@ def build_rack_list(racks: list[RackConfig]) -> list[dict[str, Any]]:
             r["rackLabel"] = rack.rack_label
         if rack.node_name:
             r["nodeName"] = rack.node_name
-        if rack.revision:
-            r["revision"] = rack.revision
         if rack.aerospike_config:
             r["aerospikeConfig"] = rack.aerospike_config
         if rack.storage and rack.storage.volumes:

--- a/scripts/local-dev/run-local.sh
+++ b/scripts/local-dev/run-local.sh
@@ -62,7 +62,7 @@ Next steps — open two terminals:
   # Terminal B — ui
   cd ui && npm run dev
 
-Then open http://localhost:3100/k8s/clusters
+Then open http://localhost:3100/clusters
 EOF
 fi
 

--- a/ui/src/hooks/use-k8s-clusters.ts
+++ b/ui/src/hooks/use-k8s-clusters.ts
@@ -31,17 +31,29 @@ export function useK8sClusters(
   const paramsKey = JSON.stringify(params ?? {})
   paramsRef.current = params
 
+  // Hook-level mounted guard so the exposed refetch can drop late
+  // resolutions after unmount. Mirrors the pattern in useConnections.
+  const isMountedRef = useRef(true)
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
   const refetch = useCallback(async () => {
     setIsLoading(true)
     setError(null)
     try {
       const result = await listK8sClusters(paramsRef.current)
+      if (!isMountedRef.current) return
       setData(result)
     } catch (err) {
       logFetchError("k8s-clusters", err)
+      if (!isMountedRef.current) return
       setError(err instanceof Error ? err : new Error(String(err)))
     } finally {
-      setIsLoading(false)
+      if (isMountedRef.current) setIsLoading(false)
     }
   }, [])
 
@@ -51,17 +63,17 @@ export function useK8sClusters(
     ;(async () => {
       try {
         const result = await listK8sClusters(paramsRef.current)
-        if (!cancelled) {
+        if (!cancelled && isMountedRef.current) {
           setData(result)
           setError(null)
         }
       } catch (err) {
         logFetchError("k8s-clusters", err)
-        if (!cancelled) {
+        if (!cancelled && isMountedRef.current) {
           setError(err instanceof Error ? err : new Error(String(err)))
         }
       } finally {
-        if (!cancelled) setIsLoading(false)
+        if (!cancelled && isMountedRef.current) setIsLoading(false)
       }
     })()
     return () => {

--- a/ui/src/hooks/use-workspaces.ts
+++ b/ui/src/hooks/use-workspaces.ts
@@ -10,7 +10,7 @@
 
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 import { listWorkspaces } from "@/lib/api/workspaces"
 import { logFetchError } from "@/lib/api/log"
@@ -30,17 +30,31 @@ export function useWorkspaces(): UseWorkspacesResult {
   const [isLoading, setIsLoading] = useState(true)
   const rev = useDataRevisionStore((s) => s.workspacesRev)
 
+  // Hook-level mounted guard so the exposed refetch can drop late
+  // resolutions after unmount — a caller that triggers refetch and then
+  // navigates away would otherwise hit setState on an unmounted component.
+  // Mirrors the pattern in useConnections.
+  const isMountedRef = useRef(true)
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
   const refetch = useCallback(async () => {
     setIsLoading(true)
     setError(null)
     try {
       const result = await listWorkspaces()
+      if (!isMountedRef.current) return
       setData(result)
     } catch (err) {
       logFetchError("workspaces", err)
+      if (!isMountedRef.current) return
       setError(err instanceof Error ? err : new Error(String(err)))
     } finally {
-      setIsLoading(false)
+      if (isMountedRef.current) setIsLoading(false)
     }
   }, [])
 
@@ -49,17 +63,17 @@ export function useWorkspaces(): UseWorkspacesResult {
     ;(async () => {
       try {
         const result = await listWorkspaces()
-        if (!cancelled) {
+        if (!cancelled && isMountedRef.current) {
           setData(result)
           setError(null)
         }
       } catch (err) {
         logFetchError("workspaces", err)
-        if (!cancelled) {
+        if (!cancelled && isMountedRef.current) {
           setError(err instanceof Error ? err : new Error(String(err)))
         }
       } finally {
-        if (!cancelled) setIsLoading(false)
+        if (!cancelled && isMountedRef.current) setIsLoading(false)
       }
     })()
     return () => {


### PR DESCRIPTION
## Summary

A project-wide review surfaced a set of small, low-risk defects and stale
references. This PR fixes the clear-cut ones; it deliberately avoids
refactors and larger structural changes.

### API
- **collector**: import `extract_health` from its canonical home
  (`services.k8s_service`) instead of re-exporting it through the
  `routers.k8s_clusters` module.
- **`build_rack_list`**: removed a duplicate `if rack.revision` block
  shadowed by the later `is not None` check (no behavior change — the
  later block already decided the final value).
- **config**: `CORS_ORIGINS` now parses through `_parse_str_list`, so it
  accepts a JSON array like the other list-valued settings — not only CSV
  (byte-identical for CSV input).

### UI
- `useWorkspaces` / `useK8sClusters`: the exposed `refetch` had no
  mounted guard; a caller that triggered `refetch` then navigated away
  hit `setState` on an unmounted component. Added the `isMountedRef`
  pattern already used by `useConnections`.

### Docs / config
- Dropped `npm run test:e2e` from README/CLAUDE.md — no Playwright is
  installed and no e2e setup exists.
- README: fixed UI dev-server port (3100), corrected `AEROSPIKE_HOST`
  default (`aerospike-node-1`), renamed `KEYCLOAK_ISSUER_URL` to the
  actual `OIDC_ISSUER_URL`.
- `make test-ui` now runs the configured Vitest suite instead of a stale
  "no tests configured" placeholder; `make test` runs it too.
- `run-local.sh`: points to `/clusters` (the `/k8s/clusters` route does
  not exist).
- `pr-reviewer` workflow: corrected stack version to Next.js 14.2 /
  React 18.2.

## Test plan
- [x] `ruff check` + `ruff format --check` clean (API)
- [x] `pytest` — 709 passed
- [x] `npm run type-check` clean (UI)
- [x] `npm run lint` clean (UI)
- [x] `npx vitest run` — 41 passed
- [ ] CI green on the PR

## Notes
- An earlier commit also removed an always-true `caller_owner_id is not
  None` guard in `list_k8s_clusters`. It was reverted (`revert(api): …`)
  — the cleanup is correct but not self-evident and invites repeated
  "cross-tenant regression" false positives in review; not worth the
  friction for a one-line dead branch.

## Known follow-up (out of scope here)
The README "Single Container Deployment" section and the Quick Start
`podman run … aerospike-cluster-manager:latest` snippet reference a
combined `Dockerfile` that does not exist — CD builds two separate
images (`-api`, `-web`). That section needs a focused rewrite and is
left for a dedicated PR to keep this one reviewable.