### PR TITLE
fix: rate-limit remaining mutation endpoints, stop swallowing cluster errors in set count

### DIFF
--- a/api/src/aerospike_cluster_manager_api/routers/clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/clusters.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 
 from aerospike_cluster_manager_api.dependencies import AerospikeClient, VerifiedConnId
 from aerospike_cluster_manager_api.info_verbs import InfoVerbNotAllowed, assert_read_only
@@ -14,6 +14,7 @@ from aerospike_cluster_manager_api.models.cluster import (
     InfoCommandResult,
 )
 from aerospike_cluster_manager_api.models.common import MessageResponse
+from aerospike_cluster_manager_api.rate_limit import limiter
 from aerospike_cluster_manager_api.services import clusters_service
 from aerospike_cluster_manager_api.services.clusters_service import (
     NamespaceConfigError,
@@ -43,7 +44,10 @@ async def get_cluster(client: AerospikeClient, conn_id: VerifiedConnId) -> Clust
     summary="Configure namespace",
     description="Update runtime-tunable parameters of an existing Aerospike namespace.",
 )
-async def configure_namespace(body: CreateNamespaceRequest, client: AerospikeClient) -> MessageResponse:
+@limiter.limit("10/minute")
+async def configure_namespace(
+    request: Request, body: CreateNamespaceRequest, client: AerospikeClient
+) -> MessageResponse:
     """Update runtime-tunable parameters of an existing Aerospike namespace."""
     try:
         message = await clusters_service.configure_namespace(client, body)

