### PR TITLE
fix(security): gate admin endpoints with VerifiedConnId to prevent cross-tenant access

### DIFF
--- a/api/src/aerospike_cluster_manager_api/routers/admin_roles.py
+++ b/api/src/aerospike_cluster_manager_api/routers/admin_roles.py
@@ -7,7 +7,7 @@ from aerospike_py.types import Privilege as AerospikePrivilege
 from fastapi import APIRouter, HTTPException, Query, Request
 from starlette.responses import Response
 
-from aerospike_cluster_manager_api.dependencies import AerospikeClient
+from aerospike_cluster_manager_api.dependencies import AerospikeClient, VerifiedConnId
 from aerospike_cluster_manager_api.models.admin import AerospikeRole, CreateRoleRequest, Privilege
 from aerospike_cluster_manager_api.rate_limit import limiter
 from aerospike_cluster_manager_api.routers._admin_utils import (
@@ -27,8 +27,14 @@ router = APIRouter(prefix="/admin", tags=["admin-roles"])
     description="Retrieve all Aerospike roles and their privileges. Requires security to be enabled in aerospike.conf.",
 )
 @admin_endpoint
-async def get_roles(client: AerospikeClient) -> list[AerospikeRole]:
+async def get_roles(client: AerospikeClient, conn_id: VerifiedConnId) -> list[AerospikeRole]:
     """Retrieve all Aerospike roles and their privileges. Requires security to be enabled in aerospike.conf."""
+    # ``conn_id`` is unused inside the body — its only job is to trigger
+    # the workspace ACL via :data:`VerifiedConnId` before the admin call
+    # reaches the Aerospike cluster. Without this gate a caller could
+    # manipulate ``conn_id`` in the path to read roles from a connection
+    # owned by a different workspace (cross-tenant data leak).
+    _ = conn_id
     raw_roles = await client.admin_query_roles()
     roles: list[AerospikeRole] = []
     for info in raw_roles:
@@ -78,8 +84,14 @@ async def get_roles(client: AerospikeClient) -> list[AerospikeRole]:
 )
 @limiter.limit("20/minute")
 @admin_endpoint
-async def create_role(request: Request, body: CreateRoleRequest, client: AerospikeClient) -> AerospikeRole:
+async def create_role(
+    request: Request,
+    body: CreateRoleRequest,
+    client: AerospikeClient,
+    conn_id: VerifiedConnId,
+) -> AerospikeRole:
     """Create a new Aerospike role with specified privileges. Requires security to be enabled in aerospike.conf."""
+    _ = conn_id
     if not body.name or not body.privileges:
         raise HTTPException(status_code=400, detail="Missing required fields: name, privileges")
 
@@ -130,9 +142,11 @@ async def create_role(request: Request, body: CreateRoleRequest, client: Aerospi
 async def delete_role(
     request: Request,
     client: AerospikeClient,
+    conn_id: VerifiedConnId,
     name: str = Query(..., min_length=1),
 ) -> Response:
     """Delete an Aerospike role by name. Requires security to be enabled in aerospike.conf."""
+    _ = conn_id
     await client.admin_drop_role(name)
 
     return Response(status_code=204)

--- a/api/src/aerospike_cluster_manager_api/routers/admin_users.py
+++ b/api/src/aerospike_cluster_manager_api/routers/admin_users.py
@@ -5,7 +5,7 @@ import logging
 from fastapi import APIRouter, HTTPException, Query, Request
 from starlette.responses import Response
 
-from aerospike_cluster_manager_api.dependencies import AerospikeClient
+from aerospike_cluster_manager_api.dependencies import AerospikeClient, VerifiedConnId
 from aerospike_cluster_manager_api.models.admin import AerospikeUser, ChangePasswordRequest, CreateUserRequest
 from aerospike_cluster_manager_api.models.common import MessageResponse
 from aerospike_cluster_manager_api.rate_limit import limiter
@@ -22,8 +22,14 @@ router = APIRouter(prefix="/admin", tags=["admin-users"])
     description="Retrieve all Aerospike users and their roles. Requires security to be enabled in aerospike.conf.",
 )
 @admin_endpoint
