### PR TITLE
fix: validate FilterCondition bin name and UI bin name for control chars/whitespace

### DIFF
--- a/api/src/aerospike_cluster_manager_api/models/query.py
+++ b/api/src/aerospike_cluster_manager_api/models/query.py
@@ -92,11 +92,23 @@ class BinDataType(StrEnum):
 class FilterCondition(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
 
-    bin: str = Field(min_length=1, max_length=15)
+    # ``BinName`` enforces length 1..15. The ``_check_bin_name`` validator
+    # below layers in control-char / whitespace rules so malformed names
+    # surface as a 422 rather than an opaque server-side 5xx (e.g.
+    # ``BinNameTooLong``). PK operators use the ``PK_BIN_PLACEHOLDER``
+    # sentinel which passes these rules. Matches ``selectBins`` /
+    # ``RecordWriteRequest.bins`` validation.
+    bin: BinName
     operator: FilterOperator
     value: BinValue | None = None
     value2: BinValue | None = None
     bin_type: BinDataType = Field(default=BinDataType.STRING, alias="binType")
+
+    @field_validator("bin")
+    @classmethod
+    def _check_bin_name(cls, value: str) -> str:
+        _validate_bin_names([value], field_label="bin name")
+        return value
 
     @model_validator(mode="after")
     def _validate_pk_operator_pairing(self) -> FilterCondition:

--- a/api/tests/test_query_models.py
+++ b/api/tests/test_query_models.py
@@ -12,7 +12,10 @@ import pytest
 from pydantic import ValidationError
 
 from aerospike_cluster_manager_api.models.query import (
+    PK_BIN_PLACEHOLDER,
+    FilterCondition,
     FilteredQueryRequest,
+    FilterOperator,
     QueryRequest,
 )
 
@@ -71,3 +74,53 @@ class TestFilteredQueryRequestSelectBins:
     def test_accepts_none_select_bins(self):
         req = FilteredQueryRequest(namespace="ns")
         assert req.select_bins is None
+
+
+class TestFilterConditionBinName:
+    """``FilterCondition.bin`` must enforce the same bin-name rules as
+    ``selectBins`` and ``RecordWriteRequest.bins`` keys: length 1..15, no
+    control characters, no leading/trailing whitespace. The PK placeholder
+    sentinel is intentionally short and printable so it passes these rules.
+    """
+
+    def test_rejects_empty_bin_name(self):
+        with pytest.raises(ValidationError):
+            FilterCondition(bin="", operator=FilterOperator.EQ, value="x")
+
+    def test_rejects_oversized_bin_name(self):
+        with pytest.raises(ValidationError):
+            FilterCondition(bin="x" * 20, operator=FilterOperator.EQ, value="x")
+
+    def test_accepts_max_length_boundary(self):
+        cond = FilterCondition(bin="x" * 15, operator=FilterOperator.EQ, value="x")
+        assert cond.bin == "x" * 15
+
+    def test_rejects_control_character_bin_name(self):
+        with pytest.raises(ValidationError):
+            FilterCondition(bin="bad\x00name", operator=FilterOperator.EQ, value="x")
+
+    def test_rejects_del_character_bin_name(self):
+        with pytest.raises(ValidationError):
+            FilterCondition(bin="bad\x7fname", operator=FilterOperator.EQ, value="x")
+
+    def test_rejects_leading_whitespace_bin_name(self):
+        with pytest.raises(ValidationError):
+            FilterCondition(bin=" bin", operator=FilterOperator.EQ, value="x")
+
+    def test_rejects_trailing_whitespace_bin_name(self):
+        with pytest.raises(ValidationError):
+            FilterCondition(bin="bin ", operator=FilterOperator.EQ, value="x")
+
+    def test_accepts_valid_bin_name(self):
+        cond = FilterCondition(bin="age", operator=FilterOperator.GT, value=18)
+        assert cond.bin == "age"
+
+    def test_pk_placeholder_still_accepted(self):
+        # PK placeholder must pass bin-name validation so PK operators keep
+        # working after the new control-char / whitespace rule.
+        cond = FilterCondition(
+            bin=PK_BIN_PLACEHOLDER,
+            operator=FilterOperator.PK_PREFIX,
+            value="user-",
+        )
+        assert cond.bin == PK_BIN_PLACEHOLDER

--- a/ui/src/components/dialogs/CreateRecordDialog.tsx
+++ b/ui/src/components/dialogs/CreateRecordDialog.tsx
@@ -50,6 +50,28 @@ const PK_TYPES: ReadonlyArray<{ value: PkType; label: string }> = [
 const SELECT_CLASSES =
   "h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
 
+// Mirrors backend bin-name validation (api/models/record.py:_validate_bin_names
+// + the BinName Annotated alias) so users see a local error before the
+// request round-trips to a 422 from FastAPI.
+const MAX_BIN_NAME_LENGTH = 15
+
+function validateBinName(name: string): string | null {
+  if (name.length === 0) return "Bin name is required."
+  if (name.length > MAX_BIN_NAME_LENGTH) {
+    return `Bin name must be at most ${MAX_BIN_NAME_LENGTH} characters.`
+  }
+  if (name !== name.trim()) {
+    return "Bin name must not have leading or trailing whitespace."
+  }
+  for (let i = 0; i < name.length; i++) {
+    const code = name.charCodeAt(i)
+    if (code < 0x20 || code === 0x7f) {
+      return "Bin name must not contain control characters."
+    }
+  }
+  return null
+}
+
 interface CreateRecordDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -124,8 +146,9 @@ export function CreateRecordDialog({
     setError(null)
     const primaryKey = pk.trim()
     if (!primaryKey) return setError("Primary key is required.")
-    const bin = binName.trim()
-    if (!bin) return setError("Bin name is required.")
+    const bin = binName
+    const binError = validateBinName(bin)
+    if (binError) return setError(binError)
 
     const parsed = parseSeedBinValue(binValue, binKind)
     if (!parsed.ok) return setError(parsed.error)


### PR DESCRIPTION
## Summary

`FilterCondition.bin` only enforced length 1..15 via pydantic `Field`, so a bin name containing control characters or leading/trailing whitespace would slip past validation and produce an opaque server-side 5xx (e.g. `BinNameTooLong`) from Aerospike. Apply the same `_validate_bin_names` helper that #389/#390 introduced for `selectBins` and `RecordWriteRequest.bins` keys, so malformed names surface as a clean 422 at the API boundary.

`CreateRecordDialog` had drifted from backend rules: it only checked `binName.trim()` was non-empty, with no max-length-15, no control-char rule, and no leading/trailing whitespace rule. Users could submit a request that backend then rejected. Add a local `validateBinName` helper that mirrors the backend rules so users see the error before round-tripping.

## What changed

- `api/models/query.py`: `FilterCondition.bin: str = Field(min_length=1, max_length=15)` → `BinName` Annotated alias + `@field_validator(\"bin\")` reusing `_validate_bin_names` (control chars + leading/trailing whitespace). The `PK_BIN_PLACEHOLDER` sentinel (`__pk__`) passes these rules unchanged.
- `api/tests/test_query_models.py`: new `TestFilterConditionBinName` class with 9 cases covering empty, oversized, max-length-15 boundary, control char (`\x00`), DEL (`\x7f`), leading whitespace, trailing whitespace, valid name, and PK placeholder.
- `ui/components/dialogs/CreateRecordDialog.tsx`: new `validateBinName()` module-local helper mirroring backend rules (length, control chars, leading/trailing whitespace); wired into `handleSubmit` replacing the loose `.trim()` check.

## Verification

- `uv run ruff check src/ tests/` clean
- `uv run ruff format --check src/ tests/` clean (126 files)
- `uv run pyright src/`: 0 errors, 0 warnings
- `uv run pytest tests/`: 838 passed (was 829 on main; +9 new tests)
- `npm run lint` clean
- `npm run build` succeeds

## Scope

3 files, +91/-3 LOC. Non-breaking: only newly rejects inputs that the server already rejected with worse messages, or that backend already rejected after the UI request round-tripped.