### PR TITLE
fix(api): balance connection gauge, accept never-expiring records, drop dead utils adapters

### DIFF
--- a/api/src/aerospike_cluster_manager_api/client_manager.py
+++ b/api/src/aerospike_cluster_manager_api/client_manager.py
@@ -144,6 +144,14 @@ class ClientManager:
             if old is not None:
                 with contextlib.suppress(AerospikeError, OSError):
                     await old.close()
+                # The stale client was counted +1 when it was first built.
+                # Closing it without the matching -1 makes the gauge over-
+                # count: a connection that flaps and reconnects climbs the
+                # ``active_aerospike_connections`` metric by one on every
+                # rebuild. Decrement here so the net effect of replacing a
+                # stale client is zero, and the +1 below reflects only the
+                # genuinely new native handle.
+                self._instruments["active_aerospike_connections"].add(-1, attributes=self._metric_attrs(conn_id))
             self._clients[key] = client
             self._instruments["active_aerospike_connections"].add(1, attributes=self._metric_attrs(conn_id))
 

--- a/api/src/aerospike_cluster_manager_api/converters.py
+++ b/api/src/aerospike_cluster_manager_api/converters.py
@@ -47,6 +47,20 @@ def record_to_model(rec: Record) -> AerospikeRecord:
         gen = 0
         ttl = 0
 
