### PR TITLE
docs: remove stale AQL terminal references

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A web-based GUI management tool for Aerospike Community Edition.
 
-Provides cluster monitoring, record browsing, query execution, index management, user/role management, UDF management, AQL terminal, and more.
+Provides cluster monitoring, record browsing, query execution, index management, user/role management, UDF management, and more.
 
 ## Overview
 
@@ -155,11 +155,10 @@ Related targets: `make kind-up/down/status`, `make acko-install/uninstall/verify
 - **Index Management** — Secondary index creation/deletion
 - **Admin** — User/role CRUD (with CE limitation indicators)
 - **UDF Management** — Lua UDF upload/delete
-- **AQL Terminal** — Web-based AQL command execution
 - **Prometheus Metrics** — Cluster metrics export
 - **OpenTelemetry Observability** — Traces, metrics, and logs via standard OTel SDK env vars; HTTP server, asyncpg, and aerospike-py spans auto-emit. See [docs/observability.md](docs/observability.md).
 - **Structured stdout logs ready for OTel Collector** — JSON output with `request_id` / `otelTraceID` / `otelSpanID` correlation fields. Optional rotating-file mirror (`LOG_FILE_PATH`) lets a pod-internal sidecar tail logs on a shared `emptyDir` and forward them via OTLP to an external OpenTelemetry Collector for vendor-specific routing (Datadog, Loki, Elasticsearch, Sentry, ...). See [docs/logging.md](docs/logging.md).
-- **Sample Data Generator** — Generate deterministic sample records with optional indexes and UDFs
+- **Sample Data Generator** — Generate deterministic sample records with optional secondary indexes
 - **K8s Cluster Management** — Full lifecycle management of Aerospike clusters on Kubernetes (see below)
   - ACL/Security configuration with role and user management via wizard
   - Rolling update strategy (batch size, max unavailable, PDB control)
@@ -253,20 +252,6 @@ Create and manage secondary indexes on Aerospike bins:
 - **Delete Index** — Remove indexes by name from a given namespace
 - **Index State** — View index status (ready, building, error) across all namespaces
 
-### AQL Terminal
-
-A web-based terminal for executing AQL-style commands against the connected cluster. Supported commands include:
-
-- `show namespaces` — List all namespaces
-- `show sets` — List all sets with object/tombstone counts
-- `show bins` — List all bin names across namespaces
-- `show indexes` / `show sindex` — List all secondary indexes
-- `status` — Show server status
-- `build` — Show server edition and build version
-- `node` — Show current node identifier
-- `statistics` — Show per-node statistics
-- Raw info commands are also supported as a fallback
-
 ### User & Role Management (ACL)
 
 Manage Aerospike access control lists (requires security to be enabled in `aerospike.conf`):
@@ -301,7 +286,6 @@ Generate deterministic sample data sets for testing and demonstration:
 
 - **Record Generation** — Create a configurable number of sample records in any namespace/set
 - **Secondary Indexes** — Optionally create indexes on sample data bins (numeric, string, geo2dsphere)
-- **UDF Registration** — Optionally register bundled Lua UDF modules alongside sample data
 
 ## Aerospike Data Management API Reference
 
@@ -377,12 +361,6 @@ All data management endpoints are prefixed with `/api` and require a `{conn_id}`
 | `POST` | `/api/udfs/{conn_id}` | Upload and register a Lua UDF module |
 | `DELETE` | `/api/udfs/{conn_id}?filename=...` | Delete a UDF module by filename |
 
-### Terminal API (`/api/terminal`)
-
-| Method | Endpoint | Description |
-|---|---|---|
-| `POST` | `/api/terminal/{conn_id}` | Execute an AQL-style terminal command |
-
 ### Metrics API (`/api/metrics`)
 
 | Method | Endpoint | Description |
@@ -393,7 +371,7 @@ All data management endpoints are prefixed with `/api` and require a `{conn_id}`
 
 | Method | Endpoint | Description |
 |---|---|---|
-| `POST` | `/api/sample-data/{conn_id}` | Generate sample records with optional indexes and UDFs |
+| `POST` | `/api/sample-data/{conn_id}` | Generate sample records with optional indexes |
 
 > Interactive API documentation (Swagger UI) is available at `http://localhost:8000/docs` when the api is running.
 

