### PR TITLE
fix: pass KEK env through compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -796,6 +796,13 @@ All environment variables with their defaults and descriptions. See `api/src/aer
 | `DB_POOL_MAX_SIZE` | `10` | Maximum number of connections in the database connection pool |
 | `DB_COMMAND_TIMEOUT` | `30` | SQL command execution timeout in seconds |
 
+### At-rest Encryption
+
+| Variable | Default | Description |
+|---|---|---|
+| `ACM_PASSWORD_KEK` | _(empty)_ | Fernet key used to encrypt stored Aerospike connection passwords. Required for persistent credentials |
+| `ACM_ALLOW_EPHEMERAL_KEK` | `false` | Dev-only escape hatch that generates a process-local key when `ACM_PASSWORD_KEK` is unset. Stored passwords become unreadable after restart |
+
 ### Kubernetes Management
 
 | Variable | Default | Description |

--- a/compose.yaml
+++ b/compose.yaml
@@ -130,6 +130,9 @@ services:
       - AEROSPIKE_HOST=${AEROSPIKE_HOST:-aerospike-node-1}
       - AEROSPIKE_PORT=${AEROSPIKE_PORT:-3000}
       - SQLITE_PATH=/app/data/connections.db
+      # ── At-rest encryption (stored connection passwords) ─────────────
+      - ACM_PASSWORD_KEK=${ACM_PASSWORD_KEK:-}
+      - ACM_ALLOW_EPHEMERAL_KEK=${ACM_ALLOW_EPHEMERAL_KEK:-false}
       # ── OIDC (off by default) ─────────────────────────────────────
       - OIDC_ENABLED=${OIDC_ENABLED:-false}
       - OIDC_ISSUER_URL=${OIDC_ISSUER_URL:-}


### PR DESCRIPTION
## Summary
- Pass ACM_PASSWORD_KEK and ACM_ALLOW_EPHEMERAL_KEK into the API compose service.
- Document both at-rest encryption variables in the root README environment table.

## Testing
- ACM_PASSWORD_KEK=dummy ACM_ALLOW_EPHEMERAL_KEK=false podman compose -f compose.yaml config | rg "ACM_PASSWORD_KEK|ACM_ALLOW_EPHEMERAL_KEK"
- rg -n "ACM_PASSWORD_KEK|ACM_ALLOW_EPHEMERAL_KEK" README.md compose.yaml .env.example