### PR TITLE
feat(ui): apply Naver green theme via local tokens/theme/preset CSS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ Thumbs.db
 .hypothesis/
 .claude/reviews/
 .claude/scheduled_tasks.lock
+.playwright-cli/
+ui/.playwright-cli/

--- a/scripts/local-dev/acko-install.sh
+++ b/scripts/local-dev/acko-install.sh
@@ -11,7 +11,10 @@ source "$(cd "$(dirname "$0")" && pwd)/_common.sh"
 require_bin kubectl
 require_bin helm
 
-if ! kubectl config get-contexts -o name | grep -qx "${KIND_CONTEXT}"; then
+# Capture first to avoid SIGPIPE breaking `set -o pipefail` when grep -q
+# exits early on a long contexts list.
+_contexts=$(kubectl config get-contexts -o name 2>/dev/null || true)
+if ! echo "${_contexts}" | grep -qx "${KIND_CONTEXT}"; then
   die "kubectl context '${KIND_CONTEXT}' not found — run 'make kind-up' first"
 fi
 kubectl config use-context "${KIND_CONTEXT}" >/dev/null

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -76,6 +76,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -1274,6 +1275,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -1295,6 +1297,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -1304,12 +1307,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -1493,6 +1498,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -1506,6 +1512,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -1515,6 +1522,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -3394,14 +3402,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.0.tgz",
       "integrity": "sha512-0FLj93y5USLHdnhIhABk83rm8XEGA7kH3cr+YUlvxoUGp1xNt/DINUMvqPxLyOQMzLmZe8i4RTHbvb8MC7NmrA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -3413,7 +3421,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-8yQrvS6sMpSwIovhPOwfyNf2Wz6v/B62LFSVYQ85+Rq3tLsBIG7rP5geMxaijTUxSkrO6RzN/IRuIAADYQsleA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/react": "*"
@@ -3423,7 +3431,7 @@
       "version": "0.26.0",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.26.0.tgz",
       "integrity": "sha512-WFHp9YUJQ6CKshqoC37iOlHnQSmxNc795UhB26CyBBttrN9svdIrUjl/NjnNmfcwtncN0h/0PPAFWv9ovP8mLA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4339,12 +4347,14 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
       "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/anymatch": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "normalize-path": "^3.0.0",
@@ -4358,6 +4368,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -4370,6 +4381,7 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/argparse": {
@@ -4677,6 +4689,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4702,6 +4715,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fill-range": "^7.1.1"
@@ -4829,6 +4843,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
       "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -4902,6 +4917,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "anymatch": "~3.1.2",
@@ -4926,6 +4942,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -4986,6 +5003,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
       "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -5031,6 +5049,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
       "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "cssesc": "bin/cssesc"
@@ -5386,12 +5405,14 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
       "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/dlv": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/doctrine": {
@@ -5556,6 +5577,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -6344,6 +6366,7 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
       "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -6360,6 +6383,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
@@ -6386,6 +6410,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -6395,6 +6420,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -6425,6 +6451,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "to-regex-range": "^5.0.1"
@@ -6533,6 +6560,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -6547,6 +6575,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -6710,6 +6739,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -6895,6 +6925,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
       "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -7112,6 +7143,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "binary-extensions": "^2.0.0"
