### PR TITLE
fix(api): validate bin-name keys in RecordWriteRequest

### DIFF
--- a/api/src/aerospike_cluster_manager_api/models/query.py
+++ b/api/src/aerospike_cluster_manager_api/models/query.py
@@ -1,30 +1,19 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import Annotated, Literal
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
-from .record import AerospikeRecord, BinValue
+from .record import AerospikeRecord, BinName, BinValue, _validate_bin_names
 
 # Sentinel bin name reserved for FilterConditions whose operator is PK_PREFIX
 # or PK_REGEX. PK operators target exp.key() rather than a bin accessor.
 PK_BIN_PLACEHOLDER = "__pk__"
 
-# Aerospike bin names: ASCII printable, no control chars / whitespace.
-# Server enforces max length 15; we reject 0x00-0x1F + 0x7F at the boundary
-# so malformed names surface as a 400 rather than an opaque server-side 5xx.
-BinName = Annotated[str, Field(min_length=1, max_length=15)]
 
-
-def _validate_bin_names(value: list[str] | None) -> list[str] | None:
-    if value is None:
-        return value
-    for name in value:
-        if any(ord(c) < 0x20 or ord(c) == 0x7F for c in name):
-            raise ValueError(f"selectBins entries must not contain control characters: {name!r}")
-        if name != name.strip():
-            raise ValueError(f"selectBins entries must not have leading/trailing whitespace: {name!r}")
+def _check_select_bin_names(value: list[str] | None) -> list[str] | None:
+    _validate_bin_names(value, field_label="selectBins entries")
     return value
 
 
@@ -49,7 +38,7 @@ class QueryRequest(BaseModel):
     @field_validator("selectBins")
     @classmethod
     def _check_select_bins(cls, value: list[str] | None) -> list[str] | None:
-        return _validate_bin_names(value)
+        return _check_select_bin_names(value)
 
 
 class QueryResponse(BaseModel):
@@ -157,7 +146,7 @@ class FilteredQueryRequest(BaseModel):
     @field_validator("select_bins")
     @classmethod
     def _check_select_bins(cls, value: list[str] | None) -> list[str] | None:
-        return _validate_bin_names(value)
+        return _check_select_bin_names(value)
 
     @model_validator(mode="after")
     def _validate_pk_fields(self) -> FilteredQueryRequest:

--- a/api/src/aerospike_cluster_manager_api/models/record.py
+++ b/api/src/aerospike_cluster_manager_api/models/record.py
@@ -1,10 +1,31 @@
 from __future__ import annotations
 
-from typing import Any, Literal
+from collections.abc import Iterable
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 BinValue = Any
+
+# Aerospike bin names: ASCII printable, no control chars / whitespace.
+# Server enforces max length 15; we reject 0x00-0x1F + 0x7F at the boundary
+# so malformed names surface as a 422 rather than an opaque server-side 5xx.
+BinName = Annotated[str, Field(min_length=1, max_length=15)]
+
+
+def _validate_bin_names(value: Iterable[str] | None, *, field_label: str = "bin name") -> None:
+    """Reject control chars and leading/trailing whitespace in bin names.
+
+    ``min_length``/``max_length`` are already enforced by the ``BinName``
+    annotation; this helper layers in the rules pydantic Field can't express.
+    """
+    if value is None:
+        return
+    for name in value:
+        if any(ord(c) < 0x20 or ord(c) == 0x7F for c in name):
+            raise ValueError(f"{field_label} must not contain control characters: {name!r}")
+        if name != name.strip():
+            raise ValueError(f"{field_label} must not have leading/trailing whitespace: {name!r}")
 
 
 class GeoJSON(BaseModel):
