### PR TITLE
fix(api): close native client leak on connect failure + map bad predicates to 400

### DIFF
--- a/api/src/aerospike_cluster_manager_api/client_manager.py
+++ b/api/src/aerospike_cluster_manager_api/client_manager.py
@@ -125,7 +125,20 @@ class ClientManager:
                 },
             ):
                 client = aerospike_py.AsyncClient(as_config)
-                await client.connect()
+                # ``connect()`` can raise *after* the constructor allocated
+                # Rust-side resources (a down/unreachable cluster, auth
+                # rejection, etc.). Without this guard each failed attempt
+                # leaks one half-open native client — and ``get_client``
+                # runs on every API request to that connection, so a single
+                # bad cluster bleeds native handles steadily. Close the
+                # half-open client before re-raising. Mirrors the fix in
+                # ``connections_service.test_connection``.
+                try:
+                    await client.connect()
+                except BaseException:
+                    with contextlib.suppress(AerospikeError, OSError):
+                        await client.close()
+                    raise
 
             old = self._clients.get(key)
             if old is not None:

--- a/api/src/aerospike_cluster_manager_api/predicate.py
+++ b/api/src/aerospike_cluster_manager_api/predicate.py
@@ -28,7 +28,16 @@ if TYPE_CHECKING:
     from aerospike_cluster_manager_api.models.query import QueryPredicate
 
 
-class UnknownPredicateOperator(ValueError):
+class PredicateError(ValueError):
+    """Base class for all client-side predicate-construction failures.
+
+    A :class:`ValueError` subclass so HTTP-boundary callers that already
+    catch ``ValueError`` keep working; callers that want to handle every
+    predicate failure in one ``except`` can target this base directly.
+    """
+
+
+class UnknownPredicateOperator(PredicateError):
     """Raised when a :class:`QueryPredicate` carries an unrecognised operator.
 
     The pydantic model enumerates the supported operators in its
@@ -42,6 +51,19 @@ class UnknownPredicateOperator(ValueError):
         self.operator = operator
 
 
+class InvalidPredicateValue(PredicateError):
+    """Raised when a :class:`QueryPredicate` is missing a required value.
+
+    ``QueryPredicate.value`` is typed ``BinValue`` (``BinValue`` is
+    ``Any``) and ``value2`` defaults to ``None``, so pydantic accepts a
+    request that omits a value entirely or supplies a ``between`` without
+    an upper bound. The aerospike-py ``predicates.*`` builders then choke
+    on the ``None`` and the raw ``TypeError`` escaped to the generic 500
+    handler. The HTTP boundary catches this :class:`ValueError` subclass
+    and maps it to a 400 instead.
+    """
+
+
 def build_predicate(pred: QueryPredicate) -> tuple[Any, ...]:
     """Convert a :class:`QueryPredicate` into an Aerospike predicate tuple.
 
@@ -52,13 +74,23 @@ def build_predicate(pred: QueryPredicate) -> tuple[Any, ...]:
         UnknownPredicateOperator: ``pred.operator`` is not in the dispatch
             table. The HTTP boundary translates this to status 400 via
             :func:`utils.build_predicate`.
