### PR TITLE
fix: OIDC 500 on JWKS outage, wrong cluster metrics, and pagination/race bugs

### DIFF
--- a/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
+++ b/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
@@ -280,18 +280,27 @@ class OIDCAuthMiddleware(BaseHTTPMiddleware):
 
     async def _refresh_jwks(self) -> None:
         client = self._get_http_client()
-        if self._jwks_uri is None:
-            well_known = f"{self.issuer_url}/.well-known/openid-configuration"
-            resp = await client.get(well_known)
-            resp.raise_for_status()
-            doc = resp.json()
-            uri = doc.get("jwks_uri")
-            if not isinstance(uri, str) or not uri:
-                raise _AuthError("OIDC discovery document is missing jwks_uri")
-            self._jwks_uri = uri
+        # A transient JWKS-endpoint outage raises httpx.HTTPError
+        # (httpx.RequestError for network failures, httpx.HTTPStatusError for
+        # non-2xx). These are NOT _AuthError, so without translation they would
+        # escape _verify -> dispatch (which only catches _AuthError) and crash
+        # every authenticated request with an unhandled HTTP 500. Translate
+        # them into _AuthError so dispatch rejects the request cleanly (401).
+        try:
+            if self._jwks_uri is None:
+                well_known = f"{self.issuer_url}/.well-known/openid-configuration"
+                resp = await client.get(well_known)
+                resp.raise_for_status()
+                doc = resp.json()
+                uri = doc.get("jwks_uri")
+                if not isinstance(uri, str) or not uri:
+                    raise _AuthError("OIDC discovery document is missing jwks_uri")
+                self._jwks_uri = uri
 
-        resp = await client.get(self._jwks_uri)
-        resp.raise_for_status()
+            resp = await client.get(self._jwks_uri)
+            resp.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise _AuthError(f"OIDC JWKS fetch failed: {exc}") from exc
         payload = resp.json()
         keys = payload.get("keys") if isinstance(payload, dict) else None
         if not isinstance(keys, list):

--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -8,9 +8,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from starlette.responses import Response
 
 from aerospike_cluster_manager_api.client_manager import client_manager
-from aerospike_cluster_manager_api.constants import INFO_BUILD, INFO_EDITION, INFO_NAMESPACES
+from aerospike_cluster_manager_api.constants import INFO_BUILD, INFO_EDITION, INFO_NAMESPACES, NS_SUM_KEYS
 from aerospike_cluster_manager_api.dependencies import CallerOwnerId, _get_verified_connection