@@ -48,9 +69,21 @@ class RecordWriteRequest(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
     key: RecordKey
-    bins: dict[str, BinValue]
+    # ``BinName`` constrains each dict key's length (1..15). The
+    # ``_check_bin_keys`` validator below layers in control-char /
+    # whitespace rules that Field cannot express. Together they reject
+    # malformed bin names at the API boundary instead of letting them
+    # bubble up as an opaque 5xx (e.g. ``BinNameTooLong``) from the
+    # Aerospike server. Matches the rules applied to ``selectBins``.
+    bins: dict[BinName, BinValue]
     ttl: int | None = None
     # Particle type to use when persisting ``key.pk``. "auto" preserves the
     # legacy heuristic (numeric-string → INTEGER); use "string" to keep digit
     # keys as STRING so subsequent reads can find them.
     pk_type: Literal["auto", "string", "int", "bytes"] = Field(default="auto", alias="pkType")
+
+    @field_validator("bins")
+    @classmethod
+    def _check_bin_keys(cls, value: dict[str, BinValue]) -> dict[str, BinValue]:
+        _validate_bin_names(value.keys(), field_label="bin name")
+        return value

--- a/api/tests/test_record_models.py
+++ b/api/tests/test_record_models.py
@@ -1,0 +1,85 @@
+"""Validation tests for ``RecordWriteRequest.bins`` keys.
+
+A bin name that is empty, oversized, or contains control characters / leading
+or trailing whitespace must be rejected at the model boundary so the HTTP
+layer returns a 422 with a clear message instead of an opaque Aerospike
+server 5xx (e.g. ``BinNameTooLong``).
+
+Mirrors the rules already applied to ``QueryRequest.selectBins`` /
+``FilteredQueryRequest.select_bins`` (see PR #389, ``test_query_models.py``).
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aerospike_cluster_manager_api.models.record import RecordKey, RecordWriteRequest
+
+
+def _key() -> RecordKey:
+    return RecordKey(namespace="ns", set="demo", pk="k1")
+
+
+class TestRecordWriteRequestBinKeys:
+    def test_rejects_empty_bin_name_key(self):
+        with pytest.raises(ValidationError):
+            RecordWriteRequest(key=_key(), bins={"": 1})
+
+    def test_rejects_oversized_bin_name_key(self):
+        with pytest.raises(ValidationError):
+            RecordWriteRequest(key=_key(), bins={"x" * 20: 1})
+
+    def test_rejects_control_character_bin_name_key(self):
+        with pytest.raises(ValidationError):
+            RecordWriteRequest(key=_key(), bins={"bad\x00name": 1})
+
+    def test_rejects_del_character_bin_name_key(self):
+        with pytest.raises(ValidationError):
+            RecordWriteRequest(key=_key(), bins={"bad\x7fname": 1})
+
+    def test_rejects_leading_whitespace_bin_name_key(self):
+        with pytest.raises(ValidationError):
+            RecordWriteRequest(key=_key(), bins={" name": 1})
+
+    def test_rejects_trailing_whitespace_bin_name_key(self):
+        with pytest.raises(ValidationError):
+            RecordWriteRequest(key=_key(), bins={"name ": 1})
+
+    def test_rejects_when_any_key_is_invalid(self):
+        # Mixed dict: one valid key, one invalid. The whole payload must be
+        # rejected rather than silently dropping the bad bin.
+        with pytest.raises(ValidationError):
+            RecordWriteRequest(key=_key(), bins={"good": 1, "x" * 20: 2})
+
+    def test_accepts_valid_bin_name_keys(self):
+        req = RecordWriteRequest(key=_key(), bins={"a": 1, "bin2": "value"})
+        assert req.bins == {"a": 1, "bin2": "value"}
+
+    def test_accepts_maximum_length_bin_name_key(self):
+        # 15 chars is the server-enforced upper bound; must be accepted.
+        name = "x" * 15
+        req = RecordWriteRequest(key=_key(), bins={name: 1})
+        assert req.bins == {name: 1}
+
+    def test_accepts_via_alias_pk_type(self):
+        # populate_by_name=True means alias ``pkType`` should also work and
+        # the bin-key validator still runs.
+        req = RecordWriteRequest.model_validate(
+            {
+                "key": {"namespace": "ns", "set": "demo", "pk": "k1"},
+                "bins": {"a": 1},
+                "pkType": "string",
+            }
+        )
+        assert req.pk_type == "string"
+        assert req.bins == {"a": 1}
+
+    def test_rejects_invalid_key_via_model_validate(self):
+        with pytest.raises(ValidationError):
+            RecordWriteRequest.model_validate(
+                {
+                    "key": {"namespace": "ns", "set": "demo", "pk": "k1"},
+                    "bins": {"x" * 20: 1},
+                }
+            )

--- a/api/tests/test_records_router.py
+++ b/api/tests/test_records_router.py
@@ -601,6 +601,62 @@ class TestPutRecordRouter:
         # The Aerospike write must never be attempted for an invalid request.
         mock_client.put.assert_not_awaited()
 
+    async def test_oversized_bin_name_returns_422(self, client: AsyncClient):
+        """A write with a bin name longer than 15 chars must be rejected at
+        the pydantic boundary (422) instead of bubbling up as an opaque 5xx
+        from the Aerospike server (``BinNameTooLong``)."""
+        mock_client = AsyncMock()
+        mock_client.put = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test",
+                json={
+                    "key": {"namespace": "test", "set": "demo", "pk": "k1"},
+                    "bins": {"x" * 20: 1},
+                },
+            )
+
+        assert resp.status_code == 422, resp.text
+        # The Aerospike write must never be attempted for an invalid request.
+        mock_client.put.assert_not_awaited()
+
+    async def test_control_char_bin_name_returns_422(self, client: AsyncClient):
+        """A write with a control char in a bin name must be rejected at the
+        pydantic boundary (422)."""
+        mock_client = AsyncMock()
+        mock_client.put = AsyncMock(return_value=None)
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test",
+                json={
+                    "key": {"namespace": "test", "set": "demo", "pk": "k1"},
+                    "bins": {"bad\x00name": 1},
+                },
+            )
+
+        assert resp.status_code == 422, resp.text
+        mock_client.put.assert_not_awaited()
+
 
 class TestConnectionRaceOn404:
     """Dependency-layer TOCTOU: connection deleted between the ACL check and


### PR DESCRIPTION
## Summary

`POST /api/records/{conn_id}` accepted any `dict[str, BinValue]` for `bins` and let oversized or control-char bin names bubble up as opaque 5xx from aerospike-py / the server. Reject them at the API boundary with a clear validation error, reusing the bin-name rules introduced in #389 for `selectBins`.

## What changed

- `models/record.py`: moved `BinName` Annotated alias and `_validate_bin_names` helper here (since `query.py` already imports `record.py` — minimum-diff location). Added `@field_validator("bins")` on `RecordWriteRequest` validating each dict KEY against bin-name rules: length 1-15, no control chars, no leading/trailing whitespace. Generalized `_validate_bin_names` with a `field_label` kwarg so the existing "selectBins entries" wording is preserved while the new path uses "bin name".
- `models/query.py`: re-imports `BinName` / `_validate_bin_names` from `record.py`; thin wrapper preserves the original error label.
- `tests/test_record_models.py` (new): 11 model-level tests covering empty key, oversized key, control chars (`\x00`, `\x7f`), leading/trailing whitespace, mixed-valid-and-invalid dict, max-length-15 boundary, alias round-trip, valid passthrough.
- `tests/test_records_router.py`: 2 integration tests through `POST /api/records/{conn_id}` confirming 422 on oversized and control-char bin names and that `client.put` is never awaited.

## Verification

- `uv run ruff check src/ tests/` clean
- `uv run ruff format --check src/ tests/` clean (126 files)
- `uv run pyright src/`: 0 errors, 0 warnings
- `uv run pytest tests/`: 829 passed (was 827 on main; +13 new tests, minor de-duplication)

## Scope

4 files, +183/-20 LOC. Non-breaking: only newly rejects inputs that the server already rejected with worse messages.

`AerospikeRecord.bins` (response-only) is intentionally not constrained — a server-stored bin must not be filtered out by validation on read.