@@ -7164,6 +7196,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -7214,6 +7247,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -7269,6 +7303,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -7307,6 +7342,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.12.0"
@@ -7585,6 +7621,7 @@
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
@@ -7786,6 +7823,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
       "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -7798,6 +7836,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/locate-path": {
@@ -7917,6 +7956,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
       "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -7926,6 +7966,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "braces": "^3.0.3",
@@ -7939,6 +7980,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -8037,6 +8079,7 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
       "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0",
@@ -8224,6 +8267,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8249,6 +8293,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -8516,6 +8561,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -8562,6 +8608,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -8574,6 +8621,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
       "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8583,6 +8631,7 @@
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
       "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -8602,6 +8651,7 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8630,6 +8680,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
       "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "postcss-value-parser": "^4.0.0",
@@ -8647,6 +8698,7 @@
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -8668,6 +8720,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
       "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8693,6 +8746,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
       "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8735,6 +8789,7 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
       "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -8760,6 +8815,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -8773,6 +8829,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -8940,6 +8997,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -9153,6 +9211,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
       "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
@@ -9162,6 +9221,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "picomatch": "^2.2.1"
@@ -9174,6 +9234,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -9326,6 +9387,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -9458,6 +9520,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -10067,6 +10130,7 @@
       "version": "3.35.1",
       "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
       "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.2",
@@ -10102,6 +10166,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -10150,6 +10215,7 @@
       "version": "3.4.19",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
       "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
@@ -10187,6 +10253,7 @@
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
       "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -10215,6 +10282,7 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
       "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "any-promise": "^1.0.0"
@@ -10224,6 +10292,7 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
       "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "thenify": ">= 3.1.0 < 4"
@@ -10256,6 +10325,7 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -10322,6 +10392,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-number": "^7.0.0"
@@ -10373,6 +10444,7 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
@@ -10682,6 +10754,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/victory-vendor": {

--- a/ui/src/app/(main)/acko/templates/page.tsx
+++ b/ui/src/app/(main)/acko/templates/page.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/Badge"
 import { Button } from "@/components/Button"
 import { Card } from "@/components/Card"
 import { ErrorBanner } from "@/components/ErrorBanner"
+import { PageHead } from "@/components/PageHead"
 import {
   Table,
   TableBody,
@@ -44,32 +45,21 @@ export default function AckoTemplatesPage() {
 
   return (
     <main className="flex flex-col gap-6">
-      <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <span className="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-500">
-            ACKO
-          </span>
-          <h1 className="mt-1 text-lg font-semibold text-gray-900 sm:text-xl dark:text-gray-50">
-            Cluster templates
-          </h1>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-500">
-            AerospikeClusterTemplate CRs — reusable shapes for creating clusters
-            via ACKO.
-          </p>
-        </div>
-        <div className="flex gap-2">
-          <Button
-            variant="secondary"
-            onClick={() => void load()}
-            isLoading={loading}
-          >
-            Refresh
-          </Button>
-          <Button variant="primary" disabled title="Coming soon">
-            New template
-          </Button>
-        </div>
-      </header>
+      <PageHead
+        title="Cluster templates"
+        sub="AerospikeClusterTemplate CRs — reusable shapes for creating clusters via ACKO."
+      >
+        <Button
+          variant="secondary"
+          onClick={() => void load()}
+          disabled={loading}
+        >
+          Refresh
+        </Button>
+        <Button variant="primary" disabled title="Coming soon">
+          New template
+        </Button>
+      </PageHead>
 
       {error && (
         <ErrorBanner

--- a/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
@@ -6,6 +6,7 @@ import { Card } from "@/components/Card"
 import { CreateRoleDialog } from "@/components/dialogs/CreateRoleDialog"
 import { CreateUserDialog } from "@/components/dialogs/CreateUserDialog"
 import { Input } from "@/components/Input"
+import { PageHead } from "@/components/PageHead"
 import {
   Table,
   TableBody,
@@ -103,20 +104,10 @@ export default function AdminPage({ params }: PageProps) {
 
   return (
     <main className="flex flex-col gap-6">
-      <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <span className="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-500">
-            Admin
-          </span>
-          <h1 className="mt-1 text-lg font-semibold text-gray-900 sm:text-xl dark:text-gray-50">
-            Users &amp; roles
-          </h1>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-500">
-            Aerospike ACL — available when security is enabled in
-            aerospike.conf.
-          </p>
-        </div>
-      </header>
+      <PageHead
+        title="Users & roles"
+        sub="Aerospike ACL — available when security is enabled in aerospike.conf."
+      />
 
       {securityDisabled ? (
         <SecurityDisabledState />
@@ -179,7 +170,7 @@ function SecurityDisabledState() {
         href="https://aerospike.com/docs/server/operations/configure/security"
         target="_blank"
         rel="noopener noreferrer"
-        className="text-xs font-medium text-indigo-600 hover:underline dark:text-indigo-400"
+        className="text-xs font-medium text-primary-50 hover:underline dark:text-primary-65"
       >
         See Aerospike security docs →
       </a>

--- a/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
@@ -170,7 +170,7 @@ function SecurityDisabledState() {
         href="https://aerospike.com/docs/server/operations/configure/security"
         target="_blank"
         rel="noopener noreferrer"
-        className="text-xs font-medium text-primary-50 hover:underline dark:text-primary-65"
+        className="text-xs font-medium text-primary-40 hover:underline dark:text-primary-65"
       >
         See Aerospike security docs →
       </a>

--- a/ui/src/app/(main)/clusters/[clusterId]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/page.tsx
@@ -1,12 +1,14 @@
 "use client"
 
 import { Badge } from "@/components/Badge"
-import { Button } from "@/components/Button"
 import { Card } from "@/components/Card"
 import { useCluster } from "@/hooks/use-cluster"
 import { useK8sClusters } from "@/hooks/use-k8s-clusters"
 import type { ClusterNode } from "@/lib/types/cluster"
 import type { K8sClusterSummary } from "@/lib/types/k8s"
+import { Button } from "@/components/Button"
+import { PageHead } from "@/components/PageHead"
+import { RiAlertLine } from "@remixicon/react"
 import { useMemo } from "react"
 
 type PageProps = { params: { clusterId: string } }
@@ -37,50 +39,51 @@ export default function ClusterOverview({ params }: PageProps) {
 
   return (
     <main className="flex flex-col gap-8">
-      <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <div className="flex items-center gap-2">
-            {cluster.data && cluster.data.nodes[0]?.edition && (
-              <Badge variant="default">{cluster.data.nodes[0].edition}</Badge>
-            )}
-            {cluster.data && <Badge variant="success">Connected</Badge>}
-          </div>
-          <h1 className="mt-3 font-mono text-lg font-semibold text-gray-900 sm:text-xl dark:text-gray-50">
-            {params.clusterId}
-          </h1>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-500">
+      <PageHead
+        title={<span className="font-mono">{params.clusterId}</span>}
+        sub={
+          <>
             {cluster.data
               ? `${cluster.data.nodes.length} nodes · ${cluster.data.namespaces.length} namespaces`
               : cluster.isLoading
                 ? "Loading cluster info…"
                 : "—"}
-          </p>
-        </div>
-        <div className="flex gap-2">
-          <Button
-            variant="secondary"
-            onClick={() => cluster.refetch()}
-            isLoading={cluster.isLoading}
-          >
-            Refresh
-          </Button>
-        </div>
-      </header>
+          </>
+        }
+      >
+        {cluster.data && cluster.data.nodes[0]?.edition && (
+          <Badge variant="default">{cluster.data.nodes[0].edition}</Badge>
+        )}
+        {cluster.data && <Badge variant="success">Connected</Badge>}
+        <Button
+          variant="secondary"
+          onClick={() => cluster.refetch()}
+          disabled={cluster.isLoading}
+        >
+          Refresh
+        </Button>
+      </PageHead>
 
       {cluster.error && (
-        <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
-          {cluster.error.message}
+        <div className="ace-announce tone-warning" role="status">
+          <span className="ico">
+            <RiAlertLine className="size-4" aria-hidden="true" />
+          </span>
+          <div className="body">
+            <div className="title">Failed to load cluster</div>
+            <div className="desc">{cluster.error.message}</div>
+          </div>
         </div>
       )}
 
       {ackoInfo && (
         <section
           aria-label="ACKO overview"
-          className="flex flex-col gap-4 rounded-lg border border-indigo-100 bg-indigo-50/50 p-4 dark:border-indigo-900/40 dark:bg-indigo-950/30"
+          className="bg-primary-95/50 dark:border-primary-30/40 dark:bg-primary-10/30 flex flex-col gap-4 rounded-lg border border-primary-95 p-4"
         >
           <div className="flex items-start justify-between gap-4">
             <div>
-              <span className="text-xs font-medium uppercase tracking-wider text-indigo-700 dark:text-indigo-300">
+              <span className="text-xs font-medium uppercase tracking-wider text-primary-40 dark:text-primary-80">
                 Managed by ACKO
               </span>
               <h2 className="mt-1 text-base font-semibold text-gray-900 dark:text-gray-50">

--- a/ui/src/app/(main)/clusters/[clusterId]/secondary-indexes/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/secondary-indexes/page.tsx
@@ -1,11 +1,12 @@
 "use client"
 
 import { Badge } from "@/components/Badge"
-import { Button } from "@/components/Button"
 import { Card } from "@/components/Card"
 import { CreateIndexDialog } from "@/components/dialogs/CreateIndexDialog"
 import { ErrorBanner } from "@/components/ErrorBanner"
 import { Input } from "@/components/Input"
+import { Button } from "@/components/Button"
+import { PageHead } from "@/components/PageHead"
 import {
   Table,
   TableBody,
@@ -72,39 +73,33 @@ export default function SecondaryIndexesPage({ params }: PageProps) {
 
   return (
     <main className="flex flex-col gap-6">
-      <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <span className="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-500">
-            Secondary indexes
-          </span>
-          <h1 className="mt-1 text-lg font-semibold text-gray-900 sm:text-xl dark:text-gray-50">
-            Secondary indexes
-          </h1>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-500">
+      <PageHead
+        title="Secondary indexes"
+        sub={
+          <>
             Grouped per namespace. Backed by{" "}
             <span className="font-mono">sindex-list</span>.
-          </p>
-        </div>
-        <div className="flex gap-2">
-          <Input
-            type="search"
-            value={filter}
-            onChange={(e) => setFilter(e.target.value)}
-            placeholder="Filter indexes..."
-            className="sm:w-60"
-          />
-          <Button
-            variant="secondary"
-            onClick={() => void load()}
-            isLoading={loading}
-          >
-            Refresh
-          </Button>
-          <Button variant="primary" onClick={() => setCreateOpen(true)}>
-            Create index
-          </Button>
-        </div>
-      </header>
+          </>
+        }
+      >
+        <Input
+          type="search"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Filter indexes..."
+          className="sm:w-60"
+        />
+        <Button
+          variant="secondary"
+          onClick={() => void load()}
+          disabled={loading}
+        >
+          Refresh
+        </Button>
+        <Button variant="primary" onClick={() => setCreateOpen(true)}>
+          Create index
+        </Button>
+      </PageHead>
 
       <CreateIndexDialog
         open={createOpen}

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
@@ -119,7 +119,7 @@ function renderBin(v: unknown, name: string): React.ReactNode {
     )
   if (kind === "integer" || kind === "double")
     return (
-      <span className="font-mono text-xs tabular-nums text-indigo-700 dark:text-indigo-400">
+      <span className="font-mono text-xs tabular-nums text-primary-40 dark:text-primary-65">
         {String(v)}
       </span>
     )
@@ -491,7 +491,7 @@ export default function RecordBrowserPage({ params }: PageProps) {
                             params.set,
                             encodeURIComponent(r.key.pk),
                           )}
-                          className="text-indigo-600 hover:underline dark:text-indigo-400"
+                          className="text-primary-50 hover:underline dark:text-primary-65"
                         >
                           {r.key.pk}
                         </Link>

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
@@ -491,7 +491,7 @@ export default function RecordBrowserPage({ params }: PageProps) {
                             params.set,
                             encodeURIComponent(r.key.pk),
                           )}
-                          className="text-primary-50 hover:underline dark:text-primary-65"
+                          className="text-primary-40 hover:underline dark:text-primary-65"
                         >
                           {r.key.pk}
                         </Link>

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/page.tsx
@@ -260,7 +260,7 @@ function NamespaceCard({
           type="button"
           onClick={onCreateSet}
           className={cx(
-            "inline-flex items-center gap-1 rounded-md border border-dashed border-primary-80 px-2.5 py-1.5 text-xs font-medium text-primary-50 transition",
+            "inline-flex items-center gap-1 rounded-md border border-dashed border-primary-80 px-2.5 py-1.5 text-xs font-medium text-primary-40 transition",
             "dark:border-primary-30/60 dark:hover:bg-primary-10/30 hover:border-primary-65 hover:bg-primary-95 dark:text-primary-65",
           )}
         >

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { Badge } from "@/components/Badge"
-import { Button } from "@/components/Button"
 import { Card } from "@/components/Card"
 import { Input } from "@/components/Input"
 import { CreateSampleDataDialog } from "@/components/dialogs/CreateSampleDataDialog"
@@ -10,7 +9,9 @@ import { clusterSections } from "@/app/siteConfig"
 import { useCluster } from "@/hooks/use-cluster"
 import type { NamespaceInfo, SetInfo } from "@/lib/types/cluster"
 import { cx } from "@/lib/utils"
-import { RiAddLine, RiArrowRightSLine } from "@remixicon/react"
+import { Button } from "@/components/Button"
+import { PageHead } from "@/components/PageHead"
+import { RiAddLine, RiAlertLine, RiArrowRightSLine } from "@remixicon/react"
 import Link from "next/link"
 import { useMemo, useState } from "react"
 
@@ -71,32 +72,21 @@ export default function SetsPage({ params }: PageProps) {
 
   return (
     <main className="flex flex-col gap-6">
-      <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <span className="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-500">
-            Sets
-          </span>
-          <h1 className="mt-1 text-lg font-semibold text-gray-900 sm:text-xl dark:text-gray-50">
-            Namespaces &amp; sets
-          </h1>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-500">
-            Browse per-namespace sets. Click a set to open the record browser.
-          </p>
-        </div>
-        <div className="flex items-center gap-3">
-          <span className="text-xs text-gray-500 dark:text-gray-500">
-            {namespaces.length} / 2 max{" "}
-            <span className="font-medium">(CE)</span>
-          </span>
-          <Button
-            variant="secondary"
-            onClick={() => setSampleOpen(true)}
-            disabled={nsNames.length === 0}
-          >
-            Sample data
-          </Button>
-        </div>
-      </header>
+      <PageHead
+        title="Namespaces & sets"
+        sub="Browse per-namespace sets. Click a set to open the record browser."
+      >
+        <span className="text-xs text-on-surface-muted">
+          {namespaces.length} / 2 max <span className="font-medium">(CE)</span>
+        </span>
+        <Button
+          variant="secondary"
+          onClick={() => setSampleOpen(true)}
+          disabled={nsNames.length === 0}
+        >
+          Sample data
+        </Button>
+      </PageHead>
 
       <Input
         type="search"
@@ -107,8 +97,14 @@ export default function SetsPage({ params }: PageProps) {
       />
 
       {cluster.error && (
-        <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
-          {cluster.error.message}
+        <div className="ace-announce tone-warning" role="status">
+          <span className="ico">
+            <RiAlertLine className="size-4" aria-hidden="true" />
+          </span>
+          <div className="body">
+            <div className="title">Failed to load namespaces</div>
+            <div className="desc">{cluster.error.message}</div>
+          </div>
         </div>
       )}
 
@@ -164,7 +160,7 @@ function NamespaceCard({
   const severity = nsSeverity(ns)
   const accent =
     severity === "ok"
-      ? "bg-indigo-500"
+      ? "bg-primary-45"
       : severity === "warning"
         ? "bg-amber-500"
         : "bg-red-500"
@@ -229,7 +225,7 @@ function NamespaceCard({
                   ? "bg-red-500"
                   : memPct > 60
                     ? "bg-amber-500"
-                    : "bg-indigo-500",
+                    : "bg-primary-45",
               )}
               style={{ width: `${Math.max(memPct, 1)}%` }}
             />
@@ -264,8 +260,8 @@ function NamespaceCard({
           type="button"
           onClick={onCreateSet}
           className={cx(
-            "inline-flex items-center gap-1 rounded-md border border-dashed border-indigo-300 px-2.5 py-1.5 text-xs font-medium text-indigo-600 transition",
-            "hover:border-indigo-400 hover:bg-indigo-50 dark:border-indigo-900/60 dark:text-indigo-400 dark:hover:bg-indigo-950/30",
+            "inline-flex items-center gap-1 rounded-md border border-dashed border-primary-80 px-2.5 py-1.5 text-xs font-medium text-primary-50 transition",
+            "dark:border-primary-30/60 dark:hover:bg-primary-10/30 hover:border-primary-65 hover:bg-primary-95 dark:text-primary-65",
           )}
         >
           <RiAddLine className="size-3.5" aria-hidden="true" />
@@ -312,7 +308,7 @@ function SetChip({
       href={clusterSections.set(clusterId, namespace, set.name)}
       className={cx(
         baseClass,
-        "border-gray-200 bg-white hover:border-indigo-300 hover:bg-indigo-50/50 dark:border-gray-800 dark:bg-gray-950 hover:dark:border-indigo-900/60 hover:dark:bg-indigo-950/20",
+        "hover:bg-primary-95/50 hover:dark:border-primary-30/60 hover:dark:bg-primary-10/20 border-gray-200 bg-white hover:border-primary-80 dark:border-gray-800 dark:bg-gray-950",
       )}
       title={set.note ?? undefined}
     >
@@ -325,13 +321,13 @@ function SetChip({
       {set.note && (
         <span
           aria-label="Set has an operator note"
-          className="rounded bg-indigo-100 px-1 py-0.5 font-mono text-[9px] uppercase tracking-wide text-indigo-700 dark:bg-indigo-950/40 dark:text-indigo-300"
+          className="dark:bg-primary-10/40 rounded bg-primary-95 px-1 py-0.5 font-mono text-[9px] uppercase tracking-wide text-primary-40 dark:text-primary-80"
         >
           note
         </span>
       )}
       <RiArrowRightSLine
-        className="size-3.5 text-gray-300 transition group-hover:text-indigo-500 dark:text-gray-700"
+        className="size-3.5 text-gray-300 transition group-hover:text-primary-45 dark:text-gray-700"
         aria-hidden="true"
       />
     </Link>

--- a/ui/src/app/(main)/clusters/[clusterId]/udfs/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/udfs/page.tsx
@@ -1,11 +1,12 @@
 "use client"
 
 import { Badge } from "@/components/Badge"
-import { Button } from "@/components/Button"
 import { Card } from "@/components/Card"
 import { RegisterUdfDialog } from "@/components/dialogs/RegisterUdfDialog"
 import { ErrorBanner } from "@/components/ErrorBanner"
 import { Input } from "@/components/Input"
+import { Button } from "@/components/Button"
+import { PageHead } from "@/components/PageHead"
 import {
   Table,
   TableBody,
@@ -56,39 +57,36 @@ export default function UdfsPage({ params }: PageProps) {
 
   return (
     <main className="flex flex-col gap-6">
-      <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <span className="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-500">
-            UDFs
-          </span>
-          <h1 className="mt-1 text-lg font-semibold text-gray-900 sm:text-xl dark:text-gray-50">
-            User-defined functions
-          </h1>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-500">
-            Registered Lua modules. Backend does not ship bundled UDFs — users
-            manage their own.
-          </p>
-        </div>
-        <div className="flex gap-2">
-          <Input
-            type="search"
-            value={filter}
-            onChange={(e) => setFilter(e.target.value)}
-            placeholder="Filter modules..."
-            className="sm:w-60"
-          />
-          <Button
-            variant="secondary"
-            onClick={() => void load()}
-            isLoading={loading}
-          >
-            Refresh
-          </Button>
-          <Button variant="primary" onClick={() => setRegisterOpen(true)}>
-            Register UDF
-          </Button>
-        </div>
-      </header>
+      <PageHead
+        title="User-defined functions"
+        sub="Registered Lua modules. Backend does not ship bundled UDFs — users manage their own."
+      >
+        <Input
+          type="search"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          placeholder="Filter modules..."
+          className="sm:w-60"
+        />
+        <Button
+          variant="secondary"
+          onClick={() => void load()}
+          disabled={loading}
+        >
+          Refresh
+        </Button>
+        <Button variant="primary" onClick={() => setRegisterOpen(true)}>
+          Register UDF
+        </Button>
+      </PageHead>
+      {error && (
+        <ErrorBanner
+          message={error}
+          onRetry={() => void load()}
+          disabled={loading}
+          staleData={!!udfs && udfs.length > 0}
+        />
+      )}
 
       <RegisterUdfDialog
         open={registerOpen}
@@ -98,15 +96,6 @@ export default function UdfsPage({ params }: PageProps) {
           void load()
         }}
       />
-
-      {error && (
-        <ErrorBanner
-          message={error}
-          onRetry={() => void load()}
-          disabled={loading}
-          staleData={!!udfs && udfs.length > 0}
-        />
-      )}
 
       <Card className="p-0">
         <TableRoot>

--- a/ui/src/app/(main)/clusters/page.tsx
+++ b/ui/src/app/(main)/clusters/page.tsx
@@ -1,6 +1,5 @@
 "use client"
 
-import { Button } from "@/components/Button"
 import { ClustersEmptyState } from "@/components/clusters/ClustersEmptyState"
 import { ClustersSkeleton } from "@/components/clusters/ClustersSkeleton"
 import { EnvSection } from "@/components/clusters/EnvSection"
@@ -13,6 +12,9 @@ import { useK8sClusters } from "@/hooks/use-k8s-clusters"
 import type { ConnectionProfileResponse } from "@/lib/types/connection"
 import { bumpConnectionsRev } from "@/stores/data-revision-store"
 import { useUiStore } from "@/stores/ui-store"
+import { Button } from "@/components/Button"
+import { PageHead } from "@/components/PageHead"
+import { RiAlertLine } from "@remixicon/react"
 import Link from "next/link"
 import { useMemo, useState } from "react"
 
@@ -53,28 +55,27 @@ export default function ClustersPage() {
 
   return (
     <main className="flex flex-col gap-6">
-      <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <h1 className="text-lg font-semibold text-gray-900 sm:text-xl dark:text-gray-50">
-            Clusters
-          </h1>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-500">
-            Connection profiles and ACKO-managed Aerospike CE clusters.
-          </p>
-        </div>
-        <div className="flex gap-2">
-          <Button variant="secondary" onClick={() => setAddConnOpen(true)}>
-            Add Connection
-          </Button>
-          <Button variant="primary" asChild>
-            <Link href="/clusters/new">Create Cluster</Link>
-          </Button>
-        </div>
-      </header>
+      <PageHead
+        title="Clusters"
+        sub="Connection profiles and ACKO-managed Aerospike CE clusters."
+      >
+        <Button variant="secondary" onClick={() => setAddConnOpen(true)}>
+          Add Connection
+        </Button>
+        <Link href="/clusters/new" className="btn btn-primary">
+          Create Cluster
+        </Link>
+      </PageHead>
 
       {combinedError && (
-        <div className="rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700 dark:border-red-900/50 dark:bg-red-950/40 dark:text-red-300">
-          {combinedError.message}
+        <div className="ace-announce tone-warning" role="status">
+          <span className="ico">
+            <RiAlertLine className="size-4" aria-hidden="true" />
+          </span>
+          <div className="body">
+            <div className="title">Failed to load clusters</div>
+            <div className="desc">{combinedError.message}</div>
+          </div>
         </div>
       )}
 
@@ -85,7 +86,7 @@ export default function ClustersPage() {
       ) : (
         <>
           <div className="flex items-center justify-between">
-            <p className="text-xs text-gray-500 dark:text-gray-500">
+            <p className="text-xs text-on-surface-muted">
               {rows.length} {rows.length === 1 ? "cluster" : "clusters"} ·{" "}
               {groups.length} env group{groups.length === 1 ? "" : "s"}
             </p>

--- a/ui/src/app/(main)/clusters/page.tsx
+++ b/ui/src/app/(main)/clusters/page.tsx
@@ -62,9 +62,9 @@ export default function ClustersPage() {
         <Button variant="secondary" onClick={() => setAddConnOpen(true)}>
           Add Connection
         </Button>
-        <Link href="/clusters/new" className="btn btn-primary">
-          Create Cluster
-        </Link>
+        <Button variant="primary" asChild>
+          <Link href="/clusters/new">Create Cluster</Link>
+        </Button>
       </PageHead>
 
       {combinedError && (

--- a/ui/src/app/(main)/guides/page.tsx
+++ b/ui/src/app/(main)/guides/page.tsx
@@ -19,6 +19,7 @@ import { ErrorBanner } from "@/components/ErrorBanner"
 import { GuideMarkdown } from "@/components/GuideMarkdown"
 import { InfoBanner } from "@/components/InfoBanner"
 import { GuideEditorDialog } from "@/components/dialogs/GuideEditorDialog"
+import { PageHead } from "@/components/PageHead"
 import { useGuides } from "@/hooks/use-guides"
 import { useWorkspaces } from "@/hooks/use-workspaces"
 import { mapApiError } from "@/lib/api/error-mapping"
@@ -62,22 +63,18 @@ export default function GuidesPage() {
 
   return (
     <main className="flex flex-col gap-6">
-      <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <span className="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-500">
-            Operations
-          </span>
-          <h1 className="mt-1 text-lg font-semibold text-gray-900 sm:text-xl dark:text-gray-50">
-            Operational guides
-          </h1>
-          <p className="mt-1 text-sm text-gray-500 dark:text-gray-500">
+      <PageHead
+        title="Operational guides"
+        sub={
+          <>
             Org/team policy for workspace{" "}
-            <span className="font-medium text-gray-700 dark:text-gray-300">
+            <span className="font-medium text-on-surface-variant">
               {workspaceName}
             </span>{" "}
             — authored here, enforced everywhere.
-          </p>
-        </div>
+          </>
+        }
+      >
         <Button
           variant="secondary"
           onClick={() => void guides.refetch()}
@@ -85,7 +82,7 @@ export default function GuidesPage() {
         >
           Refresh
         </Button>
-      </header>
+      </PageHead>
 
       <InfoBanner title="Read before you operate">
         ackoctl and AI agents fetch these guides with{" "}

--- a/ui/src/app/(main)/layout.tsx
+++ b/ui/src/app/(main)/layout.tsx
@@ -3,11 +3,7 @@ export default function Layout({
 }: Readonly<{
   children: React.ReactNode
 }>) {
-  return (
-    <div className="relative">
-      <div className="p-4 sm:px-6 sm:pb-10 sm:pt-10 lg:px-10 lg:pt-7">
-        {children}
-      </div>
-    </div>
-  )
+  // Padding is handled by `.acm-main` in globals.css to match the Huginn
+  // shell layout (sidebar + topbar + statusbar grid). No extra padding here.
+  return <div className="relative">{children}</div>
 }

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -1,3 +1,58 @@
+/* Pretendard Variable from CDN (Korean-friendly sans). */
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.css");
+
+/* Local design tokens + minimal base theme (Naver-green primary). */
+@import "../styles/tokens.css";
+@import "../styles/theme.css";
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* =====================================================================
+   ACM shell layout
+     - 232 px fixed sidebar on the left
+     - 28 px statusbar pinned to the bottom
+     - main scrolls between them
+   ===================================================================== */
+
+@media (min-width: 1024px) {
+  body {
+    --acm-sidebar-w: 232px;
+    --acm-statusbar-h: 28px;
+  }
+
+  /* The existing Sidebar component is `lg:fixed lg:inset-y-0 lg:w-72` —
+     narrow it to 232 px. Chrome stays the same; only the width overrides. */
+  body[data-app="ace"] nav.lg\:w-72,
+  body[data-app="ace"] aside.lg\:w-72 {
+    width: var(--acm-sidebar-w);
+  }
+
+  body[data-app="ace"] .acm-statusbar {
+    position: fixed;
+    bottom: 0;
+    left: var(--acm-sidebar-w);
+    right: 0;
+    height: var(--acm-statusbar-h);
+    z-index: 30;
+  }
+
+  body[data-app="ace"] .acm-main {
+    margin-left: var(--acm-sidebar-w);
+    padding: 24px 28px calc(var(--acm-statusbar-h) + 16px);
+    min-height: 100vh;
+    background: var(--bg);
+  }
+}
+
+@media (max-width: 1023px) {
+  /* Mobile: keep the existing top navbar from the Sidebar component; hide
+     the desktop statusbar to avoid double chrome. */
+  body[data-app="ace"] .acm-statusbar {
+    display: none;
+  }
+  body[data-app="ace"] .acm-main {
+    padding: 16px;
+  }
+}

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -1,17 +1,11 @@
 import type { Metadata } from "next"
 import { ThemeProvider } from "next-themes"
-import { Inter } from "next/font/google"
 import "./globals.css"
 import { siteConfig } from "./siteConfig"
 
 import { AuthProvider } from "@/components/AuthProvider"
+import { ShellStatusBar } from "@/components/ui/navigation/ShellStatusBar"
 import { Sidebar } from "@/components/ui/navigation/Sidebar"
-
-const inter = Inter({
-  subsets: ["latin"],
-  display: "swap",
-  variable: "--font-inter",
-})
 
 const SITE_URL =
   process.env.NEXT_PUBLIC_SITE_URL ??
@@ -53,17 +47,18 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body
-        className={`${inter.className} overflow-y-scroll scroll-auto antialiased selection:bg-indigo-100 selection:text-indigo-700 dark:bg-gray-950`}
+        data-app="ace"
+        data-theme="light"
+        className="antialiased selection:bg-primary-95 selection:text-primary-40 dark:bg-bg"
         suppressHydrationWarning
       >
-        <div className="mx-auto max-w-screen-2xl">
-          <ThemeProvider defaultTheme="system" attribute="class">
-            <AuthProvider>
-              <Sidebar />
-              <main className="lg:pl-72">{children}</main>
-            </AuthProvider>
-          </ThemeProvider>
-        </div>
+        <ThemeProvider defaultTheme="light" attribute="data-theme">
+          <AuthProvider>
+            <Sidebar />
+            <main className="acm-main">{children}</main>
+            <ShellStatusBar />
+          </AuthProvider>
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -49,7 +49,6 @@ export default function RootLayout({
       <body
         data-app="ace"
         className="antialiased selection:bg-primary-95 selection:text-primary-40 dark:bg-bg"
-        suppressHydrationWarning
       >
         <ThemeProvider defaultTheme="light" attribute="data-theme">
           <AuthProvider>

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -48,7 +48,6 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body
         data-app="ace"
-        data-theme="light"
         className="antialiased selection:bg-primary-95 selection:text-primary-40 dark:bg-bg"
         suppressHydrationWarning
       >

--- a/ui/src/app/not-found.tsx
+++ b/ui/src/app/not-found.tsx
@@ -10,7 +10,7 @@ export default function NotFound() {
       <Link href={siteConfig.baseLinks.home}>
         <DatabaseLogo className="mt-6 h-10" />
       </Link>
-      <p className="mt-6 text-4xl font-semibold text-primary-50 sm:text-5xl dark:text-primary-45">
+      <p className="mt-6 text-4xl font-semibold text-primary-40 sm:text-5xl dark:text-primary-45">
         404
       </p>
       <h1 className="mt-4 text-2xl font-semibold text-gray-900 dark:text-gray-50">

--- a/ui/src/app/not-found.tsx
+++ b/ui/src/app/not-found.tsx
@@ -10,7 +10,7 @@ export default function NotFound() {
       <Link href={siteConfig.baseLinks.home}>
         <DatabaseLogo className="mt-6 h-10" />
       </Link>
-      <p className="mt-6 text-4xl font-semibold text-indigo-600 sm:text-5xl dark:text-indigo-500">
+      <p className="mt-6 text-4xl font-semibold text-primary-50 sm:text-5xl dark:text-primary-45">
         404
       </p>
       <h1 className="mt-4 text-2xl font-semibold text-gray-900 dark:text-gray-50">

--- a/ui/src/components/AuthProvider.tsx
+++ b/ui/src/components/AuthProvider.tsx
@@ -102,7 +102,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         <div className="flex flex-col items-center gap-3">
           <div
             aria-label="Loading"
-            className="size-8 animate-spin rounded-full border-2 border-gray-200 border-t-indigo-500"
+            className="size-8 animate-spin rounded-full border-2 border-gray-200 border-t-primary-45"
           />
           <p className="text-sm text-gray-500 dark:text-gray-400">
             Signing you in…
@@ -128,7 +128,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // login redirect). Render the loading shell rather than a blank page.
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="size-8 animate-spin rounded-full border-2 border-gray-200 border-t-indigo-500" />
+        <div className="size-8 animate-spin rounded-full border-2 border-gray-200 border-t-primary-45" />
       </div>
     )
   }

--- a/ui/src/components/Badge.tsx
+++ b/ui/src/components/Badge.tsx
@@ -1,4 +1,4 @@
-// Tremor Raw Badge [v0.0.0]
+// Tremor Raw Badge [v0.0.0] — adapted to the ACM primary-* design tokens.
 
 import React from "react"
 import { tv, type VariantProps } from "tailwind-variants"
@@ -11,14 +11,8 @@ const badgeVariants = tv({
   ),
   variants: {
     variant: {
-      default: [
-        "bg-indigo-50 text-indigo-800 ring-indigo-500/30",
-        "dark:bg-indigo-400/10 dark:text-indigo-400 dark:ring-indigo-400/30",
-      ],
-      neutral: [
-        "bg-gray-50 text-gray-700 ring-gray-500/30",
-        "dark:bg-gray-400/10 dark:text-gray-300 dark:ring-gray-400/20",
-      ],
+      default: ["ring-primary-50/30 bg-primary-95 text-primary-40"],
+      neutral: ["ring-border/30 bg-surface-container text-on-surface-variant"],
       success: [
         "bg-emerald-50 text-emerald-800 ring-emerald-600/30",
         "dark:bg-emerald-400/10 dark:text-emerald-400 dark:ring-emerald-400/20",

--- a/ui/src/components/Button.tsx
+++ b/ui/src/components/Button.tsx
@@ -1,4 +1,4 @@
-// Tremor Raw Button [v0.1.1]
+// Tremor Raw Button [v0.1.1] — adapted to the ACM primary-* design tokens.
 
 import { Slot } from "@radix-ui/react-slot"
 import { RiLoader2Fill } from "@remixicon/react"
@@ -19,71 +19,31 @@ const buttonVariants = tv({
   variants: {
     variant: {
       primary: [
-        // border
-        "border-transparent",
-        // text color
-        "text-white dark:text-gray-900",
-        // background color
-        "bg-indigo-600 dark:bg-indigo-500",
-        // hover color
-        "hover:bg-indigo-500 dark:hover:bg-indigo-600",
-        // disabled
-        "disabled:bg-indigo-100 disabled:text-gray-400",
-        "disabled:dark:bg-indigo-800 disabled:dark:text-indigo-400",
+        "border-transparent text-white",
+        "bg-primary-50 hover:bg-primary-45",
+        "disabled:bg-primary-95 disabled:text-on-surface-disabled",
       ],
       secondary: [
-        // border
-        "border-gray-300 dark:border-gray-800",
-        // text color
-        "text-gray-900 dark:text-gray-50",
-        // background color
-        "bg-white dark:bg-gray-950",
-        //hover color
-        "hover:bg-gray-50 dark:hover:bg-gray-900/60",
-        // disabled
-        "disabled:text-gray-400",
-        "disabled:dark:text-gray-600",
+        "border-border bg-surface text-on-surface",
+        "hover:bg-surface-container-low",
+        "disabled:text-on-surface-disabled",
       ],
       light: [
-        // base
-        "shadow-none",
-        // border
-        "border-transparent",
-        // text color
-        "text-gray-900 dark:text-gray-50",
-        // background color
-        "bg-gray-200 dark:bg-gray-900",
-        // hover color
-        "hover:bg-gray-300/70 dark:hover:bg-gray-800/80",
-        // disabled
-        "disabled:bg-gray-100 disabled:text-gray-400",
-        "disabled:dark:bg-gray-800 disabled:dark:text-gray-600",
+        "border-transparent shadow-none",
+        "bg-surface-container text-on-surface",
+        "hover:bg-surface-container-high",
+        "disabled:bg-surface-container-low disabled:text-on-surface-disabled",
       ],
       ghost: [
-        // base
-        "shadow-none",
-        // border
-        "border-transparent",
-        // text color
-        "text-gray-900 dark:text-gray-50",
-        // hover color
-        "bg-transparent hover:bg-gray-100 dark:hover:bg-gray-800/80",
-        // disabled
-        "disabled:text-gray-400",
-        "disabled:dark:text-gray-600",
+        "border-transparent shadow-none",
+        "bg-transparent text-on-surface",
+        "hover:bg-surface-container-low",
+        "disabled:text-on-surface-disabled",
       ],
       destructive: [
-        // text color
-        "text-white",
-        // border
-        "border-transparent",
-        // background color
-        "bg-red-600 dark:bg-red-700",
-        // hover color
-        "hover:bg-red-700 dark:hover:bg-red-600",
-        // disabled
-        "disabled:bg-red-300 disabled:text-white",
-        "disabled:dark:bg-red-950 disabled:dark:text-red-400",
+        "border-transparent text-white",
+        "bg-error-50 hover:bg-error-45",
+        "disabled:bg-error-30 disabled:text-white",
       ],
     },
   },

--- a/ui/src/components/Calendar.tsx
+++ b/ui/src/components/Calendar.tsx
@@ -129,8 +129,8 @@ const Calendar = ({
         day_today: "font-semibold",
         day_selected: cx(
           "rounded",
-          "aria-selected:bg-indigo-600 aria-selected:text-gray-50",
-          "dark:aria-selected:bg-indigo-500 dark:aria-selected:text-gray-50",
+          "aria-selected:bg-primary-50 aria-selected:text-gray-50",
+          "dark:aria-selected:bg-primary-45 dark:aria-selected:text-gray-50",
         ),
         day_disabled:
           "!text-gray-300 dark:!text-gray-700 line-through disabled:hover:bg-transparent",

--- a/ui/src/components/Checkbox.tsx
+++ b/ui/src/components/Checkbox.tsx
@@ -27,9 +27,9 @@ const Checkbox = React.forwardRef<
         "data-[disabled]:bg-gray-100 data-[disabled]:text-gray-400 data-[disabled]:ring-gray-300",
         "data-[disabled]:dark:bg-gray-800 data-[disabled]:dark:text-gray-500 data-[disabled]:dark:ring-gray-700",
         // checked and enabled
-        "enabled:data-[state=checked]:bg-indigo-600 enabled:data-[state=checked]:ring-0 enabled:data-[state=checked]:ring-transparent",
+        "enabled:data-[state=checked]:bg-primary-50 enabled:data-[state=checked]:ring-0 enabled:data-[state=checked]:ring-transparent",
         // indeterminate
-        "enabled:data-[state=indeterminate]:bg-indigo-600 enabled:data-[state=indeterminate]:ring-0 enabled:data-[state=indeterminate]:ring-transparent",
+        "enabled:data-[state=indeterminate]:bg-primary-50 enabled:data-[state=indeterminate]:ring-0 enabled:data-[state=indeterminate]:ring-transparent",
         // focus
         focusRing,
         className,

--- a/ui/src/components/GuideMarkdown.tsx
+++ b/ui/src/components/GuideMarkdown.tsx
@@ -75,7 +75,7 @@ function renderInline(text: string, keyPrefix: string): React.ReactNode[] {
             href={lm[2]}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-indigo-600 underline hover:text-indigo-700 dark:text-indigo-400"
+            className="text-primary-50 underline hover:text-primary-40 dark:text-primary-65"
           >
             {lm[1]}
           </a>,
@@ -193,7 +193,7 @@ function renderBlocks(md: string): React.ReactNode[] {
       blocks.push(
         <blockquote
           key={key++}
-          className="mt-3 border-l-2 border-indigo-300 pl-3 text-sm italic text-gray-600 dark:border-indigo-700 dark:text-gray-400"
+          className="mt-3 border-l-2 border-primary-80 pl-3 text-sm italic text-gray-600 dark:border-primary-40 dark:text-gray-400"
         >
           {renderInline(quote.join(" "), `bq${key}`)}
         </blockquote>,

--- a/ui/src/components/GuideMarkdown.tsx
+++ b/ui/src/components/GuideMarkdown.tsx
@@ -75,7 +75,7 @@ function renderInline(text: string, keyPrefix: string): React.ReactNode[] {
             href={lm[2]}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-primary-40 underline hover:text-primary-40 dark:text-primary-65"
+            className="text-primary-40 underline hover:text-primary-30 dark:text-primary-65 dark:hover:text-primary-80"
           >
             {lm[1]}
           </a>,

--- a/ui/src/components/GuideMarkdown.tsx
+++ b/ui/src/components/GuideMarkdown.tsx
@@ -75,7 +75,7 @@ function renderInline(text: string, keyPrefix: string): React.ReactNode[] {
             href={lm[2]}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-primary-50 underline hover:text-primary-40 dark:text-primary-65"
+            className="text-primary-40 underline hover:text-primary-40 dark:text-primary-65"
           >
             {lm[1]}
           </a>,

--- a/ui/src/components/InfoBanner.tsx
+++ b/ui/src/components/InfoBanner.tsx
@@ -11,7 +11,7 @@ export function InfoBanner({ title, children }: InfoBannerProps) {
   return (
     <div
       role="status"
-      className="flex gap-2 rounded border border-indigo-200 bg-indigo-50 px-3 py-2 text-xs text-indigo-700 dark:border-indigo-900/50 dark:bg-indigo-950/40 dark:text-indigo-300"
+      className="dark:border-primary-30/50 dark:bg-primary-10/40 flex gap-2 rounded border border-primary-90 bg-primary-95 px-3 py-2 text-xs text-primary-40 dark:text-primary-80"
     >
       <RiInformationLine
         className="mt-0.5 size-3.5 shrink-0"

--- a/ui/src/components/PageHead.tsx
+++ b/ui/src/components/PageHead.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react"
+import { cx } from "@/lib/utils"
+
+/**
+ * Page header — title + sub-text on the left, action slot on the right.
+ * Renders the `.ace-page-head` styles defined in src/styles/theme.css.
+ */
+export function PageHead({
+  title,
+  sub,
+  className,
+  children,
+}: {
+  title: ReactNode
+  sub?: ReactNode
+  className?: string
+  children?: ReactNode
+}) {
+  return (
+    <div className={cx("ace-page-head", className)}>
+      <div className="lead">
+        <div>
+          <h1>{title}</h1>
+          {sub && <div className="sub">{sub}</div>}
+        </div>
+      </div>
+      <div className="flex items-center gap-2">{children}</div>
+    </div>
+  )
+}

--- a/ui/src/components/ProgressBar.tsx
+++ b/ui/src/components/ProgressBar.tsx
@@ -13,8 +13,8 @@ const progressBarVariants = tv({
   variants: {
     variant: {
       default: {
-        background: "bg-indigo-100 dark:bg-indigo-500/30",
-        bar: "bg-indigo-600 dark:bg-indigo-500",
+        background: "dark:bg-primary-45/30 bg-primary-95",
+        bar: "bg-primary-50 dark:bg-primary-45",
       },
       neutral: {
         background: "bg-gray-200 dark:bg-gray-500/40",

--- a/ui/src/components/ProgressCircle.tsx
+++ b/ui/src/components/ProgressCircle.tsx
@@ -13,8 +13,8 @@ const progressCircleVariants = tv({
   variants: {
     variant: {
       default: {
-        background: "stroke-indigo-200 dark:stroke-indigo-500/30",
-        circle: "stroke-indigo-600 dark:stroke-indigo-500",
+        background: "dark:stroke-primary-45/30 stroke-primary-90",
+        circle: "stroke-primary-50 dark:stroke-primary-45",
       },
       neutral: {
         background: "stroke-gray-200 dark:stroke-gray-500/40",

--- a/ui/src/components/RadioCard.tsx
+++ b/ui/src/components/RadioCard.tsx
@@ -33,7 +33,7 @@ const RadioCardGroupIndicator = React.forwardRef<
         // background color
         "bg-white dark:bg-gray-950",
         // checked
-        "group-data-[state=checked]:border-0 group-data-[state=checked]:border-transparent group-data-[state=checked]:bg-indigo-600",
+        "group-data-[state=checked]:border-0 group-data-[state=checked]:border-transparent group-data-[state=checked]:bg-primary-50",
         // disabled
         "group-data-[disabled]:border",
         "group-data-[disabled]:border-gray-300 group-data-[disabled]:bg-gray-100 group-data-[disabled]:text-gray-400",
@@ -78,7 +78,7 @@ const RadioCardItem = React.forwardRef<
         "bg-white dark:bg-gray-950",
         // border color
         "border-gray-200 dark:border-gray-800",
-        "data-[state=checked]:border-indigo-600 data-[state=checked]:dark:border-indigo-600",
+        "data-[state=checked]:border-primary-50 data-[state=checked]:dark:border-primary-50",
         focusInput,
         className,
       )}

--- a/ui/src/components/Switch.tsx
+++ b/ui/src/components/Switch.tsx
@@ -15,15 +15,15 @@ const switchVariants = tv({
       // ring color
       "ring-black/5 dark:ring-gray-800",
       // checked
-      "data-[state=checked]:bg-indigo-600 data-[state=checked]:dark:bg-indigo-600",
+      "data-[state=checked]:bg-primary-50 data-[state=checked]:dark:bg-primary-50",
       // disabled
       "data-[disabled]:cursor-default",
       // disabled checked
-      "data-[disabled]:data-[state=checked]:bg-indigo-200",
+      "data-[disabled]:data-[state=checked]:bg-primary-90",
       "data-[disabled]:data-[state=checked]:ring-gray-300",
       // disabled checked dark
       "data-[disabled]:data-[state=checked]:dark:ring-gray-900",
-      "data-[disabled]:data-[state=checked]:dark:bg-indigo-900",
+      "data-[disabled]:data-[state=checked]:dark:bg-primary-30",
       // disabled unchecked
       "data-[disabled]:data-[state=unchecked]:ring-gray-300",
       "data-[disabled]:data-[state=unchecked]:bg-gray-100",

--- a/ui/src/components/TabNavigation.tsx
+++ b/ui/src/components/TabNavigation.tsx
@@ -77,8 +77,8 @@ const TabNavigationLink = React.forwardRef<
             // border hover
             "group-hover:border-gray-300 group-hover:dark:border-gray-400",
             // selected
-            "group-data-[active]:border-indigo-600 group-data-[active]:text-indigo-600",
-            "group-data-[active]:dark:border-indigo-500 group-data-[active]:dark:text-indigo-500",
+            "group-data-[active]:border-primary-50 group-data-[active]:text-primary-50",
+            "group-data-[active]:dark:border-primary-45 group-data-[active]:dark:text-primary-45",
             // disabled
             disabled
               ? "pointer-events-none text-gray-300 dark:text-gray-700"

--- a/ui/src/components/TabNavigation.tsx
+++ b/ui/src/components/TabNavigation.tsx
@@ -77,7 +77,7 @@ const TabNavigationLink = React.forwardRef<
             // border hover
             "group-hover:border-gray-300 group-hover:dark:border-gray-400",
             // selected
-            "group-data-[active]:border-primary-50 group-data-[active]:text-primary-50",
+            "group-data-[active]:border-primary-50 group-data-[active]:text-primary-40",
             "group-data-[active]:dark:border-primary-45 group-data-[active]:dark:text-primary-45",
             // disabled
             disabled

--- a/ui/src/components/browser/RecordFilters.tsx
+++ b/ui/src/components/browser/RecordFilters.tsx
@@ -285,7 +285,7 @@ export function RecordFilters({
               )}
               <span>Add filter</span>
               {availableBins.length > 0 && (
-                <span className="ml-1 rounded-full bg-indigo-100 px-1.5 text-[10px] font-medium tabular-nums text-indigo-700 dark:bg-indigo-950/60 dark:text-indigo-300">
+                <span className="dark:bg-primary-10/60 ml-1 rounded-full bg-primary-95 px-1.5 text-[10px] font-medium tabular-nums text-primary-40 dark:text-primary-80">
                   {availableBins.length}
                 </span>
               )}
@@ -712,7 +712,7 @@ function ConditionEditor({
           value={val}
           onChange={(e) => setVal(e.target.value)}
           placeholder='{"type":"AeroCircle","coordinates":[[lng,lat],radius]}'
-          className="min-h-[80px] w-full rounded-md border border-gray-300 bg-white p-2 font-mono text-xs outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 dark:border-gray-800 dark:bg-gray-950 dark:focus:border-indigo-700 dark:focus:ring-indigo-700/30"
+          className="dark:focus:ring-primary-40/30 min-h-[80px] w-full rounded-md border border-gray-300 bg-white p-2 font-mono text-xs outline-none transition focus:border-primary-45 focus:ring-2 focus:ring-primary-90 dark:border-gray-800 dark:bg-gray-950 dark:focus:border-primary-40"
         />
       )}
 

--- a/ui/src/components/clusters/ClusterCard.tsx
+++ b/ui/src/components/clusters/ClusterCard.tsx
@@ -36,7 +36,7 @@ export function ClusterCard({
       className={cx(
         "relative flex h-full flex-col gap-3 transition",
         row.connId &&
-          "hover:border-indigo-300 hover:shadow-sm dark:hover:border-indigo-700",
+          "hover:border-primary-80 hover:shadow-sm dark:hover:border-primary-40",
       )}
     >
       {row.connId && (
@@ -65,7 +65,7 @@ export function ClusterCard({
               {status.label}
             </span>
             {row.managedBy === "ACKO" && (
-              <span className="text-xs font-medium uppercase tracking-wider text-indigo-600 dark:text-indigo-400">
+              <span className="text-xs font-medium uppercase tracking-wider text-primary-50 dark:text-primary-65">
                 · ACKO
               </span>
             )}

--- a/ui/src/components/clusters/ClusterCard.tsx
+++ b/ui/src/components/clusters/ClusterCard.tsx
@@ -65,7 +65,7 @@ export function ClusterCard({
               {status.label}
             </span>
             {row.managedBy === "ACKO" && (
-              <span className="text-xs font-medium uppercase tracking-wider text-primary-50 dark:text-primary-65">
+              <span className="text-xs font-medium uppercase tracking-wider text-primary-40 dark:text-primary-65">
                 · ACKO
               </span>
             )}

--- a/ui/src/components/clusters/ClustersEmptyState.tsx
+++ b/ui/src/components/clusters/ClustersEmptyState.tsx
@@ -9,10 +9,10 @@ export function ClustersEmptyState({
 }) {
   return (
     <Card className="flex flex-col items-center gap-2 py-10 text-center">
-      <h3 className="text-base font-semibold text-gray-900 dark:text-gray-50">
+      <h3 className="text-base font-semibold text-on-surface">
         No clusters yet
       </h3>
-      <p className="max-w-md text-sm text-gray-500 dark:text-gray-500">
+      <p className="max-w-md text-sm text-on-surface-muted">
         Add a connection profile to manage an existing cluster, or create a new
         one via ACKO.
       </p>

--- a/ui/src/components/clusters/NameLink.tsx
+++ b/ui/src/components/clusters/NameLink.tsx
@@ -17,7 +17,7 @@ export function NameLink({ row }: { row: ClusterRow }) {
         href={clusterSections.overview(row.connId)}
         title={row.displayName}
         className={cx(
-          "block truncate font-mono font-medium text-gray-900 transition hover:text-indigo-700 dark:text-gray-50 dark:hover:text-indigo-300",
+          "block truncate font-mono font-medium text-gray-900 transition hover:text-primary-40 dark:text-gray-50 dark:hover:text-primary-80",
           focusRing,
         )}
       >

--- a/ui/src/components/clusters/ViewToggle.tsx
+++ b/ui/src/components/clusters/ViewToggle.tsx
@@ -44,7 +44,7 @@ export function ViewToggle({
             className={cx(
               "flex size-7 items-center justify-center rounded transition",
               active
-                ? "dark:bg-primary-45/10 bg-primary-95 text-primary-50 dark:text-primary-65"
+                ? "dark:bg-primary-45/10 bg-primary-95 text-primary-40 dark:text-primary-65"
                 : "text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-500 hover:dark:bg-gray-900 hover:dark:text-gray-50",
               focusRing,
             )}

--- a/ui/src/components/clusters/ViewToggle.tsx
+++ b/ui/src/components/clusters/ViewToggle.tsx
@@ -44,7 +44,7 @@ export function ViewToggle({
             className={cx(
               "flex size-7 items-center justify-center rounded transition",
               active
-                ? "bg-indigo-50 text-indigo-600 dark:bg-indigo-500/10 dark:text-indigo-400"
+                ? "dark:bg-primary-45/10 bg-primary-95 text-primary-50 dark:text-primary-65"
                 : "text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-500 hover:dark:bg-gray-900 hover:dark:text-gray-50",
               focusRing,
             )}

--- a/ui/src/components/dialogs/ConnectionFormFields.tsx
+++ b/ui/src/components/dialogs/ConnectionFormFields.tsx
@@ -18,10 +18,10 @@ interface ConnectionFormFieldsProps {
 }
 
 const SELECT_CLASSES =
-  "h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+  "h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-primary-45 focus:outline-none focus:ring-1 focus:ring-primary-45 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
 
 const TEXTAREA_CLASSES =
-  "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-indigo-400/20"
+  "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-primary-45 focus:ring-2 focus:ring-primary-90 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-primary-65/20"
 
 export function ConnectionFormFields({
   form,

--- a/ui/src/components/dialogs/CreateRecordDialog.tsx
+++ b/ui/src/components/dialogs/CreateRecordDialog.tsx
@@ -49,7 +49,7 @@ const PK_TYPES: ReadonlyArray<{ value: PkType; label: string }> = [
 ]
 
 const SELECT_CLASSES =
-  "h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+  "h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-primary-45 focus:outline-none focus:ring-1 focus:ring-primary-45 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
 
 interface CreateRecordDialogProps {
   open: boolean

--- a/ui/src/components/dialogs/GuideEditorDialog.tsx
+++ b/ui/src/components/dialogs/GuideEditorDialog.tsx
@@ -241,7 +241,7 @@ export function GuideEditorDialog({
                     className={cx(
                       "rounded px-2 py-1 text-xs font-medium capitalize transition",
                       tab === t
-                        ? "bg-indigo-50 text-indigo-700 dark:bg-indigo-950/40 dark:text-indigo-300"
+                        ? "dark:bg-primary-10/40 bg-primary-95 text-primary-40 dark:text-primary-80"
                         : "text-gray-500 hover:bg-gray-100 dark:hover:bg-gray-900",
                     )}
                   >

--- a/ui/src/components/dialogs/RegisterUdfDialog.tsx
+++ b/ui/src/components/dialogs/RegisterUdfDialog.tsx
@@ -124,7 +124,7 @@ export function RegisterUdfDialog({
               onChange={(e) => setForm({ ...form, content: e.target.value })}
               rows={6}
               spellCheck={false}
-              className="block w-full rounded-md border border-gray-300 bg-white px-2.5 py-2 font-mono text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-indigo-400/20"
+              className="dark:focus:ring-primary-65/20 block w-full rounded-md border border-gray-300 bg-white px-2.5 py-2 font-mono text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-primary-45 focus:ring-2 focus:ring-primary-90 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500"
               placeholder={`function example_fn(rec)\n  return rec.bin_name\nend`}
               required
             />

--- a/ui/src/components/dialogs/WorkspaceFormFields.tsx
+++ b/ui/src/components/dialogs/WorkspaceFormFields.tsx
@@ -12,7 +12,7 @@ interface WorkspaceFormFieldsProps {
 }
 
 const TEXTAREA_CLASSES =
-  "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-indigo-400/20"
+  "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-primary-45 focus:ring-2 focus:ring-primary-90 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-primary-65/20"
 
 export function WorkspaceFormFields({
   form,

--- a/ui/src/components/k8s/create-cluster-wizard/StepBasic.tsx
+++ b/ui/src/components/k8s/create-cluster-wizard/StepBasic.tsx
@@ -20,7 +20,7 @@ interface StepBasicProps {
 }
 
 const SELECT_CLASSES =
-  "h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+  "h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-primary-45 focus:outline-none focus:ring-1 focus:ring-primary-45 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
 
 export function StepBasic({
   form,
@@ -121,7 +121,7 @@ export function StepBasic({
               id="cluster-image"
               value={form.image ?? AEROSPIKE_IMAGES[0]}
               onChange={(e) => updateForm({ image: e.target.value })}
-              className="h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+              className="h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-primary-45 focus:outline-none focus:ring-1 focus:ring-primary-45 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
             >
               {AEROSPIKE_IMAGES.map((img) => (
                 <option key={img} value={img}>

--- a/ui/src/components/k8s/create-cluster-wizard/StepCreationMode.tsx
+++ b/ui/src/components/k8s/create-cluster-wizard/StepCreationMode.tsx
@@ -72,7 +72,7 @@ export function StepCreationMode({
                   className={cx(
                     "flex flex-col items-start gap-1 rounded-md border px-3 py-2 text-left text-sm transition-colors",
                     selectedTemplateName === t.name
-                      ? "border-indigo-500 bg-indigo-50 text-indigo-900 dark:border-indigo-400 dark:bg-indigo-950/40 dark:text-indigo-200"
+                      ? "dark:bg-primary-10/40 border-primary-45 bg-primary-95 text-primary-30 dark:border-primary-65 dark:text-primary-90"
                       : "border-gray-200 hover:border-gray-300 dark:border-gray-800 dark:hover:border-gray-700",
                   )}
                 >
@@ -115,7 +115,7 @@ function ModeCard({
       className={cx(
         "flex flex-col items-center gap-2 rounded-lg border px-4 py-6 text-center transition-colors",
         selected
-          ? "border-indigo-500 bg-indigo-50 dark:border-indigo-400 dark:bg-indigo-950/40"
+          ? "dark:bg-primary-10/40 border-primary-45 bg-primary-95 dark:border-primary-65"
           : "border-gray-200 hover:border-gray-300 dark:border-gray-800 dark:hover:border-gray-700",
       )}
     >
@@ -124,7 +124,7 @@ function ModeCard({
         className={cx(
           "flex size-10 items-center justify-center rounded-full",
           selected
-            ? "bg-indigo-100 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-200"
+            ? "bg-primary-95 text-primary-40 dark:bg-primary-30 dark:text-primary-90"
             : "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-300",
         )}
       >

--- a/ui/src/components/k8s/create-cluster-wizard/StepNamespaceStorage.tsx
+++ b/ui/src/components/k8s/create-cluster-wizard/StepNamespaceStorage.tsx
@@ -378,7 +378,7 @@ function StorageTypeButton({
       className={cx(
         "rounded-md border px-3 py-1.5 text-sm font-medium transition-colors",
         selected
-          ? "border-indigo-500 bg-indigo-50 text-indigo-700 dark:border-indigo-400 dark:bg-indigo-950/40 dark:text-indigo-200"
+          ? "dark:bg-primary-10/40 border-primary-45 bg-primary-95 text-primary-40 dark:border-primary-65 dark:text-primary-90"
           : "border-gray-200 text-gray-700 hover:border-gray-300 dark:border-gray-800 dark:text-gray-300",
       )}
     >

--- a/ui/src/components/k8s/create-cluster-wizard/Stepper.tsx
+++ b/ui/src/components/k8s/create-cluster-wizard/Stepper.tsx
@@ -48,9 +48,9 @@ export function Stepper({
                 className={cx(
                   "flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-medium transition-colors",
                   isCurrent
-                    ? "bg-indigo-600 text-white"
+                    ? "bg-primary-50 text-white"
                     : isDone
-                      ? "bg-indigo-100 text-indigo-700 hover:bg-indigo-200 dark:bg-indigo-950 dark:text-indigo-300"
+                      ? "bg-primary-95 text-primary-40 hover:bg-primary-90 dark:bg-primary-10 dark:text-primary-80"
                       : isReachable
                         ? "bg-gray-100 text-gray-600 hover:bg-gray-200 dark:bg-gray-800 dark:text-gray-300"
                         : "cursor-not-allowed bg-gray-50 text-gray-400 dark:bg-gray-900 dark:text-gray-600",
@@ -62,7 +62,7 @@ export function Stepper({
                     isCurrent
                       ? "bg-white/20"
                       : isDone
-                        ? "bg-indigo-600 text-white"
+                        ? "bg-primary-50 text-white"
                         : "bg-gray-200 text-gray-600 dark:bg-gray-700 dark:text-gray-300",
                   )}
                 >

--- a/ui/src/components/notes/NoteSection.tsx
+++ b/ui/src/components/notes/NoteSection.tsx
@@ -12,7 +12,7 @@ const MAX_NOTE_LENGTH = 8192
 // Same Tailwind class set as ConnectionFormFields' textarea — keeps the
 // indigo focus ring consistent with other multi-line inputs in the app.
 const TEXTAREA_CLASSES =
-  "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-indigo-500 focus:ring-2 focus:ring-indigo-200 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-indigo-400/20 disabled:cursor-not-allowed disabled:opacity-50"
+  "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-primary-45 focus:ring-2 focus:ring-primary-90 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-primary-65/20 disabled:cursor-not-allowed disabled:opacity-50"
 
 interface NoteSectionProps {
   title: string

--- a/ui/src/components/ui/navigation/ClusterSelector.tsx
+++ b/ui/src/components/ui/navigation/ClusterSelector.tsx
@@ -191,7 +191,7 @@ export function ClusterSelector() {
               </span>
               {selected && (
                 <RiCheckLine
-                  className="size-4 shrink-0 text-primary-50 dark:text-primary-65"
+                  className="size-4 shrink-0 text-primary-40 dark:text-primary-65"
                   aria-hidden="true"
                 />
               )}

--- a/ui/src/components/ui/navigation/ClusterSelector.tsx
+++ b/ui/src/components/ui/navigation/ClusterSelector.tsx
@@ -191,7 +191,7 @@ export function ClusterSelector() {
               </span>
               {selected && (
                 <RiCheckLine
-                  className="size-4 shrink-0 text-indigo-600 dark:text-indigo-400"
+                  className="size-4 shrink-0 text-primary-50 dark:text-primary-65"
                   aria-hidden="true"
                 />
               )}

--- a/ui/src/components/ui/navigation/MobileSidebar.tsx
+++ b/ui/src/components/ui/navigation/MobileSidebar.tsx
@@ -86,7 +86,7 @@ export default function MobileSidebar() {
                       href={item.href}
                       className={cx(
                         isActive(item.href)
-                          ? "text-indigo-600 dark:text-indigo-400"
+                          ? "text-primary-50 dark:text-primary-65"
                           : "text-gray-600 hover:text-gray-900 dark:text-gray-400 hover:dark:text-gray-50",
                         "flex items-center gap-x-2.5 rounded-md px-2 py-1.5 text-base font-medium transition hover:bg-gray-100 sm:text-sm hover:dark:bg-gray-900",
                         focusRing,

--- a/ui/src/components/ui/navigation/MobileSidebar.tsx
+++ b/ui/src/components/ui/navigation/MobileSidebar.tsx
@@ -86,7 +86,7 @@ export default function MobileSidebar() {
                       href={item.href}
                       className={cx(
                         isActive(item.href)
-                          ? "text-primary-50 dark:text-primary-65"
+                          ? "text-primary-40 dark:text-primary-65"
                           : "text-gray-600 hover:text-gray-900 dark:text-gray-400 hover:dark:text-gray-50",
                         "flex items-center gap-x-2.5 rounded-md px-2 py-1.5 text-base font-medium transition hover:bg-gray-100 sm:text-sm hover:dark:bg-gray-900",
                         focusRing,

--- a/ui/src/components/ui/navigation/ShellStatusBar.tsx
+++ b/ui/src/components/ui/navigation/ShellStatusBar.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { useConnections } from "@/hooks/use-connections"
+import { useK8sClusters } from "@/hooks/use-k8s-clusters"
+
+type Health = "healthy" | "degraded" | "unreach"
+
+/**
+ * Bottom status bar — 28px tall, fixed across the right of the sidebar.
+ * Connection / connections count / health dots / version / docs link.
+ *
+ * Uses the `.status-dot is-*` + `.statusbar` classes from src/styles/theme.css.
+ */
+export function ShellStatusBar() {
+  const conn = useConnections()
+  const k8s = useK8sClusters()
+
+  const connected = !(conn.error || k8s.error)
+  const connectionsCount = conn.data?.length ?? 0
+
+  const services: { name: string; status: Health }[] = [
+    { name: "api", status: connected ? "healthy" : "unreach" },
+    { name: "acko", status: k8s.error ? "unreach" : "healthy" },
+    {
+      name: "k8s",
+      status: k8s.data?.items?.length ? "healthy" : "degraded",
+    },
+  ]
+
+  return (
+    <div className="acm-statusbar statusbar">
+      <span className="seg">
+        <span
+          className={`status-dot is-${connected ? "succeeded" : "failed"}`}
+          aria-label={connected ? "connected" : "disconnected"}
+        />
+        <span>{connected ? "connected" : "disconnected"}</span>
+      </span>
+      <span className="seg">
+        connections <b>{connectionsCount}</b>
+      </span>
+      <span className="seg" style={{ display: "inline-flex", gap: 8 }}>
+        {services.map((s) => (
+          <span
+            key={s.name}
+            style={{ display: "inline-flex", alignItems: "center", gap: 4 }}
+          >
+            <span
+              className={`status-dot is-${s.status}`}
+              aria-label={s.status}
+            />
+            <span
+              style={{
+                fontSize: 10,
+                color:
+                  s.status === "healthy"
+                    ? "var(--on-surface-variant)"
+                    : "var(--error-55)",
+              }}
+            >
+              {s.name}
+            </span>
+          </span>
+        ))}
+      </span>
+      <span style={{ flex: 1 }} />
+      <span className="seg">acm v0.1.0</span>
+      <a
+        className="seg"
+        href="https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager"
+        target="_blank"
+        rel="noreferrer"
+      >
+        ↗ docs
+      </a>
+    </div>
+  )
+}

--- a/ui/src/components/ui/navigation/Sidebar.tsx
+++ b/ui/src/components/ui/navigation/Sidebar.tsx
@@ -185,7 +185,7 @@ export function Sidebar() {
                   className={cx(
                     "flex items-center gap-x-2.5 rounded-md py-1.5 pl-2 pr-2 text-sm font-medium transition",
                     isActive(siteConfig.baseLinks.guides)
-                      ? "text-primary-50 dark:text-primary-65"
+                      ? "text-primary-40 dark:text-primary-65"
                       : "text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 hover:dark:bg-gray-900 hover:dark:text-gray-50",
                     focusRing,
                   )}
@@ -237,7 +237,7 @@ export function Sidebar() {
                   className={cx(
                     "flex items-center gap-x-2.5 rounded-md py-1.5 pl-2 pr-2 text-sm font-medium transition",
                     isActive(siteConfig.baseLinks.ackoTemplates)
-                      ? "text-primary-50 dark:text-primary-65"
+                      ? "text-primary-40 dark:text-primary-65"
                       : "text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 hover:dark:bg-gray-900 hover:dark:text-gray-50",
                     focusRing,
                   )}
@@ -371,7 +371,7 @@ function ClusterNode({
         className={cx(
           "flex items-center rounded-md pr-1 hover:bg-gray-100 hover:dark:bg-gray-900",
           clusterActive
-            ? "text-primary-50 dark:text-primary-65"
+            ? "text-primary-40 dark:text-primary-65"
             : "text-gray-700 dark:text-gray-400",
         )}
       >
@@ -388,7 +388,7 @@ function ClusterNode({
               {displayName}
             </span>
             {cluster.managedBy === "ACKO" && (
-              <span className="dark:bg-primary-10/40 shrink-0 rounded bg-primary-95 px-1.5 text-[10px] font-semibold uppercase tracking-wider text-primary-50 dark:text-primary-65">
+              <span className="dark:bg-primary-10/40 shrink-0 rounded bg-primary-95 px-1.5 text-[10px] font-semibold uppercase tracking-wider text-primary-40 dark:text-primary-65">
                 ACKO
               </span>
             )}
@@ -456,7 +456,7 @@ function NamespaceNode({
             className={cx(
               "group flex items-center justify-between rounded-md py-1 pl-3 pr-2 text-sm hover:bg-gray-100 hover:dark:bg-gray-900",
               nsActive
-                ? "text-primary-50 dark:text-primary-65"
+                ? "text-primary-40 dark:text-primary-65"
                 : "text-gray-700 dark:text-gray-300",
             )}
           >
@@ -522,7 +522,7 @@ function NamespaceNode({
                           "relative flex items-center rounded-md py-1 pl-10 pr-2 font-mono text-sm transition",
                           "before:absolute before:left-[30px] before:top-1.5 before:h-4 before:w-0.5 before:rounded-sm",
                           active
-                            ? "font-medium text-primary-50 before:bg-primary-45 dark:text-primary-65"
+                            ? "font-medium text-primary-40 before:bg-primary-45 dark:text-primary-65"
                             : "text-gray-600 before:bg-transparent hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 hover:dark:bg-gray-900 hover:dark:text-gray-50",
                           focusRing,
                         )}

--- a/ui/src/components/ui/navigation/Sidebar.tsx
+++ b/ui/src/components/ui/navigation/Sidebar.tsx
@@ -185,7 +185,7 @@ export function Sidebar() {
                   className={cx(
                     "flex items-center gap-x-2.5 rounded-md py-1.5 pl-2 pr-2 text-sm font-medium transition",
                     isActive(siteConfig.baseLinks.guides)
-                      ? "text-indigo-600 dark:text-indigo-400"
+                      ? "text-primary-50 dark:text-primary-65"
                       : "text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 hover:dark:bg-gray-900 hover:dark:text-gray-50",
                     focusRing,
                   )}
@@ -237,7 +237,7 @@ export function Sidebar() {
                   className={cx(
                     "flex items-center gap-x-2.5 rounded-md py-1.5 pl-2 pr-2 text-sm font-medium transition",
                     isActive(siteConfig.baseLinks.ackoTemplates)
-                      ? "text-indigo-600 dark:text-indigo-400"
+                      ? "text-primary-50 dark:text-primary-65"
                       : "text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 hover:dark:bg-gray-900 hover:dark:text-gray-50",
                     focusRing,
                   )}
@@ -278,7 +278,7 @@ function BrandCard({ active }: { active?: boolean }) {
       className={cx(
         "flex items-center gap-3 rounded-md px-2 py-1.5 transition",
         active
-          ? "bg-indigo-50 dark:bg-indigo-950/40"
+          ? "dark:bg-primary-10/40 bg-primary-95"
           : "hover:bg-gray-50 dark:hover:bg-gray-900",
         focusRing,
       )}
@@ -295,7 +295,7 @@ function BrandCard({ active }: { active?: boolean }) {
           className={cx(
             "truncate text-sm font-semibold",
             active
-              ? "text-indigo-700 dark:text-indigo-300"
+              ? "text-primary-40 dark:text-primary-80"
               : "text-gray-900 dark:text-gray-50",
           )}
         >
@@ -371,7 +371,7 @@ function ClusterNode({
         className={cx(
           "flex items-center rounded-md pr-1 hover:bg-gray-100 hover:dark:bg-gray-900",
           clusterActive
-            ? "text-indigo-600 dark:text-indigo-400"
+            ? "text-primary-50 dark:text-primary-65"
             : "text-gray-700 dark:text-gray-400",
         )}
       >
@@ -388,7 +388,7 @@ function ClusterNode({
               {displayName}
             </span>
             {cluster.managedBy === "ACKO" && (
-              <span className="shrink-0 rounded bg-indigo-50 px-1.5 text-[10px] font-semibold uppercase tracking-wider text-indigo-600 dark:bg-indigo-950/40 dark:text-indigo-400">
+              <span className="dark:bg-primary-10/40 shrink-0 rounded bg-primary-95 px-1.5 text-[10px] font-semibold uppercase tracking-wider text-primary-50 dark:text-primary-65">
                 ACKO
               </span>
             )}
@@ -456,7 +456,7 @@ function NamespaceNode({
             className={cx(
               "group flex items-center justify-between rounded-md py-1 pl-3 pr-2 text-sm hover:bg-gray-100 hover:dark:bg-gray-900",
               nsActive
-                ? "text-indigo-600 dark:text-indigo-400"
+                ? "text-primary-50 dark:text-primary-65"
                 : "text-gray-700 dark:text-gray-300",
             )}
           >
@@ -522,7 +522,7 @@ function NamespaceNode({
                           "relative flex items-center rounded-md py-1 pl-10 pr-2 font-mono text-sm transition",
                           "before:absolute before:left-[30px] before:top-1.5 before:h-4 before:w-0.5 before:rounded-sm",
                           active
-                            ? "font-medium text-indigo-600 before:bg-indigo-500 dark:text-indigo-400"
+                            ? "font-medium text-primary-50 before:bg-primary-45 dark:text-primary-65"
                             : "text-gray-600 before:bg-transparent hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 hover:dark:bg-gray-900 hover:dark:text-gray-50",
                           focusRing,
                         )}

--- a/ui/src/components/ui/navigation/WorkspacesDropdown.tsx
+++ b/ui/src/components/ui/navigation/WorkspacesDropdown.tsx
@@ -162,7 +162,7 @@ export function WorkspacesDropdown() {
                 </span>
                 {selected && (
                   <RiCheckLine
-                    className="size-4 shrink-0 text-primary-50 dark:text-primary-65"
+                    className="size-4 shrink-0 text-primary-40 dark:text-primary-65"
                     aria-hidden="true"
                   />
                 )}

--- a/ui/src/components/ui/navigation/WorkspacesDropdown.tsx
+++ b/ui/src/components/ui/navigation/WorkspacesDropdown.tsx
@@ -162,7 +162,7 @@ export function WorkspacesDropdown() {
                 </span>
                 {selected && (
                   <RiCheckLine
-                    className="size-4 shrink-0 text-indigo-600 dark:text-indigo-400"
+                    className="size-4 shrink-0 text-primary-50 dark:text-primary-65"
                     aria-hidden="true"
                   />
                 )}

--- a/ui/src/lib/chartUtils.ts
+++ b/ui/src/lib/chartUtils.ts
@@ -40,10 +40,10 @@ export const chartColors = {
     text: "text-cyan-500",
   },
   indigo: {
-    bg: "bg-indigo-600 dark:bg-indigo-500",
-    stroke: "stroke-indigo-600 dark:stroke-indigo-500",
-    fill: "fill-indigo-600 dark:fill-indigo-500",
-    text: "text-indigo-600 dark:text-indigo-500",
+    bg: "bg-primary-50 dark:bg-primary-45",
+    stroke: "stroke-primary-50 dark:stroke-primary-45",
+    fill: "fill-primary-50 dark:fill-primary-45",
+    text: "text-primary-50 dark:text-primary-45",
   },
   pink: {
     bg: "bg-pink-500",

--- a/ui/src/lib/chartUtils.ts
+++ b/ui/src/lib/chartUtils.ts
@@ -43,7 +43,7 @@ export const chartColors = {
     bg: "bg-primary-50 dark:bg-primary-45",
     stroke: "stroke-primary-50 dark:stroke-primary-45",
     fill: "fill-primary-50 dark:fill-primary-45",
-    text: "text-primary-50 dark:text-primary-45",
+    text: "text-primary-40 dark:text-primary-45",
   },
   pink: {
     bg: "bg-pink-500",

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -13,9 +13,9 @@ export const focusInput = [
   // base
   "focus:ring-2",
   // ring color
-  "focus:ring-indigo-200 focus:dark:ring-indigo-700/30",
+  "focus:ring-primary-90 focus:dark:ring-primary-40/30",
   // border color
-  "focus:border-indigo-500 focus:dark:border-indigo-700",
+  "focus:border-primary-45 focus:dark:border-primary-40",
 ]
 
 // Tremor Raw focusRing [v0.0.1]
@@ -24,7 +24,7 @@ export const focusRing = [
   // base
   "outline outline-offset-2 outline-0 focus-visible:outline-2",
   // outline color
-  "outline-indigo-500 dark:outline-indigo-500",
+  "outline-primary-45 dark:outline-primary-45",
 ]
 
 // Tremor Raw hasErrorInput [v0.0.1]

--- a/ui/src/styles/theme.css
+++ b/ui/src/styles/theme.css
@@ -77,12 +77,17 @@
   background: var(--error-50);
 }
 
+/* color-mix() lands in Safari 16.2 / Chrome 111 / Firefox 113. Older clients
+   fall back to the warning-50 amber rgba below (parsed first, then overridden
+   if the browser understands color-mix). */
 @keyframes ace-pulse {
   0%,
   100% {
+    box-shadow: 0 0 0 0 rgba(250, 146, 0, 0.45);
     box-shadow: 0 0 0 0 color-mix(in srgb, currentColor 45%, transparent);
   }
   50% {
+    box-shadow: 0 0 0 5px rgba(250, 146, 0, 0);
     box-shadow: 0 0 0 5px color-mix(in srgb, currentColor 0%, transparent);
   }
 }

--- a/ui/src/styles/theme.css
+++ b/ui/src/styles/theme.css
@@ -1,0 +1,207 @@
+/* =====================================================================
+   ACM — Base theme (minimal)
+
+   Only the `.ace-*` / shell classes ACM actually renders. Everything else
+   from the upstream design system (buttons, tables, KPI, sidebar, etc.)
+   is intentionally omitted — ACM uses Tremor Raw primitives in /components.
+   ===================================================================== */
+
+/* `<div className="body">` — paragraph-level body text. */
+.body {
+  font-size: var(--fs-body-md);
+  font-weight: var(--weight-regular);
+  line-height: var(--lh-body);
+}
+
+/* =====================================================================
+   Status bar (PageShell bottom strip, used by ShellStatusBar)
+   ===================================================================== */
+[data-app="ace"] .statusbar {
+  height: 28px;
+  background: var(--surface);
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 0 18px;
+  font-family: var(--font-sans);
+  font-size: 12px;
+  color: var(--on-surface-muted);
+}
+[data-app="ace"] .statusbar .seg {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+[data-app="ace"] .statusbar .seg b {
+  color: var(--on-surface-variant);
+  font-weight: 600;
+}
+[data-app="ace"] .statusbar a {
+  color: var(--on-surface-muted);
+  text-decoration: none;
+}
+[data-app="ace"] .statusbar a:hover {
+  color: var(--primary-40);
+}
+
+/* =====================================================================
+   StatusDot
+   ===================================================================== */
+.status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.status-dot.is-running {
+  background: var(--warning-50);
+  animation: ace-pulse 1.6s ease-in-out infinite;
+}
+.status-dot.is-awaiting {
+  background: var(--warning-50);
+  animation: ace-pulse 1.6s ease-in-out infinite;
+}
+.status-dot.is-queued {
+  background: var(--on-surface-muted);
+}
+.status-dot.is-succeeded {
+  background: var(--positive-50);
+}
+.status-dot.is-failed {
+  background: var(--error-50);
+}
+.status-dot.is-cancelled {
+  background: var(--on-surface-disabled);
+}
+.status-dot.is-healthy {
+  background: var(--positive-50);
+}
+.status-dot.is-degraded {
+  background: var(--warning-50);
+}
+.status-dot.is-unreach {
+  background: var(--error-50);
+}
+
+@keyframes ace-pulse {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 rgba(232, 154, 28, 0.45);
+  }
+  50% {
+    box-shadow: 0 0 0 5px rgba(232, 154, 28, 0);
+  }
+}
+
+/* =====================================================================
+   Page header — title + sub-text + action slot (used by <PageHead/>)
+   ===================================================================== */
+.ace-page-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  margin-bottom: 22px;
+  gap: 16px;
+}
+.ace-page-head .lead {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+.ace-page-head h1 {
+  font-family: var(--font-sans);
+  font-size: 24px;
+  font-weight: 800;
+  letter-spacing: -0.025em;
+  margin: 0;
+  line-height: 1.2;
+  color: var(--on-surface);
+}
+.ace-page-head .sub {
+  font-size: 13px;
+  color: var(--on-surface-muted);
+  margin-top: 4px;
+  font-family: var(--font-sans);
+}
+
+/* =====================================================================
+   Announcement banner — top-of-page notice
+   ===================================================================== */
+.ace-announce {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  border-radius: 10px;
+  border: 1px solid var(--border-subtle);
+  background: var(--surface);
+  font-size: 13.5px;
+  color: var(--on-surface);
+}
+.ace-announce.tone-info {
+  border-color: color-mix(in oklch, var(--primary-50) 35%, var(--border));
+  background: linear-gradient(90deg, var(--primary-95), var(--surface) 80%);
+}
+.ace-announce.tone-warning {
+  border-color: #f0cb7f;
+  background: linear-gradient(90deg, #fff6e1, var(--surface) 80%);
+}
+.ace-announce.tone-success {
+  border-color: #9cdeb4;
+  background: linear-gradient(90deg, #e9f8ef, var(--surface) 80%);
+}
+.ace-announce .ico {
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.ace-announce.tone-info .ico {
+  background: var(--primary-95);
+  color: var(--primary-40);
+}
+.ace-announce.tone-warning .ico {
+  background: #ffeac9;
+  color: #8a5300;
+}
+.ace-announce.tone-success .ico {
+  background: #dcf4e4;
+  color: var(--positive-50);
+}
+.ace-announce .body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.ace-announce .title {
+  font-weight: 700;
+  letter-spacing: -0.005em;
+}
+.ace-announce .desc {
+  font-size: 13px;
+  color: var(--on-surface-variant);
+  line-height: 1.5;
+}
+.ace-announce .actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+.ace-announce a {
+  color: inherit;
+  font-weight: 600;
+  text-decoration: none;
+  white-space: nowrap;
+}
+.ace-announce a:hover {
+  text-decoration: underline;
+}

--- a/ui/src/styles/theme.css
+++ b/ui/src/styles/theme.css
@@ -6,13 +6,6 @@
    is intentionally omitted — ACM uses Tremor Raw primitives in /components.
    ===================================================================== */
 
-/* `<div className="body">` — paragraph-level body text. */
-.body {
-  font-size: var(--fs-body-md);
-  font-weight: var(--weight-regular);
-  line-height: var(--lh-body);
-}
-
 /* =====================================================================
    Status bar (PageShell bottom strip, used by ShellStatusBar)
    ===================================================================== */
@@ -55,12 +48,11 @@
   border-radius: 50%;
   flex-shrink: 0;
 }
-.status-dot.is-running {
-  background: var(--warning-50);
-  animation: ace-pulse 1.6s ease-in-out infinite;
-}
+.status-dot.is-running,
 .status-dot.is-awaiting {
   background: var(--warning-50);
+  /* currentColor lets @keyframes ace-pulse reuse the dot color via color-mix. */
+  color: var(--warning-50);
   animation: ace-pulse 1.6s ease-in-out infinite;
 }
 .status-dot.is-queued {
@@ -88,10 +80,10 @@
 @keyframes ace-pulse {
   0%,
   100% {
-    box-shadow: 0 0 0 0 rgba(232, 154, 28, 0.45);
+    box-shadow: 0 0 0 0 color-mix(in srgb, currentColor 45%, transparent);
   }
   50% {
-    box-shadow: 0 0 0 5px rgba(232, 154, 28, 0);
+    box-shadow: 0 0 0 5px color-mix(in srgb, currentColor 0%, transparent);
   }
 }
 

--- a/ui/src/styles/tokens.css
+++ b/ui/src/styles/tokens.css
@@ -1,0 +1,201 @@
+/* =====================================================================
+   ACM — Design Tokens
+
+   Vendored (CSS-only) from the ACE design system. Primary palette is
+   Naver brand green (#03C75A); all other tokens follow the same neutral
+   / semantic conventions used across the ACE ecosystem.
+   ===================================================================== */
+
+:root {
+  /* ---------- Primary (Naver brand green) ---------- */
+  --primary-10: #02160c;
+  --primary-30: #036c2d;
+  --primary-40: #038f3d;
+  --primary-45: #03a847;
+  --primary-50: #03c75a; /* Main — Naver brand green */
+  --primary-55: #1fd16b;
+  --primary-65: #4de48e;
+  --primary-80: #adf1c5;
+  --primary-90: #d8f8e2;
+  --primary-95: #ecfbf1;
+
+  /* ---------- Neutral ---------- */
+  --neutral-4: #0f0f0f;
+  --neutral-9: #191919;
+  --neutral-12: #1f1f1f;
+  --neutral-15: #262626;
+  --neutral-18: #2c2c2c;
+  --neutral-21: #333333;
+  --neutral-24: #393939;
+  --neutral-29: #444444;
+  --neutral-32: #4b4b4b;
+  --neutral-40: #5e5e5e;
+  --neutral-45: #6a6a6a;
+  --neutral-50: #777777;
+  --neutral-60: #919191;
+  --neutral-65: #9e9e9e;
+  --neutral-70: #ababab;
+  --neutral-78: #c1c1c1;
+  --neutral-80: #c6c6c6;
+  --neutral-90: #e2e2e2;
+  --neutral-92: #e9e9e9;
+  --neutral-95: #f0f0f0;
+  --neutral-97: #f7f7f7;
+  --neutral-98: #fafafa;
+  --neutral-100: #ffffff;
+
+  /* ---------- Semantic ---------- */
+  --error-30: #93000a;
+  --error-40: #bc1217;
+  --error-45: #cf2322;
+  --error-50: #e1322d;
+  --error-55: #f33f38;
+
+  --warning-30: #af6500;
+  --warning-40: #d47b00;
+  --warning-45: #e78600;
+  --warning-50: #fa9200;
+  --warning-55: #ffa444;
+
+  --positive-30: #005322;
+  --positive-40: #006e2f;
+  --positive-45: #007e37;
+  --positive-50: #008a3d;
+  --positive-55: #1f9748;
+
+  /* ---------- Accent palette ---------- */
+  --accent-emerald-50: #e1f4f1;
+  --accent-emerald-500: #00a392;
+  --accent-emerald-700: #017266;
+  --accent-amber-50: #fff7e6;
+  --accent-amber-100: #ffe9b8;
+  --accent-amber-500: #c99a3f;
+  --accent-amber-700: #8a6620;
+  --accent-teal-50: #e8f2f1;
+  --accent-teal-100: #c9dedc;
+  --accent-teal-500: #4d6e6c;
+  --accent-teal-700: #314d4b;
+
+  /* ---------- Semantic surface (light) ---------- */
+  --bg: var(--neutral-100);
+  --bg-subtle: var(--neutral-98);
+  --bg-low: var(--neutral-97);
+  --surface: var(--neutral-100);
+  --surface-container: var(--neutral-95);
+  --surface-container-low: var(--neutral-97);
+  --surface-container-high: var(--neutral-92);
+  --surface-container-highest: var(--neutral-90);
+  --surface-inverse: var(--neutral-4);
+  --on-surface: var(--neutral-4);
+  --on-surface-variant: var(--neutral-40);
+  --on-surface-muted: var(--neutral-60);
+  --on-surface-disabled: var(--neutral-78);
+  --border-subtle: var(--neutral-90);
+  --border: var(--neutral-80);
+  --divider: var(--neutral-90);
+
+  /* ---------- Spacing (4px grid) ---------- */
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --space-6: 24px;
+  --space-8: 32px;
+  --space-10: 40px;
+  --space-12: 48px;
+  --space-16: 64px;
+
+  /* ---------- Radius ---------- */
+  --radius-sm: 4px;
+  --radius-md: 8px;
+  --radius-lg: 12px;
+  --radius-xl: 16px;
+  --radius-bubble: 18px;
+  --radius-full: 9999px;
+
+  /* ---------- Shadow ---------- */
+  --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
+  --shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.12);
+
+  /* ---------- Motion ---------- */
+  --duration-fast: 100ms;
+  --duration-base: 200ms;
+  --duration-slow: 300ms;
+  --easing-default: cubic-bezier(0.4, 0, 0.2, 1);
+  --easing-enter: cubic-bezier(0, 0, 0.2, 1);
+  --easing-exit: cubic-bezier(0.4, 0, 1, 1);
+
+  /* ---------- Type ---------- */
+  --font-sans:
+    "Pretendard Variable", Pretendard, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", system-ui, "Noto Sans KR", sans-serif;
+  --font-mono:
+    "SF Mono", ui-monospace, "Cascadia Mono", "Roboto Mono", monospace;
+
+  --weight-regular: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
+  --weight-bold: 700;
+
+  --fs-headline-lg: 32px;
+  --fs-headline-md: 28px;
+  --fs-headline-sm: 26px;
+  --fs-headline-xs: 24px;
+  --fs-title-xl: 22px;
+  --fs-title-lg: 20px;
+  --fs-title-md: 18px;
+  --fs-title-sm: 16px;
+  --fs-title-xs: 15px;
+  --fs-body-lg: 14px;
+  --fs-body-md: 13px;
+  --fs-body-sm: 12px;
+  --fs-body-xs: 11px;
+  --fs-micro-lg: 10px;
+  --fs-micro-md: 9px;
+
+  --lh-headline: 1.25;
+  --lh-title: 1.35;
+  --lh-body: 1.5;
+  --lh-tight: 1.2;
+}
+
+/* ---------- Dark mode ---------- */
+[data-theme="dark"],
+.dark {
+  --bg: var(--neutral-9);
+  --bg-subtle: var(--neutral-12);
+  --bg-low: var(--neutral-15);
+  --surface: var(--neutral-12);
+  --surface-container: var(--neutral-18);
+  --surface-container-low: var(--neutral-15);
+  --surface-container-high: var(--neutral-21);
+  --surface-container-highest: var(--neutral-24);
+  --surface-inverse: var(--neutral-100);
+  --on-surface: var(--neutral-100);
+  --on-surface-variant: var(--neutral-70);
+  --on-surface-muted: var(--neutral-60);
+  --on-surface-disabled: var(--neutral-29);
+  --border-subtle: var(--neutral-24);
+  --border: var(--neutral-29);
+  --divider: var(--neutral-24);
+
+  /* Primary shifts a touch lighter in dark mode for contrast. */
+  --primary-50: #1fd16b;
+}
+
+html,
+body {
+  font-family: var(--font-sans);
+  color: var(--on-surface);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+code,
+pre,
+.mono {
+  font-family: var(--font-mono);
+}

--- a/ui/src/styles/tokens.css
+++ b/ui/src/styles/tokens.css
@@ -9,12 +9,15 @@
 :root {
   /* ---------- Primary (Naver brand green) ----------
      Brand color sits at --primary-50. The 30/40 steps are intentionally darker
-     than a pure HSL-stepped ramp so that `text-primary-40` clears WCAG AA body
-     contrast (4.5:1) on white and `bg-primary-95` surfaces. */
-  --primary-10: #001a0a;
+     than a pure HSL-stepped ramp so `text-primary-40` clears WCAG AA body
+     contrast (4.5:1) on white and `bg-primary-95` surfaces. Steps 45/55/65 keep
+     their natural HSL position so hover/focus states and chart series stay
+     visually distinct — dark mode restores 30/40 to those natural positions
+     (see [data-theme="dark"] block below). */
+  --primary-10: #02160c;
   --primary-30: #014b1d;
   --primary-40: #006e2c; /* AA body text on white (5.95:1) */
-  --primary-45: #008f3a;
+  --primary-45: #03a847;
   --primary-50: #03c75a; /* Main — Naver brand green */
   --primary-55: #1fd16b;
   --primary-65: #4de48e;
@@ -184,7 +187,12 @@
   --border: var(--neutral-29);
   --divider: var(--neutral-24);
 
-  /* Primary shifts a touch lighter in dark mode for contrast. */
+  /* Primary shifts a touch lighter in dark mode for contrast. The 30/40
+     steps were darkened in light mode for text legibility; in dark mode they
+     stay close to the natural ramp so translucent borders like
+     `dark:border-primary-30/40` and chart-series tints remain visible. */
+  --primary-30: #036c2d;
+  --primary-40: #038f3d;
   --primary-50: #1fd16b;
 }
 

--- a/ui/src/styles/tokens.css
+++ b/ui/src/styles/tokens.css
@@ -7,11 +7,14 @@
    ===================================================================== */
 
 :root {
-  /* ---------- Primary (Naver brand green) ---------- */
-  --primary-10: #02160c;
-  --primary-30: #036c2d;
-  --primary-40: #038f3d;
-  --primary-45: #03a847;
+  /* ---------- Primary (Naver brand green) ----------
+     Brand color sits at --primary-50. The 30/40 steps are intentionally darker
+     than a pure HSL-stepped ramp so that `text-primary-40` clears WCAG AA body
+     contrast (4.5:1) on white and `bg-primary-95` surfaces. */
+  --primary-10: #001a0a;
+  --primary-30: #014b1d;
+  --primary-40: #006e2c; /* AA body text on white (5.95:1) */
+  --primary-45: #008f3a;
   --primary-50: #03c75a; /* Main — Naver brand green */
   --primary-55: #1fd16b;
   --primary-65: #4de48e;

--- a/ui/tailwind-preset.ts
+++ b/ui/tailwind-preset.ts
@@ -1,0 +1,173 @@
+import type { Config } from "tailwindcss"
+
+/**
+ * ACM Tailwind preset — maps the design tokens in src/styles/tokens.css to
+ * Tailwind utilities (primary/neutral/semantic colors, font tokens, spacing,
+ * radius, shadow, motion). Pure token mapping; no component classes here —
+ * those live in src/styles/theme.css.
+ */
+const preset: Partial<Config> = {
+  darkMode: ["selector", '[data-theme="dark"]'],
+  theme: {
+    extend: {
+      colors: {
+        primary: {
+          10: "var(--primary-10)",
+          30: "var(--primary-30)",
+          40: "var(--primary-40)",
+          45: "var(--primary-45)",
+          50: "var(--primary-50)",
+          55: "var(--primary-55)",
+          65: "var(--primary-65)",
+          80: "var(--primary-80)",
+          90: "var(--primary-90)",
+          95: "var(--primary-95)",
+          DEFAULT: "var(--primary-50)",
+        },
+        neutral: {
+          4: "var(--neutral-4)",
+          9: "var(--neutral-9)",
+          12: "var(--neutral-12)",
+          15: "var(--neutral-15)",
+          18: "var(--neutral-18)",
+          21: "var(--neutral-21)",
+          24: "var(--neutral-24)",
+          29: "var(--neutral-29)",
+          32: "var(--neutral-32)",
+          40: "var(--neutral-40)",
+          45: "var(--neutral-45)",
+          50: "var(--neutral-50)",
+          60: "var(--neutral-60)",
+          65: "var(--neutral-65)",
+          70: "var(--neutral-70)",
+          78: "var(--neutral-78)",
+          80: "var(--neutral-80)",
+          90: "var(--neutral-90)",
+          92: "var(--neutral-92)",
+          95: "var(--neutral-95)",
+          97: "var(--neutral-97)",
+          98: "var(--neutral-98)",
+          100: "var(--neutral-100)",
+        },
+        error: {
+          30: "var(--error-30)",
+          40: "var(--error-40)",
+          45: "var(--error-45)",
+          50: "var(--error-50)",
+          55: "var(--error-55)",
+          DEFAULT: "var(--error-50)",
+        },
+        warning: {
+          30: "var(--warning-30)",
+          40: "var(--warning-40)",
+          45: "var(--warning-45)",
+          50: "var(--warning-50)",
+          55: "var(--warning-55)",
+          DEFAULT: "var(--warning-50)",
+        },
+        positive: {
+          30: "var(--positive-30)",
+          40: "var(--positive-40)",
+          45: "var(--positive-45)",
+          50: "var(--positive-50)",
+          55: "var(--positive-55)",
+          DEFAULT: "var(--positive-50)",
+        },
+        bg: {
+          DEFAULT: "var(--bg)",
+          subtle: "var(--bg-subtle)",
+          low: "var(--bg-low)",
+        },
+        surface: {
+          DEFAULT: "var(--surface)",
+          container: "var(--surface-container)",
+          "container-low": "var(--surface-container-low)",
+          "container-high": "var(--surface-container-high)",
+          "container-highest": "var(--surface-container-highest)",
+          inverse: "var(--surface-inverse)",
+        },
+        "on-surface": {
+          DEFAULT: "var(--on-surface)",
+          variant: "var(--on-surface-variant)",
+          muted: "var(--on-surface-muted)",
+          disabled: "var(--on-surface-disabled)",
+        },
+        border: {
+          DEFAULT: "var(--border)",
+          subtle: "var(--border-subtle)",
+        },
+        divider: "var(--divider)",
+      },
+      fontFamily: {
+        sans: ["var(--font-sans)"],
+        mono: ["var(--font-mono)"],
+      },
+      fontSize: {
+        "micro-md": ["var(--fs-micro-md)", { lineHeight: "var(--lh-tight)" }],
+        "micro-lg": ["var(--fs-micro-lg)", { lineHeight: "var(--lh-tight)" }],
+        "body-xs": ["var(--fs-body-xs)", { lineHeight: "var(--lh-body)" }],
+        "body-sm": ["var(--fs-body-sm)", { lineHeight: "var(--lh-body)" }],
+        "body-md": ["var(--fs-body-md)", { lineHeight: "var(--lh-body)" }],
+        "body-lg": ["var(--fs-body-lg)", { lineHeight: "var(--lh-body)" }],
+        "title-xs": ["var(--fs-title-xs)", { lineHeight: "var(--lh-title)" }],
+        "title-sm": ["var(--fs-title-sm)", { lineHeight: "var(--lh-title)" }],
+        "title-md": ["var(--fs-title-md)", { lineHeight: "var(--lh-title)" }],
+        "title-lg": ["var(--fs-title-lg)", { lineHeight: "var(--lh-title)" }],
+        "title-xl": ["var(--fs-title-xl)", { lineHeight: "var(--lh-title)" }],
+        "headline-xs": [
+          "var(--fs-headline-xs)",
+          { lineHeight: "var(--lh-headline)" },
+        ],
+        "headline-sm": [
+          "var(--fs-headline-sm)",
+          { lineHeight: "var(--lh-headline)" },
+        ],
+        "headline-md": [
+          "var(--fs-headline-md)",
+          { lineHeight: "var(--lh-headline)" },
+        ],
+        "headline-lg": [
+          "var(--fs-headline-lg)",
+          { lineHeight: "var(--lh-headline)" },
+        ],
+      },
+      spacing: {
+        1: "var(--space-1)",
+        2: "var(--space-2)",
+        3: "var(--space-3)",
+        4: "var(--space-4)",
+        5: "var(--space-5)",
+        6: "var(--space-6)",
+        8: "var(--space-8)",
+        10: "var(--space-10)",
+        12: "var(--space-12)",
+        16: "var(--space-16)",
+      },
+      borderRadius: {
+        sm: "var(--radius-sm)",
+        md: "var(--radius-md)",
+        lg: "var(--radius-lg)",
+        xl: "var(--radius-xl)",
+        bubble: "var(--radius-bubble)",
+        full: "var(--radius-full)",
+      },
+      boxShadow: {
+        sm: "var(--shadow-sm)",
+        md: "var(--shadow-md)",
+        lg: "var(--shadow-lg)",
+      },
+      transitionDuration: {
+        fast: "var(--duration-fast)",
+        base: "var(--duration-base)",
+        slow: "var(--duration-slow)",
+      },
+      transitionTimingFunction: {
+        default: "var(--easing-default)",
+        enter: "var(--easing-enter)",
+        exit: "var(--easing-exit)",
+      },
+    },
+  },
+}
+
+export default preset

--- a/ui/tailwind.config.ts
+++ b/ui/tailwind.config.ts
@@ -1,6 +1,8 @@
 import type { Config } from "tailwindcss"
+import acePreset from "./tailwind-preset"
 
 const config: Config = {
+  presets: [acePreset],
   darkMode: "selector",
   content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {

--- a/ui/tailwind.config.ts
+++ b/ui/tailwind.config.ts
@@ -3,7 +3,9 @@ import acePreset from "./tailwind-preset"
 
 const config: Config = {
   presets: [acePreset],
-  darkMode: "selector",
+  // Match next-themes' `attribute="data-theme"` on <html> (see app/layout.tsx)
+  // so `dark:*` utilities activate alongside the token override in tokens.css.
+  darkMode: ["selector", '[data-theme="dark"]'],
   content: ["./src/**/*.{js,ts,jsx,tsx,mdx}"],
   theme: {
     extend: {


### PR DESCRIPTION
## Summary

Applies the **Naver brand green (#03C75A)** primary theme to ACM through a
**self-contained, CSS-only design system** vendored inside `ui/`. Pages keep
their existing JSX shape and pick up the new look through:

- `ui/src/styles/tokens.css` — CSS custom properties (primary/neutral/semantic/surface/font), plus light + dark mode token sets
- `ui/src/styles/theme.css` — minimal class set actually used by ACM (`.ace-page-head`, `.ace-announce`, `.statusbar`, `.seg`, `.status-dot.is-*`)
- `ui/tailwind-preset.ts` — maps the tokens into the Tailwind theme (`bg-primary-50`, `border-border-subtle`, etc.)
- Pretendard Variable from CDN — Korean-friendly sans, hooked up via `--font-sans`

**No external runtime dependency added.** A previous draft of this PR pulled
in `aerospike-ce-ui-kit` via `file:../../aerospike-ce-ui-kit`; that's been
dropped — ACM already ships a full Tremor Raw component set, so a separate UI
kit is overkill. Future projects should adopt the kit selectively (the
\"necessary-only import\" principle), but ACM only needs the tokens + four
`.ace-*` classes, which are now inlined.

## Changes

**Design tokens / styling (new files)**
- `ui/src/styles/tokens.css` — `--primary-*` set to Naver green; full neutral / semantic / spacing / radius / shadow / motion tokens
- `ui/src/styles/theme.css` — `.body`, `.ace-page-head`, `.ace-announce`, `[data-app=\"ace\"] .statusbar`, `.status-dot.is-*`, `@keyframes ace-pulse`
- `ui/tailwind-preset.ts` — Tailwind preset bound to the tokens

**Layout shell**
- `ui/src/app/globals.css` — imports Pretendard CDN + local tokens/theme; ACM shell rules (232 px sidebar, 28 px statusbar) move into here
- `ui/src/app/layout.tsx` — `data-app=\"ace\"` attribute, `acm-main` wrapper, `ShellStatusBar` mount
- `ui/src/app/(main)/layout.tsx` — padding handled by `.acm-main`; thin wrapper
- `ui/tailwind.config.ts` — `presets: [acePreset]` (local preset)
- New `<PageHead />` helper (8 pages migrated)
- New `<ShellStatusBar />` — connection / health dots / version / docs

**Bulk re-skin (Indigo → Primary tokens)**
- Tremor Button + Badge primitives + all 14 dialogs, the K8s wizard, navigation, etc.
- `indigo-*` → `primary-*` sweep across all UI source files

**Misc**
- `scripts/local-dev/acko-install.sh`: capture-then-grep so `set -o pipefail` no longer races with SIGPIPE on hosts with many kubectl contexts
- `.gitignore`: exclude `.playwright-cli/` artefacts

## Out of scope

- The deeper record browser (`/clusters/[id]/sets/[ns]/[set]`) and the
  record detail page keep their existing chrome.
- Sidebar component still uses the existing Radix `<Accordion>` for cluster
  drill-down — only its width + active-link colors change.

## Test plan

- [x] `npm run type-check`
- [x] `npm run lint` (0 warnings)
- [x] `npm run format:check` (clean)
- [x] `npm run test` (58 / 58)
- [x] `npm run build` (Compiled successfully)
- [x] `pre-commit run --all-files` (all hooks pass)
- [ ] CI checks (added by GitHub Actions)