### PR TITLE
fix: serve stale JWKS keys during issuer outage instead of rejecting all requests

### DIFF
--- a/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
+++ b/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
@@ -12,6 +12,13 @@ Cache invalidation triggers (in order of strictness):
   JWKS is refetched **once** before declaring the token invalid; this covers
   Keycloak realm key rotation without requiring a process restart.
 
+Outage resilience: if a TTL-driven refetch fails because the issuer's JWKS
+endpoint is transiently unreachable, the middleware keeps verifying tokens
+against the *stale* cached keys for up to ``_STALE_JWKS_GRACE_SECONDS`` rather
+than 401-ing every authenticated request. A cold cache (never warmed) still
+fails closed. Signing keys rotate on the order of days, so a brief Keycloak
+restart no longer takes the whole API down.
+
 The middleware is installed unconditionally in ``main.py``; when
 ``OIDC_ENABLED=false`` (default) it returns immediately without inspecting the
 request, so non-prod deployments need no Keycloak.
@@ -69,6 +76,23 @@ _ALLOWED_ALGS: frozenset[str] = frozenset(
 # Prevents an attacker from amplifying a flood of bogus tokens into a flood
 # of HTTP requests against the issuer.
 _KID_MISS_BACKOFF_SECONDS: int = 30
+
+# Grace window for serving *stale* JWKS keys after a failed TTL refresh.
+#
+# When the cached JWKS has passed its TTL but the issuer's JWKS endpoint is
+# transiently unreachable (Keycloak restart, network blip), rejecting every
+# request with 401 would take the whole API down for all authenticated users
+# even though the cached keys are almost certainly still valid — IdP signing
+# keys rotate on the order of days/weeks, not minutes. Within this grace
+# window we keep verifying against the stale cache and only re-attempt the
+# fetch (rate-limited) on subsequent requests. Past the grace window the
+# cache is considered untrustworthy and requests fail closed again.
+_STALE_JWKS_GRACE_SECONDS: int = 3600
+
+# Back-off between failed TTL-driven refresh attempts while serving stale
+# keys. Without this, every request during an outage would re-hit the down
+# issuer; mirrors the amplification protection on the unknown-kid path.
+_STALE_REFRESH_BACKOFF_SECONDS: int = 30
 
 
 def _public_key_from_jwk(jwk_dict: dict[str, Any]) -> Any:
@@ -135,6 +159,10 @@ class OIDCAuthMiddleware(BaseHTTPMiddleware):
         # an attacker spamming bogus kids cannot turn each request into a
         # round-trip to the issuer.
         self._last_kid_miss_refresh_at: float = 0.0
+        # Last wall-clock time a TTL-driven refresh *failed*. Used to rate-
+        # limit re-attempts while serving stale keys during an issuer
+        # outage (see ``_STALE_REFRESH_BACKOFF_SECONDS``).
+        self._last_failed_refresh_at: float = 0.0
         # Cached well-known doc — only the ``jwks_uri`` value is used today,
         # but caching it avoids two HTTP round-trips on every refetch.
         self._jwks_uri: str | None = None
@@ -267,8 +295,34 @@ class OIDCAuthMiddleware(BaseHTTPMiddleware):
             kid_missing = kid not in self._jwks_by_kid
 
             if ttl_expired:
-                # Standard TTL refresh path.
-                await self._refresh_jwks()
+                # Standard TTL refresh path. A transient issuer outage must
+                # not take the whole API down: if we already hold cached
+                # keys, fall back to them (within the stale-grace window)
+                # rather than 401-ing every authenticated request. Signing
+                # keys rotate on the order of days, so a stale cache is
+                # overwhelmingly still correct during a brief outage.
+                #
+                # While serving stale keys we also rate-limit the re-fetch
+                # attempts: without the back-off every request during an
+                # outage would re-hit the down issuer.
+                in_refresh_backoff = (
+                    self._can_serve_stale(now) and now - self._last_failed_refresh_at < _STALE_REFRESH_BACKOFF_SECONDS
+                )
+                if not in_refresh_backoff:
+                    try:
+                        await self._refresh_jwks()
+                    except _AuthError:
+                        if self._can_serve_stale(now):
+                            self._last_failed_refresh_at = now
+                            logger.warning(
+                                "OIDC JWKS refresh failed; serving stale cached keys "
+                                "(%d key(s), within %ds grace window)",
+                                len(self._jwks_by_kid),
+                                _STALE_JWKS_GRACE_SECONDS,
+                            )
+                        else:
+                            # Cold cache, or grace window exhausted — fail closed.
+                            raise
             elif kid_missing and (now - self._last_kid_miss_refresh_at >= _KID_MISS_BACKOFF_SECONDS):
                 # Unknown-kid refresh, but rate-limited via back-off window so
                 # a flood of bogus kids cannot amplify into JWKS requests.
@@ -277,6 +331,18 @@ class OIDCAuthMiddleware(BaseHTTPMiddleware):
                 self._last_kid_miss_refresh_at = now
                 await self._refresh_jwks()
             return self._jwks_by_kid.get(kid)
+
+    def _can_serve_stale(self, now: float) -> bool:
+        """Return True if stale cached keys may still back a verification.
+
+        Requires (a) a non-empty cache (a cold start has nothing to fall
+        back on and must fail closed) and (b) the cache having gone stale
+        no longer than ``_STALE_JWKS_GRACE_SECONDS`` ago. Beyond the grace
+        window the keys are treated as untrustworthy.
+        """
+        if not self._jwks_by_kid:
+            return False
+        return now - self._jwks_expires_at <= _STALE_JWKS_GRACE_SECONDS
 
     async def _refresh_jwks(self) -> None:
         client = self._get_http_client()

--- a/api/tests/test_oidc_auth.py
+++ b/api/tests/test_oidc_auth.py
@@ -84,6 +84,10 @@ class _JWKSMock:
         self.jwks = list(jwks)
         self.well_known_calls = 0
         self.jwks_calls = 0
+        # When set, the JWKS endpoint simulates an issuer outage: the
+        # ``.well-known`` doc still serves (it is cached after the first
+        # hit anyway) but the certs endpoint raises a connection error.
+        self.outage = False
 
     def update(self, jwks: list[dict]) -> None:
         self.jwks = list(jwks)
@@ -101,6 +105,8 @@ class _JWKSMock:
             )
         if path.endswith("/protocol/openid-connect/certs"):
             self.jwks_calls += 1
