### PR TITLE
ci(cd): bump actions/{upload,download}-artifact to v5

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -107,7 +107,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: digests-${{ matrix.name }}-${{ steps.prep.outputs.platform_pair }}
           path: /tmp/digests/*
@@ -138,7 +138,7 @@ jobs:
           echo "IMAGE=ghcr.io/${REPO}${{ matrix.suffix }}" >> "$GITHUB_ENV"
 
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: /tmp/digests
           pattern: digests-${{ matrix.name }}-*


### PR DESCRIPTION
## Summary

- Bump `actions/upload-artifact` and `actions/download-artifact` from v4 to v5 in `cd.yaml`.

## Why

GitHub is removing Node.js 20 support from runners on **2026-09-16** and forcing Node.js 24 as the default on **2026-06-02** ([changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). The v4 versions still run on Node.js 20 and emitted deprecation warnings in the most recent CD run ([26501755925](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/actions/runs/26501755925)).

v5.0.0 of both actions updates the runtime to Node.js 24.

## Breaking change check

- `upload-artifact` v5.0.0: only changes Node runtime — no behavioral break.
- `download-artifact` v5.0.0: breaking change affects **single-artifact downloads by ID** (`artifact-ids:` parameter). This workflow downloads multiple artifacts via `pattern: digests-... + merge-multiple: true`, so behavior is unchanged.

## Test plan

- [ ] PR CI green
- [ ] After merge: next CD on main publishes multi-arch manifests for both api/web with no deprecation warnings