### PR TITLE
fix(api): add response_model to remaining POST 201 endpoints (follow-up #408)

### DIFF
--- a/api/src/aerospike_cluster_manager_api/routers/admin_roles.py
+++ b/api/src/aerospike_cluster_manager_api/routers/admin_roles.py
@@ -79,6 +79,7 @@ async def get_roles(client: AerospikeClient, conn_id: VerifiedConnId) -> list[Ae
 @router.post(
     "/{conn_id}/roles",
     status_code=201,
+    response_model=AerospikeRole,
     summary="Create role",
     description="Create a new Aerospike role with specified privileges. Requires security to be enabled in aerospike.conf.",
 )

--- a/api/src/aerospike_cluster_manager_api/routers/admin_users.py
+++ b/api/src/aerospike_cluster_manager_api/routers/admin_users.py
@@ -48,6 +48,7 @@ async def get_users(client: AerospikeClient, conn_id: VerifiedConnId) -> list[Ae
 @router.post(
     "/{conn_id}/users",
     status_code=201,
+    response_model=AerospikeUser,
     summary="Create user",
     description="Create a new Aerospike user with specified roles. Requires security to be enabled in aerospike.conf.",
 )

--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -47,7 +47,13 @@ async def list_connections(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-@router.post("", status_code=201, summary="Create connection", description="Create a new Aerospike connection profile.")
+@router.post(
+    "",
+    status_code=201,
+    response_model=ConnectionProfileResponse,
+    summary="Create connection",
+    description="Create a new Aerospike connection profile.",
+)
 @limiter.limit("10/minute")
 async def create_connection(
     request: Request,

--- a/api/src/aerospike_cluster_manager_api/routers/indexes.py
+++ b/api/src/aerospike_cluster_manager_api/routers/indexes.py
@@ -67,6 +67,7 @@ async def get_indexes(client: AerospikeClient) -> list[SecondaryIndex]:
 @router.post(
     "/{conn_id}",
     status_code=201,
+    response_model=SecondaryIndex,
     summary="Create secondary index",
     description="Create a new secondary index on a specified namespace, set, and bin.",
 )

--- a/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
@@ -551,7 +551,12 @@ async def reset_circuit_breaker(
     return {"message": "Circuit breaker reset triggered", "namespace": namespace, "name": name}
 
 
-@router.post("/clusters/import", status_code=201, summary="Import K8s Aerospike cluster from CR")
+@router.post(
+    "/clusters/import",
+    status_code=201,
+    response_model=K8sClusterSummary,
+    summary="Import K8s Aerospike cluster from CR",
+)
 @limiter.limit("20/minute")
 @_k8s_endpoint("import Kubernetes cluster")
 async def import_k8s_cluster(
@@ -614,7 +619,7 @@ async def import_k8s_cluster(
     return extract_summary(result)
 
 
-@router.post("/clusters", status_code=201, summary="Create K8s Aerospike cluster")
+@router.post("/clusters", status_code=201, response_model=K8sClusterSummary, summary="Create K8s Aerospike cluster")
 @limiter.limit("20/minute")
 @_k8s_endpoint("create Kubernetes cluster")
 async def create_k8s_cluster(
@@ -1034,7 +1039,9 @@ async def get_k8s_template(
     )
 
 
-@router.post("/templates", status_code=201, summary="Create K8s AerospikeClusterTemplate")
+@router.post(
+    "/templates", status_code=201, response_model=K8sTemplateSummary, summary="Create K8s AerospikeClusterTemplate"
+)
 @limiter.limit("20/minute")
 @_k8s_endpoint("create Kubernetes template")
 async def create_k8s_template(
@@ -1191,6 +1198,7 @@ class CloneClusterRequest(BaseModel):
 @router.post(
     "/clusters/{namespace}/{name}/clone",
     status_code=201,
+    response_model=K8sClusterSummary,
     summary="Clone an existing K8s Aerospike cluster",
 )
 @limiter.limit("20/minute")

--- a/api/src/aerospike_cluster_manager_api/routers/sample_data.py
+++ b/api/src/aerospike_cluster_manager_api/routers/sample_data.py
@@ -13,6 +13,7 @@ router = APIRouter(prefix="/sample-data", tags=["sample-data"])
 @router.post(
     "/{conn_id}",
     status_code=201,
+    response_model=CreateSampleDataResponse,
     summary="Create sample data set",
     description="Generate deterministic sample records with optional secondary indexes.",
 )

--- a/api/src/aerospike_cluster_manager_api/routers/udfs.py
+++ b/api/src/aerospike_cluster_manager_api/routers/udfs.py
@@ -55,6 +55,7 @@ async def get_udfs(client: AerospikeClient) -> list[UDFModule]:
 @router.post(
     "/{conn_id}",
     status_code=201,
+    response_model=UDFModule,
     summary="Upload UDF module",
     description="Upload and register a Lua UDF module to the Aerospike cluster.",
 )

--- a/api/src/aerospike_cluster_manager_api/routers/workspaces.py
+++ b/api/src/aerospike_cluster_manager_api/routers/workspaces.py
@@ -43,6 +43,7 @@ async def list_workspaces(caller_owner_id: CallerOwnerId) -> list[WorkspaceRespo
 @router.post(
     "",
     status_code=201,
+    response_model=WorkspaceResponse,
     summary="Create workspace",
     description="Create a new workspace. The id and ownerId are populated server-side.",
 )


### PR DESCRIPTION
## Summary

Follow-up to [#408](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/408). PR #408 established that POST handlers returning typed Pydantic models MUST declare `response_model=` — without it:

- FastAPI skips response validation
- OpenAPI schema reports `Any` instead of the typed shape
- Downstream codegen consumers (UI types, ackoctl) fall back to `Any`

PR #408 covered `clusters.py`, `records.py`, and `query.py`. This PR closes the gap for every other `@router.post(..., status_code=201)` handler.

## Endpoints added

| File | Endpoint | response_model |
|---|---|---|
| `routers/indexes.py` | `create_index` | `SecondaryIndex` |
| `routers/admin_users.py` | `create_user` | `AerospikeUser` |
| `routers/admin_roles.py` | `create_role` | `AerospikeRole` |
| `routers/udfs.py` | `upload_udf` | `UDFModule` |
| `routers/connections.py` | `create_connection` | `ConnectionProfileResponse` |
| `routers/workspaces.py` | `create_workspace` | `WorkspaceResponse` |
| `routers/sample_data.py` | `create_sample_data` | `CreateSampleDataResponse` |
| `routers/k8s_clusters.py` | `import_k8s_cluster` | `K8sClusterSummary` |
| `routers/k8s_clusters.py` | `create_k8s_cluster` | `K8sClusterSummary` |
| `routers/k8s_clusters.py` | `create_k8s_template` | `K8sTemplateSummary` |
| `routers/k8s_clusters.py` | `clone_k8s_cluster` | `K8sClusterSummary` |

Total: **11 endpoints across 8 files** — purely decorator additions, no logic change.

## Test plan

- [x] \`uv run ruff check src\` — clean
- [x] \`uv run ruff format --check src\` — 82 files idempotent (CI gate satisfied)
- [x] \`uv run pytest tests/ -q\` — **879 passed**, 2 pre-existing RuntimeWarnings (unrelated)

## Notes

- Each endpoint's existing return-type annotation already matches the added \`response_model\`; this PR makes that contract explicit on the decorator so OpenAPI sees it.
- \`put_record\` in \`records.py\` is intentionally untouched — already covered in #408.