+            if self.outage:
+                raise httpx.ConnectError("JWKS endpoint unreachable")
             return httpx.Response(200, json={"keys": list(self.jwks)})
         return httpx.Response(404)
 
@@ -422,6 +428,71 @@ async def test_jwks_fetch_non_200_yields_401_not_500():
     assert resp.status_code in (401, 503)
     assert resp.status_code != 500
     assert "detail" in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_jwks_outage_after_warm_cache_serves_stale_keys():
+    """A JWKS-endpoint outage that strikes *after* the cache went stale must
+    not 401 every authenticated request. Within the stale-grace window the
+    middleware keeps verifying against the still-valid cached keys."""
+    priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    # TTL=0 forces a TTL-driven refresh attempt on every request, which is
+    # exactly the path that previously failed closed during an outage.
+    app = _build_app(http_client=_client_for(mock), jwks_cache_ttl_seconds=0)
+    token = _sign(priv, jwk["kid"])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        # Warm the cache with a successful fetch.
+        resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+        assert resp.status_code == 200
+
+        # Issuer goes down. The cached keys are still cryptographically valid.
+        mock.outage = True
+        for _ in range(5):
+            resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+            assert resp.status_code == 200, "stale cached keys must still verify a valid token during an outage"
+            assert resp.json() == {"sub": "user-1"}
+
+
+@pytest.mark.asyncio
+async def test_jwks_outage_with_cold_cache_still_fails_closed():
+    """An outage with a cold cache (never warmed) has no keys to fall back on
+    and must fail closed — the stale-cache path must not weaken a cold start."""
+    priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    mock.outage = True  # down before the very first request
+    app = _build_app(http_client=_client_for(mock), jwks_cache_ttl_seconds=0)
+    token = _sign(priv, jwk["kid"])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+    assert resp.status_code in (401, 503)
+    assert resp.status_code != 500
+    assert "detail" in resp.json()
+
+
+@pytest.mark.asyncio
+async def test_jwks_outage_rate_limits_refetch_attempts():
+    """While serving stale keys during an outage, the middleware must not
+    re-hit the down issuer on every request — repeated failed fetches are
+    rate-limited the same way the unknown-kid storm path is."""
+    priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    app = _build_app(http_client=_client_for(mock), jwks_cache_ttl_seconds=0)
+    token = _sign(priv, jwk["kid"])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        await ac.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+        mock.outage = True
+        baseline = mock.jwks_calls
+        for _ in range(10):
+            resp = await ac.get("/api/me", headers={"Authorization": f"Bearer {token}"})
+            assert resp.status_code == 200
+        # At most one re-fetch attempt within the back-off window.
+        assert mock.jwks_calls - baseline <= 1, (
+            "JWKS endpoint was re-hit on every request during an outage (back-off failed)"
+        )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Autonomous code-quality run 2026-05-23.

