### PR TITLE
feat(api): export aerospike-py traces and logs to the OTel pipeline

### DIFF
--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -137,6 +137,24 @@ CM_SSE_BROADCAST_PER_CONNECTION: bool = os.getenv("CM_SSE_BROADCAST_PER_CONNECTI
 OTEL_ENABLED: bool = os.getenv("OTEL_SDK_DISABLED", "true").lower() not in ("true", "1", "yes")
 
 # ---------------------------------------------------------------------------
+# aerospike-py native instrumentation
+# ---------------------------------------------------------------------------
+# aerospike-py runs an async Rust core that carries its own observability
+# surface (a stdlib-logging bridge and an OTLP span exporter). ACM opts into
+# both — see observability.apply_aerospike_py_log_level / _init_aerospike_py_tracing
+# and docs/observability.md. Both knobs are read live from os.environ in
+# observability.py (so tests can monkeypatch them, matching how
+# setup_observability reads OTEL_SDK_DISABLED); they are documented here as the
+# canonical place to grep for "what env vars does ACM read?":
+#
+#   AEROSPIKE_PY_LOG_LEVEL — verbosity of the Rust-core log bridge into ACM's
+#     logging tree (DEBUG / INFO / WARNING / ERROR / TRACE / OFF). Defaults to
+#     LOG_LEVEL; a separate knob because the core is very chatty at DEBUG/TRACE.
+#   AEROSPIKE_PY_TRACING — "false" / "0" / "no" / "off" suppresses aerospike-py's
+#     OTLP span exporter. Defaults on; only takes effect when OTel is enabled.
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
 # At-rest encryption for stored connection passwords
 # ---------------------------------------------------------------------------
 # Fernet key used by ``secrets_crypto.encrypt_password`` to wrap the

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -23,7 +23,11 @@ from aerospike_cluster_manager_api.events.collector import collector
 from aerospike_cluster_manager_api.logging_config import setup_logging
 from aerospike_cluster_manager_api.middleware.oidc_auth import OIDCAuthMiddleware
 from aerospike_cluster_manager_api.middleware.trace_id import TraceIDMiddleware
-from aerospike_cluster_manager_api.observability import setup_observability
+from aerospike_cluster_manager_api.observability import (
+    apply_aerospike_py_log_level,
+    setup_observability,
+    shutdown_observability,
+)
 from aerospike_cluster_manager_api.rate_limit import limiter
 from aerospike_cluster_manager_api.routers import (
     admin_roles,
@@ -50,6 +54,9 @@ if config.K8S_MANAGEMENT_ENABLED:
 # is a no-op when OTEL_SDK_DISABLED=true.
 setup_observability()
 setup_logging(config.LOG_LEVEL, config.LOG_FORMAT)
+# Open aerospike-py's Rust-core log bridge now that the formatter is configured,
+# so client-core records share ACM's formatting and OTLP log pipeline.
+apply_aerospike_py_log_level()
 logger = logging.getLogger(__name__)
 
 
@@ -70,6 +77,9 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     await client_manager.close_all()
     await db.close_db()
     logger.info("Shutdown complete")
+    # Flush the OTel pipeline last so the final spans/logs/metrics batch —
+    # including the line above — is exported before the exporters close.
+    shutdown_observability()
 
 
 app = FastAPI(

--- a/api/src/aerospike_cluster_manager_api/observability.py
+++ b/api/src/aerospike_cluster_manager_api/observability.py
@@ -24,6 +24,7 @@ import os
 from importlib.metadata import PackageNotFoundError, version
 from typing import Any
 
+import aerospike_py
 from opentelemetry import metrics, trace
 from opentelemetry._logs import set_logger_provider
 from opentelemetry.instrumentation.asyncpg import AsyncPGInstrumentor
@@ -40,6 +41,12 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 logger = logging.getLogger(__name__)
 
 _initialized = False
+# Python OTel SDK providers, retained at module scope so shutdown_observability()
+# can flush and stop them deterministically instead of relying on interpreter
+# atexit ordering. None until setup_observability() runs the enabled path.
+_tracer_provider: TracerProvider | None = None
+_meter_provider: MeterProvider | None = None
+_logger_provider: LoggerProvider | None = None
 
 
 def _service_version() -> str:
@@ -78,12 +85,141 @@ def _otlp_exporters() -> tuple[type[Any], type[Any], type[Any]]:
     return GrpcSpanExporter, GrpcMetricExporter, GrpcLogExporter
 
 
+# ---------------------------------------------------------------------------
+# aerospike-py native instrumentation
+#
+# aerospike-py runs an async Rust core. It is a hard dependency of ACM and
+# carries its own observability surface that does NOT come for free with the
+# ``[otel]`` extra:
+#
+#   * Logs  — the Rust core forwards log records into the stdlib ``logging``
+#     tree (loggers ``aerospike_py`` / ``_aerospike`` / ``aerospike_core``),
+#     but only once ``set_log_level`` opens that bridge at a chosen verbosity.
+#   * Traces — the Rust core emits ``aerospike.<op>`` spans through its OWN
+#     OTLP exporter, started by ``init_tracing()``. The ``[otel]`` extra only
+#     wires W3C context *propagation* so those spans nest under ACM's active
+#     span — it does not start span *emission*. Before this wiring ACM
+#     produced FastAPI/asyncpg spans but silently dropped every
+#     Aerospike-operation span, despite docs/observability.md claiming
+#     otherwise.
+#
+# Every call below is wrapped so a failure can never break app startup or
+# shutdown — observability is best-effort, exactly like the log file mirror.
+# ---------------------------------------------------------------------------
+
+# stdlib logging level name -> aerospike_py.LOG_LEVEL_* constant.
+_AEROSPIKE_PY_LOG_LEVELS: dict[str, int] = {
+    "OFF": aerospike_py.LOG_LEVEL_OFF,
+    "NONE": aerospike_py.LOG_LEVEL_OFF,
+    "CRITICAL": aerospike_py.LOG_LEVEL_ERROR,
+    "FATAL": aerospike_py.LOG_LEVEL_ERROR,
+    "ERROR": aerospike_py.LOG_LEVEL_ERROR,
+    "WARNING": aerospike_py.LOG_LEVEL_WARN,
+    "WARN": aerospike_py.LOG_LEVEL_WARN,
+    "INFO": aerospike_py.LOG_LEVEL_INFO,
+    "NOTSET": aerospike_py.LOG_LEVEL_INFO,
+    "DEBUG": aerospike_py.LOG_LEVEL_DEBUG,
+    "TRACE": aerospike_py.LOG_LEVEL_TRACE,
+}
+
+
+def apply_aerospike_py_log_level(level_name: str | None = None) -> None:
+    """Route aerospike-py's Rust-core logs into the stdlib logging tree.
+
+    Call once at startup, after :func:`logging_config.setup_logging`, so the
+    records land in ACM's configured formatter (and, when OTel is on, the
+    OTLP log pipeline). Unlike tracing, this applies regardless of
+    ``OTEL_SDK_DISABLED`` — the Rust-core logs are useful on stdout alone.
+
+    ``level_name`` defaults to ``AEROSPIKE_PY_LOG_LEVEL`` and then to
+    ``LOG_LEVEL``. The Rust core is very chatty at DEBUG/TRACE, hence the
+    dedicated env var: keep ACM at INFO while turning the client core up (or
+    the reverse). Unknown names fall back to INFO.
+    """
+    name = (level_name or os.getenv("AEROSPIKE_PY_LOG_LEVEL") or os.getenv("LOG_LEVEL", "INFO")).strip().upper()
+    level = _AEROSPIKE_PY_LOG_LEVELS.get(name, aerospike_py.LOG_LEVEL_INFO)
+    try:
+        aerospike_py.set_log_level(level)
+    except Exception:  # observability must never break startup
+        logger.warning("aerospike-py set_log_level(%s) failed; Rust-core logs unrouted", name, exc_info=True)
+        return
+    logger.info("aerospike-py log level set to %s", name)
+
+
+def _init_aerospike_py_tracing() -> bool:
+    """Start aerospike-py's native OTLP span exporter. Idempotent.
+
+    Only meaningful when OTel is enabled — aerospike-py's ``init_tracing()``
+    honours ``OTEL_SDK_DISABLED`` itself, so this is reached only from the
+    enabled branch of :func:`setup_observability`. Set ``AEROSPIKE_PY_TRACING``
+    falsy to opt out (the per-operation spans can be high-volume).
+
+    Returns True if aerospike-py tracing was started, False if skipped/failed.
+    """
+    if os.getenv("AEROSPIKE_PY_TRACING", "true").strip().lower() in ("false", "0", "no", "off"):
+        logger.info("aerospike-py tracing skipped (AEROSPIKE_PY_TRACING is falsy)")
+        return False
+
+    # aerospike-py's Rust exporter speaks OTLP/gRPC only. If ACM itself is
+    # configured for HTTP, the endpoint must still accept gRPC (collector port
+    # 4317) or aerospike.<op> spans are silently dropped on export.
+    protocol = os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc").strip().lower()
+    if protocol not in ("", "grpc"):
+        logger.warning(
+            "OTEL_EXPORTER_OTLP_PROTOCOL=%s but aerospike-py exports spans over OTLP/gRPC only; "
+            "point OTEL_EXPORTER_OTLP_ENDPOINT at a gRPC-capable collector port (4317) "
+            "or aerospike.<op> spans will be dropped",
+            protocol,
+        )
+
+    try:
+        aerospike_py.init_tracing()
+    except Exception:  # observability must never break startup
+        logger.warning("aerospike-py init_tracing() failed; Aerospike-operation spans disabled", exc_info=True)
+        return False
+    logger.info("aerospike-py OTLP span exporter started")
+    return True
+
+
+def shutdown_observability() -> None:
+    """Flush and stop the OTel pipeline. Call last in lifespan shutdown.
+
+    Both aerospike-py's Rust tracer and the Python OTel SDK providers buffer a
+    final batch of spans/metrics/logs. The Python SDK does register an atexit
+    flush, but shutting the providers down explicitly here exports that batch
+    deterministically — before the process tears down — rather than relying on
+    interpreter atexit ordering. Safe to call when observability was never
+    enabled: every step is a guarded no-op.
+    """
+    try:
+        dropped = aerospike_py.dropped_log_count()
+        if dropped:
+            logger.warning("aerospike-py dropped %d Rust-core log record(s) under GIL contention", dropped)
+        aerospike_py.shutdown_tracing()
+    except Exception:  # observability must never break shutdown
+        logger.warning("aerospike-py shutdown_tracing() failed", exc_info=True)
+
+    # Flush the Python SDK providers. shutdown() is idempotent in the SDK, so a
+    # later atexit call is harmless.
+    for name, provider in (
+        ("tracer", _tracer_provider),
+        ("meter", _meter_provider),
+        ("logger", _logger_provider),
+    ):
+        if provider is None:
+            continue
+        try:
+            provider.shutdown()
+        except Exception:  # observability must never break shutdown
+            logger.warning("OTel %s provider shutdown failed", name, exc_info=True)
+
+
 def setup_observability() -> bool:
     """Initialize OTel providers once. Idempotent.
 
     Returns True if observability was activated, False if disabled.
     """
-    global _initialized
+    global _initialized, _tracer_provider, _meter_provider, _logger_provider
     if _initialized:
         return True
     if os.getenv("OTEL_SDK_DISABLED", "true").lower() in ("true", "1", "yes"):
@@ -114,6 +250,11 @@ def setup_observability() -> bool:
     logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter_cls()))
     set_logger_provider(logger_provider)
 
+    # Retain the providers so shutdown_observability() can flush them explicitly.
+    _tracer_provider = tracer_provider
+    _meter_provider = meter_provider
+    _logger_provider = logger_provider
+
     # set_logging_format=False so we don't override the formatter that
     # logging_config.setup_logging configures. We only need the LogRecord
     # attribute injection (otelTraceID/otelSpanID).
@@ -125,6 +266,10 @@ def setup_observability() -> bool:
     # created afterwards. Without this, no HTTP request spans are produced and
     # asyncpg child spans float without an HTTP parent (see #264).
     FastAPIInstrumentor().instrument()
+
+    # Start aerospike-py's own OTLP span exporter so Aerospike-operation spans
+    # are actually emitted (the [otel] extra only wires context propagation).
+    _init_aerospike_py_tracing()
 
     _initialized = True
     logger.info("OpenTelemetry providers initialized")

--- a/api/tests/test_observability.py
+++ b/api/tests/test_observability.py
@@ -14,8 +14,14 @@ import aerospike_cluster_manager_api.observability as obs
 def reset_initialized_flag():
     """Tests must not bleed initialization state into each other."""
     obs._initialized = False
+    obs._tracer_provider = None
+    obs._meter_provider = None
+    obs._logger_provider = None
     yield
     obs._initialized = False
+    obs._tracer_provider = None
+    obs._meter_provider = None
+    obs._logger_provider = None
 
 
 def test_setup_observability_disabled_returns_false(monkeypatch):
@@ -105,3 +111,137 @@ def test_module_reload_resets_state():
     """Re-importing the module produces a fresh _initialized flag."""
     importlib.reload(obs)
     assert obs._initialized is False
+
+
+# ---------------------------------------------------------------------------
+# aerospike-py native instrumentation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "level_name",
+    ["DEBUG", "INFO", "WARNING", "WARN", "ERROR", "CRITICAL", "TRACE", "OFF"],
+)
+def test_apply_aerospike_py_log_level_maps_names(level_name):
+    """Each stdlib level name maps to the matching aerospike_py LOG_LEVEL_* constant."""
+    with patch.object(obs, "aerospike_py") as mock_ap:
+        obs.apply_aerospike_py_log_level(level_name)
+    mock_ap.set_log_level.assert_called_once_with(obs._AEROSPIKE_PY_LOG_LEVELS[level_name])
+
+
+def test_apply_aerospike_py_log_level_unknown_falls_back_to_info(monkeypatch):
+    """An unrecognised level name must not crash — it falls back to INFO."""
+    monkeypatch.delenv("AEROSPIKE_PY_LOG_LEVEL", raising=False)
+    with patch.object(obs, "aerospike_py") as mock_ap:
+        obs.apply_aerospike_py_log_level("BOGUS")
+    mock_ap.set_log_level.assert_called_once_with(mock_ap.LOG_LEVEL_INFO)
+
+
+def test_apply_aerospike_py_log_level_reads_env_default(monkeypatch):
+    """With no explicit arg, AEROSPIKE_PY_LOG_LEVEL drives the level."""
+    monkeypatch.setenv("AEROSPIKE_PY_LOG_LEVEL", "DEBUG")
+    with patch.object(obs, "aerospike_py") as mock_ap:
+        obs.apply_aerospike_py_log_level()
+    mock_ap.set_log_level.assert_called_once_with(obs._AEROSPIKE_PY_LOG_LEVELS["DEBUG"])
+
+
+def test_apply_aerospike_py_log_level_falls_back_to_log_level(monkeypatch):
+    """When AEROSPIKE_PY_LOG_LEVEL is unset, LOG_LEVEL is used."""
+    monkeypatch.delenv("AEROSPIKE_PY_LOG_LEVEL", raising=False)
+    monkeypatch.setenv("LOG_LEVEL", "WARNING")
+    with patch.object(obs, "aerospike_py") as mock_ap:
+        obs.apply_aerospike_py_log_level()
+    mock_ap.set_log_level.assert_called_once_with(obs._AEROSPIKE_PY_LOG_LEVELS["WARNING"])
+
+
+def test_apply_aerospike_py_log_level_swallows_errors():
+    """A failing set_log_level must never propagate out of startup."""
+    with patch.object(obs, "aerospike_py") as mock_ap:
+        mock_ap.set_log_level.side_effect = RuntimeError("boom")
+        obs.apply_aerospike_py_log_level("INFO")  # must not raise
+
+
+def test_init_aerospike_py_tracing_calls_init(monkeypatch):
+    """The default path starts aerospike-py's native OTLP exporter."""
+    monkeypatch.delenv("AEROSPIKE_PY_TRACING", raising=False)
+    with patch.object(obs, "aerospike_py") as mock_ap:
+        assert obs._init_aerospike_py_tracing() is True
+    mock_ap.init_tracing.assert_called_once_with()
+
+
+@pytest.mark.parametrize("falsy", ["false", "0", "no", "off", "FALSE", "Off"])
+def test_init_aerospike_py_tracing_opt_out(monkeypatch, falsy):
+    """AEROSPIKE_PY_TRACING falsy values skip aerospike-py span emission."""
+    monkeypatch.setenv("AEROSPIKE_PY_TRACING", falsy)
+    with patch.object(obs, "aerospike_py") as mock_ap:
+        assert obs._init_aerospike_py_tracing() is False
+    mock_ap.init_tracing.assert_not_called()
+
+
+def test_init_aerospike_py_tracing_swallows_errors(monkeypatch):
+    """A failing init_tracing (e.g. collector down) must not crash startup."""
+    monkeypatch.delenv("AEROSPIKE_PY_TRACING", raising=False)
+    with patch.object(obs, "aerospike_py") as mock_ap:
+        mock_ap.init_tracing.side_effect = RuntimeError("collector down")
+        assert obs._init_aerospike_py_tracing() is False  # must not raise
+
+
+def test_shutdown_observability_flushes_tracer():
+    """shutdown_observability flushes aerospike-py's Rust tracer."""
+    with patch.object(obs, "aerospike_py") as mock_ap:
+        mock_ap.dropped_log_count.return_value = 0
+        obs.shutdown_observability()
+    mock_ap.shutdown_tracing.assert_called_once_with()
+
+
+def test_shutdown_observability_swallows_errors():
+    """A failing shutdown_tracing must never propagate out of lifespan shutdown."""
+    with patch.object(obs, "aerospike_py") as mock_ap:
+        mock_ap.shutdown_tracing.side_effect = RuntimeError("boom")
+        obs.shutdown_observability()  # must not raise
+
+
+def test_shutdown_observability_shuts_down_python_providers():
+    """The Python OTel SDK providers are flushed alongside aerospike-py."""
+    from unittest.mock import MagicMock
+
+    tp, mp, lp = MagicMock(), MagicMock(), MagicMock()
+    obs._tracer_provider = tp
+    obs._meter_provider = mp
+    obs._logger_provider = lp
+    with patch.object(obs, "aerospike_py"):
+        obs.shutdown_observability()
+    tp.shutdown.assert_called_once_with()
+    mp.shutdown.assert_called_once_with()
+    lp.shutdown.assert_called_once_with()
+
+
+def test_shutdown_observability_provider_error_swallowed():
+    """A failing provider.shutdown() must not propagate out of lifespan shutdown."""
+    from unittest.mock import MagicMock
+
+    bad = MagicMock()
+    bad.shutdown.side_effect = RuntimeError("boom")
+    obs._tracer_provider = bad
+    with patch.object(obs, "aerospike_py"):
+        obs.shutdown_observability()  # must not raise
+    bad.shutdown.assert_called_once_with()
+
+
+def test_setup_observability_starts_aerospike_py_tracing(monkeypatch):
+    """The enabled path wires aerospike-py span emission, not just propagation."""
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "false")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    monkeypatch.delenv("AEROSPIKE_PY_TRACING", raising=False)
+    with patch.object(obs, "aerospike_py") as mock_ap:
+        assert obs.setup_observability() is True
+    mock_ap.init_tracing.assert_called_once_with()
+
+
+def test_setup_observability_disabled_skips_aerospike_py_tracing(monkeypatch):
+    """When OTel is disabled, aerospike-py tracing is never started."""
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+    with patch.object(obs, "aerospike_py") as mock_ap:
+        assert obs.setup_observability() is False
+    mock_ap.init_tracing.assert_not_called()

