### PR TITLE
fix(observability): honor OTEL_*_EXPORTER=none for per-signal disable

### DIFF
--- a/api/src/aerospike_cluster_manager_api/observability.py
+++ b/api/src/aerospike_cluster_manager_api/observability.py
@@ -28,6 +28,7 @@ selection here so the operator can switch protocol via env alone.
 
 from __future__ import annotations
 
+import importlib
 import logging
 import os
 from importlib.metadata import PackageNotFoundError, version
@@ -109,7 +110,7 @@ def _otlp_exporter_class(signal: str) -> type[Any] | None:
     grpc_module, http_module, class_name = _EXPORTER_MODULES[signal]
     protocol = os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc").strip().lower()
     module_path = http_module if protocol in ("http/protobuf", "http") else grpc_module
-    module = __import__(module_path, fromlist=[class_name])
+    module = importlib.import_module(module_path)
     return getattr(module, class_name)
 
 
@@ -300,8 +301,9 @@ def setup_observability() -> bool:
 
     # Start aerospike-py's own OTLP span exporter so Aerospike-operation spans
     # are actually emitted (the [otel] extra only wires context propagation).
-    # Skip when traces are disabled — there is no global TracerProvider for the
-    # Rust core's spans to nest under, and the gRPC exporter would just churn.
+    # Skip when traces are disabled — OTEL_TRACES_EXPORTER=none should apply
+    # to aerospike-py's Rust OTLP exporter too, otherwise the Rust spans would
+    # keep being exported even after the Python side stopped.
     if span_exporter_cls is not None:
         _init_aerospike_py_tracing()
 

--- a/api/src/aerospike_cluster_manager_api/observability.py
+++ b/api/src/aerospike_cluster_manager_api/observability.py
@@ -11,6 +11,15 @@ service-level convenience this module adds on top is
 ``OTEL_DEPLOYMENT_ENVIRONMENT`` mapped to the ``deployment.environment``
 resource attribute.
 
+Per-signal disable is honored: setting ``OTEL_TRACES_EXPORTER=none`` /
+``OTEL_METRICS_EXPORTER=none`` / ``OTEL_LOGS_EXPORTER=none`` skips construction
+of the matching provider so its NoOp default survives globally, while the
+remaining signals continue to export. This matters when the OTel collector only
+ships a subset of pipelines (e.g. traces+logs but no metrics receiver) — the
+all-or-nothing ``OTEL_SDK_DISABLED=true`` would otherwise force operators to
+choose between every signal or none. Reference:
+https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection
+
 The OTel SDK does NOT auto-pick the exporter implementation from
 ``OTEL_EXPORTER_OTLP_PROTOCOL`` — the package layout requires the caller to
 import either the gRPC or the HTTP/protobuf exporter explicitly. We do that
@@ -56,33 +65,52 @@ def _service_version() -> str:
         return "unknown"
 
 