+    # Aerospike reports a never-expiring record (one written with the
+    # namespace default of "no expiry") as a negative TTL sentinel — the
+    # native client surfaces ``-1`` for "live forever" and ``-2`` for
+    # "don't update TTL". ``RecordMeta.ttl`` is constrained ``ge=0``, so a
+    # raw negative TTL would fail Pydantic validation and turn a perfectly
+    # valid read into an opaque HTTP 500. Normalize any negative sentinel
+    # to ``0``, which is the wire contract's existing "no expiry" value.
+    if isinstance(ttl, int) and ttl < 0:
+        ttl = 0
+    # Generation is likewise constrained ``ge=0``; clamp defensively so a
+    # malformed/uninitialised meta can never 500 the read path.
+    if isinstance(gen, int) and gen < 0:
+        gen = 0
+
     return AerospikeRecord(
         key=RecordKey(
             namespace=ns,

--- a/api/src/aerospike_cluster_manager_api/pk.py
+++ b/api/src/aerospike_cluster_manager_api/pk.py
@@ -11,12 +11,12 @@ Design rules:
   libraries — the same code is reused by service-layer callers (which
   raise domain exceptions) and by any non-HTTP caller.
 * Domain failures surface as ``ValueError`` subclasses defined here.
-  HTTP-boundary callers (``utils.py``) catch them and re-raise as
-  :class:`fastapi.HTTPException` with the right status code.
+  HTTP-boundary callers (the records / query routers) catch them and
+  re-raise as :class:`fastapi.HTTPException` with the right status code.
 
-Previously these helpers were duplicated three times — ``services.query_service``,
-``services.records_service``, and ``utils`` each carried a near byte-identical
-copy, plus their own ``PkType`` ``Literal``. This module collapses them.
+Previously these helpers were duplicated across ``services.query_service``
+and ``services.records_service``, each carrying a near byte-identical copy
+plus its own ``PkType`` ``Literal``. This module collapses them.
 """
 
 from __future__ import annotations

--- a/api/src/aerospike_cluster_manager_api/predicate.py
+++ b/api/src/aerospike_cluster_manager_api/predicate.py
@@ -9,14 +9,9 @@ Design rules:
 * Must not import ``fastapi`` or any HTTP-shaping libraries — service
   callers (``query_service``, ``records_service``) share the same code.
 * Unknown operators surface as :class:`UnknownPredicateOperator` (a
-  :class:`ValueError` subclass). HTTP-boundary callers (``utils.py``)
-  catch it and re-raise as :class:`fastapi.HTTPException` with status
-  400.
-
-Previously :func:`utils.build_predicate` raised
-:class:`fastapi.HTTPException` directly, leaking HTTP coupling into the
-service layer (services imported it locally to dodge the issue). This
-module fixes the leak.
+  :class:`ValueError` subclass). The records and query routers catch
+  ``PredicateError`` / ``ValueError`` at the HTTP boundary and re-raise
+  as :class:`fastapi.HTTPException` with status 400.
 """
 
 from __future__ import annotations
@@ -72,8 +67,8 @@ def build_predicate(pred: QueryPredicate) -> tuple[Any, ...]:
 
     Raises:
         UnknownPredicateOperator: ``pred.operator`` is not in the dispatch
-            table. The HTTP boundary translates this to status 400 via
-            :func:`utils.build_predicate`.
+            table. The records / query routers translate this to status
+            400 at the HTTP boundary.
         InvalidPredicateValue: a required ``value`` (or ``value2`` for
             ``between``) is missing. Also a :class:`ValueError`, so the
             HTTP boundary maps it to 400.

--- a/api/src/aerospike_cluster_manager_api/utils.py
+++ b/api/src/aerospike_cluster_manager_api/utils.py
@@ -1,67 +1,23 @@
-"""Shared utility functions — FastAPI adapters around HTTP-free domain logic.
+"""Shared utility functions.
 
-The genuine domain logic lives in dedicated modules so any non-HTTP caller
-can reuse it without dragging FastAPI in:
+This module currently holds a single host-string parser. The
+primary-key and predicate helpers that used to live here have been
+removed: services call the domain modules directly —
 
 * :mod:`aerospike_cluster_manager_api.pk` — primary-key resolution and
-  read-with-fallback.
+  read-with-fallback (used by ``records_service`` / ``query_service``).
 * :mod:`aerospike_cluster_manager_api.predicate` — predicate-tuple
-  construction.
+  construction (used by ``records_service`` / ``query_service``).
 
-The functions in this module are thin adapters: they call the domain
-helpers and translate the domain exceptions into
-:class:`fastapi.HTTPException` with the correct HTTP status code.
+The old ``utils`` adapters (``build_predicate``, ``resolve_pk``,
+``auto_detect_pk``, ``get_with_pk_fallback``, and the ``PkType``
+re-export) had no callers left — every router and service imports the
+domain helpers directly — so they were dead code and have been deleted.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
-from fastapi import HTTPException
-
-from aerospike_cluster_manager_api.pk import (
-    PkType,
-)
-from aerospike_cluster_manager_api.pk import (
-    get_with_pk_fallback as _get_with_pk_fallback_domain,
-)
-from aerospike_cluster_manager_api.pk import (
-    resolve_pk as _resolve_pk_domain,
-)
-from aerospike_cluster_manager_api.predicate import (
-    UnknownPredicateOperator,
-)
-from aerospike_cluster_manager_api.predicate import (
-    build_predicate as _build_predicate_domain,
-)
-
-if TYPE_CHECKING:
-    from aerospike_cluster_manager_api.models.query import QueryPredicate
-
-
-# Re-export ``PkType`` for legacy callers that import it from ``utils``.
-__all__ = [
-    "PkType",
-    "auto_detect_pk",
-    "build_predicate",
-    "get_with_pk_fallback",
-    "parse_host_port",
-    "resolve_pk",
-]
-
-
-def build_predicate(pred: QueryPredicate) -> tuple[Any, ...]:
-    """Convert a :class:`QueryPredicate` into an Aerospike predicate tuple.
-
-    Thin FastAPI adapter around
-    :func:`aerospike_cluster_manager_api.predicate.build_predicate`. Used
-    only by HTTP routers — services should call the domain function
-    directly so the HTTP coupling stays at the boundary.
-    """
-    try:
-        return _build_predicate_domain(pred)
-    except UnknownPredicateOperator as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+__all__ = ["parse_host_port"]
 
 
 def parse_host_port(host_str: str, default_port: int) -> tuple[str, int]:
@@ -73,46 +29,3 @@ def parse_host_port(host_str: str, default_port: int) -> tuple[str, int]:
         except ValueError:
             return (host_str, default_port)
     return (host_str, default_port)
-
-
-def resolve_pk(pk: str, pk_type: PkType = "auto") -> str | int | bytes:
-    """Resolve a string primary key into the typed value Aerospike expects.
-
-    Thin FastAPI adapter around
-    :func:`aerospike_cluster_manager_api.pk.resolve_pk`. Domain
-    :class:`ValueError` from explicit ``int`` / ``bytes`` mismatches is
-    re-raised as :class:`fastapi.HTTPException` (400) so HTTP callers
-    don't have to translate it themselves. Service callers should use
-    the domain helper directly.
-    """
-    try:
-        return _resolve_pk_domain(pk, pk_type)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-
-
-# Backward-compat alias — existing callers keep working. Prefer ``resolve_pk``.
-def auto_detect_pk(pk: str) -> str | int:
-    """Deprecated: use ``resolve_pk(pk, pk_type='auto')`` instead."""
-    result = resolve_pk(pk, "auto")
-    # auto mode never returns bytes; cast to satisfy the narrower return type.
-    if isinstance(result, bytes):  # pragma: no cover — defensive, unreachable
-        raise TypeError("resolve_pk(auto) unexpectedly returned bytes")
-    return result
-
-
-async def get_with_pk_fallback(
-    client: Any,
-    key_tuple: tuple[str, str, str | int | bytes],
-    pk_raw: str,
-    pk_type: PkType,
-    policy: dict[str, Any],
-) -> Any:
-    """Read a record, retrying the alternate PK type if ``auto`` guessed wrong.
-
-    Thin pass-through to
-    :func:`aerospike_cluster_manager_api.pk.get_with_pk_fallback`. The
-    domain function does not raise HTTP-specific exceptions, so this
-    adapter is just a stable import path for legacy router callers.
-    """
-    return await _get_with_pk_fallback_domain(client, key_tuple, pk_raw, pk_type, policy)

--- a/api/tests/test_client_manager.py
+++ b/api/tests/test_client_manager.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -316,3 +316,71 @@ class TestClientManagerSessionKeying:
         mgr = ClientManager()
         with pytest.raises(ValueError, match="non-None session id"):
             await mgr.close_session(None)  # type: ignore[arg-type]
+
+
+class TestClientManagerConnectionGauge:
+    """The ``active_aerospike_connections`` gauge must reflect reality.
+
+    Replacing a stale (disconnected) cached client used to add +1 to the
+    gauge without the matching -1 for the closed handle, so a flapping
+    connection's gauge climbed by one on every reconnect.
+    """
+
+    @staticmethod
+    def _net_delta(mgr: ClientManager) -> int:
+        """Sum of every value passed to the connection-gauge ``add``."""
+        instrument = mgr._instruments["active_aerospike_connections"]
+        return sum(call.args[0] for call in instrument.add.call_args_list)
+
+    async def test_replacing_stale_client_keeps_gauge_balanced(self, mock_db_profile):
+        """A reconnect after a dropped connection must net to +1, not +2.
+
+        First get_client builds + caches a client and adds +1. The cached
+        client then reports is_connected()=False (the cluster dropped it).
+        The next get_client closes the stale client and builds a fresh one
+        — the gauge must end at +1 total (one live native handle), not +2.
+        """
+        stale_client = AsyncMock(name="stale")
+        # ``is_connected`` is called synchronously (no await) in the manager,
+        # so it must be a plain MagicMock — an AsyncMock would return a
+        # truthy coroutine and the stale client would never be rebuilt.
+        # The first get_client builds against an empty cache (is_connected
+        # is never consulted). The second get_client finds the cached stale
+        # client and consults is_connected once → False forces a rebuild.
+        stale_client.is_connected = MagicMock(return_value=False)
+        fresh_client = AsyncMock(name="fresh")
+        fresh_client.is_connected = MagicMock(return_value=True)
+
+        with patch(
+            "aerospike_cluster_manager_api.client_manager.aerospike_py.AsyncClient",
+            side_effect=[stale_client, fresh_client],
+        ):
+            mgr = ClientManager()
+            mgr._instruments["active_aerospike_connections"] = MagicMock()
+
+            first = await mgr.get_client("conn-1")
+            assert first is stale_client
+
+            second = await mgr.get_client("conn-1")
+            assert second is fresh_client
+
+            # The stale client must have been closed exactly once.
+            stale_client.close.assert_awaited_once()
+            # Net gauge delta: +1 (build) -1 (close stale) +1 (build) = +1.
+            assert self._net_delta(mgr) == 1
+
+    async def test_single_build_adds_one(self, mock_db_profile):
+        """A plain build with no stale predecessor nets to exactly +1."""
+        mock_client = AsyncMock()
+        mock_client.is_connected = MagicMock(return_value=True)
+
+        with patch(
+            "aerospike_cluster_manager_api.client_manager.aerospike_py.AsyncClient",
+            return_value=mock_client,
+        ):
+            mgr = ClientManager()
+            mgr._instruments["active_aerospike_connections"] = MagicMock()
+
+            await mgr.get_client("conn-1")
+
+            assert self._net_delta(mgr) == 1

--- a/api/tests/test_converters.py
+++ b/api/tests/test_converters.py
@@ -197,3 +197,35 @@ class TestRecordToModel:
         assert data["key"]["digest"] == "abcd"
         assert data["meta"]["generation"] == 2
         assert data["bins"]["name"] == "Bob"
+
+    def test_never_expiring_record_ttl_minus_one(self):
+        """A never-expiring record (ttl=-1) must not 500 the read path.
+
+        Aerospike reports a record written with the namespace's "no expiry"
+        default as the negative TTL sentinel ``-1``. ``RecordMeta.ttl`` is
+        constrained ``ge=0``, so a raw ``-1`` would fail Pydantic validation
+        and surface as an opaque HTTP 500. The converter normalizes it to
+        ``0`` (the wire contract's existing "no expiry" value)."""
+        rec = Record(key=("test", "myset", "pk-1", b"\x00"), meta={"gen": 3, "ttl": -1}, bins={"x": 1})
+
+        record = record_to_model(rec)
+
+        assert record.meta.ttl == 0
+        assert record.meta.generation == 3
+
+    def test_dont_update_ttl_sentinel_minus_two(self):
+        """The ``-2`` ("don't update TTL") sentinel is also normalized to 0."""
+        rec = Record(key=("test", "myset", "pk-1", b"\x00"), meta={"gen": 1, "ttl": -2}, bins={"x": 1})
+
+        record = record_to_model(rec)
+
+        assert record.meta.ttl == 0
+
+    def test_negative_generation_clamped(self):
+        """A malformed negative generation is clamped to 0 instead of 500ing."""
+        rec = Record(key=("test", "myset", "pk-1", b"\x00"), meta={"gen": -5, "ttl": 100}, bins={"x": 1})
+
+        record = record_to_model(rec)
+
+        assert record.meta.generation == 0
+        assert record.meta.ttl == 100


### PR DESCRIPTION
Automated code-improvement run against `origin/main`. Three genuine backend correctness fixes, focused on the FastAPI `api/src/` surface.

## Issue 1 — `active_aerospike_connections` gauge over-counts on reconnect

**Problem:** A connection that drops and reconnects climbs the `active_aerospike_connections` OTel gauge by one on every rebuild, so dashboards steadily over-report live native handles.

**Root cause:** In `client_manager.ClientManager.get_client`, when the cached client fails the `is_connected()` check it is rebuilt. The replacement path closes the stale `old` client but only calls `add(1)` for the new one — it never emits the matching `add(-1)` for the closed handle. The `old` client was already counted `+1` when it was first built, so each replacement nets `+1` instead of `0`.

**Fix:** Emit `add(-1)` for the stale client at the moment it is closed, before the `+1` for the fresh client. Net effect of a replacement is now zero. `close_client` / `close_session` / `close_all` were already balanced; only the in-`get_client` replacement path leaked.

**Test:** `TestClientManagerConnectionGauge` — `test_replacing_stale_client_keeps_gauge_balanced` (reconnect nets `+1`, stale handle closed once) and `test_single_build_adds_one`.

## Issue 2 — never-expiring records crash the read path with HTTP 500

**Problem:** Reading a record that was written with no expiry (the common `default-ttl 0` namespace setup) returns an opaque HTTP 500.

**Root cause:** Aerospike reports a never-expiring record as a negative TTL sentinel — the native client surfaces `-1` ("live forever") and `-2` ("don't update TTL"). `models.record.RecordMeta.ttl` is constrained `Field(ge=0)`, so `converters.record_to_model` building `RecordMeta(ttl=-1)` raises a Pydantic `ValidationError`, which escapes as a generic 500.

**Fix:** Normalize any negative `ttl` (and, defensively, any negative `generation`) to `0` in `record_to_model` before constructing `RecordMeta`. `0` is already the wire contract's "no expiry" value, so this is non-breaking — no model field or alias changes.

**Test:** `test_converters.py` — `test_never_expiring_record_ttl_minus_one`, `test_dont_update_ttl_sentinel_minus_two`, `test_negative_generation_clamped`.

## Issue 3 — dead adapters in `utils.py`

**Problem:** `utils.py` carried `build_predicate`, `resolve_pk`, `auto_detect_pk`, `get_with_pk_fallback`, and a `PkType` re-export. PR #387 explicitly flagged `build_predicate` as dead.

**Root cause:** Every router and service imports the domain helpers directly (`predicate.build_predicate`, `pk.resolve_pk`, `pk.get_with_pk_fallback`). The `utils` adapters had no callers — verified with a repo-wide grep across `api/` and `ui/`. Only `parse_host_port` is live (imported by `client_manager` and `connections_service`).

**Fix:** Removed the dead adapters; `utils.py` now exposes only `parse_host_port`. Updated the now-stale docstring references to `utils.py` in `pk.py` and `predicate.py`. No behavior change — nothing imported the removed symbols.

**Test:** Covered by the full suite still passing (no import breakage).

## Verification

- `python -m pytest api/tests -q` — **803 tests, all pass** (5 new).
- `ruff check api/` — clean.
- `ruff format --check api/` — clean (124 files already formatted).
- UI untouched.

## Scope

7 files, +144 / -114. Backend only. No version-key edits, no route/model renames, no breaking changes. The 7th file (`pk.py`) is a 10-line docstring-only update removing references to the `utils` adapters deleted in Issue 3.