-async def get_users(client: AerospikeClient) -> list[AerospikeUser]:
+async def get_users(client: AerospikeClient, conn_id: VerifiedConnId) -> list[AerospikeUser]:
     """Retrieve all Aerospike users and their roles. Requires security to be enabled in aerospike.conf."""
+    # ``conn_id`` is unused inside the body — its only job is to trigger
+    # the workspace ACL via :data:`VerifiedConnId` before the admin call
+    # reaches the Aerospike cluster. Without this gate a caller could
+    # manipulate ``conn_id`` in the path to read users from a connection
+    # owned by a different workspace (cross-tenant data leak).
+    _ = conn_id
     raw_users = await client.admin_query_users_info()
     users: list[AerospikeUser] = []
     for info in raw_users:
@@ -47,8 +53,16 @@ async def get_users(client: AerospikeClient) -> list[AerospikeUser]:
 )
 @limiter.limit("20/minute")
 @admin_endpoint
-async def create_user(request: Request, body: CreateUserRequest, client: AerospikeClient) -> AerospikeUser:
+async def create_user(
+    request: Request,
+    body: CreateUserRequest,
+    client: AerospikeClient,
+    conn_id: VerifiedConnId,
+) -> AerospikeUser:
     """Create a new Aerospike user with specified roles. Requires security to be enabled in aerospike.conf."""
+    # ``conn_id`` gates the destructive call behind the workspace ACL —
+    # see ``get_users`` above for the full rationale.
+    _ = conn_id
     if not body.username or not body.password:
         raise HTTPException(status_code=400, detail="Missing required fields: username, password")
 
@@ -71,8 +85,14 @@ async def create_user(request: Request, body: CreateUserRequest, client: Aerospi
 )
 @limiter.limit("20/minute")
 @admin_endpoint
-async def change_password(request: Request, body: ChangePasswordRequest, client: AerospikeClient) -> MessageResponse:
+async def change_password(
+    request: Request,
+    body: ChangePasswordRequest,
+    client: AerospikeClient,
+    conn_id: VerifiedConnId,
+) -> MessageResponse:
     """Change the password for an existing Aerospike user. Requires security to be enabled in aerospike.conf."""
+    _ = conn_id
     if not body.username or not body.password:
         raise HTTPException(status_code=400, detail="Missing required fields: username, password")
 