-def _otlp_exporters() -> tuple[type[Any], type[Any], type[Any]]:
-    """Pick gRPC or HTTP/protobuf OTLP exporters per ``OTEL_EXPORTER_OTLP_PROTOCOL``."""
-    protocol = os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc").lower()
-    if protocol in ("http/protobuf", "http"):
-        from opentelemetry.exporter.otlp.proto.http._log_exporter import (
-            OTLPLogExporter as HttpLogExporter,
-        )
-        from opentelemetry.exporter.otlp.proto.http.metric_exporter import (
-            OTLPMetricExporter as HttpMetricExporter,
-        )
-        from opentelemetry.exporter.otlp.proto.http.trace_exporter import (
-            OTLPSpanExporter as HttpSpanExporter,
+# Maps OTel signal name -> (grpc_module_path, http_module_path, class_name). The
+# package layout differs per signal (note the leading underscore on log
+# exporters), so we keep this table central to make the selection code below
+# data-driven instead of branchy.
+_EXPORTER_MODULES: dict[str, tuple[str, str, str]] = {
+    "traces": (
+        "opentelemetry.exporter.otlp.proto.grpc.trace_exporter",
+        "opentelemetry.exporter.otlp.proto.http.trace_exporter",
+        "OTLPSpanExporter",
+    ),
+    "metrics": (
+        "opentelemetry.exporter.otlp.proto.grpc.metric_exporter",
+        "opentelemetry.exporter.otlp.proto.http.metric_exporter",
+        "OTLPMetricExporter",
+    ),
+    "logs": (
+        "opentelemetry.exporter.otlp.proto.grpc._log_exporter",
+        "opentelemetry.exporter.otlp.proto.http._log_exporter",
+        "OTLPLogExporter",
+    ),
+}
+
+
+def _otlp_exporter_class(signal: str) -> type[Any] | None:
+    """Return the OTLP exporter class for ``signal`` (traces/metrics/logs).
+
+    Returns ``None`` when ``OTEL_<SIGNAL>_EXPORTER=none``, signalling that the
+    caller must skip provider construction for that signal so its NoOp global
+    default survives. ``OTEL_EXPORTER_OTLP_PROTOCOL`` selects gRPC vs HTTP.
+    """
+    selection = os.getenv(f"OTEL_{signal.upper()}_EXPORTER", "otlp").strip().lower()
+    if selection == "none":
+        return None
+    if selection != "otlp":
+        # Stay strict: silently accepting an unsupported value would let an
+        # operator believe Jaeger / console / Prometheus export is configured
+        # when in fact nothing happens. Surface the misconfig at startup.
+        raise ValueError(
+            f"Unsupported OTEL_{signal.upper()}_EXPORTER={selection!r}; expected 'otlp' or 'none'"
         )
 
-        return HttpSpanExporter, HttpMetricExporter, HttpLogExporter
-
-    from opentelemetry.exporter.otlp.proto.grpc._log_exporter import (
-        OTLPLogExporter as GrpcLogExporter,
-    )
-    from opentelemetry.exporter.otlp.proto.grpc.metric_exporter import (
-        OTLPMetricExporter as GrpcMetricExporter,
-    )
-    from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import (
-        OTLPSpanExporter as GrpcSpanExporter,
-    )
-
-    return GrpcSpanExporter, GrpcMetricExporter, GrpcLogExporter
+    grpc_module, http_module, class_name = _EXPORTER_MODULES[signal]
+    protocol = os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc").strip().lower()
+    module_path = http_module if protocol in ("http/protobuf", "http") else grpc_module
+    module = __import__(module_path, fromlist=[class_name])
+    return getattr(module, class_name)
 
 
 # ---------------------------------------------------------------------------
@@ -225,7 +253,9 @@ def setup_observability() -> bool:
     if os.getenv("OTEL_SDK_DISABLED", "true").lower() in ("true", "1", "yes"):
         return False
 
-    span_exporter_cls, metric_exporter_cls, log_exporter_cls = _otlp_exporters()
+    span_exporter_cls = _otlp_exporter_class("traces")
+    metric_exporter_cls = _otlp_exporter_class("metrics")
+    log_exporter_cls = _otlp_exporter_class("logs")
 
     resource = Resource.create(
         {
@@ -236,24 +266,25 @@ def setup_observability() -> bool:
         }
     )
 
-    tracer_provider = TracerProvider(resource=resource)
-    tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter_cls()))
-    trace.set_tracer_provider(tracer_provider)
+    if span_exporter_cls is not None:
+        tracer_provider = TracerProvider(resource=resource)
+        tracer_provider.add_span_processor(BatchSpanProcessor(span_exporter_cls()))
+        trace.set_tracer_provider(tracer_provider)
+        _tracer_provider = tracer_provider
 
-    meter_provider = MeterProvider(
-        resource=resource,
-        metric_readers=[PeriodicExportingMetricReader(metric_exporter_cls())],
-    )
-    metrics.set_meter_provider(meter_provider)
+    if metric_exporter_cls is not None:
+        meter_provider = MeterProvider(
+            resource=resource,
+            metric_readers=[PeriodicExportingMetricReader(metric_exporter_cls())],
+        )
+        metrics.set_meter_provider(meter_provider)
+        _meter_provider = meter_provider
 