-from aerospike_cluster_manager_api.info_parser import parse_kv_pairs, parse_list, safe_int
+from aerospike_cluster_manager_api.info_parser import aggregate_node_kv, parse_list, safe_int
 from aerospike_cluster_manager_api.models.connection import (
     ConnectionProfileResponse,
     ConnectionStatus,
@@ -146,16 +146,20 @@ async def get_connection_health(conn_id: str = Depends(_get_verified_connection)
         disk_total = 0
 
         try:
-            # Fetch all namespace info in parallel
+            # Fetch all namespace info from every node in parallel. info_all
+            # returns per-node responses; aggregate_node_kv sums the size keys
+            # across nodes for an accurate cluster-wide total. Sampling a single
+            # random node and multiplying by node_count is wrong on an
+            # unbalanced cluster.
             if namespaces:
                 ns_infos = await asyncio.gather(
-                    *[client.info_random_node(f"namespace/{ns_name}") for ns_name in namespaces]
+                    *[client.info_all(f"namespace/{ns_name}") for ns_name in namespaces]
                 )
             else:
                 ns_infos = []
 
             for ns_info in ns_infos:
-                kv = parse_kv_pairs(ns_info)
+                kv = aggregate_node_kv(ns_info, keys_to_sum=NS_SUM_KEYS)
                 # CE 8 uses unified data_used_bytes/data_total_bytes for both memory and device.
                 # Fall back to legacy memory_used_bytes/memory-size for older versions.
                 ns_data_used = (
@@ -168,11 +172,10 @@ async def get_connection_health(conn_id: str = Depends(_get_verified_connection)
                     if "data_total_bytes" in kv
                     else safe_int(kv.get("memory-size"))
                 )
-                # Multiply per-node values by node count for cluster-wide estimate
-                memory_used += ns_data_used * node_count
-                memory_total += ns_data_total * node_count
-                disk_used += safe_int(kv.get("device_used_bytes")) * node_count
-                disk_total += safe_int(kv.get("device-total-bytes")) * node_count
+                memory_used += ns_data_used
+                memory_total += ns_data_total
+                disk_used += safe_int(kv.get("device_used_bytes"))
+                disk_total += safe_int(kv.get("device-total-bytes"))
         except Exception:
             logger.debug("Failed to collect namespace stats for connection '%s'", conn_id, exc_info=True)
 

--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -152,9 +152,7 @@ async def get_connection_health(conn_id: str = Depends(_get_verified_connection)
             # random node and multiplying by node_count is wrong on an
             # unbalanced cluster.
             if namespaces:
-                ns_infos = await asyncio.gather(
-                    *[client.info_all(f"namespace/{ns_name}") for ns_name in namespaces]
-                )
+                ns_infos = await asyncio.gather(*[client.info_all(f"namespace/{ns_name}") for ns_name in namespaces])
             else:
                 ns_infos = []
 

--- a/api/src/aerospike_cluster_manager_api/routers/indexes.py
+++ b/api/src/aerospike_cluster_manager_api/routers/indexes.py
@@ -4,13 +4,14 @@ import logging
 from typing import Any, Literal, cast
 
 from aerospike_py.exception import AerospikeError, IndexFoundError, IndexNotFound
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from starlette.responses import Response
 
 from aerospike_cluster_manager_api.constants import INFO_NAMESPACES, info_sindex
 from aerospike_cluster_manager_api.dependencies import AerospikeClient
 from aerospike_cluster_manager_api.info_parser import parse_list, parse_records
 from aerospike_cluster_manager_api.models.index import CreateIndexRequest, SecondaryIndex
+from aerospike_cluster_manager_api.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
 
@@ -69,7 +70,8 @@ async def get_indexes(client: AerospikeClient) -> list[SecondaryIndex]:
     summary="Create secondary index",
     description="Create a new secondary index on a specified namespace, set, and bin.",
 )
-async def create_index(body: CreateIndexRequest, client: AerospikeClient) -> SecondaryIndex:
+@limiter.limit("10/minute")
+async def create_index(request: Request, body: CreateIndexRequest, client: AerospikeClient) -> SecondaryIndex:
     """Create a new secondary index on a specified namespace, set, and bin.
 
     aerospike-py internally calls ``IndexTask.wait_till_complete`` after the
@@ -115,7 +117,9 @@ async def create_index(body: CreateIndexRequest, client: AerospikeClient) -> Sec
     summary="Delete secondary index",
     description="Remove a secondary index by name from the specified namespace.",
 )
+@limiter.limit("10/minute")
 async def delete_index(
+    request: Request,
     client: AerospikeClient,
     name: str = Query(..., min_length=1),
     ns: str = Query(..., min_length=1),

--- a/api/src/aerospike_cluster_manager_api/services/records_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/records_service.py
@@ -422,12 +422,18 @@ async def list_records(
         logger.exception("Query failed for ns=%s set=%s; returning empty page", namespace, set_name)
         raw_results = []
 
+    # When the scan returned a full page, there is more data regardless of
+    # set_total. set_total is an independent info-command estimate that can
+    # lag the actual scan on an eventually-consistent set, which would
+    # otherwise make has_more falsely False on a full page.
+    has_more = True if len(raw_results) >= limit else set_total > len(raw_results)
+
     return ListRecordsResult(
         records=raw_results,
         total=set_total,
         page=1,
         page_size=page_size,
-        has_more=set_total > len(raw_results),
+        has_more=has_more,
         total_estimated=True,
     )
 

--- a/api/tests/test_oidc_auth.py
+++ b/api/tests/test_oidc_auth.py
@@ -373,6 +373,58 @@ async def test_unknown_kid_back_off_prevents_amplification():
 
 
 @pytest.mark.asyncio
+async def test_jwks_fetch_network_error_yields_401_not_500():
+    """A transient JWKS-endpoint network outage must be rejected cleanly (401)
+    rather than escaping as an unhandled HTTP 500 on every request."""
+    priv, jwk = _rsa_keypair()
+    token = _sign(priv, jwk["kid"])
+
+    def _failing_handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("JWKS endpoint unreachable")
+
+    transport = httpx.MockTransport(_failing_handler)
+    failing_client = httpx.AsyncClient(transport=transport, timeout=5.0)
+    app = _build_app(http_client=failing_client)
+    asgi = ASGITransport(app=app)
+    async with AsyncClient(transport=asgi, base_url="http://test") as ac:
+        resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code in (401, 503)
+    assert resp.status_code != 500
+    assert "detail" in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_jwks_fetch_non_200_yields_401_not_500():
+    """A non-200 response from the JWKS endpoint (e.g. 503 from the IdP) must
+    be rejected cleanly rather than crashing the request with an HTTP 500."""
+    priv, jwk = _rsa_keypair()
+    token = _sign(priv, jwk["kid"])
+
+    def _error_handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/.well-known/openid-configuration"):
+            return httpx.Response(
+                200,
+                json={
+                    "issuer": ISSUER,
+                    "jwks_uri": f"{ISSUER}/protocol/openid-connect/certs",
+                },
+            )
+        # JWKS endpoint itself is down.
+        return httpx.Response(503, text="service unavailable")
+
+    transport = httpx.MockTransport(_error_handler)
+    failing_client = httpx.AsyncClient(transport=transport, timeout=5.0)
+    app = _build_app(http_client=failing_client)
+    asgi = ASGITransport(app=app)
+    async with AsyncClient(transport=asgi, base_url="http://test") as ac:
+        resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code in (401, 503)
+    assert resp.status_code != 500
+    assert "detail" in resp.json()
+
+
+@pytest.mark.asyncio
 async def test_disabled_middleware_is_passthrough():
     mock = _JWKSMock([])
     app = _build_app(enabled=False, http_client=_client_for(mock))

--- a/ui/src/hooks/use-k8s-clusters.ts
+++ b/ui/src/hooks/use-k8s-clusters.ts
@@ -60,9 +60,13 @@ export function useK8sClusters(
   useEffect(() => {
     let cancelled = false
     setIsLoading(true)
+    // Use the params parsed from paramsKey — the exact value the effect
+    // depends on — rather than paramsRef.current, which under React 18
+    // batching can be ahead of or behind paramsKey and cause a stale fetch.
+    const effectParams = JSON.parse(paramsKey) as ListK8sClustersParams
     ;(async () => {
       try {
-        const result = await listK8sClusters(paramsRef.current)
+        const result = await listK8sClusters(effectParams)
         if (!cancelled && isMountedRef.current) {
           setData(result)
           setError(null)


### PR DESCRIPTION
Fixes from the 2026-05 code audit. Five independent bug fixes, one commit each. Scope is limited to the audited files plus tests.

## Fix 1 (P0, API outage) — OIDC JWKS fetch failure crashed every authenticated request with HTTP 500

**Problem:** `_refresh_jwks` in `middleware/oidc_auth.py` called `client.get(...)` + `resp.raise_for_status()`. A transient JWKS-endpoint outage raises `httpx.RequestError` / `httpx.HTTPStatusError`, which are not `_AuthError`. They escaped `_verify` -> `dispatch` (which only catches `_AuthError`) and produced an unhandled HTTP 500 on every request while OIDC was enabled.

**Fix:** Wrapped the discovery + JWKS-certs fetch in `_refresh_jwks` and translated `httpx.HTTPError` (the umbrella covering both `RequestError` and `HTTPStatusError`) into `_AuthError`. `dispatch` maps `_AuthError` to a clean 401. Added two tests in `test_oidc_auth.py`: a network error (`httpx.ConnectError`) and a non-200 JWKS response (503) — both assert the request is rejected cleanly and is not a 500.

**Impact:** A flapping IdP/JWKS endpoint now degrades to 401s for the affected requests instead of taking down the whole authenticated API surface.

## Fix 2 (P1, wrong metrics) — connection-health namespace stats sampled per random node then multiplied by node count

**Problem:** `get_connection_health` in `routers/connections.py` fetched per-namespace stats via `info_random_node` then multiplied per-node values by `node_count`. On an unbalanced cluster this over/under-estimates memory and disk.

**Fix:** Switched the per-namespace fetch to `client.info_all(...)` + `aggregate_node_kv(..., keys_to_sum=NS_SUM_KEYS)` — the same approach `metrics_service` already uses — and dropped the `* node_count` multiplication. Removed the now-unused `parse_kv_pairs` import.

**Impact:** Connection-health memory/disk totals now reflect the actual cluster-wide sum.

## Fix 3 (P1, stale-param race) — `useK8sClusters` refetch effect ignored `paramsRef` updates

**Problem:** In `ui/src/hooks/use-k8s-clusters.ts` the fetch effect depended on `paramsKey` (`JSON.stringify(params)`) but called `listK8sClusters(paramsRef.current)`. Under React 18 batching the ref can be ahead of/behind the key, causing a fetch with stale params.

**Fix:** Parse the params from `paramsKey` inside the effect, so the value used and the value depended on are identical. Public hook API unchanged.

**Impact:** The K8s clusters list now always fetches with the params the effect re-ran for.

## Fix 4 (P1, wrong pagination) — `list_records` `hasMore` from a cluster-total estimate disagreed with the actual scan

**Problem:** In `services/records_service.py`, `has_more = set_total > len(raw_results)` where `set_total` is an independent info-command estimate. On an eventually-consistent set `set_total` can lag the scan, making `has_more` falsely `False` on a full page and hiding remaining records.

**Fix:** When the scan returned a full page (`len(raw_results) >= limit`), force `has_more = True`; `set_total` is still used only for the displayed estimate.

**Impact:** Pagination no longer drops the next page when the set-total estimate trails the scan.

## Fix 5 (P2, consistency) — secondary-index create/delete not rate-limited

**Problem:** `create_index` and `delete_index` in `routers/indexes.py` only had the global default rate limit, unlike every other mutation route.

**Fix:** Added `@limiter.limit("10/minute")` to both handlers (consistent with `connections.py` create/delete and `sets.py` truncate), including the `request: Request` parameter the decorator requires.

**Impact:** Index mutations get the same per-route abuse protection as other mutations.

## Verification

Backend (`api/`):
- `uv run ruff check src tests` — All checks passed
- `uv run pytest tests/` — 747 passed, 2 warnings (pre-existing, unrelated mock warnings in `test_client_manager.py`)
- New OIDC tests included (`test_jwks_fetch_network_error_yields_401_not_500`, `test_jwks_fetch_non_200_yields_401_not_500`) — pass

Frontend (`ui/`):
- `npm run type-check` (`tsc --noEmit`) — clean
- `npm run lint` (`next lint`) — No ESLint warnings or errors

No `version` fields were edited.