### PR TITLE
fix: extend bin-name validation to remaining models and UI dialogs

### DIFF
--- a/api/src/aerospike_cluster_manager_api/models/index.py
+++ b/api/src/aerospike_cluster_manager_api/models/index.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+from .record import BinName, _validate_bin_names
 
 
 class SecondaryIndex(BaseModel):
@@ -17,6 +19,17 @@ class SecondaryIndex(BaseModel):
 class CreateIndexRequest(BaseModel):
     namespace: str = Field(min_length=1, max_length=31)
     set: str = Field(min_length=1, max_length=63)
-    bin: str = Field(min_length=1, max_length=15)
+    # ``BinName`` enforces length 1..15; the ``_check_bin_name`` validator
+    # below layers in control-char / whitespace rules so malformed names
+    # surface as a 422 rather than an opaque server-side 5xx (e.g.
+    # ``BinNameTooLong``). Matches ``FilterCondition.bin`` / ``selectBins`` /
+    # ``RecordWriteRequest.bins``.
+    bin: BinName
     name: str = Field(min_length=1, max_length=255)
     type: Literal["numeric", "string", "geo2dsphere"]
+
+    @field_validator("bin")
+    @classmethod
+    def _check_bin_name(cls, value: str) -> str:
+        _validate_bin_names([value], field_label="bin name")
+        return value

--- a/api/src/aerospike_cluster_manager_api/models/query.py
+++ b/api/src/aerospike_cluster_manager_api/models/query.py
@@ -18,10 +18,20 @@ def _check_select_bin_names(value: list[str] | None) -> list[str] | None:
 
 
 class QueryPredicate(BaseModel):
-    bin: str = Field(min_length=1, max_length=15)
+    # ``BinName`` enforces length 1..15; the ``_check_bin_name`` validator
+    # below layers in control-char / whitespace rules so malformed names
+    # surface as a 422 rather than an opaque server-side 5xx. Matches
+    # ``FilterCondition.bin`` / ``selectBins`` / ``RecordWriteRequest.bins``.
+    bin: BinName
     operator: Literal["equals", "between", "contains", "geo_within_region", "geo_contains_point"]
     value: BinValue
     value2: BinValue | None = None
+
+    @field_validator("bin")
+    @classmethod
+    def _check_bin_name(cls, value: str) -> str:
+        _validate_bin_names([value], field_label="bin name")
+        return value
 
 
 class QueryRequest(BaseModel):