-    logger_provider = LoggerProvider(resource=resource)
-    logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter_cls()))
-    set_logger_provider(logger_provider)
-
-    # Retain the providers so shutdown_observability() can flush them explicitly.
-    _tracer_provider = tracer_provider
-    _meter_provider = meter_provider
-    _logger_provider = logger_provider
+    if log_exporter_cls is not None:
+        logger_provider = LoggerProvider(resource=resource)
+        logger_provider.add_log_record_processor(BatchLogRecordProcessor(log_exporter_cls()))
+        set_logger_provider(logger_provider)
+        _logger_provider = logger_provider
 
     # set_logging_format=False so we don't override the formatter that
     # logging_config.setup_logging configures. We only need the LogRecord
@@ -269,10 +300,18 @@ def setup_observability() -> bool:
 
     # Start aerospike-py's own OTLP span exporter so Aerospike-operation spans
     # are actually emitted (the [otel] extra only wires context propagation).
-    _init_aerospike_py_tracing()
+    # Skip when traces are disabled — there is no global TracerProvider for the
+    # Rust core's spans to nest under, and the gRPC exporter would just churn.
+    if span_exporter_cls is not None:
+        _init_aerospike_py_tracing()
 
     _initialized = True
-    logger.info("OpenTelemetry providers initialized")
+    logger.info(
+        "OpenTelemetry providers initialized (traces=%s metrics=%s logs=%s)",
+        "on" if span_exporter_cls else "off",
+        "on" if metric_exporter_cls else "off",
+        "on" if log_exporter_cls else "off",
+    )
     return True
 
 

--- a/api/src/aerospike_cluster_manager_api/observability.py
+++ b/api/src/aerospike_cluster_manager_api/observability.py
@@ -103,9 +103,7 @@ def _otlp_exporter_class(signal: str) -> type[Any] | None:
         # Stay strict: silently accepting an unsupported value would let an
         # operator believe Jaeger / console / Prometheus export is configured
         # when in fact nothing happens. Surface the misconfig at startup.
-        raise ValueError(
-            f"Unsupported OTEL_{signal.upper()}_EXPORTER={selection!r}; expected 'otlp' or 'none'"
-        )
+        raise ValueError(f"Unsupported OTEL_{signal.upper()}_EXPORTER={selection!r}; expected 'otlp' or 'none'")
 
     grpc_module, http_module, class_name = _EXPORTER_MODULES[signal]
     protocol = os.getenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc").strip().lower()

--- a/api/tests/test_observability.py
+++ b/api/tests/test_observability.py
@@ -62,14 +62,131 @@ def test_setup_observability_idempotent(monkeypatch):
 def test_otlp_exporter_selection(monkeypatch, protocol, expected_module):
     """OTEL_EXPORTER_OTLP_PROTOCOL determines which exporter module is imported."""
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", protocol)
-    span_cls, _, _ = obs._otlp_exporters()
+    span_cls = obs._otlp_exporter_class("traces")
+    assert span_cls is not None
     assert span_cls.__module__ == expected_module
 
 
 def test_otlp_exporter_default_grpc(monkeypatch):
     monkeypatch.delenv("OTEL_EXPORTER_OTLP_PROTOCOL", raising=False)
-    span_cls, _, _ = obs._otlp_exporters()
+    span_cls = obs._otlp_exporter_class("traces")
+    assert span_cls is not None
     assert "grpc" in span_cls.__module__
