### PR TITLE
fix(api): reject empty/oversized selectBins entries at validation time

### DIFF
--- a/api/src/aerospike_cluster_manager_api/models/query.py
+++ b/api/src/aerospike_cluster_manager_api/models/query.py
@@ -1,15 +1,31 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from .record import AerospikeRecord, BinValue
 
 # Sentinel bin name reserved for FilterConditions whose operator is PK_PREFIX
 # or PK_REGEX. PK operators target exp.key() rather than a bin accessor.
 PK_BIN_PLACEHOLDER = "__pk__"
+
+# Aerospike bin names: ASCII printable, no control chars / whitespace.
+# Server enforces max length 15; we reject 0x00-0x1F + 0x7F at the boundary
+# so malformed names surface as a 400 rather than an opaque server-side 5xx.
+BinName = Annotated[str, Field(min_length=1, max_length=15)]
+
+
+def _validate_bin_names(value: list[str] | None) -> list[str] | None:
+    if value is None:
+        return value
+    for name in value:
+        if any(ord(c) < 0x20 or ord(c) == 0x7F for c in name):
+            raise ValueError(f"selectBins entries must not contain control characters: {name!r}")
+        if name != name.strip():
+            raise ValueError(f"selectBins entries must not have leading/trailing whitespace: {name!r}")
+    return value
 
 
 class QueryPredicate(BaseModel):
@@ -23,12 +39,17 @@ class QueryRequest(BaseModel):
     namespace: str = Field(min_length=1, max_length=31)
     set: str | None = Field(default=None, max_length=63)
     predicate: QueryPredicate | None = None
-    selectBins: list[str] | None = None
+    selectBins: list[BinName] | None = Field(default=None, min_length=1)
     expression: str | None = Field(default=None, max_length=4096)
     maxRecords: int | None = Field(default=None, ge=1, le=1_000_000)
     primaryKey: str | None = Field(default=None, max_length=1024)
     # Particle type for primaryKey resolution. "auto" retries alternate type on NOT_FOUND.
     pkType: Literal["auto", "string", "int", "bytes"] = "auto"
+
+    @field_validator("selectBins")
+    @classmethod
+    def _check_select_bins(cls, value: list[str] | None) -> list[str] | None:
+        return _validate_bin_names(value)
 
 
 class QueryResponse(BaseModel):
@@ -122,7 +143,7 @@ class FilteredQueryRequest(BaseModel):
     set: str | None = Field(default=None, max_length=63)
     filters: FilterGroup | None = None
     predicate: QueryPredicate | None = None
-    select_bins: list[str] | None = Field(default=None, alias="selectBins")
+    select_bins: list[BinName] | None = Field(default=None, min_length=1, alias="selectBins")
     max_records: int | None = Field(default=None, ge=1, le=1_000_000, alias="maxRecords")
     page: int = Field(default=1, ge=1)
     page_size: int = Field(default=25, ge=1, le=500, alias="pageSize")
@@ -132,6 +153,11 @@ class FilteredQueryRequest(BaseModel):
     # Canonical PK search field; primary_key kept for backward compatibility.
     pk_pattern: str | None = Field(default=None, max_length=4096, alias="pkPattern")
     pk_match_mode: Literal["exact", "prefix", "regex"] = Field(default="exact", alias="pkMatchMode")
+
+    @field_validator("select_bins")
+    @classmethod
+    def _check_select_bins(cls, value: list[str] | None) -> list[str] | None:
+        return _validate_bin_names(value)
 
     @model_validator(mode="after")
     def _validate_pk_fields(self) -> FilteredQueryRequest:

