### PR TITLE
fix: close test-connection client on connect failure, map bad filter values to 400

### DIFF
--- a/api/src/aerospike_cluster_manager_api/expression_builder.py
+++ b/api/src/aerospike_cluster_manager_api/expression_builder.py
@@ -25,6 +25,19 @@ class InvalidPkPatternError(ValueError):
     """Raised when a user-supplied PK regex/prefix pattern is malformed."""
 
 
+class InvalidFilterValueError(ValueError):
+    """Raised when a filter condition's value is missing or type-incompatible.
+
+    ``FilterCondition.value`` / ``value2`` are typed ``BinValue | None``
+    (``BinValue`` is ``Any``), so pydantic accepts a request that omits a
+    value or supplies one that cannot be coerced to the declared
+    ``bin_type`` (e.g. ``binType=integer`` with ``value="abc"`` or no
+    ``value`` at all). Without this guard the raw ``int()``/``float()``
+    ``TypeError``/``ValueError`` escaped to the generic 500 handler; the
+    HTTP boundary catches this subclass and maps it to a 400 instead.
+    """
+
+
 # Hard cap on user-supplied regex length. 256 is comfortably above any
 # legitimate PK / bin pattern we've seen, well below the size at which
 # pathological backtracking becomes feasible.
@@ -81,11 +94,25 @@ def _bin_accessor(bin_name: str, bin_type: BinDataType) -> dict:
 
 
 def _val_accessor(value: object, bin_type: BinDataType) -> dict:
-    """Return the correct typed value expression."""
+    """Return the correct typed value expression.
+
+    Raises :class:`InvalidFilterValueError` when ``value`` is ``None`` or
+    cannot be coerced to a numeric ``bin_type`` — the request-model layer
+    permits ``BinValue | None`` so the type mismatch is a 400-class user
+    error, not a server fault.
+    """
+    if value is None:
+        raise InvalidFilterValueError(f"Filter value is required for bin_type={bin_type.value!r}")
     if bin_type == BinDataType.INTEGER:
-        return exp.int_val(int(value))  # type: ignore[arg-type]
+        try:
+            return exp.int_val(int(value))  # type: ignore[arg-type]
+        except (TypeError, ValueError) as exc:
+            raise InvalidFilterValueError(f"Filter value {value!r} is not a valid integer") from exc
     if bin_type == BinDataType.FLOAT:
-        return exp.float_val(float(value))  # type: ignore[arg-type]
+        try:
+            return exp.float_val(float(value))  # type: ignore[arg-type]
+        except (TypeError, ValueError) as exc:
+            raise InvalidFilterValueError(f"Filter value {value!r} is not a valid float") from exc
     if bin_type == BinDataType.STRING:
         return exp.string_val(str(value))
     if bin_type == BinDataType.BOOL:
@@ -120,20 +147,28 @@ def _build_condition(cond: FilterCondition) -> dict:
         return cmp_fn(_bin_accessor(bin_name, bin_type), _val_accessor(cond.value, bin_type))
 
     if op == FilterOperator.BETWEEN:
+        if cond.value is None or cond.value2 is None:
+            raise InvalidFilterValueError("BETWEEN requires both 'value' (lower bound) and 'value2' (upper bound)")
         return exp.and_(
             exp.ge(_bin_accessor(bin_name, bin_type), _val_accessor(cond.value, bin_type)),
             exp.le(_bin_accessor(bin_name, bin_type), _val_accessor(cond.value2, bin_type)),
         )
 
     if op == FilterOperator.CONTAINS:
+        if cond.value is None:
+            raise InvalidFilterValueError(f"Operator {op.value!r} requires a 'value'")
         pattern = f".*{re.escape(str(cond.value))}.*"
         return exp.regex_compare(pattern, REGEX_FLAG_ICASE, exp.string_bin(bin_name))
 
     if op == FilterOperator.NOT_CONTAINS:
+        if cond.value is None:
+            raise InvalidFilterValueError(f"Operator {op.value!r} requires a 'value'")
         pattern = f".*{re.escape(str(cond.value))}.*"
         return exp.not_(exp.regex_compare(pattern, REGEX_FLAG_ICASE, exp.string_bin(bin_name)))
 
     if op == FilterOperator.REGEX:
+        if cond.value is None:
+            raise InvalidFilterValueError(f"Operator {op.value!r} requires a 'value'")
         regex = str(cond.value)
         _validate_pattern(regex)
         return exp.regex_compare(regex, REGEX_FLAG_ICASE, exp.string_bin(bin_name))

--- a/api/src/aerospike_cluster_manager_api/routers/records.py
+++ b/api/src/aerospike_cluster_manager_api/routers/records.py
@@ -21,6 +21,7 @@ from aerospike_cluster_manager_api.models.record import (
 from aerospike_cluster_manager_api.rate_limit import limiter
 from aerospike_cluster_manager_api.services import records_service
 from aerospike_cluster_manager_api.services.records_service import (
+    InvalidFilterValueError,
     InvalidPkPattern,
     PrimaryKeyMissing,
     SetRequiredForPkLookup,
@@ -346,6 +347,10 @@ async def get_filtered_records(
     except SetRequiredForPkLookup as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except InvalidPkPattern as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except InvalidFilterValueError as exc:
+        # A missing / type-incompatible filter value is a client error —
+        # 400, not the opaque 500 the raw int()/float() exception produced.
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     models = [record_to_model(r) for r in result.records]

--- a/api/src/aerospike_cluster_manager_api/services/connections_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/connections_service.py
@@ -371,8 +371,12 @@ async def test_connection(req: TestConnectionRequest) -> TestConnectionResult:
             config["password"] = req.password
 
         client = aerospike_py.AsyncClient(config)
-        await client.connect()
+        # close() must cover the whole client lifetime: ``connect()`` can
+        # raise *after* the constructor allocated Rust-side resources, and a
+        # close confined to a post-connect block would then leak the
+        # half-open client (one orphaned native handle per failed probe).
         try:
+            await client.connect()
             if not client.is_connected():
                 return TestConnectionResult(success=False, message="Failed to connect")
             return TestConnectionResult(success=True, message="Connected successfully")

--- a/api/src/aerospike_cluster_manager_api/services/records_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/records_service.py
@@ -41,6 +41,7 @@ from aerospike_cluster_manager_api.constants import (
     info_sets,
 )
 from aerospike_cluster_manager_api.expression_builder import (
+    InvalidFilterValueError,
     InvalidPkPatternError,
     build_expression,
     build_pk_filter_expression,
@@ -70,6 +71,7 @@ logger = logging.getLogger(__name__)
 # :mod:`aerospike_cluster_manager_api.pk`.
 __all__ = [
     "FilterRecordsResult",
+    "InvalidFilterValueError",
     "InvalidPkPattern",
     "ListRecordsResult",
     "PkType",

--- a/api/tests/test_connections_service.py
+++ b/api/tests/test_connections_service.py
@@ -320,6 +320,28 @@ class TestTestConnection:
         assert result.success is False
         assert result.message == "connection failed"
 
+    async def test_closes_client_when_connect_raises(self, init_test_db):
+        """The constructed AsyncClient must be closed even when connect() fails.
+
+        connect() can raise *after* the constructor allocated Rust-side
+        resources. A close confined to a post-connect block would then leak
+        one half-open native client per failed probe.
+        """
+        mock_client = AsyncMock()
+        mock_client.connect = AsyncMock(side_effect=Exception("Connection refused"))
+        mock_client.is_connected = lambda: False
+        mock_client.close = AsyncMock()
+
+        with patch(
+            "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
+            return_value=mock_client,
+        ):
+            result = await connections_service.test_connection(_TestConnectionRequest(hosts=["unreachable"], port=3000))
+
+        assert result.success is False
+        assert result.message == "connection failed"
+        mock_client.close.assert_awaited_once()
+
     async def test_passes_credentials(self, init_test_db):
         mock_client = AsyncMock()
         mock_client.connect = AsyncMock()

--- a/api/tests/test_expression_builder.py
+++ b/api/tests/test_expression_builder.py
@@ -7,6 +7,7 @@ from aerospike_py import exp
 
 from aerospike_cluster_manager_api.expression_builder import (
     REGEX_FLAG_ICASE,
+    InvalidFilterValueError,
     InvalidPkPatternError,
     _build_condition,
     build_expression,
@@ -203,3 +204,77 @@ class TestBuildExpressionWithPkConditions:
         pk_part = build_pk_filter_expression("usr_", "prefix")
         bin_part = exp.gt(exp.int_bin("age"), exp.int_val(21))
         assert expr == exp.and_(pk_part, bin_part)
+
+
+class TestFilterValueValidation:
+    """``FilterCondition.value``/``value2`` are ``BinValue | None``, so a
+    request can omit a value or supply one that cannot be coerced to the
+    declared bin_type. Those must surface as ``InvalidFilterValueError``
+    (mapped to HTTP 400) instead of a raw int()/float() exception escaping
+    to the generic 500 handler."""
+
+    def test_missing_value_for_comparison_raises(self):
+        cond = FilterCondition(bin="age", operator=FilterOperator.EQ, bin_type=BinDataType.INTEGER)
+        with pytest.raises(InvalidFilterValueError, match="required"):
+            _build_condition(cond)
+
+    def test_non_numeric_value_for_integer_bin_raises(self):
+        cond = FilterCondition(
+            bin="age",
+            operator=FilterOperator.GT,
+            value="not-a-number",
+            bin_type=BinDataType.INTEGER,
+        )
+        with pytest.raises(InvalidFilterValueError, match="not a valid integer"):
+            _build_condition(cond)
+
+    def test_non_numeric_value_for_float_bin_raises(self):
+        cond = FilterCondition(
+            bin="ratio",
+            operator=FilterOperator.LE,
+            value="abc",
+            bin_type=BinDataType.FLOAT,
+        )
+        with pytest.raises(InvalidFilterValueError, match="not a valid float"):
+            _build_condition(cond)
+
+    def test_between_without_value2_raises(self):
+        cond = FilterCondition(
+            bin="age",
+            operator=FilterOperator.BETWEEN,
+            value=10,
+            bin_type=BinDataType.INTEGER,
+        )
+        with pytest.raises(InvalidFilterValueError, match="value2"):
+            _build_condition(cond)
+
+    def test_contains_without_value_raises(self):
+        cond = FilterCondition(bin="name", operator=FilterOperator.CONTAINS, bin_type=BinDataType.STRING)
+        with pytest.raises(InvalidFilterValueError, match="requires a 'value'"):
+            _build_condition(cond)
+
+    def test_regex_without_value_raises(self):
+        cond = FilterCondition(bin="name", operator=FilterOperator.REGEX, bin_type=BinDataType.STRING)
+        with pytest.raises(InvalidFilterValueError, match="requires a 'value'"):
+            _build_condition(cond)
+
+    def test_valid_between_still_builds(self):
+        cond = FilterCondition(
+            bin="age",
+            operator=FilterOperator.BETWEEN,
+            value=10,
+            value2=20,
+            bin_type=BinDataType.INTEGER,
+        )
+        expr = _build_condition(cond)
+        expected = exp.and_(
+            exp.ge(exp.int_bin("age"), exp.int_val(10)),
+            exp.le(exp.int_bin("age"), exp.int_val(20)),
+        )
+        assert expr == expected
+
+    def test_invalid_filter_value_error_is_value_error_subclass(self):
+        # The records router relies on this being catchable distinctly from
+        # plain ValueError, but it must remain a ValueError for callers that
+        # only know the base type.
+        assert issubclass(InvalidFilterValueError, ValueError)

--- a/api/tests/test_records_router.py
+++ b/api/tests/test_records_router.py
@@ -464,3 +464,71 @@ class TestFilteredRecordsPkMatchMode:
         assert body["hasMore"] is True
         assert body["returnedRecords"] == 5
         assert len(body["records"]) == 5
+
+    async def test_invalid_filter_value_returns_400(self, client: AsyncClient):
+        """A bin filter with a value that cannot be coerced to the declared
+        binType is a client error — 400, not the opaque 500 the raw int()
+        TypeError/ValueError used to produce."""
+        mock_client = _build_query_mock()
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test/filter",
+                json={
+                    "namespace": "test",
+                    "set": "demo",
+                    "filters": {
+                        "logic": "and",
+                        "conditions": [
+                            {"bin": "age", "operator": "eq", "value": "not-a-number", "binType": "integer"},
+                        ],
+                    },
+                },
+            )
+
+        assert resp.status_code == 400
+        assert "integer" in resp.json()["detail"]
+        # The scan never executes when the filter cannot be built.
+        mock_client.query.assert_not_called()
+
+    async def test_between_missing_value2_returns_400(self, client: AsyncClient):
+        """BETWEEN with no upper bound must surface as 400, not a 500 from a
+        raw int(None) TypeError."""
+        mock_client = _build_query_mock()
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test/filter",
+                json={
+                    "namespace": "test",
+                    "set": "demo",
+                    "filters": {
+                        "logic": "and",
+                        "conditions": [
+                            {"bin": "age", "operator": "between", "value": 10, "binType": "integer"},
+                        ],
+                    },
+                },
+            )
+
+        assert resp.status_code == 400
+        assert "value2" in resp.json()["detail"]
+        mock_client.query.assert_not_called()


### PR DESCRIPTION
## Summary

A fresh deep review of the FastAPI backend (`api/`) on top of the recently merged code-quality hardening surfaced two genuine correctness bugs. This PR fixes both with regression tests; no public types or routes change.

## Fix 1 — Resource leak in `connections_service.test_connection` (severity: medium)

`POST /api/connections/test` builds an `aerospike_py.AsyncClient`, then `await client.connect()`. The `try/finally` that owns `client.close()` only wrapped the *post-connect* block. `connect()` can raise after the constructor already allocated Rust-side native resources — every failed connectivity probe then leaked one half-open native client.

The `try/finally` now covers the whole client lifetime from construction onward, so `close()` runs whether `connect()` succeeds or raises.

## Fix 2 — Opaque HTTP 500 on malformed filter values (severity: medium)

`FilterCondition.value` / `value2` are typed `BinValue | None` (`BinValue = Any`), so pydantic accepts a request that omits a value or supplies one incompatible with the declared `binType`. `expression_builder._val_accessor` then called `int()` / `float()` directly:

- `{"bin":"age","operator":"eq","binType":"integer"}` (no `value`) → `TypeError`
- `{"bin":"age","operator":"eq","value":"abc","binType":"integer"}` → `ValueError`
- `BETWEEN` with no `value2` → `int(None)` `TypeError`

All of these escaped to the generic 500 handler — a client mistake reported as a server fault.

Added `InvalidFilterValueError` (a `ValueError` subclass) raised for missing / type-incompatible values across the comparison, `BETWEEN`, `CONTAINS`, `NOT_CONTAINS`, and `REGEX` operators. The `POST /records/{conn_id}/filter` router maps it to **HTTP 400**, alongside the existing `InvalidPkPattern` → 400 handling. The scan never reaches the wire when the filter cannot be built.

## Tests

- `test_connections_service.py` — `test_closes_client_when_connect_raises`: asserts `close()` is awaited when `connect()` fails.
- `test_expression_builder.py` — `TestFilterValueValidation`: 8 cases covering missing value, non-numeric int/float values, `BETWEEN` missing `value2`, `CONTAINS`/`REGEX` missing value, a valid `BETWEEN` still building, and the `ValueError` subclass contract.
- `test_records_router.py` — `test_invalid_filter_value_returns_400`, `test_between_missing_value2_returns_400`: end-to-end 400 mapping with `mock_client.query.assert_not_called()`.

## Verification

- `uv run pytest tests/` — full API suite passes (788 tests).
- `ruff check src tests` — clean.
- `ruff format --check src tests` — clean.

No `version` keys touched (auto-release handles bumps). No breaking changes.