+        InvalidPredicateValue: a required ``value`` (or ``value2`` for
+            ``between``) is missing. Also a :class:`ValueError`, so the
+            HTTP boundary maps it to 400.
     """
     from aerospike_py import INDEX_TYPE_LIST, predicates
 
     op = pred.operator
+    # Every supported operator needs a non-None ``value``; ``between`` also
+    # needs a non-None ``value2``. Validate here so a missing bound surfaces
+    # as a clean 400 instead of an opaque 500 from the aerospike-py builder.
+    if pred.value is None:
+        raise InvalidPredicateValue(f"predicate operator {op!r} requires a 'value'")
     if op == "equals":
         return predicates.equals(pred.bin, pred.value)
     if op == "between":
+        if pred.value2 is None:
+            raise InvalidPredicateValue("predicate operator 'between' requires both 'value' and 'value2'")
         return predicates.between(pred.bin, pred.value, pred.value2)
     if op == "contains":
         return predicates.contains(pred.bin, INDEX_TYPE_LIST, pred.value)

--- a/api/src/aerospike_cluster_manager_api/routers/records.py
+++ b/api/src/aerospike_cluster_manager_api/routers/records.py
@@ -18,6 +18,7 @@ from aerospike_cluster_manager_api.models.record import (
     RecordListResponse,
     RecordWriteRequest,
 )
+from aerospike_cluster_manager_api.predicate import PredicateError
 from aerospike_cluster_manager_api.rate_limit import limiter
 from aerospike_cluster_manager_api.services import records_service
 from aerospike_cluster_manager_api.services.records_service import (
@@ -351,6 +352,12 @@ async def get_filtered_records(
     except InvalidFilterValueError as exc:
         # A missing / type-incompatible filter value is a client error —
         # 400, not the opaque 500 the raw int()/float() exception produced.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except PredicateError as exc:
+        # A bad ``predicate`` (unknown operator, missing value/value2) is a
+        # client error. ``query.py`` already maps these via its generic
+        # ValueError catch; the filter endpoint must too — otherwise a bad
+        # predicate here escaped as an opaque 500.
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     models = [record_to_model(r) for r in result.records]

--- a/api/src/aerospike_cluster_manager_api/services/query_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/query_service.py
@@ -142,9 +142,9 @@ async def execute_query(client: aerospike_py.AsyncClient, body: QueryRequest) ->
     # ---- Scan branch ------------------------------------------------------
     q = client.query(body.namespace, body.set or "")
     if body.predicate:
-        # build_predicate raises ``UnknownPredicateOperator`` (a ``ValueError``)
-        # for unknown operators — the HTTP router catches it via
-        # ``utils.build_predicate``'s adapter.
+        # build_predicate raises ``PredicateError`` (a ``ValueError``) for an
+        # unknown operator or a missing value/value2 — the query router's
+        # generic ``ValueError`` catch maps it to HTTP 400.
         q.where(build_predicate(body.predicate))
     if body.selectBins:
         q.select(*body.selectBins)

--- a/api/src/aerospike_cluster_manager_api/services/records_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/records_service.py
@@ -533,9 +533,9 @@ async def filter_records(client: aerospike_py.AsyncClient, body: FilteredQueryRe
     q = client.query(body.namespace, body.set or "")
 
     if body.predicate:
-        # build_predicate raises ``UnknownPredicateOperator`` (a ``ValueError``)
-        # for unknown operators — the HTTP router catches it via
-        # ``utils.build_predicate``'s adapter.
+        # build_predicate raises ``PredicateError`` (a ``ValueError``) for an
+        # unknown operator or a missing value/value2 — the records router
+        # catches it and maps it to HTTP 400.
         q.where(build_predicate(body.predicate))
 
     if body.select_bins:

--- a/api/tests/test_client_manager.py
+++ b/api/tests/test_client_manager.py
@@ -56,6 +56,53 @@ class TestClientManagerTendInterval:
             assert call_args["tend_interval"] == 1000
 
 
+class TestClientManagerConnectFailure:
+    """get_client must not leak a half-open native client when connect() raises."""
+
+    async def test_connect_failure_closes_half_open_client(self, mock_db_profile):
+        """connect() raising after the constructor allocated Rust-side
+        resources must trigger client.close() before the error propagates,
+        otherwise every failed attempt leaks one native handle."""
+        leaky_client = AsyncMock()
+        leaky_client.connect = AsyncMock(side_effect=ConnectionError("cluster unreachable"))
+
+        with patch(
+            "aerospike_cluster_manager_api.client_manager.aerospike_py.AsyncClient",
+            return_value=leaky_client,
+        ):
+            mgr = ClientManager()
+            with pytest.raises(ConnectionError, match="cluster unreachable"):
+                await mgr.get_client("conn-1")
+
+            # The half-open client must have been closed exactly once.
+            leaky_client.close.assert_awaited_once()
+            # Nothing got cached — a failed connect leaves no slot behind.
+            assert (None, "conn-1") not in mgr._clients
+
+    async def test_connect_failure_does_not_cache_client(self, mock_db_profile):
+        """After a failed connect, a subsequent successful get_client builds
+        a fresh client rather than handing back the dead one."""
+        good_client = AsyncMock()
+        good_client.is_connected.return_value = True
+
+        clients = [
+            AsyncMock(connect=AsyncMock(side_effect=ConnectionError("down"))),
+            good_client,
+        ]
+
+        with patch(
+            "aerospike_cluster_manager_api.client_manager.aerospike_py.AsyncClient",
+            side_effect=clients,
+        ):
+            mgr = ClientManager()
+            with pytest.raises(ConnectionError):
+                await mgr.get_client("conn-1")
+
+            result = await mgr.get_client("conn-1")
+            assert result is good_client
+            assert mgr._clients[(None, "conn-1")] is good_client
+
+
 class TestClientManagerConcurrency:
     async def test_concurrent_get_client_same_conn_creates_one_client(self, mock_db_profile):
         """Concurrent get_client() for the same conn_id should create only one AsyncClient."""

--- a/api/tests/test_predicate.py
+++ b/api/tests/test_predicate.py
@@ -1,0 +1,57 @@
+"""Unit tests for the HTTP-free predicate builder.
+
+``predicate.build_predicate`` translates a :class:`QueryPredicate` into the
+tuple aerospike-py expects on a query's ``where`` clause. ``QueryPredicate``
+permits ``value=None`` (``BinValue`` is ``Any``) and defaults ``value2`` to
+``None``, so a request can omit a bound the aerospike-py builder requires.
+These tests pin the input-validation contract: a missing value/value2 must
+surface as a :class:`PredicateError` (a ``ValueError``) so the HTTP boundary
+maps it to a clean 400 instead of an opaque 500.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aerospike_cluster_manager_api.models.query import QueryPredicate
+from aerospike_cluster_manager_api.predicate import (
+    InvalidPredicateValue,
+    PredicateError,
+    build_predicate,
+)
+
+
+class TestBuildPredicateValidation:
+    def test_equals_with_value_builds_ok(self):
+        pred = QueryPredicate(bin="age", operator="equals", value=30)
+        result = build_predicate(pred)
+        assert isinstance(result, tuple)
+
+    def test_between_with_both_bounds_builds_ok(self):
+        pred = QueryPredicate(bin="age", operator="between", value=10, value2=20)
+        result = build_predicate(pred)
+        assert isinstance(result, tuple)
+
+    def test_between_missing_value2_raises_predicate_error(self):
+        """BETWEEN with no upper bound must raise, not let None reach the
+        aerospike-py builder where it becomes an opaque 500."""
+        pred = QueryPredicate(bin="age", operator="between", value=10)
+        with pytest.raises(InvalidPredicateValue, match="between"):
+            build_predicate(pred)
+
+    def test_missing_value_raises_predicate_error(self):
+        """An operator with value=None must raise InvalidPredicateValue."""
+        pred = QueryPredicate(bin="age", operator="equals", value=None)
+        with pytest.raises(InvalidPredicateValue, match="value"):
+            build_predicate(pred)
+
+    def test_contains_missing_value_raises_predicate_error(self):
+        pred = QueryPredicate(bin="tags", operator="contains", value=None)
+        with pytest.raises(InvalidPredicateValue):
+            build_predicate(pred)
+
+    def test_predicate_error_is_value_error(self):
+        """PredicateError must remain a ValueError subclass so callers that
+        catch ValueError (e.g. the query router) keep working."""
+        assert issubclass(PredicateError, ValueError)
+        assert issubclass(InvalidPredicateValue, PredicateError)