@@ -92,9 +112,11 @@ async def change_password(request: Request, body: ChangePasswordRequest, client:
 async def delete_user(
     request: Request,
     client: AerospikeClient,
+    conn_id: VerifiedConnId,
     username: str = Query(..., min_length=1),
 ) -> Response:
     """Delete an Aerospike user by username. Requires security to be enabled in aerospike.conf."""
+    _ = conn_id
     await client.admin_drop_user(username)
 
     return Response(status_code=204)

--- a/api/src/aerospike_cluster_manager_api/routers/records.py
+++ b/api/src/aerospike_cluster_manager_api/routers/records.py
@@ -359,10 +359,12 @@ async def get_filtered_records(
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except PredicateError as exc:
         # A bad ``predicate`` (unknown operator, missing value/value2) is a
-        # client error. ``query.py`` already maps these via its generic
-        # ValueError catch; the filter endpoint must too — otherwise a bad
-        # predicate here escaped as an opaque 500.
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        # client-side schema-level error. Map to 422 to align with
+        # ``query.py`` (PR #408) — ``PredicateError`` is a ``ValueError``
+        # subclass so this branch MUST be ordered before any generic
+        # ``ValueError`` catch, otherwise the more accurate 422 would
+        # silently degrade to 400.
+        raise HTTPException(status_code=422, detail=f"Invalid predicate: {exc}") from exc
 
     models = [record_to_model(r) for r in result.records]
     # Filter scans always carry a set scope (SetRequiredForPkLookup is

--- a/api/tests/test_admin_acl.py
+++ b/api/tests/test_admin_acl.py
@@ -1,0 +1,231 @@
+"""Workspace ACL coverage for the admin_users / admin_roles routers.
+
+P0 regression guard: before this fix the admin endpoints accepted
+``conn_id`` in the path but never resolved it through
+:data:`VerifiedConnId`, so a caller who knew (or guessed) a foreign
+connection id could read/mutate users and roles on a cluster owned by
+a different workspace — cross-tenant privilege escalation.
+
+These tests pin the contract by seeding a connection inside Alice's
+workspace and then issuing admin requests as Bob; every endpoint must
+404 (identity-404, not 403, matching the wire shape used by every
+other ACL-gated router so id enumeration stays impossible).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from aerospike_cluster_manager_api import db
+from aerospike_cluster_manager_api.dependencies import _resolve_caller_owner_id
+from aerospike_cluster_manager_api.main import app
+from aerospike_cluster_manager_api.models.connection import ConnectionProfile
+from aerospike_cluster_manager_api.models.workspace import Workspace
+
+
+@asynccontextmanager
+async def _noop_lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    yield
+
+
+def _override_caller(owner_id: str) -> None:
+    app.dependency_overrides[_resolve_caller_owner_id] = lambda: owner_id
+
+
+def _clear_caller_override() -> None:
+    app.dependency_overrides.pop(_resolve_caller_owner_id, None)
+
+
+@pytest.fixture()
+async def client(init_test_db):
+    original_lifespan = app.router.lifespan_context
+    app.router.lifespan_context = _noop_lifespan
+
+    app.state.limiter.enabled = False
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.state.limiter.enabled = True
+    app.router.lifespan_context = original_lifespan
+    _clear_caller_override()
+
+
+async def _seed_workspace(ws_id: str, owner_id: str) -> None:
+    now = datetime.now(UTC).isoformat()
+    await db.create_workspace(
+        Workspace(
+            id=ws_id,
+            name=f"ws-{ws_id}",
+            color="#6366F1",
+            description=None,
+            isDefault=False,
+            ownerId=owner_id,
+            createdAt=now,
+            updatedAt=now,
+        )
+    )
+
+
+async def _seed_connection(conn_id: str, workspace_id: str) -> None:
+    now = datetime.now(UTC).isoformat()
+    await db.create_connection(
+        ConnectionProfile(
+            id=conn_id,
+            name=f"test-{conn_id}",
+            hosts=["localhost"],
+            port=3000,
+            color="#0097D3",
+            workspaceId=workspace_id,
+            createdAt=now,
+            updatedAt=now,
+        )
+    )
+
+
+def _no_aerospike_client():
+    """Patch the aerospike client factory so it never actually runs.
+
+    The ACL gate (``_get_verified_connection``) runs BEFORE the
+    aerospike client is built. If the ACL correctly rejects the request
+    we never reach this mock; if it doesn't, the mock keeps the test
+    from accidentally talking to a real Aerospike cluster.
+    """
+    return patch(
+        "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+        AsyncMock(return_value=AsyncMock()),
+    )
+
+
+class TestAdminUsersWorkspaceAcl:
+    """Bob must not be able to list / create / change / delete users on
+    Alice's connection."""
+
+    async def test_cross_owner_list_users_returns_404(self, client: AsyncClient) -> None:
+        await _seed_workspace("ws-alice-u1", "alice")
+        await _seed_connection("conn-alice-u1", workspace_id="ws-alice-u1")
+
+        _override_caller("bob")
+        with _no_aerospike_client():
+            resp = await client.get("/api/admin/conn-alice-u1/users")
+
+        assert resp.status_code == 404, resp.text
+
+    async def test_cross_owner_create_user_returns_404(self, client: AsyncClient) -> None:
+        await _seed_workspace("ws-alice-u2", "alice")
+        await _seed_connection("conn-alice-u2", workspace_id="ws-alice-u2")
+
+        _override_caller("bob")
+        with _no_aerospike_client():
+            resp = await client.post(
+                "/api/admin/conn-alice-u2/users",
+                json={"username": "evil", "password": "evil-pw", "roles": ["read"]},
+            )
+
+        assert resp.status_code == 404, resp.text
+
+    async def test_cross_owner_change_password_returns_404(self, client: AsyncClient) -> None:
+        await _seed_workspace("ws-alice-u3", "alice")
+        await _seed_connection("conn-alice-u3", workspace_id="ws-alice-u3")
+
+        _override_caller("bob")
+        with _no_aerospike_client():
+            resp = await client.patch(
+                "/api/admin/conn-alice-u3/users",
+                json={"username": "alice", "password": "stolen"},
+            )
+
+        assert resp.status_code == 404, resp.text
+
+    async def test_cross_owner_delete_user_returns_404(self, client: AsyncClient) -> None:
+        await _seed_workspace("ws-alice-u4", "alice")
+        await _seed_connection("conn-alice-u4", workspace_id="ws-alice-u4")
+
+        _override_caller("bob")
+        with _no_aerospike_client():
+            resp = await client.delete("/api/admin/conn-alice-u4/users?username=alice")
+
+        assert resp.status_code == 404, resp.text
+
+    async def test_owner_can_list_own_users(self, client: AsyncClient) -> None:
+        """Sanity: the gate must not break access for the rightful owner."""
+        await _seed_workspace("ws-alice-u5", "alice")
+        await _seed_connection("conn-alice-u5", workspace_id="ws-alice-u5")
+
+        mock_client = AsyncMock()
+        mock_client.admin_query_users_info = AsyncMock(return_value=[])
+
+        _override_caller("alice")
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            AsyncMock(return_value=mock_client),
+        ):
+            resp = await client.get("/api/admin/conn-alice-u5/users")
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == []
+
+
+class TestAdminRolesWorkspaceAcl:
+    """Bob must not be able to list / create / delete roles on Alice's
+    connection."""
+
+    async def test_cross_owner_list_roles_returns_404(self, client: AsyncClient) -> None:
+        await _seed_workspace("ws-alice-r1", "alice")
+        await _seed_connection("conn-alice-r1", workspace_id="ws-alice-r1")
+
+        _override_caller("bob")
+        with _no_aerospike_client():
+            resp = await client.get("/api/admin/conn-alice-r1/roles")
+
+        assert resp.status_code == 404, resp.text
+
+    async def test_cross_owner_create_role_returns_404(self, client: AsyncClient) -> None:
+        await _seed_workspace("ws-alice-r2", "alice")
+        await _seed_connection("conn-alice-r2", workspace_id="ws-alice-r2")
+
+        _override_caller("bob")
+        with _no_aerospike_client():
+            resp = await client.post(
+                "/api/admin/conn-alice-r2/roles",
+                json={
+                    "name": "evil_role",
+                    "privileges": [{"code": "read-write", "namespace": "test", "set": ""}],
+                },
+            )
+
+        assert resp.status_code == 404, resp.text
+
+    async def test_cross_owner_delete_role_returns_404(self, client: AsyncClient) -> None:
+        await _seed_workspace("ws-alice-r3", "alice")
+        await _seed_connection("conn-alice-r3", workspace_id="ws-alice-r3")
+
+        _override_caller("bob")
+        with _no_aerospike_client():
+            resp = await client.delete("/api/admin/conn-alice-r3/roles?name=admin")
+
+        assert resp.status_code == 404, resp.text
+
+    async def test_owner_can_list_own_roles(self, client: AsyncClient) -> None:
+        """Sanity: the gate must not break access for the rightful owner."""
+        await _seed_workspace("ws-alice-r4", "alice")
+        await _seed_connection("conn-alice-r4", workspace_id="ws-alice-r4")
+
+        mock_client = AsyncMock()
+        mock_client.admin_query_roles = AsyncMock(return_value=[])
+
+        _override_caller("alice")
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            AsyncMock(return_value=mock_client),
+        ):
+            resp = await client.get("/api/admin/conn-alice-r4/roles")
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json() == []

