### PR TITLE
fix(api): report degradation instead of failing on transient ping/db errors

### DIFF
--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -524,8 +524,18 @@ async def health_check(detail: bool = Query(False)) -> dict:
     if not detail:
         return {"status": "ok"}
 
-    # Check DB health
-    db_ok = await db.check_health()
+    # Check DB health. db.check_health() dispatches through _get_backend(),
+    # which raises DBNotInitialized when init_db() has not run (or is still
+    # running). The backends' own check_health() swallow errors and return
+    # False, but that guard sits BEFORE their try-block — so an uninitialized
+    # backend would surface as an unhandled 500 instead of a "degraded"
+    # report. Treat any failure as not-healthy so the endpoint always returns
+    # a structured 200 status the readiness probe can act on.
+    try:
+        db_ok = await db.check_health()
+    except Exception:
+        logger.warning("Health check: database is not ready", exc_info=True)
+        db_ok = False
 
     overall = "ok" if db_ok else "degraded"
     return {

--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -198,6 +198,20 @@ async def get_connection_health(conn_id: str = Depends(_get_verified_connection)
         except Exception:
             logger.debug("Failed to collect namespace stats for connection '%s'", conn_id, exc_info=True)
 
+        # Compute tend health defensively BEFORE the success-path constructor.
+        # namespaces/build/edition were already fetched successfully, so the
+        # cluster is reachable. A transient AerospikeError/OSError from ping()
+        # must NOT bubble into the outer `except (AerospikeError, OSError)` and
+        # flip the response to connected=false for an otherwise-healthy cluster
+        # — degrade tendHealthy to None instead.
+        tend_healthy: bool | None = None
+        if hasattr(client, "ping"):  # ping() added in aerospike-py 0.0.5
+            try:
+                tend_healthy = await client.ping()  # type: ignore[attr-defined]
+            except (AerospikeError, OSError):
+                logger.debug("ping() failed for connection '%s'; reporting tendHealthy=None", conn_id, exc_info=True)
+                tend_healthy = None
+
         return ConnectionStatus(
             connected=True,
             nodeCount=node_count,
@@ -208,7 +222,7 @@ async def get_connection_health(conn_id: str = Depends(_get_verified_connection)
             memoryTotal=memory_total,
             diskUsed=disk_used,
             diskTotal=disk_total,
-            tendHealthy=await client.ping() if hasattr(client, "ping") else None,  # type: ignore[attr-defined]  # ping() added in aerospike-py 0.0.5
+            tendHealthy=tend_healthy,
         )
     except AerospikeTimeoutError as exc:
         logger.warning("Health check timed out for connection '%s'", conn_id, exc_info=True)

--- a/api/tests/test_connections_router.py
+++ b/api/tests/test_connections_router.py
@@ -8,9 +8,10 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from aerospike_py.exception import AerospikeError
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
@@ -385,6 +386,83 @@ class TestTestConnection:
         call_args = mock_cls.call_args[0][0]
         assert call_args["user"] == "admin"
         assert call_args["password"] == "secret"
+
+
+class TestConnectionHealth:
+    """Robustness of GET /api/connections/{id}/health.
+
+    The endpoint always returns HTTP 200 and uses ``connected: false`` to
+    signal an unreachable cluster. A transient ``ping()`` failure must NOT be
+    mistaken for an unreachable cluster once namespaces/build/edition have
+    already been fetched successfully.
+    """
+
+    @staticmethod
+    def _make_reachable_client() -> AsyncMock:
+        """A mock AsyncClient where the cluster is reachable (info calls succeed)."""
+        mock = AsyncMock()
+        # get_node_names() is synchronous in the router.
+        mock.get_node_names = Mock(return_value=["node1", "node2"])
+
+        def info_random_node_side_effect(cmd: str) -> str:
+            if cmd == "namespaces":
+                return "test;bar"
+            if cmd == "build":
+                return "8.1.0.0"
+            if cmd == "edition":
+                return "Community Edition"
+            return ""
+
+        mock.info_random_node.side_effect = info_random_node_side_effect
+        # No namespace-level stats needed for this assertion; return empty.
+        mock.info_all.return_value = []
+        return mock
+
+    async def test_transient_ping_failure_keeps_connected_true(self, client: AsyncClient, sample_connection):
+        """namespaces/build/edition succeed but ping() raises -> connected=True, tendHealthy=None.
+
+        Regression: ping() was evaluated inside the success-path constructor,
+        so a transient AerospikeError leaked into the outer handler and the
+        endpoint wrongly reported the reachable cluster as disconnected.
+        """
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+
+        mock_as_client = self._make_reachable_client()
+        mock_as_client.ping = AsyncMock(side_effect=AerospikeError("transient tend failure"))
+
+        with patch(
+            "aerospike_cluster_manager_api.routers.connections.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.get(f"/api/connections/{sample_connection.id}/health")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["connected"] is True
+        assert body["tendHealthy"] is None
+        assert body["build"] == "8.1.0.0"
+
+    async def test_healthy_ping_reports_tend_healthy_true(self, client: AsyncClient, sample_connection):
+        """Sanity: a successful ping() surfaces tendHealthy=True alongside connected=True."""
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+
+        mock_as_client = self._make_reachable_client()
+        mock_as_client.ping = AsyncMock(return_value=True)
+
+        with patch(
+            "aerospike_cluster_manager_api.routers.connections.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.get(f"/api/connections/{sample_connection.id}/health")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["connected"] is True
+        assert body["tendHealthy"] is True
 
 
 class TestConnectionSSRF:

--- a/api/tests/test_db.py
+++ b/api/tests/test_db.py
@@ -8,9 +8,13 @@ from __future__ import annotations
 
 import asyncio
 import sqlite3
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 
 import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
 
 from aerospike_cluster_manager_api import db
 from aerospike_cluster_manager_api.models.connection import ConnectionProfile
@@ -333,6 +337,42 @@ class TestGetBackendWithoutInit:
                 db._get_backend()
         finally:
             db._backend = original
+
+
+@asynccontextmanager
+async def _noop_lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    """No-op lifespan so the app does not call db.init_db() on startup."""
+    yield
+
+
+class TestHealthEndpointUninitializedDb:
+    """Regression: /api/health?detail=true must report 'degraded' (HTTP 200)
+    rather than raising a 500 when the DB backend is uninitialized.
+
+    db.check_health() dispatches through _get_backend(), which raises
+    DBNotInitialized when init_db() has not run. The endpoint now guards that
+    call so an uninitialized/unready backend surfaces as degraded.
+    """
+
+    async def test_detail_health_reports_degraded_when_backend_uninitialized(self):
+        from aerospike_cluster_manager_api.main import app
+
+        original_backend = db._backend
+        original_lifespan = app.router.lifespan_context
+        app.router.lifespan_context = _noop_lifespan
+        db._backend = None
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as ac:
+                resp = await ac.get("/api/health?detail=true")
+        finally:
+            app.router.lifespan_context = original_lifespan
+            db._backend = original_backend
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "degraded"
+        assert body["components"]["database"]["status"] == "error"
 
 
 class TestSqliteWriteConcurrency:


### PR DESCRIPTION
## Summary

Two **backend** (FastAPI) robustness fixes found by a code analysis sweep against `main`. No API route changes, no Pydantic public-type/wire-alias changes.

### 1. (P1) Transient `client.ping()` failure flips a reachable cluster to `connected=false`
In `get_connection_health` (`routers/connections.py`), `tendHealthy=await client.ping()` was evaluated **inside** the success-path `ConnectionStatus(...)` constructor — *after* namespaces/build/edition had already been fetched successfully. A transient `AerospikeError`/`OSError` from `ping()` was caught by the outer `except (AerospikeError, OSError)`, returning `connected=false` for a demonstrably reachable cluster — exactly the "transient blip mistaken for permanent failure" the endpoint docstring warns against.

**Fix:** compute `tend_healthy` in a guarded `try/except (AerospikeError, OSError)` *before* the constructor, degrading only that one field (`tendHealthy: bool | None` already allows `None`).

### 2. (P1) `/api/health?detail=true` can 500 instead of reporting `degraded`
The endpoint called `db.check_health()`. The backends' `check_health()` swallow errors and return `False`, but the dispatch wrapper calls `_get_backend()` first, which raises `DBNotInitialized` when the backend is `None` — *before* any try-block — yielding an unhandled 500 in exactly the scenario the probe exists to report.

**Fix:** guard the call in the endpoint (`try/except Exception → db_ok = False`) so it returns 200 with `status="degraded"`.

## Tests
- `test_connections_router.py`: namespaces/build/edition succeed but `ping()` raises → `connected=True`, `tendHealthy is None`; plus a healthy-ping sanity test.
- `test_db.py`: `health?detail=true` with uninitialized backend → HTTP 200, `status="degraded"` (no raised exception/500).

## Verification
- `uv run ruff check src tests` ✅
- `uv run ruff format --check src tests` ✅ (130 files formatted)
- `uv run pytest` ✅ full suite green (new tests included)

🤖 Automated improvement sweep (analysis → fix → verify).