### PR TITLE
fix: map deleted-connection race to 404 and reject empty-bins writes

### DIFF
--- a/api/src/aerospike_cluster_manager_api/dependencies.py
+++ b/api/src/aerospike_cluster_manager_api/dependencies.py
@@ -185,9 +185,25 @@ async def _get_connection_profile(
 
 
 async def _get_client(conn_id: str = Depends(_get_verified_connection)) -> aerospike_py.AsyncClient:
-    """Resolve *conn_id* and return a cached Aerospike async client."""
+    """Resolve *conn_id* and return a cached Aerospike async client.
+
+    ``_get_verified_connection`` runs first and 404s a missing connection,
+    but :meth:`client_manager.get_client` re-reads the profile from the DB
+    and raises ``ValueError`` when it is gone. That happens on a TOCTOU
+    race — the profile is deleted between the dependency's existence check
+    and this client fetch. Map it to 404 (the connection genuinely no
+    longer exists) so the race surfaces with the same wire shape as a
+    plain missing connection instead of escaping as an opaque 500.
+    """
     try:
         return await client_manager.get_client(conn_id)
+    except ValueError as e:
+        # Connection profile vanished between the ACL check and now.
+        logger.warning("Connection '%s' disappeared before client could be built: %s", conn_id, e)
+        raise HTTPException(
+            status_code=404,
+            detail=f"Connection '{conn_id}' not found",
+        ) from e
     except (AerospikeError, ClusterError, ConnectionRefusedError, OSError) as e:
         logger.warning("Failed to connect to Aerospike for connection '%s': %s", conn_id, e)
         raise HTTPException(

--- a/api/src/aerospike_cluster_manager_api/services/records_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/records_service.py
@@ -375,7 +375,8 @@ async def put_record(client: aerospike_py.AsyncClient, body: RecordWriteRequest)
 
     Raises:
         PrimaryKeyMissing: ``body.key`` omits namespace, set, or pk.
-        ValueError: explicit ``pk_type`` rejected the resolved value.
+        ValueError: explicit ``pk_type`` rejected the resolved value, or
+            ``body.bins`` is empty (a write needs at least one bin).
     """
     k = body.key
     if not k.namespace:
@@ -384,6 +385,14 @@ async def put_record(client: aerospike_py.AsyncClient, body: RecordWriteRequest)
         raise PrimaryKeyMissing("set")
     if not k.pk:
         raise PrimaryKeyMissing("pk")
+    # ``RecordWriteRequest.bins`` is ``dict[str, BinValue]`` with no
+    # min-length constraint, so pydantic accepts ``bins={}``. An Aerospike
+    # write with zero bins is not a meaningful create/update — aerospike-py
+    # surfaces it as a server-side parameter error that would otherwise
+    # escape as an opaque HTTP 500. Reject it here so the router maps it to
+    # a clear 400 instead.
+    if not body.bins:
+        raise ValueError("at least one bin is required to write a record")
 
     key_tuple = (k.namespace, k.set, resolve_pk(k.pk, body.pk_type))
 

--- a/api/tests/test_records_router.py
+++ b/api/tests/test_records_router.py
@@ -532,3 +532,67 @@ class TestFilteredRecordsPkMatchMode:
         assert resp.status_code == 400
         assert "value2" in resp.json()["detail"]
         mock_client.query.assert_not_called()
+
+
+class TestPutRecordRouter:
+    """POST /records/{conn_id} — record write path."""
+
+    async def test_empty_bins_returns_400(self, client: AsyncClient):
+        """A write request with an empty ``bins`` object must surface as a
+        clean 400, not an opaque 500 from an aerospike-py parameter error.
+
+        ``RecordWriteRequest.bins`` has no min-length constraint so the
+        empty dict passes pydantic; the service-layer guard rejects it and
+        the router maps the ValueError to 400."""
+        mock_client = AsyncMock()
+        mock_client.put = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test",
+                json={
+                    "key": {"namespace": "test", "set": "demo", "pk": "k1"},
+                    "bins": {},
+                },
+            )
+
+        assert resp.status_code == 400, resp.text
+        assert "bin" in resp.json()["detail"].lower()
+        # The Aerospike write must never be attempted for an invalid request.
+        mock_client.put.assert_not_awaited()
+
+
+class TestConnectionRaceOn404:
+    """Dependency-layer TOCTOU: connection deleted between the ACL check and
+    the client fetch must surface as 404, not an opaque 500."""
+
+    async def test_deleted_connection_race_returns_404(self, client: AsyncClient):
+        """``client_manager.get_client`` raises ``ValueError`` when the
+        profile vanished after ``_get_verified_connection`` cleared it.
+        ``_get_client`` must translate that to a 404."""
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(side_effect=ValueError("Connection profile 'conn-test' not found")),
+            ),
+        ):
+            resp = await client.get(
+                "/api/records/conn-test/detail",
+                params={"ns": "test", "set": "demo", "pk": "42"},
+            )
+
+        assert resp.status_code == 404, resp.text
+        assert "conn-test" in resp.json()["detail"]

--- a/api/tests/test_records_service.py
+++ b/api/tests/test_records_service.py
@@ -240,6 +240,25 @@ class TestPutRecord:
         with pytest.raises(PrimaryKeyMissing):
             await records_service.put_record(client, body)
 
+    async def test_empty_bins_raises_value_error(self):
+        """A write with zero bins is rejected before reaching the client.
+
+        ``RecordWriteRequest.bins`` has no min-length constraint, so an
+        empty dict passes pydantic. Without this guard the empty-bins
+        ``put`` would surface as an opaque aerospike-py server error
+        (HTTP 500); the router maps the ValueError to a clean 400.
+        """
+        client = AsyncMock()
+        client.put = AsyncMock(return_value=None)
+        body = RecordWriteRequest(
+            key=RecordKey(namespace="test", set="demo", pk="k1"),
+            bins={},
+        )
+        with pytest.raises(ValueError, match="at least one bin"):
+            await records_service.put_record(client, body)
+        # The client write must never be attempted for an invalid request.
+        client.put.assert_not_awaited()
+
 
 # ---------------------------------------------------------------------------
 # record_exists


### PR DESCRIPTION
## Summary

A fresh deep code review of the FastAPI backend (`api/`) on `origin/main` surfaced two genuine correctness bugs — both currently produce an opaque **HTTP 500** for what is really a client/race-class error. This PR fixes both with regression test coverage.

Total scope: 4 files, ~110 LOC (incl. tests). No model renames, no route changes, fully backward compatible.

## Bug 1 — Deleted-connection TOCTOU race leaks an opaque 500 (severity: medium)

`_get_client` in `api/src/aerospike_cluster_manager_api/dependencies.py` only caught `AerospikeError`, `ClusterError`, `ConnectionRefusedError`, and `OSError`.

But `client_manager.get_client` re-reads the connection profile from the DB and raises a plain `ValueError("Connection profile '...' not found")` when it is gone. This fires on a real TOCTOU race: the profile is deleted between `_get_verified_connection`'s existence check and the `get_client` call. There is **no catch-all `Exception` handler** in `main.py` (only `AerospikeError` and subclasses), so the `ValueError` escaped to Starlette's default handler and became a generic 500.

**Fix:** `_get_client` now catches `ValueError` and maps it to **404**, matching the wire shape of a plain missing connection.

## Bug 2 — Empty-bins record write leaks an opaque 500 (severity: medium)

`RecordWriteRequest.bins` is typed `dict[str, BinValue]` with **no min-length constraint**, so pydantic happily accepts `bins={}`. An Aerospike write with zero bins is not a meaningful create/update — aerospike-py surfaces it as a server-side parameter error, which escaped to the global `AerospikeError` handler as a **500**.

**Fix:** `put_record` in `api/src/aerospike_cluster_manager_api/services/records_service.py` now rejects empty bins with a `ValueError` *before* touching the client. The records router already maps `ValueError` → **400**, so the client gets a clear, actionable error. The client write is never attempted for an invalid request.

## Tests

New regression tests (all passing):

- `test_records_service.py::TestPutRecord::test_empty_bins_raises_value_error` — service-layer guard, asserts `client.put` is never awaited.
- `test_records_router.py::TestPutRecordRouter::test_empty_bins_returns_400` — end-to-end 400 via the router.
- `test_records_router.py::TestConnectionRaceOn404::test_deleted_connection_race_returns_404` — `ValueError` from `get_client` → 404.

## Verification

Run from `api/`:

- `uv run ruff check .` — **pass** (All checks passed)
- `uv run ruff format --check .` — **pass** (123 files already formatted)
- `uv run pytest` — **pass** (789 passed)

No UI/TypeScript code touched.