--- a/api/tests/test_records_router.py
+++ b/api/tests/test_records_router.py
@@ -533,11 +533,12 @@ class TestFilteredRecordsPkMatchMode:
         assert "value2" in resp.json()["detail"]
         mock_client.query.assert_not_called()
 
-    async def test_predicate_between_missing_value2_returns_400(self, client: AsyncClient):
-        """A ``predicate`` BETWEEN without value2 must map to 400 on the
-        filter endpoint. Before the fix this escaped as an opaque 500
-        because get_filtered_records did not catch the predicate
-        ValueError that build_predicate raises."""
+    async def test_predicate_between_missing_value2_returns_422(self, client: AsyncClient):
+        """A ``predicate`` BETWEEN without value2 must map to 422 on the
+        filter endpoint, aligning with the ``query.py`` mapping (PR #408).
+        ``PredicateError`` is a client-side schema-level error; routing it
+        through the generic ``ValueError`` → 400 branch would silently
+        degrade the more accurate 422 mapping."""
         mock_client = _build_query_mock()
 
         with (
@@ -559,8 +560,10 @@ class TestFilteredRecordsPkMatchMode:
                 },
             )
 
-        assert resp.status_code == 400
-        assert "between" in resp.json()["detail"]
+        assert resp.status_code == 422, resp.text
+        body = resp.json()
+        assert "predicate" in body["detail"].lower()
+        assert "between" in body["detail"]
         # The predicate is rejected before the scan executes.
         mock_client.query.return_value.results.assert_not_called()
 


