### PR TITLE
ci(cd): build per-platform on native runners to avoid QEMU timeouts

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,11 +1,16 @@
 name: CD
-# On push to main: builds multi-arch (amd64/arm64) container images and pushes to GHCR.
+# On push to main or a v* tag: builds multi-arch (amd64/arm64) container images
+# and pushes them to GHCR.
 #
-# Builds three images per push:
+# Builds two images per push:
 #   - ghcr.io/<repo>-api      — FastAPI API only (Dockerfile.api)
 #   - ghcr.io/<repo>-web      — Next.js Web frontend (Dockerfile.web)
 #
-# The split images are what the ACKO UI deployments consume.
+# Each platform is built on its NATIVE runner (amd64 on ubuntu-latest, arm64
+# on ubuntu-24.04-arm) to avoid QEMU emulation, which previously caused the
+# web image's `npm ci` step to hit the 60-minute job timeout (#239, v0.30.0).
+# Per-platform digests are then merged into a single multi-arch manifest list
+# (with all tags) in a follow-on `merge` job.
 
 on:
   push:
@@ -21,10 +26,10 @@ env:
   REGISTRY: ghcr.io
 
 jobs:
-  build-and-push:
-    name: Build & Push (${{ matrix.name }})
-    runs-on: ubuntu-latest
-    timeout-minutes: 60
+  build:
+    name: Build (${{ matrix.name }}/${{ matrix.platform }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -35,20 +40,109 @@ jobs:
           - name: api
             dockerfile: Dockerfile.api
             suffix: -api
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - name: api
+            dockerfile: Dockerfile.api
+            suffix: -api
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
           - name: web
             dockerfile: Dockerfile.web
             suffix: -web
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - name: web
+            dockerfile: Dockerfile.web
+            suffix: -web
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - uses: actions/checkout@v6
 
+      - name: Prepare names
+        id: prep
+        run: |
+          REPO="${GITHUB_REPOSITORY,,}"
+          PLATFORM_PAIR="${{ matrix.platform }}"
+          PLATFORM_PAIR="${PLATFORM_PAIR//\//-}"
+          echo "IMAGE=ghcr.io/${REPO}${{ matrix.suffix }}" >> "$GITHUB_ENV"
+          echo "platform_pair=${PLATFORM_PAIR}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract image labels
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ${{ env.IMAGE }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          # Per-platform cache scope so amd64/arm64 don't overwrite each other.
+          # Only main writes — tags read but don't churn the cache.
+          cache-from: type=gha,scope=${{ matrix.name }}-${{ steps.prep.outputs.platform_pair }}
+          cache-to: ${{ github.ref == 'refs/heads/main' && format('type=gha,mode=max,scope={0}-{1}', matrix.name, steps.prep.outputs.platform_pair) || '' }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.name }}-${{ steps.prep.outputs.platform_pair }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    name: Merge manifests (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: api
+            suffix: -api
+          - name: web
+            suffix: -web
+
+    steps:
       - name: Set lowercase image name
         run: |
           REPO="${GITHUB_REPOSITORY,,}"
           echo "IMAGE=ghcr.io/${REPO}${{ matrix.suffix }}" >> "$GITHUB_ENV"
 
-      - name: Set up QEMU (for multi-arch builds)
-        uses: docker/setup-qemu-action@v4
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-${{ matrix.name }}-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -72,18 +166,13 @@ jobs:
             type=sha,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
 
-      - name: Build & Push (multi-arch)
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          # Read main's cache for every event (tag, dispatch, branch). Without
-          # this, tag pushes do a cold multi-arch build via QEMU and the
-          # ui job times out at 30 minutes (#239 release).
-          cache-from: type=gha,scope=${{ matrix.name }}
-          # Only main writes to the cache so tags don't churn it.
-          cache-to: ${{ github.ref == 'refs/heads/main' && format('type=gha,mode=max,scope={0}', matrix.name) || '' }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.IMAGE }}@sha256:%s ' *)
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect "${{ env.IMAGE }}:${{ steps.meta.outputs.version }}"


### PR DESCRIPTION
## Summary

- Split the multi-arch container build so each platform runs on its **native runner** (amd64 on `ubuntu-latest`, arm64 on `ubuntu-24.04-arm`), then merge per-platform digests into a single manifest list in a follow-on `merge` job.
- Fixes the long-standing problem where the web image's arm64 `npm ci` step routinely hit the 60-minute job timeout under QEMU emulation when main's cache was cold.

## Why

- v0.30.0 tag CD ([run 26480472161](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/actions/runs/26480472161)) was cancelled at 1h0m20s — `linux/arm64 deps 4/4 RUN npm ci` never finished. amd64 was done in <1 minute on the same run.
- The preceding main push (Naver green theme merge) hit the same timeout, which is why main's cache never warmed and the tag build ran cold.
- `ubuntu-24.04-arm` is GitHub-hosted and free for public repos, so no QEMU is needed anymore.

## What changed

- `build` job runs **4 times** (api/web × amd64/arm64), each on its native runner, pushing **by digest only** (`push-by-digest=true`, no tags).
- New `merge` job (2 instances: api/web) downloads digests via artifacts and creates the multi-arch manifest list with all tags (semver, sha, branch, `latest`).
- Per-platform cache scope (`scope=<image>-<platform-pair>`) so amd64/arm64 caches don't overwrite each other.
- Per-job `timeout-minutes` lowered from 60 to 30 (build) / 10 (merge) since each step is much smaller now.

## Test plan

- [ ] PR CI green
- [ ] After merge: next push to main triggers CD; verify all 4 `build` jobs succeed and both `merge` jobs publish multi-arch manifests
- [ ] Verify `podman manifest inspect ghcr.io/aerospike-ce-ecosystem/aerospike-cluster-manager-{api,web}:latest` shows both `amd64` and `arm64` entries
- [ ] Next `v*` tag push completes without the previous 1h timeout