### PR TITLE
fix(api): add VerifiedConnId to delete_record, guard ping() AttributeError, add ping() to test_connection

### DIFF
--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -189,7 +189,7 @@ async def get_connection_health(conn_id: str = Depends(_get_verified_connection)
             memoryTotal=memory_total,
             diskUsed=disk_used,
             diskTotal=disk_total,
-            tendHealthy=await client.ping(),  # type: ignore[attr-defined]  # ping() added in aerospike-py 0.0.5
+            tendHealthy=await client.ping() if hasattr(client, "ping") else None,  # type: ignore[attr-defined]  # ping() added in aerospike-py 0.0.5
         )
     except AerospikeTimeoutError as exc:
         logger.warning("Health check timed out for connection '%s'", conn_id, exc_info=True)

--- a/api/src/aerospike_cluster_manager_api/routers/records.py
+++ b/api/src/aerospike_cluster_manager_api/routers/records.py
@@ -252,6 +252,7 @@ async def put_record(
 async def delete_record(
     request: Request,
     client: AerospikeClient,
+    conn_id: VerifiedConnId,
     ns: str = Query(..., min_length=1),
     set: str = Query(..., min_length=1),
     pk: str = Query(..., min_length=1),
@@ -269,6 +270,11 @@ async def delete_record(
     via the global handler and break common UI / CLI retry patterns where the
     same DELETE is replayed after a network blip.
     """
+    # ``conn_id`` is unused inside the body — its only job is to trigger
+    # the workspace ACL via :data:`VerifiedConnId` before the destructive
+    # call reaches the service layer. Keep the parameter present so the
+    # dependency runs.
+    _ = conn_id
     try:
         await records_service.delete_record(client, ns, set, pk, pk_type)
     except RecordNotFound:

--- a/api/src/aerospike_cluster_manager_api/services/connections_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/connections_service.py
@@ -379,6 +379,15 @@ async def test_connection(req: TestConnectionRequest) -> TestConnectionResult:
             await client.connect()
             if not client.is_connected():
                 return TestConnectionResult(success=False, message="Failed to connect")
+            # Liveness probe: ``is_connected()`` only reflects the local
+            # client state. ``ping()`` round-trips an info request to a
+            # random node so a half-open / stale cluster handle surfaces
+            # as a real failure here rather than as a misleading success.
+            # ``hasattr`` guard keeps older aerospike-py (pre-0.0.5)
+            # builds working — those clients fall back to the
+            # ``is_connected()``-only check.
+            if hasattr(client, "ping"):
+                await client.ping()
             return TestConnectionResult(success=True, message="Connected successfully")
         finally:
             with contextlib.suppress(AerospikeError, OSError):


### PR DESCRIPTION
## Summary

- **routers/records.py** — Thread `VerifiedConnId` through `delete_record` so the workspace ACL fires explicitly at the handler boundary (matching `put_record` / `delete_record_bin`). Defense-in-depth in case `_get_client` wiring changes later.
- **routers/connections.py** — Wrap `tendHealthy=await client.ping()` with a `hasattr(client, "ping")` guard so older aerospike-py builds (pre-0.0.5) don't blow up the health endpoint with an unhandled `AttributeError`.
- **services/connections_service.py** — After `client.is_connected()` in `test_connection`, also call `await client.ping()` (hasattr-guarded). `is_connected()` only reflects local client state; `ping()` round-trips an info request so a half-open / stale cluster handle surfaces as a real failure instead of a misleading success. Stays inside the existing try/finally so `client.close()` still runs.

## Test plan

- [x] `uv run ruff check src` — passes
- [x] `uv run ruff format --check src` — passes
- [x] `uv run pytest tests -k "test_connection or delete_record or get_connection_health" -x` — 64 passed
- [x] `uv run pytest tests -k "records" -x` — 109 passed
- [ ] Manual: hit `DELETE /records/{conn_id}` from a workspace the caller does not own → 404 (not 204)
- [ ] Manual: pin aerospike-py to a pre-0.0.5 build and hit `GET /connections/{id}/health` → still returns `connected: true` (no 500)
- [ ] Manual: `POST /connections/test` against a host where TCP handshake works but the cluster is unreachable → `success: false` instead of a misleading `success: true`