### PR TITLE
fix(ci): pin artifact actions to versions that run on Node.js 24

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -107,7 +107,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ matrix.name }}-${{ steps.prep.outputs.platform_pair }}
           path: /tmp/digests/*
@@ -138,7 +138,7 @@ jobs:
           echo "IMAGE=ghcr.io/${REPO}${{ matrix.suffix }}" >> "$GITHUB_ENV"
 
       - name: Download digests
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-${{ matrix.name }}-*


### PR DESCRIPTION
## Summary

Follow-up to #406 — bumping to v5 didn't actually move the actions onto Node.js 24.

- `actions/upload-artifact`: v5 → **v7**
- `actions/download-artifact`: v5 → **v8**

## Why

The v5 bump in #406 still emitted Node.js 20 deprecation warnings in [CD run 26502610147](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/actions/runs/26502610147). Per the upstream v6 release notes:

> v5 had preliminary support for Node.js 24, however this action was by default still running on Node.js 20. Now this action by default will run on Node.js 24.

So v5's `runs.using` is `node20` and only v6+ actually flips the default. Confirmed by inspecting each tag's `action.yml`:

```yaml
# v7.0.1 (upload-artifact) / v8.0.1 (download-artifact)
runs:
  using: 'node24'
```

## Breaking change check

- **upload-artifact v6 → v7**: adds optional `archive: false` for direct single-file uploads; ESM migration. We don't use `archive`, ESM is transparent — no behavioral change for our usage (`path: /tmp/digests/*`).
- **download-artifact v6 → v8**:
  - v6/v7: Node 24 runtime
  - v8: ESM migration, direct download support, **hash-mismatch defaults to error** (was warning). Our usage (`pattern: digests-...-*` + `merge-multiple: true`) is unchanged and stricter hash checking is desirable.

## Test plan

- [ ] PR CI green
- [ ] After merge: next CD on main publishes multi-arch manifests with **no** Node.js 20 deprecation warnings