### PR TITLE
fix(ui): stabilize useOnWindowResize listener and guard useCluster refetch

### DIFF
--- a/ui/src/hooks/use-cluster.ts
+++ b/ui/src/hooks/use-cluster.ts
@@ -5,7 +5,7 @@
 
 "use client"
 
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 import { getCluster } from "@/lib/api/clusters"
 import { logFetchError } from "@/lib/api/log"
@@ -25,18 +25,30 @@ export function useCluster(
   const [error, setError] = useState<Error | null>(null)
   const [isLoading, setIsLoading] = useState<boolean>(!!connId)
 
+  // Mounted guard so a refetch resolving after unmount doesn't setState.
+  // Mirrors useGuides / useConnections.
+  const isMountedRef = useRef(true)
+  useEffect(() => {
+    isMountedRef.current = true
+    return () => {
+      isMountedRef.current = false
+    }
+  }, [])
+
   const refetch = useCallback(async () => {
     if (!connId) return
     setIsLoading(true)
     setError(null)
     try {
       const result = await getCluster(connId)
+      if (!isMountedRef.current) return
       setData(result)
     } catch (err) {
       logFetchError("cluster", err)
+      if (!isMountedRef.current) return
       setError(err instanceof Error ? err : new Error(String(err)))
     } finally {
-      setIsLoading(false)
+      if (isMountedRef.current) setIsLoading(false)
     }
   }, [connId])
 

--- a/ui/src/lib/useOnWindowResize.tsx
+++ b/ui/src/lib/useOnWindowResize.tsx
@@ -3,13 +3,22 @@
 import * as React from "react"
 
 export const useOnWindowResize = (handler: { (): void }) => {
+  // Stash the latest handler in a ref so callers passing an inline function
+  // don't cause the effect to re-bind the resize listener every render. The
+  // listener stays installed for the component lifetime and always invokes
+  // the freshest handler.
+  const handlerRef = React.useRef(handler)
+  React.useEffect(() => {
+    handlerRef.current = handler
+  }, [handler])
+
   React.useEffect(() => {
     const handleResize = () => {
-      handler()
+      handlerRef.current()
     }
     handleResize()
     window.addEventListener("resize", handleResize)
 
     return () => window.removeEventListener("resize", handleResize)
-  }, [handler])
+  }, [])
 }


### PR DESCRIPTION
## Summary

Two React lifecycle hardening fixes in `ui/`. The other three findings on the original list were verified against current code and dropped — they are already implemented.

### Shipped

- **`ui/src/lib/useOnWindowResize.tsx`** — stash the handler in a ref and depend on `[]` for the listener-binding effect. Previously the resize listener was removed and re-added on every render when callers passed an inline function (which is the common case at the call sites).
- **`ui/src/hooks/use-cluster.ts`** — `refetch()` now respects an `isMountedRef` guard before every `setState`, matching the pattern already used in `useGuides` and `useConnections`. Prevents a setState-after-unmount when a user-triggered refetch resolves after navigation.

### Dropped after verification

- **`middleware/oidc_auth.py` `aclose()`** — already idempotent (clears `_http_client` after closing so a second call is a no-op) AND already skips injected clients via `_owns_http_client`. Existing tests `test_aclose_closes_self_constructed_client`, `test_aclose_leaves_injected_client_untouched`, and `test_aclose_noop_when_client_never_built` confirm.
- **`models/record.py` `RecordWriteRequest.bins`** — bin-name validation is already in place: `BinName = Annotated[str, Field(min_length=1, max_length=15)]` plus a `field_validator` that rejects control chars and leading/trailing whitespace. Server limit is 15, not 255.
- **`components/AuthProvider.tsx`** — every `await` that is followed by a `setState` is already guarded by the `cancelled` flag. The only unguarded await is `kc.login()`, which is followed by an unconditional `return` with no state mutation, so there's no leak.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run type-check` clean
- [ ] CI to confirm no regressions in existing vitest / pytest suites