--- a/api/tests/test_records_router.py
+++ b/api/tests/test_records_router.py
@@ -533,6 +533,37 @@ class TestFilteredRecordsPkMatchMode:
         assert "value2" in resp.json()["detail"]
         mock_client.query.assert_not_called()
 
+    async def test_predicate_between_missing_value2_returns_400(self, client: AsyncClient):
+        """A ``predicate`` BETWEEN without value2 must map to 400 on the
+        filter endpoint. Before the fix this escaped as an opaque 500
+        because get_filtered_records did not catch the predicate
+        ValueError that build_predicate raises."""
+        mock_client = _build_query_mock()
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test/filter",
+                json={
+                    "namespace": "test",
+                    "set": "demo",
+                    "predicate": {"bin": "age", "operator": "between", "value": 10},
+                },
+            )
+
+        assert resp.status_code == 400
+        assert "between" in resp.json()["detail"]
+        # The predicate is rejected before the scan executes.
+        mock_client.query.return_value.results.assert_not_called()
+
 
 class TestPutRecordRouter:
     """POST /records/{conn_id} — record write path."""


### PR DESCRIPTION
Two backend correctness fixes found in a fresh review of the FastAPI API. Both turn an opaque failure into the correct behaviour; neither is a breaking change.

## Fix 1 — Async resource leak: half-open native client on connect failure