### PR DESCRIPTION
## Summary

**P0 security fix** — the admin user / role endpoints accepted `conn_id` in the path but never resolved it through `VerifiedConnId`, so a caller who knew (or guessed) a foreign connection id could read or mutate users / roles on a cluster owned by a different workspace. Cross-tenant privilege escalation.

- `admin_users.py` (GET / POST / PATCH / DELETE `/admin/{conn_id}/users`) and `admin_roles.py` (GET / POST / DELETE `/admin/{conn_id}/roles`) now bind `conn_id: VerifiedConnId` and consume it with `_ = conn_id`, matching the established pattern in `records.py` (e.g. PUT/DELETE `/records/{conn_id}`).
- The workspace ACL gate (`_get_verified_connection`) now runs before the admin call ever reaches the Aerospike cluster — same 404-on-mismatch wire shape used by every other ACL-gated router, so id enumeration stays impossible.

### Bonus (P1) — PredicateError alignment

`records.py:365` was mapping `PredicateError` to **400**, but `query.py:33` (added in #408) maps it to **422**. Aligned `records.py` to 422 with the same `Invalid predicate: ...` detail prefix. Branch ordering is preserved (PredicateError catch is already before any generic ValueError catch — `PredicateError` is a `ValueError` subclass).

## Attack vector this closes

```
# Bob owns workspace ws-bob. Alice owns workspace ws-alice containing conn-alice.
# Before the fix:
curl -X POST /api/admin/conn-alice/users \
    -H "Authorization: Bearer <bob's token>" \
    -d '{"username":"evil","password":"...","roles":["user-admin"]}'
# -> 201 (Bob just created a user on Alice's cluster)

# After the fix:
# -> 404 (identity-404, same wire shape as a missing conn_id)
```

## Files touched

| File | Change |
|------|--------|
| `api/src/aerospike_cluster_manager_api/routers/admin_users.py` | `conn_id: VerifiedConnId` on all 4 endpoints |
| `api/src/aerospike_cluster_manager_api/routers/admin_roles.py` | `conn_id: VerifiedConnId` on all 3 endpoints |
| `api/src/aerospike_cluster_manager_api/routers/records.py` | `PredicateError` -> 422 (was 400) |
| `api/tests/test_records_router.py` | rename + update predicate test to 422 |
| `api/tests/test_admin_acl.py` | **new** — 9 tests covering cross-owner 404 + owner-can-access sanity for both routers |

## Test plan

- [x] `cd api && uv run pytest tests/ -x -q` — all 949 tests pass
- [x] `cd api && uv run ruff check src tests` — clean
- [x] `cd api && uv run ruff format --check src tests` — 129 files already formatted
- [x] New `test_admin_acl.py` (9 tests) verifies:
  - Bob gets 404 on every admin user / role endpoint when targeting Alice's connection
  - Alice can still list her own users / roles (gate doesn't false-positive)
- [x] Updated `test_predicate_between_missing_value2_returns_422` confirms the new 422 mapping with the `Invalid predicate: ...` detail prefix