--- a/api/README.md
+++ b/api/README.md
@@ -38,7 +38,6 @@ export AEROSPIKE_PORT=14790
 | `/api/admin/users/{conn_id}` | User management (Enterprise) |
 | `/api/admin/roles/{conn_id}` | Role management (Enterprise) |
 | `/api/udfs/{conn_id}` | UDF management |
-| `/api/terminal/{conn_id}` | AQL terminal |
 | `/api/metrics/{conn_id}` | Metrics & monitoring |
 | `/api/k8s/clusters` | K8s AerospikeCluster lifecycle (CRUD, scale, operations, HPA) |
 | `/api/k8s/templates` | K8s AerospikeClusterTemplate management |

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,6 @@
 Guides for the Aerospike Cluster Manager.
 
 - [Architecture Overview](./architecture.md) -- System architecture, component roles, deployment models, and environment configuration.
-- [Data Management Guide](./data-management.md) -- Connection management, record browser, query builder, indexes, ACL, UDFs, AQL terminal, and metrics.
+- [Data Management Guide](./data-management.md) -- Connection management, record browser, query builder, indexes, ACL, UDFs, and metrics.
 - [Kubernetes Cluster Management Guide](./k8s-management.md) -- K8s cluster creation wizard, template management, operations, and monitoring.
 - [Troubleshooting Guide](./troubleshooting.md) -- Common issues and solutions for connectivity, K8s management, PostgreSQL, CORS, pod logs, timeouts, and database pool tuning.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,7 +6,7 @@ This document describes how the Aerospike Cluster Manager integrates with the Ae
 
 The Aerospike Cluster Manager is a web-based GUI that provides two primary capabilities:
 
-1. **Aerospike Data Management** -- Direct interaction with Aerospike clusters (record browsing, queries, index management, ACL, UDFs, AQL terminal, metrics).
+1. **Aerospike Data Management** -- Direct interaction with Aerospike clusters (record browsing, queries, index management, ACL, UDFs, metrics).
 2. **Kubernetes Cluster Lifecycle Management** -- Full GUI for managing `AerospikeCluster` and `AerospikeClusterTemplate` custom resources deployed by the Aerospike CE Kubernetes Operator.
 
 ```
@@ -28,7 +28,6 @@ The Aerospike Cluster Manager is a web-based GUI that provides two primary capab
 |  |  indexes,     |  |  via asyncio.to_thread()    |  |
 |  |  admin,       |  |                             |  |
 |  |  udfs,        |  |                             |  |
-|  |  terminal,    |  |                             |  |
 |  |  metrics)     |  |                             |  |
 |  +-------+-------+  +-------------+---------------+  |
 |          |                        |                   |
@@ -67,7 +66,7 @@ The Aerospike Cluster Manager is a web-based GUI that provides two primary capab
 
 ### UI (Next.js 14)
 
-- **App Router** pages under `src/app/` for each feature area (`/browser`, `/cluster`, `/k8s/clusters`, `/k8s/templates`, `/admin`, `/indexes`, `/udfs`, `/terminal`, `/settings`).
+- **App Router** pages under `src/app/` for each feature area (`/browser`, `/cluster`, `/k8s/clusters`, `/k8s/templates`, `/admin`, `/indexes`, `/udfs`, `/settings`).
 - **Zustand stores** manage client-side state (`connection-store`, `k8s-cluster-store`, `browser-store`, `query-store`, `admin-store`, `metrics-store`, `filter-store`, `ui-store`, `toast-store`).
 - K8s features are conditionally shown based on whether `GET /api/k8s/clusters` returns a 404 (K8s disabled) or a successful response.
 - The **K8s cluster creation wizard** is a multi-step form with 11 steps (Step 0–10) covering creation mode, basic config, namespace/storage, monitoring, resources, ACL/security, rolling update, rack config, sidecars, advanced settings, and review.
@@ -251,7 +250,6 @@ The PostgreSQL connection pool is configurable via `DB_POOL_MIN_SIZE`, `DB_POOL_
 | Index Management | Yes | Yes |
 | Admin (Users/Roles) | Yes | Yes |
 | UDF Management | Yes | Yes |