**Problem.** `ClientManager.get_client` constructed an `aerospike_py.AsyncClient` and then `await client.connect()` with no cleanup guard.

**Root cause.** `connect()` can raise *after* the constructor allocated Rust-side resources (unreachable cluster, auth rejection, network blip). The freshly-built client was then never closed, leaking one half-open native handle per failed attempt. `get_client` runs on *every* API request to a connection, so a single down cluster bleeds native handles steadily until process restart. This is the exact leak that was fixed for `connections_service.test_connection` in #385 — `client_manager` was missed.

**Fix.** Wrap `connect()`; on any exception, close the half-open client (suppressing close-time errors) before re-raising. `api/src/aerospike_cluster_manager_api/client_manager.py:119`.

**Test.** `test_client_manager.py::TestClientManagerConnectFailure` — asserts `close()` is awaited exactly once on connect failure, nothing is cached, and a subsequent successful `get_client` builds a fresh client.

## Fix 2 — Invalid query predicates returned 500 instead of 400

**Problem.** A `QueryPredicate` with `value=None`, or `operator="between"` without `value2`, produced an opaque HTTP 500.

**Root cause.** `QueryPredicate.value` is `BinValue` (`= Any`) and `value2` defaults to `None`, so pydantic accepts a request that omits a required bound. `predicate.build_predicate` passed the `None` straight into the aerospike-py `predicates.*` builders, where it surfaced as a raw `TypeError` → generic 500 handler. Separately, the records filter endpoint (`POST /records/{conn_id}/filter`) never caught the `ValueError` `build_predicate` raises, so even an *unknown operator* escaped as 500 there — only the query router (`POST /query/{conn_id}`) caught it. The in-code comments claimed the router handled it; they were stale.

**Fix.**
- Added `PredicateError` (base) and `InvalidPredicateValue`; `build_predicate` now validates `value` / `value2` and raises `PredicateError` (a `ValueError`).
- `records.py::get_filtered_records` now catches `PredicateError` → 400.
- Corrected the stale comments in `records_service` / `query_service`.

`api/src/aerospike_cluster_manager_api/predicate.py`, `routers/records.py:347`.

**Test.** `test_predicate.py` (new, 6 cases — value/value2 validation + subclass contract) and `test_records_router.py::test_predicate_between_missing_value2_returns_400` (filter endpoint maps bad predicate to 400, scan never runs).

## Verification

- `ruff check .` — pass
- `ruff format --check .` — pass (124 files)
- `pytest tests/` — pass (full suite, all green)

No `ui/` files touched. No version bumps. No breaking changes.