--- a/compose.yaml
+++ b/compose.yaml
@@ -154,6 +154,17 @@ services:
       # ── Logging ───────────────────────────────────────────────────
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       - LOG_FORMAT=${LOG_FORMAT:-text}
+      # ── OpenTelemetry (off by default) ────────────────────────────
+      # Set OTEL_SDK_DISABLED=false and start with `--profile observability`
+      # to run the bundled collector. See docs/observability.md.
+      - OTEL_SDK_DISABLED=${OTEL_SDK_DISABLED:-true}
+      - OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:-http://otel-collector:4317}
+      - OTEL_EXPORTER_OTLP_PROTOCOL=${OTEL_EXPORTER_OTLP_PROTOCOL:-grpc}
+      - OTEL_SERVICE_NAME=${OTEL_SERVICE_NAME:-aerospike-cluster-manager-api}
+      - OTEL_DEPLOYMENT_ENVIRONMENT=${OTEL_DEPLOYMENT_ENVIRONMENT:-local}
+      # aerospike-py Rust-core log bridge + native OTLP span exporter.
+      - AEROSPIKE_PY_LOG_LEVEL=${AEROSPIKE_PY_LOG_LEVEL:-INFO}
+      - AEROSPIKE_PY_TRACING=${AEROSPIKE_PY_TRACING:-true}
     volumes:
       - app-data:/app/data
     healthcheck:
@@ -183,6 +194,23 @@ services:
     depends_on:
       aerospike-cluster-manager-api:
         condition: service_healthy
+    restart: unless-stopped
+
+  # ── OpenTelemetry Collector (opt-in: `--profile observability`) ─────
+  # Receives OTLP traces/metrics/logs from the API and from aerospike-py's
+  # Rust core, then prints them with the debug exporter so the pipeline can
+  # be verified locally: `podman logs -f otel-collector`. Swap the exporter
+  # in otel/otel-collector.yaml for a real backend in production.
+  otel-collector:
+    container_name: otel-collector
+    image: otel/opentelemetry-collector-contrib:latest
+    profiles: ["observability"]
+    command: ["--config=/etc/otelcol-contrib/otel-collector.yaml"]
+    volumes:
+      - ./otel/otel-collector.yaml:/etc/otelcol-contrib/otel-collector.yaml:ro
+    ports:
+      - "4317:4317"  # OTLP gRPC
+      - "4318:4318"  # OTLP HTTP
     restart: unless-stopped
 
 volumes:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -11,9 +11,26 @@ variables for any of them.
 
 ## Quick start: send everything to a local collector
 
+``compose.yaml`` ships an ``otel-collector`` service (config in
+``otel/otel-collector.yaml``) behind the ``observability`` profile. Start the
+full stack with OTel turned on:
+
 ```bash
-docker run --rm -d --name otel-collector \
+OTEL_SDK_DISABLED=false podman compose --profile observability up
+```
+
+Then tail the collector to watch every signal arrive:
+
+```bash
+podman logs -f otel-collector
+```
+
+To run the API outside compose against a standalone collector:
+
+```bash
+podman run --rm -d --name otel-collector \
   -p 4317:4317 -p 4318:4318 \
+  -v "$PWD/otel/otel-collector.yaml:/etc/otelcol-contrib/otel-collector.yaml:ro" \
   otel/opentelemetry-collector-contrib:latest \
   --config=/etc/otelcol-contrib/otel-collector.yaml
 
@@ -27,8 +44,9 @@ uvicorn aerospike_cluster_manager_api.main:app --host 0.0.0.0 --port 8000
 Open the collector logs and you will see:
 
 - HTTP server spans for every API request (``/api/v1/clusters/...`` etc.)
-- ``aerospike.<op>`` spans emitted automatically by ``aerospike-py[otel]``
-  for every Aerospike operation
+- ``aerospike.<op>`` spans for every Aerospike operation — emitted by
+  aerospike-py's Rust core once ACM starts its exporter at boot (see
+  [aerospike-py native instrumentation](#aerospike-py-native-instrumentation))
 - ``asm.events.collect`` / ``asm.events.broadcast`` spans for the SSE event loop
 - ``asm.aerospike.client.connect`` / ``...close`` spans for the
   connection-pool lifecycle
@@ -55,6 +73,52 @@ The exporter selection in the API picks the right module per
 ``OTEL_EXPORTER_OTLP_PROTOCOL`` — ``grpc`` imports
 ``opentelemetry.exporter.otlp.proto.grpc`` and ``http`` /
 ``http/protobuf`` imports ``opentelemetry.exporter.otlp.proto.http``.
+
+## aerospike-py native instrumentation
+
+ACM's Aerospike client, ``aerospike-py``, runs an async Rust core. That core
+carries its own observability surface, and ACM opts into both halves of it.
+
+### Traces — ``aerospike.<op>`` spans
+
+The Rust core emits one span per Aerospike operation (``aerospike.get``,
+``aerospike.put``, ``aerospike.batch_read``, …) carrying ``db.*`` and
+``server.*`` attributes. The ``aerospike-py[otel]`` extra ACM depends on only
+wires **W3C context propagation** — so those spans nest under ACM's active
+FastAPI/handler span — it does **not** start span emission. Emission requires
+an explicit ``init_tracing()`` call, which builds aerospike-py's own OTLP
+exporter from the standard ``OTEL_EXPORTER_OTLP_*`` env vars.
+
+ACM makes that call in ``observability.setup_observability()`` whenever OTel is
+enabled, and flushes it in ``shutdown_observability()`` at lifespan shutdown.
+Before this wiring, ACM produced FastAPI and asyncpg spans but silently dropped
+every Aerospike-operation span.
+
+> **OTLP/gRPC only.** aerospike-py's Rust exporter speaks OTLP/gRPC.
+> ``OTEL_EXPORTER_OTLP_ENDPOINT`` must reach a gRPC-capable collector port
+> (4317). If you set ``OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`` for ACM's
+> own Python SDK, aerospike-py still needs a gRPC endpoint or its spans are
+> dropped — ACM logs a warning at startup when it detects this mismatch.
+
+### Logs — Rust-core log bridge
+
+The Rust core forwards its log records into the stdlib ``logging`` tree under
+the ``aerospike_py`` / ``_aerospike`` / ``aerospike_core`` loggers. ACM opens
+that bridge at startup via ``set_log_level()``, so client-core records share
+ACM's formatter and — when OTel is enabled — the OTLP log pipeline, exactly
+like any other ACM log line. ``shutdown_observability()`` additionally surfaces
+``dropped_log_count()`` if the core had to drop records under GIL contention.
+
+### Configuration
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| ``AEROSPIKE_PY_LOG_LEVEL`` | Verbosity of the aerospike-py Rust-core log bridge. Accepts standard level names (``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``) plus ``TRACE`` and ``OFF``. Kept separate from ``LOG_LEVEL`` because the core is very chatty at ``DEBUG``/``TRACE``. | value of ``LOG_LEVEL`` |
+| ``AEROSPIKE_PY_TRACING`` | Start aerospike-py's native OTLP span exporter. Only takes effect when OTel is enabled; set falsy to suppress the high-volume per-operation spans. | ``true`` |
+
+All aerospike-py observability calls are best-effort: a failure in
+``init_tracing``, ``set_log_level``, or ``shutdown_tracing`` is caught and
+logged as a warning — it never blocks ACM startup or shutdown.
 
 ## Custom metrics emitted
 
@@ -86,6 +150,11 @@ ui:
       serviceName: aerospike-cluster-manager-api
       resourceAttributes: "deployment.environment=staging,team=platform"
       headers: ""
+      # aerospike-py Rust-core instrumentation (see "aerospike-py native
+      # instrumentation" above). Defaults are sensible — override only to
+      # tune log verbosity or to suppress the per-operation spans.
+      aerospikePyLogLevel: INFO
+      aerospikePyTracing: true
 ```
 
 When ``ui.api.otel.enabled=false`` (default), the deployment sets