+
+
+@pytest.mark.parametrize("signal", ["traces", "metrics", "logs"])
+def test_otlp_exporter_class_signal_disabled_returns_none(monkeypatch, signal):
+    """OTEL_<SIGNAL>_EXPORTER=none yields None so the caller skips that provider."""
+    monkeypatch.setenv(f"OTEL_{signal.upper()}_EXPORTER", "none")
+    assert obs._otlp_exporter_class(signal) is None
+
+
+@pytest.mark.parametrize("none_alias", ["none", "NONE", "None", " none "])
+def test_otlp_exporter_class_disable_is_case_and_whitespace_insensitive(monkeypatch, none_alias):
+    """Operators commonly set values with stray whitespace or mixed case; honor those."""
+    monkeypatch.setenv("OTEL_METRICS_EXPORTER", none_alias)
+    assert obs._otlp_exporter_class("metrics") is None
+
+
+def test_otlp_exporter_class_unsupported_value_raises(monkeypatch):
+    """Unknown exporter names must fail loud, not silently fall back to OTLP."""
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "jaeger")
+    with pytest.raises(ValueError, match="Unsupported OTEL_TRACES_EXPORTER"):
+        obs._otlp_exporter_class("traces")
+
+
+def test_otlp_exporter_class_default_is_otlp(monkeypatch):
+    """Per the OTel SDK spec, an unset OTEL_<SIGNAL>_EXPORTER defaults to 'otlp'."""
+    monkeypatch.delenv("OTEL_TRACES_EXPORTER", raising=False)
+    assert obs._otlp_exporter_class("traces") is not None
+
+
+def test_setup_observability_skips_metrics_when_disabled(monkeypatch):
+    """OTEL_METRICS_EXPORTER=none must not construct a MeterProvider — a partial
+    collector (logs+traces but no metrics receiver) is a common deployment.
+    Regression for #403.
+    """
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "false")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    monkeypatch.setenv("OTEL_METRICS_EXPORTER", "none")
+    monkeypatch.delenv("AEROSPIKE_PY_TRACING", raising=False)
+
+    with (
+        patch("aerospike_cluster_manager_api.observability.TracerProvider") as mock_tp,
+        patch("aerospike_cluster_manager_api.observability.MeterProvider") as mock_mp,
+        patch("aerospike_cluster_manager_api.observability.LoggerProvider") as mock_lp,
+        patch.object(obs, "aerospike_py"),
+    ):
+        assert obs.setup_observability() is True
+
+    mock_tp.assert_called_once()
+    mock_mp.assert_not_called()
+    mock_lp.assert_called_once()
+
+
+def test_setup_observability_skips_traces_when_disabled(monkeypatch):
+    """OTEL_TRACES_EXPORTER=none disables both Python TracerProvider AND
+    aerospike-py's Rust OTLP exporter — the Rust spans would nest under a NoOp
+    parent and the gRPC exporter would just churn endlessly otherwise.
+    """
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "false")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "none")
+    monkeypatch.delenv("AEROSPIKE_PY_TRACING", raising=False)
+
+    with (
+        patch("aerospike_cluster_manager_api.observability.TracerProvider") as mock_tp,
+        patch("aerospike_cluster_manager_api.observability.MeterProvider") as mock_mp,
+        patch("aerospike_cluster_manager_api.observability.LoggerProvider") as mock_lp,
+        patch.object(obs, "aerospike_py") as mock_ap,
+    ):
+        assert obs.setup_observability() is True
+
+    mock_tp.assert_not_called()
+    mock_mp.assert_called_once()
+    mock_lp.assert_called_once()
+    mock_ap.init_tracing.assert_not_called()
+
+
+def test_setup_observability_skips_logs_when_disabled(monkeypatch):
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "false")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    monkeypatch.setenv("OTEL_LOGS_EXPORTER", "none")
+
+    with (
+        patch("aerospike_cluster_manager_api.observability.TracerProvider") as mock_tp,
+        patch("aerospike_cluster_manager_api.observability.MeterProvider") as mock_mp,
+        patch("aerospike_cluster_manager_api.observability.LoggerProvider") as mock_lp,
+        patch.object(obs, "aerospike_py"),
+    ):
+        assert obs.setup_observability() is True
+
+    mock_tp.assert_called_once()
+    mock_mp.assert_called_once()
+    mock_lp.assert_not_called()
+
+
+def test_setup_observability_all_signals_disabled_still_returns_true(monkeypatch):
+    """Disabling every signal individually is a valid no-op configuration — equivalent
+    to OTEL_SDK_DISABLED=true but reached by per-signal flags. Must not crash and
+    must not retain any of the SDK providers.
+    """
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "false")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "grpc")
+    monkeypatch.setenv("OTEL_TRACES_EXPORTER", "none")
+    monkeypatch.setenv("OTEL_METRICS_EXPORTER", "none")
+    monkeypatch.setenv("OTEL_LOGS_EXPORTER", "none")
+
+    with patch.object(obs, "aerospike_py"):
+        assert obs.setup_observability() is True
+
+    assert obs._tracer_provider is None
+    assert obs._meter_provider is None
+    assert obs._logger_provider is None
 
 
 def test_make_instruments_returns_four_keys():