--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -90,7 +90,9 @@ async def get_connection(
 @router.put(
     "/{conn_id}", summary="Update connection", description="Update an existing connection profile with new settings."
 )
+@limiter.limit("10/minute")
 async def update_connection(
+    request: Request,
     body: UpdateConnectionRequest,
     caller_owner_id: CallerOwnerId,
     conn_id: str = Depends(_get_verified_connection),

--- a/api/src/aerospike_cluster_manager_api/routers/guides.py
+++ b/api/src/aerospike_cluster_manager_api/routers/guides.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, HTTPException, Path
+from fastapi import APIRouter, HTTPException, Path, Request
 from pydantic import BaseModel
 from starlette.responses import Response
 
@@ -28,6 +28,7 @@ from aerospike_cluster_manager_api.models.guide import (
     GuideType,
     UpsertGuideRequest,
 )
+from aerospike_cluster_manager_api.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +91,9 @@ async def get_guide(
         "empty PUT body is rejected with 422."
     ),
 )
+@limiter.limit("20/minute")
 async def upsert_guide(
+    request: Request,
     body: UpsertGuideRequest,
     caller_owner_id: CallerOwnerId,
     workspace_id: VerifiedWorkspaceId,
@@ -106,7 +109,9 @@ async def upsert_guide(
     summary="Delete an operational guide",
     description="Remove an operational guide. No-op (still 204) when the guide does not exist.",
 )
+@limiter.limit("20/minute")
 async def delete_guide(
+    request: Request,
     workspace_id: VerifiedWorkspaceId,
     guide_type: GuideTypePath,
 ) -> Response:

--- a/api/src/aerospike_cluster_manager_api/routers/notes.py
+++ b/api/src/aerospike_cluster_manager_api/routers/notes.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import logging
 from typing import Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Path, Query
+from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
 from pydantic import BaseModel
 from starlette.responses import Response
 
@@ -34,6 +34,7 @@ from aerospike_cluster_manager_api.models.note import (
 )
 from aerospike_cluster_manager_api.models.workspace import SYSTEM_OWNER_ID
 from aerospike_cluster_manager_api.pk import resolve_pk
+from aerospike_cluster_manager_api.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
 
@@ -104,7 +105,9 @@ class SetNotesListResponse(BaseModel):
     summary="Upsert set note",
     description="Create or update an operator note attached to a set.",
 )
+@limiter.limit("20/minute")
 async def upsert_set_note(
+    request: Request,
     body: UpsertSetNoteRequest,
     caller_owner_id: CallerOwnerId,
     conn_id: str = Depends(_assert_caller_owns_connection),
@@ -127,7 +130,9 @@ async def upsert_set_note(
     summary="Delete set note",
     description="Remove the operator note attached to a set. No-op when no note exists.",
 )
+@limiter.limit("20/minute")
 async def delete_set_note(
+    request: Request,
     conn_id: str = Depends(_assert_caller_owns_connection),
     namespace: str = Path(..., min_length=1, max_length=31),
     set_name: str = Path(..., min_length=1, max_length=63),
@@ -163,7 +168,9 @@ class RecordNotesListResponse(BaseModel):
     summary="Upsert record note",
     description="Create or update an operator note on a single record.",
 )
+@limiter.limit("20/minute")
 async def upsert_record_note(
+    request: Request,
     body: UpsertRecordNoteRequest,
     caller_owner_id: CallerOwnerId,
     conn_id: str = Depends(_assert_caller_owns_connection),
@@ -192,7 +199,9 @@ async def upsert_record_note(
     summary="Delete record note",
     description="Remove the operator note on a single record. No-op when none exists.",
 )
+@limiter.limit("20/minute")
 async def delete_record_note(
+    request: Request,
     conn_id: str = Depends(_assert_caller_owns_connection),
     namespace: str = Path(..., min_length=1, max_length=31),
     set_name: str = Path(..., min_length=1, max_length=63),

--- a/api/src/aerospike_cluster_manager_api/routers/workspaces.py
+++ b/api/src/aerospike_cluster_manager_api/routers/workspaces.py
@@ -78,7 +78,9 @@ async def get_workspace(
         "``ownerId`` is read-only and silently ignored — Phase 2 forbids workspace transfers."
     ),
 )
+@limiter.limit("10/minute")
 async def update_workspace(
+    request: Request,
     body: UpdateWorkspaceRequest,
     caller_owner_id: CallerOwnerId,
     workspace_id: str = Path(),

--- a/api/src/aerospike_cluster_manager_api/services/records_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/records_service.py
@@ -151,6 +151,15 @@ async def _get_set_object_count(client: aerospike_py.AsyncClient, ns: str, set_n
 
     Fetches the namespace replication-factor first to de-duplicate counts
     across nodes, matching the same approach used in ``clusters_service``.
+
+    Connectivity / timeout / backpressure errors (``ClusterError``,
+    ``AerospikeTimeoutError``, ``BackpressureError``) are re-raised so the
+    global exception handlers in :mod:`main` can map them to 503/504. The
+    callers (:func:`list_records`, :func:`run_filtered_query`) deliberately
+    propagate those same classes — swallowing them here would make a
+    transient timeout report ``total=0`` on a non-empty set. Only narrow,
+    best-effort failures (other ``AerospikeError`` / ``OSError``) fall back
+    to 0.
     """
     if not set_name:
         return 0
@@ -164,6 +173,9 @@ async def _get_set_object_count(client: aerospike_py.AsyncClient, ns: str, set_n
         for s in agg:
             if s["name"] == set_name:
                 return s["objects"]
+    except (ClusterError, AerospikeTimeoutError, BackpressureError):
+        # Infrastructure failure — must surface as 503/504, not a fake 0.
+        raise
     except (AerospikeError, OSError):
         logger.debug("Failed to get set object count for %s.%s", ns, set_name, exc_info=True)
     return 0

--- a/api/tests/test_records_service.py
+++ b/api/tests/test_records_service.py
@@ -428,6 +428,64 @@ class TestTruncateSet:
 
 
 # ---------------------------------------------------------------------------
+# _get_set_object_count (info-command set total)
+# ---------------------------------------------------------------------------
+
+
+class TestGetSetObjectCount:
+    """The set-total helper backs ``total`` on list_records / run_filtered_query.
+
+    A transient cluster failure here must NOT be swallowed into ``0`` — that
+    would make a non-empty result set report ``total=0``. ClusterError /
+    AerospikeTimeoutError / BackpressureError must propagate so the global
+    handlers in ``main`` map them to 503/504, mirroring the scan path.
+    """
+
+    async def test_cluster_error_propagates_not_zero(self):
+        client = AsyncMock()
+        client.info_all = AsyncMock(side_effect=ClusterError("cluster down"))
+
+        with pytest.raises(ClusterError):
+            await records_service._get_set_object_count(client, "test", "demo")
+
+    async def test_timeout_error_propagates_not_zero(self):
+        client = AsyncMock()
+        client.info_all = AsyncMock(side_effect=AerospikeTimeoutError("timeout"))
+
+        with pytest.raises(AerospikeTimeoutError):
+            await records_service._get_set_object_count(client, "test", "demo")
+
+    async def test_backpressure_error_propagates_not_zero(self):
+        client = AsyncMock()
+        client.info_all = AsyncMock(side_effect=BackpressureError("queue full"))
+
+        with pytest.raises(BackpressureError):
+            await records_service._get_set_object_count(client, "test", "demo")
+
+    async def test_generic_aerospike_error_is_best_effort_zero(self):
+        """Non-infrastructure AerospikeError stays best-effort → 0."""
+        client = AsyncMock()
+        client.info_all = AsyncMock(side_effect=AerospikeError("sparse namespace"))
+
+        assert await records_service._get_set_object_count(client, "test", "demo") == 0
+
+    async def test_os_error_is_best_effort_zero(self):
+        client = AsyncMock()
+        client.info_all = AsyncMock(side_effect=OSError("socket hiccup"))
+
+        assert await records_service._get_set_object_count(client, "test", "demo") == 0
+
+    async def test_list_records_propagates_set_count_timeout(self):
+        """End-to-end: a timeout while computing the set total during a scan
+        must surface, not collapse the page into a fake total=0."""
+        client, _query = _build_query_mock([_make_record()])
+        client.info_all = AsyncMock(side_effect=AerospikeTimeoutError("info timeout"))
+
+        with pytest.raises(AerospikeTimeoutError):
+            await records_service.list_records(client, "test", "demo", page_size=25)
+
+
+# ---------------------------------------------------------------------------
 # list_records (scan with limit)
 # ---------------------------------------------------------------------------
 

--- a/api/tests/test_security_headers.py
+++ b/api/tests/test_security_headers.py
@@ -209,3 +209,50 @@ def test_limiter_carries_global_default_limits():
     # The Limiter's internal _default_limits is the runtime source of truth;
     # accessing the protected attribute here is a deliberate test-of-glue.
     assert limiter._default_limits, "Limiter must be constructed with default_limits"
+
+
+# ---------------------------------------------------------------------------
+# Per-route rate limits on mutation endpoints
+#
+# The global 60/minute default is a backstop; every destructive/write route
+# must additionally carry an explicit, stricter ``@limiter.limit(...)``. A
+# mutation route that forgets the decorator silently relies on the loose
+# global default — exactly the gap commit 5eb26da closed for create/delete
+# index and this follow-up closes for the rest of the mutation surface.
+# ---------------------------------------------------------------------------
+
+# (module, function) pairs for every per-route-limited mutation endpoint.
+# slowapi keys _route_limits by ``f"{func.__module__}.{func.__name__}"``.
+_RATE_LIMITED_MUTATION_ROUTES = [
+    ("aerospike_cluster_manager_api.routers.indexes", "create_index"),
+    ("aerospike_cluster_manager_api.routers.indexes", "delete_index"),
+    ("aerospike_cluster_manager_api.routers.connections", "create_connection"),
+    ("aerospike_cluster_manager_api.routers.connections", "update_connection"),
+    ("aerospike_cluster_manager_api.routers.connections", "delete_connection"),
+    ("aerospike_cluster_manager_api.routers.clusters", "configure_namespace"),
+    ("aerospike_cluster_manager_api.routers.notes", "upsert_set_note"),
+    ("aerospike_cluster_manager_api.routers.notes", "delete_set_note"),
+    ("aerospike_cluster_manager_api.routers.notes", "upsert_record_note"),
+    ("aerospike_cluster_manager_api.routers.notes", "delete_record_note"),
+    ("aerospike_cluster_manager_api.routers.guides", "upsert_guide"),
+    ("aerospike_cluster_manager_api.routers.guides", "delete_guide"),
+    ("aerospike_cluster_manager_api.routers.workspaces", "create_workspace"),
+    ("aerospike_cluster_manager_api.routers.workspaces", "update_workspace"),
+    ("aerospike_cluster_manager_api.routers.workspaces", "delete_workspace"),
+]
+
+
+@pytest.mark.parametrize(("module", "func_name"), _RATE_LIMITED_MUTATION_ROUTES)
+def test_mutation_route_carries_explicit_rate_limit(module: str, func_name: str):
+    """Every mutation endpoint must register an explicit per-route limit.
+
+    Importing the app wires up all routers, which runs the ``@limiter.limit``
+    decorators and populates ``limiter._route_limits``. A missing key means the
+    route fell back to the loose global default — the regression this guards.
+    """
+    # Importing main ensures every router module is loaded and decorated.
+    from aerospike_cluster_manager_api.main import app  # noqa: F401
+    from aerospike_cluster_manager_api.rate_limit import limiter
+
+    key = f"{module}.{func_name}"
+    assert key in limiter._route_limits, f"mutation route {key} is missing an explicit @limiter.limit(...) decorator"


### PR DESCRIPTION
Follow-up to the 2026-05 code audit (#381). Two independent backend hardening fixes.

## Fix 1 [P1] — Mutation endpoints missing per-route rate limits

**Problem:** Commit 5eb26da added `@limiter.limit("10/minute")` to `create_index`/`delete_index` because they relied solely on the loose 60/minute global default. The same gap remained on every other mutation endpoint — a destructive write route protected only by the global default is effectively unrate-limited for abuse purposes.

**Fix:** Added an explicit `@limiter.limit(...)` decorator (and the required `request: Request` first parameter) to:
- `connections.py` — `update_connection` — `10/minute`
- `clusters.py` — `configure_namespace` (destructive set-config) — `10/minute`
- `notes.py` — `upsert_set_note`, `delete_set_note`, `upsert_record_note`, `delete_record_note` — `20/minute`
- `guides.py` — `upsert_guide`, `delete_guide` — `20/minute`
- `workspaces.py` — `update_workspace` — `10/minute`

Limits match existing convention: `10/minute` for connection/cluster/workspace mutations (same as `create_connection` / sets-truncate), `20/minute` for the higher-volume interactive notes/guides surface. `limiter` import added to `clusters.py`, `notes.py`, `guides.py` where missing. Pattern mirrors the already-decorated `create_index` / `create_connection` routes exactly.

## Fix 2 [P2] — `_get_set_object_count` swallowed infrastructure errors

**Problem:** `records_service._get_set_object_count` caught the broad `(AerospikeError, OSError)` and returned `0`. That swallowed `ClusterError` / `AerospikeTimeoutError` / `BackpressureError` — the exact classes the surrounding scan code (`list_records`, `run_filtered_query`) deliberately re-raises so the global handlers in `main` map them to 503/504. A transient timeout while computing the set total made a non-empty result set report `total=0`.

**Fix:** Added a preceding `except (ClusterError, AerospikeTimeoutError, BackpressureError): raise` clause so infrastructure failures propagate, while other `AerospikeError` / `OSError` stay best-effort → `0`. Exception classes reuse the existing imports in the file.

## Tests
- `test_security_headers.py` — parametrized test asserting every mutation route registers an explicit per-route limit in `limiter._route_limits` (catches a future route that forgets the decorator).
- `test_records_service.py` — `TestGetSetObjectCount`: ClusterError/timeout/backpressure propagate; generic AerospikeError/OSError stay best-effort 0; plus an end-to-end `list_records` propagation test.

## Verification
- `uv run pytest` — full API suite passes (the 2 warnings are pre-existing, unrelated).
- `pre-commit run --files <changed>` — ruff / ruff-format / pyright pass.

## No breaking changes
Adding a `request: Request` parameter is invisible to API clients (FastAPI injects it). No public Pydantic/TypeScript types, JSON wire aliases, or `version:` fields touched. Frontend untouched.