-| AQL Terminal | Yes | Yes |
 | Sample Data Generator | Yes | Yes |
 | K8s Cluster Lifecycle | No | Yes |
 | K8s Template Management | No | Yes |

--- a/docs/data-management.md
+++ b/docs/data-management.md
@@ -116,23 +116,6 @@ The UDFs page (`/udfs/{connId}`) manages Lua User-Defined Functions:
 - **Upload** -- Register a new Lua UDF module by pasting script content in the browser.
 - **Delete** -- Remove a registered UDF module by filename.
 
-## AQL Terminal
-
-The terminal page (`/terminal/{connId}`) provides a web-based AQL command execution interface. Supported commands:
-
-| Command | Description |
-|---------|-------------|
-| `show namespaces` | List all namespaces |
-| `show sets` | List all sets with object/tombstone counts |
-| `show bins` | List all bin names across namespaces |
-| `show indexes` / `show sindex` | List all secondary indexes |
-| `status` | Show server status |
-| `build` | Show server edition and build version |
-| `node` | Show current node identifier |
-| `statistics` | Show per-node statistics |
-
-Raw `asinfo` commands are also supported as a fallback for commands not covered above.
-
 ## Prometheus Metrics & Monitoring
 
 The cluster dashboard provides real-time metrics with historical time-series data:
@@ -150,7 +133,6 @@ Generate deterministic sample data for testing and demonstration:
 
 - **Record Generation** -- Create a configurable number of sample records in any namespace/set.
 - **Secondary Indexes** -- Optionally create indexes on sample data bins.
-- **UDF Registration** -- Optionally register bundled Lua UDF modules alongside sample data.
 
 ## Settings
 
@@ -159,7 +141,7 @@ The settings page (`/settings`) provides:
 - **Theme** -- Light, Dark, or System theme selection.
 - **CE Limitations** -- Reference card showing Aerospike Community Edition restrictions (max nodes, namespaces, data capacity, durable deletes, XDR).
 - **About** -- Application version and framework information.
-- **Keyboard Shortcuts** -- `Cmd+B` (toggle sidebar), `` Cmd+` `` (toggle terminal).
+- **Keyboard Shortcuts** -- `Cmd+B` (toggle sidebar).
 
 ## See also
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -36,7 +36,7 @@ Common issues and their solutions when running the Aerospike Cluster Manager.
 
 1. **ACL enabled but credentials not provided** -- If the Aerospike server has security enabled, the connection profile must include valid username and password.
 
-2. **Namespace does not exist** -- Verify the target namespace exists on the server. Use the AQL terminal or cluster overview to check available namespaces.
+2. **Namespace does not exist** -- Verify the target namespace exists on the server. Use the cluster overview to check available namespaces.
 
 3. **Storage full** -- Check namespace memory/device usage in the cluster dashboard. Aerospike stops writes when high-water-mark thresholds are reached.
 

--- a/ui/src/app/(main)/clusters/[clusterId]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/page.tsx
@@ -64,13 +64,6 @@ export default function ClusterOverview({ params }: PageProps) {
           >
             Refresh
           </Button>
-          <Button
-            variant="primary"
-            disabled
-            title="Use the dedicated terminal page"
-          >
-            Open in AQL
-          </Button>
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- Remove references to the non-existent AQL terminal page/API and its disabled UI affordance.
- Correct sample-data wording so it only claims deterministic records plus optional secondary indexes, not bundled UDF registration.

## Testing
- targeted `rg` checks for stale AQL terminal and sample UDF claims
- `cd ui && npm run type-check`
- `git diff --check`