### PR TITLE
fix(api): add missing response_model on typed router endpoints (follow-up #408)

### DIFF
--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -30,7 +30,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/connections", tags=["connections"])
 
 
-@router.get("", summary="List connections", description="Retrieve all saved Aerospike connection profiles.")
+@router.get(
+    "",
+    response_model=list[ConnectionProfileResponse],
+    summary="List connections",
+    description="Retrieve all saved Aerospike connection profiles.",
+)
 async def list_connections(
     caller_owner_id: CallerOwnerId,
     workspace_id: str | None = Query(default=None, description="Filter by workspace id."),
@@ -47,7 +52,13 @@ async def list_connections(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-@router.post("", status_code=201, summary="Create connection", description="Create a new Aerospike connection profile.")
+@router.post(
+    "",
+    status_code=201,
+    response_model=ConnectionProfileResponse,
+    summary="Create connection",
+    description="Create a new Aerospike connection profile.",
+)
 @limiter.limit("10/minute")
 async def create_connection(
     request: Request,
@@ -65,7 +76,12 @@ async def create_connection(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
 
-@router.get("/{conn_id}", summary="Get connection", description="Retrieve a single connection profile by its ID.")
+@router.get(
+    "/{conn_id}",
+    response_model=ConnectionProfileResponse,
+    summary="Get connection",
+    description="Retrieve a single connection profile by its ID.",
+)
 async def get_connection(
     caller_owner_id: CallerOwnerId,
     conn_id: str = Depends(_get_verified_connection),
@@ -88,7 +104,10 @@ async def get_connection(
 
 
 @router.put(
-    "/{conn_id}", summary="Update connection", description="Update an existing connection profile with new settings."
+    "/{conn_id}",
+    response_model=ConnectionProfileResponse,
+    summary="Update connection",
+    description="Update an existing connection profile with new settings.",
 )
 @limiter.limit("10/minute")
 async def update_connection(

--- a/api/src/aerospike_cluster_manager_api/routers/guides.py
+++ b/api/src/aerospike_cluster_manager_api/routers/guides.py
@@ -48,6 +48,7 @@ class GuidesListResponse(BaseModel):
 
 @router.get(
     "/{workspace_id}",
+    response_model=GuidesListResponse,
     summary="List operational guides",
     description=(
         "List the operational guides registered for a workspace. A workspace "
@@ -62,6 +63,7 @@ async def list_guides(workspace_id: VerifiedWorkspaceId) -> GuidesListResponse:
 
 @router.get(
     "/{workspace_id}/{guide_type}",
+    response_model=GuideResponse,
     summary="Get an operational guide",
     description=(
         "Fetch the Markdown body of one operational guide. Returns 404 when "
@@ -83,6 +85,7 @@ async def get_guide(
 
 @router.put(
     "/{workspace_id}/{guide_type}",
+    response_model=GuideResponse,
     summary="Register or update an operational guide",
     description=(
         "Create or replace the Markdown body of an operational guide. The "

--- a/api/src/aerospike_cluster_manager_api/routers/indexes.py
+++ b/api/src/aerospike_cluster_manager_api/routers/indexes.py
@@ -34,6 +34,7 @@ async def _index_exists(client: Any, namespace: str, name: str) -> bool:
 
 @router.get(
     "/{conn_id}",
+    response_model=list[SecondaryIndex],
     summary="List secondary indexes",
     description="Retrieve all secondary indexes across all namespaces in the cluster.",
 )
@@ -67,6 +68,7 @@ async def get_indexes(client: AerospikeClient) -> list[SecondaryIndex]:
 @router.post(
     "/{conn_id}",
     status_code=201,
+    response_model=SecondaryIndex,
     summary="Create secondary index",
     description="Create a new secondary index on a specified namespace, set, and bin.",
 )

--- a/api/src/aerospike_cluster_manager_api/routers/notes.py
+++ b/api/src/aerospike_cluster_manager_api/routers/notes.py
@@ -102,6 +102,7 @@ class SetNotesListResponse(BaseModel):
 
 @router.put(
     "/sets/{conn_id}/{namespace}/{set_name}",
+    response_model=SetNote,
     summary="Upsert set note",
     description="Create or update an operator note attached to a set.",
 )
@@ -143,6 +144,7 @@ async def delete_set_note(
 
 @router.get(
     "/sets/{conn_id}",
+    response_model=SetNotesListResponse,
     summary="List set notes",
     description="List set-level operator notes for a connection, optionally filtered by namespace.",
 )
@@ -165,6 +167,7 @@ class RecordNotesListResponse(BaseModel):
 
 @router.put(
     "/records/{conn_id}/{namespace}/{set_name}/{pk}",
+    response_model=RecordNote,
     summary="Upsert record note",
     description="Create or update an operator note on a single record.",
 )
@@ -215,6 +218,7 @@ async def delete_record_note(
 
 @router.get(
     "/records/{conn_id}",
+    response_model=RecordNotesListResponse,
     summary="List record notes",
     description=(
         "List record-level notes for a (connection, namespace, set). This is the "

--- a/api/src/aerospike_cluster_manager_api/routers/udfs.py
+++ b/api/src/aerospike_cluster_manager_api/routers/udfs.py
@@ -44,6 +44,7 @@ async def _list_udfs(c) -> list[UDFModule]:
 
 @router.get(
     "/{conn_id}",
+    response_model=list[UDFModule],
     summary="List UDF modules",
     description="Retrieve all registered UDF modules from the Aerospike cluster.",
 )
@@ -55,6 +56,7 @@ async def get_udfs(client: AerospikeClient) -> list[UDFModule]:
 @router.post(
     "/{conn_id}",
     status_code=201,
+    response_model=UDFModule,
     summary="Upload UDF module",
     description="Upload and register a Lua UDF module to the Aerospike cluster.",
 )

--- a/api/src/aerospike_cluster_manager_api/routers/workspaces.py
+++ b/api/src/aerospike_cluster_manager_api/routers/workspaces.py
@@ -28,6 +28,7 @@ router = APIRouter(prefix="/workspaces", tags=["workspaces"])
 
 @router.get(
     "",
+    response_model=list[WorkspaceResponse],
     summary="List workspaces",
     description=(
         "Retrieve workspaces visible to the caller. The built-in default sorts first. "
@@ -43,6 +44,7 @@ async def list_workspaces(caller_owner_id: CallerOwnerId) -> list[WorkspaceRespo
 @router.post(
     "",
     status_code=201,
+    response_model=WorkspaceResponse,
     summary="Create workspace",
     description="Create a new workspace. The id and ownerId are populated server-side.",
 )
@@ -57,6 +59,7 @@ async def create_workspace(
 
 @router.get(
     "/{workspace_id}",
+    response_model=WorkspaceResponse,
     summary="Get workspace",
     description="Retrieve a single workspace by id. Returns 404 when the row is invisible to the caller.",
 )
@@ -72,6 +75,7 @@ async def get_workspace(
 
 @router.put(
     "/{workspace_id}",
+    response_model=WorkspaceResponse,
     summary="Update workspace",
     description=(
         "Update a workspace's name, color, or description. The default workspace can be renamed. "


### PR DESCRIPTION
## Summary

[PR #408](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/408) fixed the missing-`response_model` issue on `clusters` / `records` / `query`. The same defect remains on six other routers: every endpoint listed below declares a Pydantic return type as a function annotation but never sets `response_model=`, so:

- FastAPI does not coerce / strip the response — fields the service layer accidentally adds leak through.
- OpenAPI / Swagger / ReDoc omit the response schema entirely.

Same fix, applied across the board:

| Router | Endpoints fixed |
|---|---|
| `connections.py` | `list`, `create`, `get`, `update` (`ConnectionProfileResponse`) |
| `workspaces.py` | `list`, `create`, `get`, `update` (`WorkspaceResponse`) |
| `guides.py` | `list_guides`, `get_guide`, `upsert_guide` (`GuidesListResponse` / `GuideResponse`) |
| `indexes.py` | `get_indexes`, `create_index` (`SecondaryIndex`) |
| `udfs.py` | `get_udfs`, `upload_udf` (`UDFModule`) |
| `notes.py` | `upsert_set_note`, `list_set_notes`, `upsert_record_note`, `list_record_notes` |

Skipped on purpose:

- Endpoints returning `Response(204)` (delete handlers).
- Endpoints returning `ConnectionStatus | Response` unions — already carry `response_model=None`.
- `connections.test_connection` — returns a plain `dict[str, bool | str]`, intentionally untyped.

## Testing

- `uv run ruff check src` — clean.
- `uv run ruff format --check src` — clean.
- `uv run pytest tests/` — 879 passed (2 pre-existing warnings unrelated to this change).

## Why this is safe

No new fields enter responses, no field types change. The added `response_model=...` matches the existing function-annotation return type exactly, so the only observable effect is that FastAPI now respects the type at serialization time and OpenAPI shows the schema.