### PR TITLE
fix: serialize migrations, close JWKS client, harden cache locking

### DIFF
--- a/api/src/aerospike_cluster_manager_api/client_manager.py
+++ b/api/src/aerospike_cluster_manager_api/client_manager.py
@@ -160,7 +160,7 @@ class ClientManager:
             # info_cache is keyed by conn_id only -- invalidating cross-
             # session is the conservative choice since the underlying
             # cluster info doesn't depend on which session asked.
-            info_cache.invalidate_connection(conn_id)
+            await info_cache.invalidate_connection(conn_id)
             if client is not None:
                 with (
                     _tracer.start_as_current_span(
@@ -194,7 +194,7 @@ class ClientManager:
                 self._conn_locks.pop(k, None)
         for key, client in zip(keys, clients, strict=True):
             conn_id = key[1]
-            info_cache.invalidate_connection(conn_id)
+            await info_cache.invalidate_connection(conn_id)
             with (
                 _tracer.start_as_current_span(
                     "asm.aerospike.client.close",
@@ -212,7 +212,7 @@ class ClientManager:
             )
 
     async def close_all(self) -> None:
-        info_cache.clear()
+        await info_cache.clear()
         async with self._global_lock:
             clients = list(self._clients.values())
             count = len(clients)

--- a/api/src/aerospike_cluster_manager_api/db/_postgres.py
+++ b/api/src/aerospike_cluster_manager_api/db/_postgres.py
@@ -191,37 +191,44 @@ async def _apply_migrations(conn: asyncpg.Connection | asyncpg.pool.PoolConnecti
 
         await conn.execute("ALTER TABLE connections ADD COLUMN IF NOT EXISTS labels JSONB")
         await conn.execute("ALTER TABLE connections ADD COLUMN IF NOT EXISTS workspace_id TEXT")
+
+        # workspaces.owner_id (issue #307 — Phase 0b). On PG the
+        # ``IF NOT EXISTS`` clause makes the migration idempotent and
+        # metadata-only on PG ≥ 11 (no full table rewrite). Existing rows
+        # backfill via the column ``DEFAULT 'system'``; the workspace ACL
+        # treats that sentinel as accessible to any authenticated caller
+        # (legacy single-tenant semantics).
+        #
+        # This block — owner_id add, default-workspace seed, and the
+        # connections.workspace_id backfill — MUST stay inside the advisory
+        # lock. The backfill writes the FK target (workspace_id) that the
+        # default-workspace INSERT just created; on a multi-replica rolling
+        # deploy, running it after pg_advisory_unlock lets a second replica
+        # interleave and violate the FK introduced in the same migration.
+        await conn.execute("ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS owner_id TEXT NOT NULL DEFAULT 'system'")
+
+        # Seed the built-in default workspace and back-fill any pre-existing
+        # connections. Idempotent: ON CONFLICT DO NOTHING / WHERE workspace_id IS NULL.
+        now = datetime.now(UTC).isoformat()
+        await conn.execute(
+            """INSERT INTO workspaces
+                   (id, name, color, description, is_default, owner_id, created_at, updated_at)
+               VALUES ($1, $2, $3, $4, TRUE, $5, $6, $7)
+               ON CONFLICT (id) DO NOTHING""",
+            DEFAULT_WORKSPACE_ID,
+            "Default",
+            "#6366F1",
+            "Default workspace",
+            SYSTEM_OWNER_ID,
+            now,
+            now,
+        )
+        await conn.execute(
+            "UPDATE connections SET workspace_id = $1 WHERE workspace_id IS NULL",
+            DEFAULT_WORKSPACE_ID,
+        )
     finally:
         await conn.execute("SELECT pg_advisory_unlock($1)", _MIGRATION_ADVISORY_LOCK_KEY)
-
-    # workspaces.owner_id (issue #307 — Phase 0b). On PG the
-    # ``IF NOT EXISTS`` clause makes the migration idempotent and
-    # metadata-only on PG ≥ 11 (no full table rewrite). Existing rows
-    # backfill via the column ``DEFAULT 'system'``; the workspace ACL
-    # treats that sentinel as accessible to any authenticated caller
-    # (legacy single-tenant semantics).
-    await conn.execute("ALTER TABLE workspaces ADD COLUMN IF NOT EXISTS owner_id TEXT NOT NULL DEFAULT 'system'")
-
-    # Seed the built-in default workspace and back-fill any pre-existing
-    # connections. Idempotent: ON CONFLICT DO NOTHING / WHERE workspace_id IS NULL.
-    now = datetime.now(UTC).isoformat()
-    await conn.execute(
-        """INSERT INTO workspaces
-               (id, name, color, description, is_default, owner_id, created_at, updated_at)
-           VALUES ($1, $2, $3, $4, TRUE, $5, $6, $7)
-           ON CONFLICT (id) DO NOTHING""",
-        DEFAULT_WORKSPACE_ID,
-        "Default",
-        "#6366F1",
-        "Default workspace",
-        SYSTEM_OWNER_ID,
-        now,
-        now,
-    )
-    await conn.execute(
-        "UPDATE connections SET workspace_id = $1 WHERE workspace_id IS NULL",
-        DEFAULT_WORKSPACE_ID,
-    )
 
 
 async def init_db() -> None:

--- a/api/src/aerospike_cluster_manager_api/db/_sqlite.py
+++ b/api/src/aerospike_cluster_manager_api/db/_sqlite.py
@@ -175,10 +175,28 @@ def _get_conn() -> aiosqlite.Connection:
     return _conn
 
 
+async def _table_columns(conn: aiosqlite.Connection, table: str) -> set[str]:
+    """Return the current column-name set for ``table``.
+
+    Re-queried before every migration step so a process that crashed
+    mid-``_apply_migrations`` (rolling restart) resumes safely: each
+    branch decides idempotently against the live schema rather than a
+    stale snapshot taken at function entry. SQLite has no
+    ``ADD COLUMN IF NOT EXISTS`` before 3.35, so this explicit guard is
+    the portable equivalent.
+    """
+    async with conn.execute(f"PRAGMA table_info({table})") as cursor:
+        return {row[1] for row in await cursor.fetchall()}
+
+
 async def _apply_migrations(conn: aiosqlite.Connection) -> None:
-    """Add columns introduced after the initial schema."""
-    async with conn.execute("PRAGMA table_info(connections)") as cursor:
-        columns = {row[1] for row in await cursor.fetchall()}
+    """Add columns introduced after the initial schema.
+
+    Every step re-reads ``PRAGMA table_info`` immediately before acting
+    (via :func:`_table_columns`) so a mid-migration restart can resume
+    without crashing on an already-applied step.
+    """
+    columns = await _table_columns(conn, "connections")
 
     # description -> note rename. Idempotent across all DB ages:
     #   * fresh DB (CREATE TABLE has note already): both branches skip
@@ -192,15 +210,16 @@ async def _apply_migrations(conn: aiosqlite.Connection) -> None:
             logger.info("Migrating SQLite: adding connections.note column")
             await conn.execute("ALTER TABLE connections ADD COLUMN note TEXT")
         await conn.commit()
-        # refresh column set for downstream checks
-        async with conn.execute("PRAGMA table_info(connections)") as cursor:
-            columns = {row[1] for row in await cursor.fetchall()}
 
+    # Re-query before each remaining step so a partially-applied
+    # migration (process killed between two ALTERs) resumes cleanly.
+    columns = await _table_columns(conn, "connections")
     if "labels" not in columns:
         logger.info("Migrating SQLite: adding labels column")
         await conn.execute("ALTER TABLE connections ADD COLUMN labels TEXT")
         await conn.commit()
 
+    columns = await _table_columns(conn, "connections")
     if "workspace_id" not in columns:
         logger.info("Migrating SQLite: adding workspace_id column")
         await conn.execute("ALTER TABLE connections ADD COLUMN workspace_id TEXT")
@@ -213,8 +232,7 @@ async def _apply_migrations(conn: aiosqlite.Connection) -> None:
     # Existing rows backfill to ``'system'`` via the column default — the
     # workspace ACL treats that as accessible to any authenticated caller
     # (legacy single-tenant semantics).
-    async with conn.execute("PRAGMA table_info(workspaces)") as cursor:
-        ws_columns = {row[1] for row in await cursor.fetchall()}
+    ws_columns = await _table_columns(conn, "workspaces")
     if "owner_id" not in ws_columns:
         logger.info("Migrating SQLite: adding workspaces.owner_id column")
         await conn.execute("ALTER TABLE workspaces ADD COLUMN owner_id TEXT NOT NULL DEFAULT 'system'")

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -61,6 +61,23 @@ apply_aerospike_py_log_level()
 logger = logging.getLogger(__name__)
 
 
+def _find_oidc_middleware(app: FastAPI) -> OIDCAuthMiddleware | None:
+    """Locate the live OIDCAuthMiddleware instance in the built ASGI stack.
+
+    Starlette instantiates middleware lazily inside
+    ``build_middleware_stack()``; the resulting instances form a chain
+    via each layer's ``app`` attribute. We walk that chain so the
+    lifespan shutdown hook can close the middleware's JWKS HTTP client.
+    Returns ``None`` when OIDC is disabled (the middleware is never added).
+    """
+    node: object | None = app.middleware_stack
+    while node is not None:
+        if isinstance(node, OIDCAuthMiddleware):
+            return node
+        node = getattr(node, "app", None)
+    return None
+
+
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     logger.info("Starting Aerospike Cluster Manager API")
@@ -76,6 +93,12 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     if config.SSE_ENABLED:
         await collector.stop()
     await client_manager.close_all()
+    # Close the OIDC middleware's lazily-created JWKS HTTP client, if it
+    # built one. _find_oidc_middleware walks the built middleware stack;
+    # it returns None when OIDC is disabled (no middleware installed).
+    oidc_mw = _find_oidc_middleware(_app)
+    if oidc_mw is not None:
+        await oidc_mw.aclose()
     await db.close_db()
     logger.info("Shutdown complete")
     # Flush the OTel pipeline last so the final spans/logs/metrics batch —

--- a/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
+++ b/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
@@ -389,6 +389,19 @@ class OIDCAuthMiddleware(BaseHTTPMiddleware):
             self._http_client = httpx.AsyncClient(timeout=httpx.Timeout(10.0))
         return self._http_client
 
+    async def aclose(self) -> None:
+        """Close the lazily-created JWKS HTTP client on app shutdown.
+
+        Only closes a client this middleware constructed itself
+        (``_owns_http_client``). A client injected by a test (or any
+        future caller) is left untouched — its lifecycle belongs to
+        whoever passed it in. Safe to call multiple times: the client
+        reference is cleared so a second call is a no-op.
+        """
+        if self._owns_http_client and self._http_client is not None:
+            await self._http_client.aclose()
+            self._http_client = None
+
 
 # ----------------------------------------------------------------------
 # Helpers

--- a/api/src/aerospike_cluster_manager_api/routers/udfs.py
+++ b/api/src/aerospike_cluster_manager_api/routers/udfs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import tempfile
@@ -18,6 +19,12 @@ from aerospike_cluster_manager_api.rate_limit import limiter
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/udfs", tags=["udfs"])
+
+
+def _write_text(path: str, content: str) -> None:
+    """Write *content* to *path*. Runs in a worker thread via asyncio.to_thread."""
+    with open(path, "w") as f:
+        f.write(content)
 
 
 async def _list_udfs(c) -> list[UDFModule]:
@@ -65,8 +72,10 @@ async def upload_udf(request: Request, body: UploadUDFRequest, client: Aerospike
     """
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = os.path.join(tmpdir, body.filename)
-        with open(tmp_path, "w") as f:
-            f.write(body.content)
+        # The Lua source is written off the event loop — a synchronous
+        # open()/write() in an async handler blocks the whole loop while
+        # the file hits disk. asyncio.to_thread keeps the handler async.
+        await asyncio.to_thread(_write_text, tmp_path, body.content)
         await client.udf_put(tmp_path)
 
     # Re-fetch to get actual hash

--- a/api/src/aerospike_cluster_manager_api/services/info_cache.py
+++ b/api/src/aerospike_cluster_manager_api/services/info_cache.py
@@ -73,17 +73,29 @@ class InfoCache:
             self._store[key] = _CacheEntry(value, ttl)
             return value
 
-    def invalidate_connection(self, conn_id: str) -> None:
-        """Remove all cached entries for *conn_id*."""
-        keys_to_remove = [k for k in self._store if k[0] == conn_id]
-        for k in keys_to_remove:
-            self._store.pop(k, None)
-            self._locks.pop(k, None)
+    async def invalidate_connection(self, conn_id: str) -> None:
+        """Remove all cached entries for *conn_id*.
 
-    def clear(self) -> None:
-        """Drop the entire cache."""
-        self._store.clear()
-        self._locks.clear()
+        Holds ``_global_lock`` while mutating ``_store`` / ``_locks`` so it
+        cannot race a concurrent :meth:`get_or_fetch` (which writes
+        ``_store`` under a per-key lock obtained via ``_get_lock``).
+        """
+        async with self._global_lock:
+            keys_to_remove = [k for k in self._store if k[0] == conn_id]
+            for k in keys_to_remove:
+                self._store.pop(k, None)
+                self._locks.pop(k, None)
+
+    async def clear(self) -> None:
+        """Drop the entire cache.
+
+        Guarded by ``_global_lock`` for the same reason as
+        :meth:`invalidate_connection` — a bare ``dict.clear()`` would race
+        concurrent ``get_or_fetch`` writers.
+        """
+        async with self._global_lock:
+            self._store.clear()
+            self._locks.clear()
 
 
 _STATIC_COMMANDS = frozenset({"build", "edition"})

--- a/api/tests/test_cluster_batch.py
+++ b/api/tests/test_cluster_batch.py
@@ -97,11 +97,11 @@ async def client(init_test_db):
 
 
 @pytest.fixture(autouse=True)
-def _clear_cache():
+async def _clear_cache():
     """Ensure the info cache is clean for each test."""
-    info_cache.clear()
+    await info_cache.clear()
     yield
-    info_cache.clear()
+    await info_cache.clear()
 
 
 class TestGetClusterParallel:

--- a/api/tests/test_clusters_router_info.py
+++ b/api/tests/test_clusters_router_info.py
@@ -82,10 +82,10 @@ async def client(init_test_db):
 
 
 @pytest.fixture(autouse=True)
-def _clear_cache():
-    info_cache.clear()
+async def _clear_cache():
+    await info_cache.clear()
     yield
-    info_cache.clear()
+    await info_cache.clear()
 
 
 class TestExecuteInfoSingleNodeReadOnly:

--- a/api/tests/test_clusters_service.py
+++ b/api/tests/test_clusters_service.py
@@ -33,11 +33,11 @@ def _info_all_result(name: str, resp: str) -> tuple[str, int | None, str]:
 
 
 @pytest.fixture(autouse=True)
-def _clear_info_cache():
+async def _clear_info_cache():
     """Ensure the info cache is clean for each test in this module."""
-    info_cache.clear()
+    await info_cache.clear()
     yield
-    info_cache.clear()
+    await info_cache.clear()
 
 
 def _make_mock_client() -> AsyncMock:

--- a/api/tests/test_info_cache.py
+++ b/api/tests/test_info_cache.py
@@ -78,7 +78,7 @@ class TestInfoCache:
         await cache.get_or_fetch("conn-1", "build", fetcher, ttl=60.0)
         await cache.get_or_fetch("conn-1", "edition", fetcher, ttl=60.0)
 
-        cache.invalidate_connection("conn-1")
+        await cache.invalidate_connection("conn-1")
 
         v3 = await cache.get_or_fetch("conn-1", "build", fetcher, ttl=60.0)
         assert v3 == "v3"
@@ -92,7 +92,7 @@ class TestInfoCache:
         await cache.get_or_fetch("conn-1", "build", fetcher, ttl=60.0)
         await cache.get_or_fetch("conn-2", "build", fetcher, ttl=60.0)
 
-        cache.invalidate_connection("conn-1")
+        await cache.invalidate_connection("conn-1")
 
         v3 = await cache.get_or_fetch("conn-2", "build", fetcher, ttl=60.0)
         assert v3 == "b"  # Still cached
@@ -104,7 +104,7 @@ class TestInfoCache:
         fetcher = AsyncMock(side_effect=["v1", "v2"])
 
         await cache.get_or_fetch("conn-1", "build", fetcher, ttl=60.0)
-        cache.clear()
+        await cache.clear()
 
         v2 = await cache.get_or_fetch("conn-1", "build", fetcher, ttl=60.0)
         assert v2 == "v2"

--- a/api/tests/test_oidc_auth.py
+++ b/api/tests/test_oidc_auth.py
@@ -575,3 +575,64 @@ async def test_main_request_logging_masks_query_token():
     output = buf.getvalue()
     assert "access_token=***" in output, f"expected masked token in log, got: {output!r}"
     assert "secret123" not in output, f"raw token leaked in log: {output!r}"
+
+
+# ---------------------------------------------------------------------------
+# JWKS HTTP client lifecycle — aclose()
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_aclose_closes_self_constructed_client():
+    """aclose() must close the lazily-created JWKS client and clear it."""
+    mw = OIDCAuthMiddleware(
+        app=lambda *a, **kw: None,  # type: ignore[arg-type]
+        enabled=False,
+        issuer_url=ISSUER,
+        audience=AUDIENCE,
+    )
+    # Lazily build the client the way _refresh_jwks does in production.
+    client = mw._get_http_client()
+    assert client is mw._http_client
+    assert mw._owns_http_client is True
+    assert client.is_closed is False
+
+    await mw.aclose()
+    assert client.is_closed is True
+    # Reference cleared so a second aclose() is a no-op.
+    assert mw._http_client is None
+    await mw.aclose()
+
+
+@pytest.mark.asyncio
+async def test_aclose_leaves_injected_client_untouched():
+    """An injected client is owned by the caller — aclose() must not close it."""
+    _priv, jwk = _rsa_keypair()
+    injected = _client_for(_JWKSMock([jwk]))
+    mw = OIDCAuthMiddleware(
+        app=lambda *a, **kw: None,  # type: ignore[arg-type]
+        enabled=False,
+        issuer_url=ISSUER,
+        audience=AUDIENCE,
+        http_client=injected,
+    )
+    assert mw._owns_http_client is False
+
+    await mw.aclose()
+    # The injected client's lifecycle belongs to the test, not the middleware.
+    assert injected.is_closed is False
+    await injected.aclose()
+
+
+@pytest.mark.asyncio
+async def test_aclose_noop_when_client_never_built():
+    """aclose() is safe when no JWKS fetch ever happened (cold middleware)."""
+    mw = OIDCAuthMiddleware(
+        app=lambda *a, **kw: None,  # type: ignore[arg-type]
+        enabled=False,
+        issuer_url=ISSUER,
+        audience=AUDIENCE,
+    )
+    assert mw._http_client is None
+    await mw.aclose()  # must not raise
+    assert mw._http_client is None

--- a/api/tests/test_workspace_migrations.py
+++ b/api/tests/test_workspace_migrations.py
@@ -305,3 +305,85 @@ class TestWorkspaceOwnerIdMigration:
         fetched = await db.get_workspace("ws-team-real")
         assert fetched is not None
         assert fetched.ownerId == "user-real"
+
+
+class TestPartialMigrationResume:
+    """A process killed mid-``_apply_migrations`` must resume cleanly.
+
+    ``_apply_migrations`` re-queries ``PRAGMA table_info`` before every step,
+    so a DB where only some of the post-schema columns were applied (the
+    crash window between two ``ALTER TABLE`` statements) finishes the rest
+    on the next startup instead of crashing on an already-applied step.
+    """
+
+    async def test_resumes_when_note_applied_but_labels_missing(self, tmp_path):
+        from aerospike_cluster_manager_api.db import _sqlite
+
+        db_path = str(tmp_path / "partial-migration.db")
+
+        # Simulate a crash *after* the description->note rename but *before*
+        # the labels / workspace_id ALTERs ran: note exists, the rest don't.
+        async with aiosqlite.connect(db_path) as conn:
+            await conn.execute(
+                """CREATE TABLE connections (
+                    id           TEXT PRIMARY KEY,
+                    name         TEXT NOT NULL,
+                    hosts        TEXT NOT NULL,
+                    port         INTEGER NOT NULL DEFAULT 3000,
+                    cluster_name TEXT,
+                    username     TEXT,
+                    password     TEXT,
+                    color        TEXT NOT NULL DEFAULT '#0097D3',
+                    note         TEXT,
+                    created_at   TEXT NOT NULL,
+                    updated_at   TEXT NOT NULL
+                )"""
+            )
+            await conn.execute(
+                """CREATE TABLE workspaces (
+                    id          TEXT PRIMARY KEY,
+                    name        TEXT NOT NULL,
+                    color       TEXT NOT NULL DEFAULT '#6366F1',
+                    description TEXT,
+                    is_default  INTEGER NOT NULL DEFAULT 0,
+                    created_at  TEXT NOT NULL,
+                    updated_at  TEXT NOT NULL
+                )"""
+            )
+            now = datetime.now(UTC).isoformat()
+            await conn.execute(
+                """INSERT INTO connections
+                       (id, name, hosts, port, color, note, created_at, updated_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                ("conn-partial-1", "half-migrated", json.dumps(["h"]), 3000, "#FFFFFF", "kept note", now, now),
+            )
+            await conn.commit()
+
+        # Run the migration directly, twice — the second run proves every
+        # branch is idempotent against the live schema (resume-safe).
+        async with aiosqlite.connect(db_path) as conn:
+            import sqlite3 as _sqlite3
+
+            conn.row_factory = _sqlite3.Row
+            await conn.execute("PRAGMA foreign_keys=ON")
+            await _sqlite._apply_migrations(conn)
+            await _sqlite._apply_migrations(conn)
+            cols = await _sqlite._table_columns(conn, "connections")
+            ws_cols = await _sqlite._table_columns(conn, "workspaces")
+
+        # The missing columns were filled in; the pre-existing note survived.
+        assert {"note", "labels", "workspace_id"} <= cols
+        assert "owner_id" in ws_cols
+
+        with (
+            patch("aerospike_cluster_manager_api.config.ENABLE_POSTGRES", False),
+            patch("aerospike_cluster_manager_api.config.SQLITE_PATH", db_path),
+        ):
+            await db.init_db()
+            try:
+                profile = await db.get_connection("conn-partial-1")
+            finally:
+                await db.close_db()
+        assert profile is not None
+        assert profile.note == "kept note"
+        assert profile.workspaceId == DEFAULT_WORKSPACE_ID


### PR DESCRIPTION
## Summary

Scoped code-quality follow-up fixing five concurrency / lifecycle defects in the FastAPI backend. All five findings were verified against the current code before changing anything; none were already handled.

## Fixes

### [P0] PostgreSQL migrations ran outside the advisory lock — `db/_postgres.py`
`_apply_migrations` released `pg_advisory_unlock` and *then* ran the `workspaces.owner_id` column add, the default-workspace seed `INSERT`, and the `connections.workspace_id` backfill. On a multi-replica rolling deploy a second replica could interleave between the unlock and the backfill and violate the FK introduced in the same migration block.

**Fix:** moved that whole post-lock block inside the advisory-lock scope (before `finally: pg_advisory_unlock`), so the entire migration is serialized across replicas.

### [P1] OIDC JWKS `httpx.AsyncClient` never closed — `middleware/oidc_auth.py` + `main.py`
`_get_http_client()` lazily creates an `httpx.AsyncClient` that was never `aclose()`d — a connection-pool leak on every shutdown.

**Fix:** added `OIDCAuthMiddleware.aclose()` which closes the client **only when the middleware owns it** (respects the existing `_owns_http_client` flag — an injected test client is left untouched). Wired it into the FastAPI `lifespan` shutdown hook via a new `_find_oidc_middleware` helper that walks the built ASGI middleware stack (returns `None` when OIDC is disabled).

### [P1] SQLite `_apply_migrations` not idempotent per-step — `db/_sqlite.py`
A mid-migration restart could crash on an already-applied step: the `labels` / `workspace_id` branches decided against a column snapshot taken once at function entry.

**Fix:** new `_table_columns()` helper re-queries `PRAGMA table_info` immediately before every migration branch, so a partially-applied migration resumes cleanly.

### [P2] `info_cache` mutated `_store` without the lock — `services/info_cache.py` + `client_manager.py`
`invalidate_connection` / `clear` mutated the shared `_store` / `_locks` without holding `_global_lock`, racing `get_or_fetch`.

**Fix:** made both `async` and guarded their bodies with `async with self._global_lock`. Updated the `client_manager.py` call sites (already-async `close_client` / `close_session` / `close_all`) to `await`, plus the three autouse test fixtures that reset the cache.

### [P2] Blocking `open()`/`write()` in an async handler — `routers/udfs.py`
`upload_udf` wrote the Lua source with a synchronous `open()`/`write()`, blocking the event loop.

**Fix:** moved the write off-loop via `await asyncio.to_thread(_write_text, ...)`. No new dependency (`aiofiles` is not in `pyproject.toml`).

## Tests

New focused regression tests:
- `test_oidc_auth.py`: `aclose()` closes a self-constructed client and clears the reference; leaves an injected client untouched; is a no-op on a cold middleware.
- `test_workspace_migrations.py::TestPartialMigrationResume`: a DB with `note` applied but `labels`/`workspace_id` missing (crash window) finishes the migration on the next run; `_apply_migrations` is safe to run twice.
- `test_info_cache.py` + 3 autouse fixtures updated for the now-async `invalidate_connection` / `clear`.

## Verification

- `ruff check src tests` — All checks passed
- `ruff format --check src tests` — 123 files already formatted
- `pyright src/` — 0 errors, 0 warnings
- `pytest tests/` — **775 passed** (2 pre-existing unrelated warnings in `test_client_manager.py`)
- `pre-commit run --files <changed>` — all hooks Passed

## Notes

13 files changed (~150 LOC production code + regression tests). The file count is above the ~6-file guideline because making `info_cache.clear()` async mechanically rippled into 4 test-fixture files — required signature follow-through, not added scope. No `version` keys edited; no MAJOR bump.