--- a/api/tests/test_observability.py
+++ b/api/tests/test_observability.py
@@ -127,8 +127,9 @@ def test_setup_observability_skips_metrics_when_disabled(monkeypatch):
 
 def test_setup_observability_skips_traces_when_disabled(monkeypatch):
     """OTEL_TRACES_EXPORTER=none disables both Python TracerProvider AND
-    aerospike-py's Rust OTLP exporter — the Rust spans would nest under a NoOp
-    parent and the gRPC exporter would just churn endlessly otherwise.
+    aerospike-py's Rust OTLP exporter — disabling traces on the Python side
+    must propagate to the Rust side too, or aerospike.<op> spans keep flowing
+    while the Python pipeline reports traces=off.
     """
     monkeypatch.setenv("OTEL_SDK_DISABLED", "false")
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4317")


### PR DESCRIPTION
## Summary

Closes #403.

`setup_observability()` unconditionally constructed `TracerProvider` / `MeterProvider` / `LoggerProvider` with their OTLP exporters wired in, ignoring the standard `OTEL_TRACES_EXPORTER` / `OTEL_METRICS_EXPORTER` / `OTEL_LOGS_EXPORTER` environment variables. The module docstring promised these env vars would be honored, and the [OpenTelemetry SDK env-var spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection) requires it, so operators had no in-band way to disable one signal while keeping the others (the all-or-nothing `OTEL_SDK_DISABLED=true` was the only escape hatch).

This caused the symptom reported in #403: with `OTEL_METRICS_EXPORTER=none` set against a collector that only ships `service.pipelines.{logs,traces}`, the API still attempted metric exports every 60 s and logged an ERROR each time — which was itself shipped through the OTLP logs pipeline back to the same collector.

## What changes

- `_otlp_exporters()` (returns three classes) is replaced by `_otlp_exporter_class(signal)` which returns `None` when `OTEL_<SIGNAL>_EXPORTER=none` and raises `ValueError` on unsupported values (so a typo like `=jaeger` fails loudly at startup rather than silently skipping).
- `setup_observability()` now branches per signal: provider construction and `set_X_provider()` are skipped entirely for any signal disabled by env. The matching `_X_provider` module-scope var stays `None` so `shutdown_observability()` no-ops correctly.
- aerospike-py's native Rust OTLP span exporter (`aerospike_py.init_tracing`) is also skipped when traces are disabled — without a Python `TracerProvider` for its spans to nest under, it would churn a gRPC connection indefinitely against a collector that has no traces pipeline.
- The final startup log now reports which signals were activated: `OpenTelemetry providers initialized (traces=on metrics=off logs=on)`.

## Test plan

- [x] Unit tests for the new `_otlp_exporter_class(signal)` covering each signal disabled, mixed case / whitespace, unsupported value (raises), and default `otlp` selection.
- [x] Unit tests verifying `setup_observability()` skips the matching provider class when each signal is set to `none`, and the all-three-disabled case completes without leaving any provider attached.
- [x] All 51 tests in `test_observability.py` pass locally (`uv run pytest tests/test_observability.py`).
- [x] `pyright` clean on the modified module.
- [ ] QA on Kind cluster — operator + cluster-manager api both deployed with a partial collector (logs+traces, no metrics receiver) and `OTEL_METRICS_EXPORTER=none`; verify no `UNIMPLEMENTED` log noise.