### PR TITLE
fix(api,k8s): guard reset_circuit_breaker and template patches with expected_workspace_id

### DIFF
--- a/api/src/aerospike_cluster_manager_api/k8s_client.py
+++ b/api/src/aerospike_cluster_manager_api/k8s_client.py
@@ -477,11 +477,52 @@ class K8sClient:
         logger.debug("_delete_cluster_sync(namespace=%s, name=%s)", namespace, name)
         return self._delete_custom_object_sync(PLURAL, namespace, name)
 
-    def _patch_cluster_status_sync(self, namespace: str, name: str, status_patch: dict[str, Any]) -> dict[str, Any]:
-        """Patch the status subresource of an AerospikeCluster CR."""
-        logger.debug("_patch_cluster_status_sync(namespace=%s, name=%s)", namespace, name)
+    def _patch_cluster_status_sync(
+        self,
+        namespace: str,
+        name: str,
+        status_patch: dict[str, Any],
+        *,
+        expected_workspace_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Patch the status subresource of an AerospikeCluster CR.
+
+        ``expected_workspace_id`` mirrors the P1-4 guard on
+        :meth:`_patch_cluster_sync`: when supplied, the CR is refetched
+        and its ``acm.aerospike.com/workspace`` label is re-verified
+        immediately before the status apply. A concurrent re-label that
+        slips between the caller's ACL check and the status patch aborts
+        with 409 ``Conflict`` instead of mutating a CR the caller no
+        longer owns.
+        """
+        logger.debug(
+            "_patch_cluster_status_sync(namespace=%s, name=%s, expected_workspace_id=%s)",
+            namespace,
+            name,
+            expected_workspace_id,
+        )
         self._ensure_initialized()
         try:
+            if expected_workspace_id is not None:
+                # Re-read the CR and re-verify the workspace label is
+                # still what the caller authorised. The status
+                # subresource patch path does not flow through
+                # ``_patch_with_resource_version``, so the verify hook
+                # has to be inlined here. A label mismatch raises 409
+                # exactly like the cluster-spec patch path does.
+                current = self._get_custom_object_sync(PLURAL, namespace, name)
+                workspace_label = "acm.aerospike.com/workspace"
+                labels = (current.get("metadata", {}) or {}).get("labels") or {}
+                actual = labels.get(workspace_label)
+                if actual != expected_workspace_id:
+                    raise K8sApiError(
+                        status=409,
+                        reason="Conflict",
+                        message=(
+                            f"Workspace label on cluster {namespace}/{name} changed "
+                            "between ACL check and status patch; refusing to apply."
+                        ),
+                    )
             body = {"status": status_patch}
             return cast(
                 dict[str, Any],
@@ -495,6 +536,11 @@ class K8sClient:
                     _request_timeout=_K8S_API_TIMEOUT,
                 ),
             )
+        except K8sApiError:
+            # Re-verify mismatch (and any K8sApiError raised by the
+            # nested fetch) propagates unwrapped so the router maps it
+            # to a stable Conflict / status code.
+            raise
         except Exception as e:
             raise self._wrap_api_exception(e) from e
 
@@ -587,13 +633,50 @@ class K8sClient:
         logger.debug("_create_template_sync()")
         return self._create_cluster_custom_object_sync(TEMPLATE_PLURAL, body)
 
-    def _patch_template_sync(self, name: str, body: dict[str, Any]) -> dict[str, Any]:
-        logger.debug("_patch_template_sync(name=%s)", name)
+    def _patch_template_sync(
+        self,
+        name: str,
+        body: dict[str, Any],
+        *,
+        expected_workspace_id: str | None = None,
+    ) -> dict[str, Any]:
+        logger.debug(
+            "_patch_template_sync(name=%s, expected_workspace_id=%s)",
+            name,
+            expected_workspace_id,
+        )
+
+        verify = None
+        if expected_workspace_id is not None:
+            workspace_label = "acm.aerospike.com/workspace"
+
+            def _assert_label_unchanged(current: dict[str, Any]) -> None:
+                # Mirrors the verify callback used by ``_patch_cluster_sync``:
+                # re-read the template's workspace label before each retry's
+                # apply, and abort with 409 Conflict if a concurrent
+                # re-labelling slipped between the router's ACL gate and
+                # this patch. Closes the TOCTOU window for template spec
+                # mutations.
+                labels = (current.get("metadata", {}) or {}).get("labels") or {}
+                actual = labels.get(workspace_label)
+                if actual != expected_workspace_id:
+                    raise K8sApiError(
+                        status=409,
+                        reason="Conflict",
+                        message=(
+                            f"Workspace label on template {name} changed "
+                            "between ACL check and patch; refusing to apply."
+                        ),
+                    )
+
+            verify = _assert_label_unchanged
+
         return self._patch_with_resource_version(
             fetch=lambda: self._get_cluster_custom_object_sync(TEMPLATE_PLURAL, name),
             apply=lambda payload: self._patch_cluster_custom_object_sync(TEMPLATE_PLURAL, name, payload),
             body=body,
             label=f"template {name}",
+            verify=verify,
         )
 
     def _delete_template_sync(self, name: str) -> dict[str, Any]:
@@ -819,8 +902,29 @@ class K8sClient:
     async def delete_cluster(self, namespace: str, name: str) -> dict[str, Any]:
         return await asyncio.to_thread(self._delete_cluster_sync, namespace, name)
 
-    async def patch_cluster_status(self, namespace: str, name: str, status_patch: dict[str, Any]) -> dict[str, Any]:
-        return await asyncio.to_thread(self._patch_cluster_status_sync, namespace, name, status_patch)
+    async def patch_cluster_status(
+        self,
+        namespace: str,
+        name: str,
+        status_patch: dict[str, Any],
+        *,
+        expected_workspace_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Patch an AerospikeCluster status subresource.
+
+        ``expected_workspace_id`` (P1-4) closes the TOCTOU window
+        between the caller's ACL check and the status apply: a
+        concurrent re-labelling of the CR aborts with 409
+        ``Conflict`` instead of leaking the mutation across tenants.
+        Mirrors the guard on :meth:`patch_cluster`.
+        """
+        return await asyncio.to_thread(
+            self._patch_cluster_status_sync,
+            namespace,
+            name,
+            status_patch,
+            expected_workspace_id=expected_workspace_id,
+        )
 
     async def list_namespaces(self) -> list[str]:
         return await asyncio.to_thread(self._list_namespaces_sync)
@@ -843,8 +947,19 @@ class K8sClient:
     async def create_template(self, body: dict[str, Any]) -> dict[str, Any]:
         return await asyncio.to_thread(self._create_template_sync, body)
 
-    async def patch_template(self, name: str, body: dict[str, Any]) -> dict[str, Any]:
-        return await asyncio.to_thread(self._patch_template_sync, name, body)
+    async def patch_template(
+        self,
+        name: str,
+        body: dict[str, Any],
+        *,
+        expected_workspace_id: str | None = None,
+    ) -> dict[str, Any]:
+        return await asyncio.to_thread(
+            self._patch_template_sync,
+            name,
+            body,
+            expected_workspace_id=expected_workspace_id,
+        )
 
     async def delete_template(self, name: str) -> dict[str, Any]:
         return await asyncio.to_thread(self._delete_template_sync, name)

--- a/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
@@ -525,7 +525,11 @@ async def reset_circuit_breaker(
 ) -> dict[str, str]:
     """Reset the circuit breaker by patching status counters and annotating the CR."""
     cr = await _assert_caller_owns_k8s_cluster(namespace, name, caller_owner_id)
-    # 1. Reset status subresource (clear error state)
+    # 1. Reset status subresource (clear error state).
+    # ``expected_workspace_id`` closes the TOCTOU window between the
+    # ACL check above and the status apply: a concurrent re-label
+    # aborts with 409 instead of mutating a CR the caller no longer
+    # owns. Mirrors the guard already on patch_cluster below.
     await k8s_client.patch_cluster_status(
         namespace,
         name,
@@ -533,6 +537,7 @@ async def reset_circuit_breaker(
             "failedReconcileCount": 0,
             "lastReconcileError": "",
         },
+        expected_workspace_id=_cr_workspace_id(cr),
     )
     # 2. Annotate to trigger fresh reconciliation
     patch: dict[str, Any] = {
@@ -1073,11 +1078,16 @@ async def update_k8s_template(
     name: str = _K8S_NAME,
 ) -> K8sTemplateSummary:
 
-    await _assert_template_visible(name, caller_owner_id, for_mutation=True)
+    item = await _assert_template_visible(name, caller_owner_id, for_mutation=True)
     patch = build_template_update_patch(body)
     if not patch.get("spec"):
         raise HTTPException(status_code=400, detail="No fields to update")
-    result = await k8s_client.patch_template(name, patch)
+    # ``expected_workspace_id`` closes the TOCTOU window between
+    # ``_assert_template_visible`` and the patch apply: a concurrent
+    # re-labelling of the template aborts with 409 Conflict instead
+    # of mutating a template the caller no longer owns. Mirrors the
+    # guard on patch_cluster for AerospikeCluster CRs.
+    result = await k8s_client.patch_template(name, patch, expected_workspace_id=_cr_workspace_id(item))
     return extract_template_summary(result)
 
 

--- a/api/tests/test_k8s_workspace_toctou_guard.py
+++ b/api/tests/test_k8s_workspace_toctou_guard.py
@@ -1,0 +1,140 @@
+"""Tests that the two TOCTOU-vulnerable K8s mutation paths now thread
+``expected_workspace_id`` through to ``k8s_client``.
+
+The two paths are:
+
+* ``POST /k8s/clusters/{ns}/{name}/circuit-breaker/reset`` —
+  ``reset_circuit_breaker`` patches the status subresource via
+  ``k8s_client.patch_cluster_status``.
+* ``PATCH /k8s/templates/{name}`` — ``update_k8s_template`` patches the
+  template spec via ``k8s_client.patch_template``.
+
+Without the guard, a concurrent re-labelling between the router's ACL
+check and the apply lets a caller mutate a CR they no longer own. The
+guard mirrors the pre-existing ``_patch_cluster_sync`` verify pattern.
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+
+@asynccontextmanager
+async def _noop_lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    yield
+
+
+SAMPLE_CR: dict = {
+    "apiVersion": "acko.io/v1alpha1",
+    "kind": "AerospikeCluster",
+    "metadata": {
+        "name": "demo",
+        "namespace": "aerospike",
+        "labels": {"acm.aerospike.com/workspace": "ws-abc"},
+    },
+    "spec": {"size": 2, "image": "aerospike/aerospike-server:7.0.0.0"},
+    "status": {"phase": "Running", "size": 2},
+}
+
+
+SAMPLE_TEMPLATE: dict = {
+    "apiVersion": "acko.io/v1alpha1",
+    "kind": "AerospikeClusterTemplate",
+    "metadata": {
+        "name": "ce-template",
+        "labels": {"acm.aerospike.com/workspace": "ws-xyz"},
+    },
+    "spec": {"image": "aerospike/aerospike-server:7.0.0.0"},
+}
+
+
+@pytest.fixture()
+async def client():
+    """httpx AsyncClient wired to the FastAPI app with K8S_MANAGEMENT_ENABLED=True."""
+    with patch("aerospike_cluster_manager_api.config.K8S_MANAGEMENT_ENABLED", True):
+        import aerospike_cluster_manager_api.main as main_mod
+        import aerospike_cluster_manager_api.routers.k8s_clusters as k8s_mod
+
+        importlib.reload(k8s_mod)
+        importlib.reload(main_mod)
+        test_app = main_mod.app
+
+        original_lifespan = test_app.router.lifespan_context
+        test_app.router.lifespan_context = _noop_lifespan
+        test_app.state.limiter.enabled = False
+
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+
+        test_app.state.limiter.enabled = True
+        test_app.router.lifespan_context = original_lifespan
+
+
+class TestResetCircuitBreakerForwardsExpectedWorkspaceId:
+    async def test_status_patch_threads_workspace_id(self, client: AsyncClient):
+        """``patch_cluster_status`` must receive ``expected_workspace_id``
+        matching the CR loaded by the ACL gate so a concurrent re-label
+        is rejected at apply time, not silently honoured.
+        """
+        mock_assert = AsyncMock(return_value=SAMPLE_CR)
+        mock_patch_status = AsyncMock(return_value=SAMPLE_CR)
+        mock_patch_cluster = AsyncMock(return_value=SAMPLE_CR)
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.routers.k8s_clusters._assert_caller_owns_k8s_cluster",
+                mock_assert,
+            ),
+            patch(
+                "aerospike_cluster_manager_api.routers.k8s_clusters.k8s_client.patch_cluster_status",
+                mock_patch_status,
+            ),
+            patch(
+                "aerospike_cluster_manager_api.routers.k8s_clusters.k8s_client.patch_cluster",
+                mock_patch_cluster,
+            ),
+        ):
+            response = await client.post("/api/k8s/clusters/aerospike/demo/reset-circuit-breaker")
+
+        assert response.status_code == 200
+        mock_patch_status.assert_awaited_once()
+        _, kwargs = mock_patch_status.call_args
+        assert kwargs.get("expected_workspace_id") == "ws-abc"
+
+
+class TestUpdateK8sTemplateForwardsExpectedWorkspaceId:
+    async def test_template_patch_threads_workspace_id(self, client: AsyncClient):
+        """``patch_template`` must receive ``expected_workspace_id``
+        matching the template loaded by ``_assert_template_visible`` so a
+        concurrent re-label is rejected at apply time.
+        """
+        mock_assert = AsyncMock(return_value=SAMPLE_TEMPLATE)
+        mock_patch = AsyncMock(return_value=SAMPLE_TEMPLATE)
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.routers.k8s_clusters._assert_template_visible",
+                mock_assert,
+            ),
+            patch(
+                "aerospike_cluster_manager_api.routers.k8s_clusters.k8s_client.patch_template",
+                mock_patch,
+            ),
+        ):
+            response = await client.patch(
+                "/api/k8s/templates/ce-template",
+                json={"image": "aerospike/aerospike-server:7.0.0.1"},
+            )
+
+        assert response.status_code == 200
+        mock_patch.assert_awaited_once()
+        _, kwargs = mock_patch.call_args
+        assert kwargs.get("expected_workspace_id") == "ws-xyz"


### PR DESCRIPTION
## Summary

Two K8s mutation paths skipped the `expected_workspace_id` re-verify pattern already established by `_patch_cluster_sync` (see `k8s_client.py` around line 444). Each one reads the CR up-front via an ACL helper, then patches without re-checking the workspace label — so a concurrent re-label between the read and the apply lets a caller mutate a CR they no longer own.

### Hole 1 — `reset_circuit_breaker` status patch
- Router: `routers/k8s_clusters.py:520`. `_assert_caller_owns_k8s_cluster` reads the CR, then `k8s_client.patch_cluster_status` applies a status patch with **no** workspace re-verify. The subsequent `patch_cluster` call IS gated, so the status subresource was the only TOCTOU hole on this route.

### Hole 2 — `update_k8s_template` spec patch
- Router: `routers/k8s_clusters.py:1069`. `_assert_template_visible` returns the template CR; `k8s_client.patch_template` then applies the spec patch with **no** workspace re-verify. Templates are cluster-scoped, so the same re-label race applies.

## What changed

`k8s_client.py`:
- `_patch_cluster_status_sync` + `patch_cluster_status` now accept `expected_workspace_id: str | None = None`. When supplied, the function re-fetches the CR and compares its `acm.aerospike.com/workspace` label immediately before applying; a mismatch raises `K8sApiError(409, "Conflict", ...)`. (Status subresource patches don't flow through `_patch_with_resource_version`, so the verify hook is inlined here.)
- `_patch_template_sync` + `patch_template` accept the same kwarg and feed it into the existing `_patch_with_resource_version` verify-callback path that `patch_cluster` already uses.

Routers thread the value from the CRs they already have:
- `reset_circuit_breaker`: `expected_workspace_id=_cr_workspace_id(cr)`
- `update_k8s_template`: `expected_workspace_id=_cr_workspace_id(item)` (the helper now returns the template CR; the variable was previously unused).

The mismatched-label `K8sApiError(409)` is mapped to a 409 response by the global handler.

## Test plan

`tests/test_k8s_workspace_toctou_guard.py` (new) adds two endpoint tests that mock the ACL helpers to return labelled CRs and assert the downstream apply calls receive the matching `expected_workspace_id` kwarg.

- [x] `uv run ruff check src tests/test_k8s_workspace_toctou_guard.py` — clean
- [x] `uv run ruff format --check src tests/test_k8s_workspace_toctou_guard.py` — clean
- [x] `uv run pytest tests -k k8s` — 41 passed, no regressions
- [ ] Manual: verify a re-label between ACL check and apply returns 409 (mock-based — production-side requires a contender)

## Scope

- No new endpoint.
- No Pydantic / public type rename.
- No `_patch_cluster_sync` refactor; the new paths intentionally mirror its established pattern.
- UI untouched.