@@ -99,7 +168,7 @@ produces:
 ```
 http.server (FastAPI)
 └── asm.events.collect (only if collector loop runs concurrently)
-└── aerospike.info (auto, from aerospike-py[otel])
+└── aerospike.info (from aerospike-py's Rust core)
 └── asm.aerospike.client.connect (first call only — pooled afterwards)
 ```
 

--- a/otel/otel-collector.yaml
+++ b/otel/otel-collector.yaml
@@ -1,0 +1,50 @@
+# OpenTelemetry Collector config for local development.
+#
+# Used by the `otel-collector` service in compose.yaml, which is gated behind
+# the `observability` profile:
+#
+#   OTEL_SDK_DISABLED=false podman compose --profile observability up
+#
+# It accepts OTLP over gRPC (4317) and HTTP (4318) and prints every signal
+# with the `debug` exporter so you can confirm the pipeline end to end —
+# including the `aerospike.<op>` spans emitted by aerospike-py's Rust core:
+#
+#   podman logs -f otel-collector
+#
+# For a real deployment, replace the `debug` exporter with an OTLP exporter
+# pointing at your tracing/metrics/logs backend (Tempo, Jaeger, Prometheus
+# remote-write, Loki, a vendor endpoint, ...).
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  # Batch before export to reduce the number of outgoing requests.
+  batch: {}
+
+exporters:
+  # Prints received telemetry to the collector's stdout. `detailed` includes
+  # span/resource attributes so aerospike-py spans (db.operation.name,
+  # db.namespace, server.address, ...) are visible.
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [debug]


