### PR TITLE
chore(deps): block dependabot major version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,24 +1,40 @@
 version: 2
+# Major version bumps are intentionally excluded from every ecosystem below.
+# They routinely carry breaking changes that fail CI and need manual migration
+# (e.g. recharts 2->3, typescript 5->6, eslint 8->10, @vitejs/plugin-react 4->6).
+# Bump majors deliberately by hand, in a dedicated PR, with the migration done.
 updates:
   - package-ecosystem: "pip"
     directory: "/api"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/ui"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "monthly"
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 3
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary

Dependabot has been opening **major-version** PRs that all fail CI because each major bump carries breaking changes requiring manual migration:

| PR | Bump | CI failure |
|----|------|-----------|
| #366 | recharts 2 → 3 | `LineChart.tsx` TS2322 type error |
| #365 | typescript 5 → 6 | `globals.css` side-effect import (TS2882) |
| #364 | eslint 8 → 10 | flat-config migration required (`next lint` + eslintrc) |
| #363 | @vitejs/plugin-react 4 → 6 | ESM-only, `vitest.config.ts` cannot `require` it |

These churn the PR queue and can never be merged as-is.

## Change

Add an `ignore` rule for `version-update:semver-major` to every ecosystem in `.github/dependabot.yml` (pip, npm, docker, github-actions). Dependabot now only proposes **minor/patch** updates, which are safe to auto-review and merge.

Major upgrades are still possible — they are now done deliberately by hand in a dedicated PR with the migration completed.

## Follow-up

PRs #363–#366 are superseded by this policy and will be closed.