--- a/api/tests/test_query_models.py
+++ b/api/tests/test_query_models.py
@@ -1,0 +1,73 @@
+"""Validation tests for ``QueryRequest`` and ``FilteredQueryRequest`` selectBins.
+
+An empty list, an empty string, an oversized name, or a name with control
+characters must be rejected at the model boundary so the HTTP layer returns
+a 400 with a clear message instead of an opaque Aerospike server 5xx (e.g.,
+``BinNameTooLong``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aerospike_cluster_manager_api.models.query import (
+    FilteredQueryRequest,
+    QueryRequest,
+)
+
+
+class TestQueryRequestSelectBins:
+    def test_rejects_empty_select_bins(self):
+        with pytest.raises(ValidationError):
+            QueryRequest(namespace="ns", selectBins=[])
+
+    def test_rejects_oversized_bin_name(self):
+        with pytest.raises(ValidationError):
+            QueryRequest(namespace="ns", selectBins=["x" * 20])
+
+    def test_rejects_empty_bin_name(self):
+        with pytest.raises(ValidationError):
+            QueryRequest(namespace="ns", selectBins=[""])
+
+    def test_rejects_control_character_bin_name(self):
+        with pytest.raises(ValidationError):
+            QueryRequest(namespace="ns", selectBins=["bad\x00name"])
+
+    def test_accepts_valid_bin_names(self):
+        req = QueryRequest(namespace="ns", selectBins=["a", "bin2"])
+        assert req.selectBins == ["a", "bin2"]
+
+    def test_accepts_none_select_bins(self):
+        req = QueryRequest(namespace="ns")
+        assert req.selectBins is None
+
+
+class TestFilteredQueryRequestSelectBins:
+    def test_rejects_empty_select_bins_by_field_name(self):
+        with pytest.raises(ValidationError):
+            FilteredQueryRequest(namespace="ns", select_bins=[])
+
+    def test_rejects_empty_select_bins_by_alias(self):
+        with pytest.raises(ValidationError):
+            FilteredQueryRequest.model_validate({"namespace": "ns", "selectBins": []})
+
+    def test_rejects_oversized_bin_name_by_alias(self):
+        with pytest.raises(ValidationError):
+            FilteredQueryRequest.model_validate({"namespace": "ns", "selectBins": ["x" * 20]})
+
+    def test_rejects_empty_bin_name_by_alias(self):
+        with pytest.raises(ValidationError):
+            FilteredQueryRequest.model_validate({"namespace": "ns", "selectBins": [""]})
+
+    def test_rejects_control_character_bin_name(self):
+        with pytest.raises(ValidationError):
+            FilteredQueryRequest(namespace="ns", select_bins=["bad\x01name"])
+
+    def test_accepts_valid_bin_names_by_alias(self):
+        req = FilteredQueryRequest.model_validate({"namespace": "ns", "selectBins": ["a", "bin2"]})
+        assert req.select_bins == ["a", "bin2"]
+
+    def test_accepts_none_select_bins(self):
+        req = FilteredQueryRequest(namespace="ns")
+        assert req.select_bins is None


### PR DESCRIPTION
Automated code-improvement run against `origin/main`. One backend correctness fix on the FastAPI request-model surface.

## Issue — `selectBins` accepts empty list and invalid bin names; bug surfaces only server-side

**Problem:**
- `selectBins=[]` (empty list) silently passes validation. The query service then calls `q.select(*[])`, which the native client maps to "return only metadata" rather than "return all bins" — silent semantic shift away from what callers asked for.
- Individual bin names are unchecked. Aerospike enforces bin names ≤ 15 chars with no control characters; a malformed entry surfaces as an opaque server error (`BinNameTooLong`) that maps to a 5xx instead of the 400 the client expected.

**Root cause:** Both `QueryRequest.selectBins` and `FilteredQueryRequest.select_bins` were declared `list[str] | None = None`, with no inner-type or list-length constraints. Compare with `QueryPredicate.bin` and `FilterCondition.bin`, which are already `Field(min_length=1, max_length=15)`.

**Fix:** Introduce a `BinName = Annotated[str, Field(min_length=1, max_length=15)]` alias, type the list elements with it, and mark the field `min_length=1` so empty lists raise. A small `field_validator` rejects control characters (`0x00`-`0x1F` + `0x7F`) and leading/trailing whitespace, mirroring server-side bin-name rules and consistent with the predicate/condition validation already in this module.

The default (`None`) and any list of valid bin names still validate. The only inputs newly rejected are inputs the server already rejected with an opaque 5xx — **not** a breaking change.

**Test:** `api/tests/test_query_models.py` — 13 new tests covering empty list, empty string, oversized name, control character, and the positive path for both `QueryRequest` (snake) and `FilteredQueryRequest` (alias + field-name forms).

## Verification

- `uv run python -m pytest api/tests -q` — **816 tests, all pass** (13 new).
- `uv run ruff check api/` — clean.
- `uv run ruff format --check api/` — clean (125 files already formatted).
- UI untouched.

## Scope

2 files, +103 / -4. Backend only. No version-key edits, no route changes, no model renames, no breaking changes.