### PR DESCRIPTION
## Summary

ACM already configured an OpenTelemetry SDK and depends on `aerospike-py[otel]`, but it **never called `aerospike_py.init_tracing()`**. The `[otel]` extra only wires W3C context *propagation* — span *emission* requires that explicit call. As a result every `aerospike.<op>` span was silently dropped, even though `docs/observability.md` claimed they were "emitted automatically".

This PR wires aerospike-py's native instrumentation into ACM's observability pipeline so its **traces and Rust-core logs are actually collected**.

## Changes

- **`observability.py`** — `setup_observability()` now starts aerospike-py's native OTLP span exporter (`init_tracing()`); a new `apply_aerospike_py_log_level()` routes the Rust core's logs into the stdlib `logging` tree; `shutdown_observability()` flushes both aerospike-py's tracer and the Python OTel SDK providers. Every aerospike-py call is best-effort — a failure can never break startup or shutdown.
- **`config.py`** — documents the `AEROSPIKE_PY_LOG_LEVEL` / `AEROSPIKE_PY_TRACING` env knobs.
- **`main.py`** — applies the Rust-core log level after `setup_logging`; flushes the OTel pipeline last on lifespan shutdown.
- **`compose.yaml` + `otel/otel-collector.yaml`** — an opt-in `observability` profile that runs an OTel Collector printing every signal, so the pipeline is verifiable locally with `podman compose --profile observability up`.
- **`docs/observability.md`** — corrects the inaccurate "automatic spans" claim and documents the aerospike-py instrumentation surface.

## Behaviour

Off by default (`OTEL_SDK_DISABLED=true`) — zero runtime cost. When OTel is enabled, `aerospike.<op>` spans now nest under ACM's FastAPI/handler spans, and the client core's logs flow through ACM's formatter and OTLP log pipeline.

> aerospike-py's Rust exporter speaks **OTLP/gRPC only**; ACM logs a warning at startup if `OTEL_EXPORTER_OTLP_PROTOCOL` is set to HTTP.

## Testing

- New `test_observability.py` cases cover log-level mapping, tracing opt-out, error swallowing, and setup/shutdown wiring.
- Full suite: **735 passed**. `ruff`, `ruff format`, `pyright` all clean.

## Notes

Companion to **aerospike-ce-kubernetes-operator#279**, which adds an OpenTelemetry pipeline to the operator. Together they give end-to-end traces across the cluster-manager API and the operator.