--- a/api/tests/test_index_models.py
+++ b/api/tests/test_index_models.py
@@ -1,0 +1,60 @@
+"""Validation tests for ``CreateIndexRequest.bin``.
+
+The ``bin`` field must enforce the same rules as ``FilterCondition.bin`` and
+``RecordWriteRequest.bins`` keys: length 1..15, no control characters, no
+leading/trailing whitespace. Otherwise malformed names round-trip to
+Aerospike and surface as opaque server-side 5xxs (e.g. ``BinNameTooLong``)
+instead of a clean 422 at the API boundary.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from aerospike_cluster_manager_api.models.index import CreateIndexRequest
+
+
+class TestCreateIndexRequestBinValidation:
+    def _base_kwargs(self, **overrides: object) -> dict[str, object]:
+        kwargs: dict[str, object] = {
+            "namespace": "test",
+            "set": "users",
+            "bin": "email",
+            "name": "idx_users_email",
+            "type": "string",
+        }
+        kwargs.update(overrides)
+        return kwargs
+
+    def test_rejects_empty_bin_name(self):
+        with pytest.raises(ValidationError):
+            CreateIndexRequest(**self._base_kwargs(bin=""))
+
+    def test_rejects_oversized_bin_name(self):
+        with pytest.raises(ValidationError):
+            CreateIndexRequest(**self._base_kwargs(bin="x" * 20))
+
+    def test_accepts_max_length_boundary(self):
+        req = CreateIndexRequest(**self._base_kwargs(bin="x" * 15))
+        assert req.bin == "x" * 15
+
+    def test_rejects_control_character_bin_name(self):
+        with pytest.raises(ValidationError):
+            CreateIndexRequest(**self._base_kwargs(bin="bad\x00name"))
+
+    def test_rejects_del_character_bin_name(self):
+        with pytest.raises(ValidationError):
+            CreateIndexRequest(**self._base_kwargs(bin="bad\x7fname"))
+
+    def test_rejects_leading_whitespace_bin_name(self):
+        with pytest.raises(ValidationError):
+            CreateIndexRequest(**self._base_kwargs(bin=" email"))
+
+    def test_rejects_trailing_whitespace_bin_name(self):
+        with pytest.raises(ValidationError):
+            CreateIndexRequest(**self._base_kwargs(bin="email "))
+
+    def test_accepts_valid_bin_name(self):
+        req = CreateIndexRequest(**self._base_kwargs(bin="email"))
+        assert req.bin == "email"

--- a/api/tests/test_query_models.py
+++ b/api/tests/test_query_models.py
@@ -16,6 +16,7 @@ from aerospike_cluster_manager_api.models.query import (
     FilterCondition,
     FilteredQueryRequest,
     FilterOperator,
+    QueryPredicate,
     QueryRequest,
 )
 
@@ -124,3 +125,46 @@ class TestFilterConditionBinName:
             value="user-",
         )
         assert cond.bin == PK_BIN_PLACEHOLDER
+
+
+class TestQueryPredicateBinValidation:
+    """``QueryPredicate.bin`` must enforce the same bin-name rules as
+    ``FilterCondition.bin`` (length 1..15, no control characters, no
+    leading/trailing whitespace) so malformed predicates fail at the API
+    boundary with a 422 instead of an opaque server-side 5xx.
+    """
+
+    def test_rejects_empty_bin_name(self):
+        with pytest.raises(ValidationError):
+            QueryPredicate(bin="", operator="equals", value=1)
+
+    def test_rejects_oversized_bin_name(self):
+        with pytest.raises(ValidationError):
+            QueryPredicate(bin="x" * 20, operator="equals", value=1)
+
+    def test_rejects_control_character_bin_name(self):
+        with pytest.raises(ValidationError):
+            QueryPredicate(bin="bad\x00name", operator="equals", value=1)
+
+    def test_rejects_del_character_bin_name(self):
+        with pytest.raises(ValidationError):
+            QueryPredicate(bin="bad\x7fname", operator="equals", value=1)
+
+    def test_rejects_leading_whitespace_bin_name(self):
+        with pytest.raises(ValidationError):
+            QueryPredicate(bin=" bin", operator="equals", value=1)
+
+    def test_rejects_trailing_whitespace_bin_name(self):
+        with pytest.raises(ValidationError):
+            QueryPredicate(bin="bin ", operator="equals", value=1)
+
+    def test_accepts_valid_bin_name(self):
+        pred = QueryPredicate(bin="age", operator="equals", value=30)
+        assert pred.bin == "age"
+
+    def test_accepts_pk_placeholder(self):
+        # QueryPredicate doesn't enforce PK-operator pairing like
+        # FilterCondition does, but the placeholder still satisfies bin-name
+        # rules so it round-trips cleanly.
+        pred = QueryPredicate(bin=PK_BIN_PLACEHOLDER, operator="equals", value="x")
+        assert pred.bin == PK_BIN_PLACEHOLDER

--- a/ui/src/components/dialogs/CreateIndexDialog.tsx
+++ b/ui/src/components/dialogs/CreateIndexDialog.tsx
@@ -23,6 +23,7 @@ import {
 import { ApiError } from "@/lib/api/client"
 import { createIndex } from "@/lib/api/indexes"
 import type { SecondaryIndexType } from "@/lib/types/index"
+import { validateBinName } from "@/lib/validation"
 
 interface CreateIndexDialogProps {
   open: boolean
@@ -79,7 +80,11 @@ export function CreateIndexDialog({
 
     const name = form.name.trim()
     const namespace = form.namespace.trim()
-    const bin = form.bin.trim()
+    // Don't trim the bin name — validateBinName mirrors backend
+    // ``_validate_bin_names`` which rejects leading/trailing whitespace
+    // outright rather than silently fixing it. Surfacing the error keeps
+    // the local check aligned with the eventual 422 from the API.
+    const bin = form.bin
     const set = form.set.trim()
 
     if (!name) {
@@ -90,8 +95,9 @@ export function CreateIndexDialog({
       setError("Namespace is required.")
       return
     }
-    if (!bin) {
-      setError("Bin is required.")
+    const binError = validateBinName(bin)
+    if (binError) {
+      setError(binError)
       return
     }
 

--- a/ui/src/components/dialogs/CreateRecordDialog.tsx
+++ b/ui/src/components/dialogs/CreateRecordDialog.tsx
@@ -16,6 +16,7 @@ import { Label } from "@/components/Label"
 import { ApiError } from "@/lib/api/client"
 import { putRecord } from "@/lib/api/records"
 import type { BinValue, PkType } from "@/lib/types/record"
+import { validateBinName } from "@/lib/validation"
 
 /**
  * Create a new record in (namespace, set). Mirrors the seed-record half of
@@ -49,28 +50,6 @@ const PK_TYPES: ReadonlyArray<{ value: PkType; label: string }> = [
 
 const SELECT_CLASSES =
   "h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
-
-// Mirrors backend bin-name validation (api/models/record.py:_validate_bin_names
-// + the BinName Annotated alias) so users see a local error before the
-// request round-trips to a 422 from FastAPI.
-const MAX_BIN_NAME_LENGTH = 15
-
-function validateBinName(name: string): string | null {
-  if (name.length === 0) return "Bin name is required."
-  if (name.length > MAX_BIN_NAME_LENGTH) {
-    return `Bin name must be at most ${MAX_BIN_NAME_LENGTH} characters.`
-  }
-  if (name !== name.trim()) {
-    return "Bin name must not have leading or trailing whitespace."
-  }
-  for (let i = 0; i < name.length; i++) {
-    const code = name.charCodeAt(i)
-    if (code < 0x20 || code === 0x7f) {
-      return "Bin name must not contain control characters."
-    }
-  }
-  return null
-}
 
 interface CreateRecordDialogProps {
   open: boolean

--- a/ui/src/components/dialogs/CreateSetDialog.tsx
+++ b/ui/src/components/dialogs/CreateSetDialog.tsx
@@ -15,6 +15,7 @@ import { Input } from "@/components/Input"
 import { Label } from "@/components/Label"
 import { ApiError } from "@/lib/api/client"
 import { putRecord } from "@/lib/api/records"
+import { validateBinName } from "@/lib/validation"
 
 /**
  * Aerospike sets are created implicitly when a record with a new `set` value is written.
@@ -59,8 +60,13 @@ export function CreateSetDialog({
     if (!set) return setError("Set name is required")
     const primaryKey = pk.trim()
     if (!primaryKey) return setError("Primary key is required")
-    const bin = binName.trim()
-    if (!bin) return setError("Bin name is required")
+    // Don't trim the bin name — validateBinName mirrors backend
+    // ``_validate_bin_names`` which rejects leading/trailing whitespace
+    // outright rather than silently fixing it. Surfacing the error keeps
+    // the local check aligned with the eventual 422.
+    const bin = binName
+    const binError = validateBinName(bin)
+    if (binError) return setError(binError)
 
     setLoading(true)
     try {

--- a/ui/src/lib/validation.test.ts
+++ b/ui/src/lib/validation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest"
+
+import { validateBinName } from "./validation"
+
+describe("validateBinName", () => {
+  it("rejects empty name", () => {
+    expect(validateBinName("")).toMatch(/required/)
+  })
+
+  it("rejects name longer than 15 chars", () => {
+    expect(validateBinName("x".repeat(16))).toMatch(/at most 15/)
+  })
+
+  it("accepts max-length boundary (15 chars)", () => {
+    expect(validateBinName("x".repeat(15))).toBeNull()
+  })
+
+  it("rejects leading whitespace", () => {
+    expect(validateBinName(" bin")).toMatch(/whitespace/)
+  })
+
+  it("rejects trailing whitespace", () => {
+    expect(validateBinName("bin ")).toMatch(/whitespace/)
+  })
+
+  it("rejects control character (NUL)", () => {
+    expect(validateBinName("bad\x00name")).toMatch(/control characters/)
+  })
+
+  it("rejects DEL character (0x7F)", () => {
+    expect(validateBinName("bad\x7fname")).toMatch(/control characters/)
+  })
+
+  it("accepts a valid bin name", () => {
+    expect(validateBinName("age")).toBeNull()
+  })
+
+  it("accepts the PK placeholder sentinel", () => {
+    // ``__pk__`` is the bin sentinel used by FilterCondition PK operators
+    // and must round-trip through this validator unchanged.
+    expect(validateBinName("__pk__")).toBeNull()
+  })
+})

--- a/ui/src/lib/validation.ts
+++ b/ui/src/lib/validation.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared form validators that mirror backend Pydantic rules so dialogs can
+ * surface errors locally before round-tripping to a 422.
+ *
+ * Keep this in sync with ``api/src/aerospike_cluster_manager_api/models/record.py``
+ * (``BinName`` alias + ``_validate_bin_names`` helper) and the ``BinName``
+ * users in ``models/query.py`` / ``models/index.py``.
+ */
+
+export const MAX_BIN_NAME_LENGTH = 15
+
+/**
+ * Validate an Aerospike bin name against the same rules the backend enforces:
+ * length 1..15, no ASCII control characters (0x00..0x1F + 0x7F), no
+ * leading/trailing whitespace. Returns ``null`` on success or a
+ * human-readable error message on failure.
+ */
+export function validateBinName(name: string): string | null {
+  if (name.length === 0) return "Bin name is required."
+  if (name.length > MAX_BIN_NAME_LENGTH) {
+    return `Bin name must be at most ${MAX_BIN_NAME_LENGTH} characters.`
+  }
+  if (name !== name.trim()) {
+    return "Bin name must not have leading or trailing whitespace."
+  }
+  for (let i = 0; i < name.length; i++) {
+    const code = name.charCodeAt(i)
+    if (code < 0x20 || code === 0x7f) {
+      return "Bin name must not contain control characters."
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Why

PR #391 plugged the `FilterCondition.bin` gap (length 1..15 only via pydantic `Field` let control chars / leading-trailing whitespace through and surfaced as an opaque server-side 5xx like `BinNameTooLong`). The same loose check still applied to four other places that ride the same validation contract:

- `QueryPredicate.bin` (legacy non-filtered query path)
- `CreateIndexRequest.bin` (secondary-index creation)
- `CreateSetDialog` (only had a bare `.trim()` empty check)
- `CreateIndexDialog` (same)

Without these, a user could still POST a `\x00`/DEL/leading-space bin name through those endpoints/dialogs and get an opaque 5xx instead of a clean 422.

## What

### Backend (Python / Pydantic)

- `models/query.py` — `QueryPredicate.bin`: `str` → `BinName` + `@field_validator` calling the existing `_validate_bin_names` helper from `models/record.py`.
- `models/index.py` — `CreateIndexRequest.bin`: same change.

Both reuse the helper PR #391 introduced; no logic duplication.

### Frontend (TypeScript / React)

- New `ui/src/lib/validation.ts` — exports a shared `validateBinName(name: string): string | null` (extracted from the inlined helper in `CreateRecordDialog`).
- `CreateRecordDialog.tsx`: now imports from the shared util (no behavior change).
- `CreateSetDialog.tsx`: bare `.trim()` empty check replaced with `validateBinName()`.
- `CreateIndexDialog.tsx`: same.

For Set/Index dialogs the bin name is no longer silently `.trim()`-ed — the validator surfaces leading/trailing whitespace as an error, matching backend behavior (the backend rejects it; trimming locally hid the eventual 422).

## Tests

- `api/tests/test_query_models.py`: `TestQueryPredicateBinValidation` mirrors the FilterCondition matrix (empty / oversized / 0x00 / 0x7F / leading-trailing whitespace / valid / PK placeholder).
- New `api/tests/test_index_models.py`: `TestCreateIndexRequestBinValidation` covering the same matrix plus the 15-char boundary.
- New `ui/src/lib/validation.test.ts`: 9 vitest cases mirroring the backend matrix.

## Verification

- Backend: 854 tests pass; `ruff check`, `ruff format --check`, `pyright src` all clean.
- Frontend: 58 tests pass (incl. 9 new); `next lint` clean; `next build` succeeds.

## Scope

- 9 files (4 modified src + 1 new util + 3 new/modified tests + 1 new util-test); 224 insertions, 30 deletions.
- No version bumps. No unrelated models touched.

Follow-up to #391.