## Issue

**OIDC JWKS outage rejects all valid tokens once the cache TTL expires** — Severity: **P1** (availability)

`OIDCAuthMiddleware._key_for_kid` refreshes the JWKS cache on TTL expiry. When the issuer's JWKS endpoint is transiently unreachable (Keycloak restart, network blip), the refresh raises `_AuthError` and **every authenticated request gets a 401** — even though the cached signing keys are still cryptographically valid.

PR #381 fixed the *500-on-outage* crash (translating `httpx` errors to `_AuthError`/401), but the deeper availability bug remained: a brief outage that outlasts the cache TTL (default 600s) takes the **entire API down for all authenticated users** despite holding perfectly usable keys. IdP signing keys rotate on the order of days/weeks, so a stale cache is overwhelmingly still correct during a short outage.

### Fix

- A failed TTL-driven refresh now **falls back to the stale cached keys** for up to a 1h grace window (`_STALE_JWKS_GRACE_SECONDS`) instead of 401-ing every request.
- Re-fetch attempts during an outage are **rate-limited** (`_STALE_REFRESH_BACKOFF_SECONDS`, 30s) so the outage cannot amplify into a flood of requests against the down issuer — mirrors the existing unknown-kid amplification protection.
- A **cold cache** (never warmed) still **fails closed** — the stale path does not weaken a cold start.
- **Past the grace window** the cache is treated as untrustworthy and requests fail closed again.

The change is contained to the JWKS-cache path; token signature/exp/iss/aud verification is unchanged.

## Tests

Added 3 tests to `api/tests/test_oidc_auth.py` (extended `_JWKSMock` with a toggleable `outage` flag):

- `test_jwks_outage_after_warm_cache_serves_stale_keys` — valid token keeps verifying (200) during an outage after the cache went stale.
- `test_jwks_outage_with_cold_cache_still_fails_closed` — outage before any warm fetch fails closed (401/503, never 500).
- `test_jwks_outage_rate_limits_refetch_attempts` — at most one re-fetch attempt within the back-off window during a sustained outage.

## Verification

- `ruff check src tests` — passed
- `ruff format --check src tests` — passed (123 files)
- `pytest tests/` — **791 passed** (23 in `test_oidc_auth.py`, including the 3 new tests)
- No live-cluster tests were needed for this change; no UI changes.