### PR TITLE
fix(api): correctly coerce string boolean filter values

### DIFF
--- a/api/src/aerospike_cluster_manager_api/expression_builder.py
+++ b/api/src/aerospike_cluster_manager_api/expression_builder.py
@@ -43,6 +43,41 @@ class InvalidFilterValueError(ValueError):
 # pathological backtracking becomes feasible.
 _MAX_REGEX_PATTERN_LENGTH = 256
 
+# String spellings accepted for a ``bin_type=bool`` filter value. JSON clients
+# routinely send booleans as strings ("false", "0"), and the naive ``bool(str)``
+# coercion treats every non-empty string as ``True`` — so ``value="false"``
+# would silently build a filter matching ``True``. Parse explicitly instead.
+_BOOL_TRUE_STRINGS = frozenset({"true", "1", "yes", "on"})
+_BOOL_FALSE_STRINGS = frozenset({"false", "0", "no", "off"})
+
+
+def _coerce_bool(value: object) -> bool:
+    """Coerce a filter value to ``bool`` without the ``bool(str)`` footgun.
+
+    ``bool("false")`` and ``bool("0")`` are both ``True`` in Python because
+    any non-empty string is truthy. A filter for a boolean bin equal to
+    ``false`` is commonly sent over JSON as the string ``"false"`` (or
+    ``"0"``), so the naive coercion silently inverts the user's intent.
+
+    Rules:
+        - genuine ``bool`` → returned as-is.
+        - ``int`` / ``float`` → standard truthiness (``0`` → ``False``).
+        - ``str`` → parsed case-insensitively against the known true/false
+          spellings; anything else raises :class:`InvalidFilterValueError`.
+    """
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int | float):
+        return bool(value)
+    if isinstance(value, str):
+        token = value.strip().lower()
+        if token in _BOOL_TRUE_STRINGS:
+            return True
+        if token in _BOOL_FALSE_STRINGS:
+            return False
+    raise InvalidFilterValueError(f"Filter value {value!r} is not a valid boolean")
+
+
 # Heuristic detector for the classic "evil regex" shapes that drive
 # catastrophic backtracking in Python's ``re`` engine: a quantifier
 # wrapped in a quantified group, e.g. ``(a+)+``, ``(a*)*``, ``(a?)+``,
@@ -116,7 +151,7 @@ def _val_accessor(value: object, bin_type: BinDataType) -> dict:
     if bin_type == BinDataType.STRING:
         return exp.string_val(str(value))
     if bin_type == BinDataType.BOOL:
-        return exp.bool_val(bool(value))
+        return exp.bool_val(_coerce_bool(value))
     if bin_type == BinDataType.GEO:
         geo_str = value if isinstance(value, str) else json.dumps(value)
         return exp.geo_val(geo_str)

--- a/api/tests/test_expression_builder.py
+++ b/api/tests/test_expression_builder.py
@@ -278,3 +278,71 @@ class TestFilterValueValidation:
         # plain ValueError, but it must remain a ValueError for callers that
         # only know the base type.
         assert issubclass(InvalidFilterValueError, ValueError)
+
+
+class TestBoolFilterValueCoercion:
+    """A ``bin_type=bool`` filter value arrives as ``BinValue`` (``Any``), so a
+    JSON client commonly sends booleans as the strings ``"true"`` / ``"false"``.
+
+    The previous ``bool(value)`` coercion was a footgun: ``bool("false")`` and
+    ``bool("0")`` are both ``True`` in Python (any non-empty string is truthy),
+    so a filter for ``is_active == false`` silently built one matching ``True``
+    and returned the opposite set of records.
+    """
+
+    @pytest.mark.parametrize("falsey", ["false", "False", "FALSE", " false ", "0", "no", "off"])
+    def test_string_false_spellings_build_false_filter(self, falsey: str):
+        cond = FilterCondition(
+            bin="active",
+            operator=FilterOperator.EQ,
+            value=falsey,
+            bin_type=BinDataType.BOOL,
+        )
+        expr = _build_condition(cond)
+        assert expr == exp.eq(exp.bool_bin("active"), exp.bool_val(False))
+
+    @pytest.mark.parametrize("truthy", ["true", "True", "TRUE", " true ", "1", "yes", "on"])
+    def test_string_true_spellings_build_true_filter(self, truthy: str):
+        cond = FilterCondition(
+            bin="active",
+            operator=FilterOperator.EQ,
+            value=truthy,
+            bin_type=BinDataType.BOOL,
+        )
+        expr = _build_condition(cond)
+        assert expr == exp.eq(exp.bool_bin("active"), exp.bool_val(True))
+
+    def test_genuine_bool_false_is_preserved(self):
+        cond = FilterCondition(
+            bin="active",
+            operator=FilterOperator.EQ,
+            value=False,
+            bin_type=BinDataType.BOOL,
+        )
+        expr = _build_condition(cond)
+        assert expr == exp.eq(exp.bool_bin("active"), exp.bool_val(False))
+
+    def test_integer_zero_is_false(self):
+        cond = FilterCondition(
+            bin="active",
+            operator=FilterOperator.EQ,
+            value=0,
+            bin_type=BinDataType.BOOL,
+        )
+        expr = _build_condition(cond)
+        assert expr == exp.eq(exp.bool_bin("active"), exp.bool_val(False))
+
+    def test_missing_value_for_bool_raises(self):
+        cond = FilterCondition(bin="active", operator=FilterOperator.EQ, bin_type=BinDataType.BOOL)
+        with pytest.raises(InvalidFilterValueError, match="required"):
+            _build_condition(cond)
+
+    def test_unrecognized_string_for_bool_raises(self):
+        cond = FilterCondition(
+            bin="active",
+            operator=FilterOperator.EQ,
+            value="maybe",
+            bin_type=BinDataType.BOOL,
+        )
+        with pytest.raises(InvalidFilterValueError, match="not a valid boolean"):
+            _build_condition(cond)


### PR DESCRIPTION
## Bug

The filtered-record-scan expression builder mis-coerced boolean filter values.

`FilterCondition.value` is typed `BinValue | None` where `BinValue = Any`, so a JSON client legitimately sends a boolean filter value as a **string** (`"true"` / `"false"`) — which is exactly what the UI/ackoctl do for query-builder text inputs. For `bin_type=bool` the builder did:

```python
return exp.bool_val(bool(value))
```

In Python every non-empty string is truthy, so `bool("false")` and `bool("0")` are both `True`. A user filtering `is_active == false` (sent as `value="false"`) therefore silently built a filter matching **`True`** and got the **opposite** set of records back — a quiet correctness bug with no error surfaced.

## Fix

Replace the naive cast with a dedicated `_coerce_bool()` helper in `expression_builder.py`:

- genuine `bool` → returned as-is
- `int` / `float` → standard truthiness (`0` → `False`)
- `str` → parsed case-insensitively against `true/false/1/0/yes/no/on/off`
- anything else → `InvalidFilterValueError` (mapped to HTTP 400 by the records router), consistent with the existing integer/float value-validation path

No public type, wire alias, or version field changed. Scope: 2 files.

## Verification

Ran in `api/` with `uv` (Python 3.13):

- `uv run pytest tests/test_expression_builder.py -v` → **51 passed** (12 new in `TestBoolFilterValueCoercion`)
- Proof the tests catch the bug: stashing only the source fix and re-running the new tests → **8 failures** showing `bool_val: True != False` for `"false"`/`"False"`/`"0"`/`"no"`/`"off"` plus the missing rejection path. With the fix applied → all pass.
- `uv run ruff check src tests` → **All checks passed!**
- `uv run ruff format --check src tests` → **130 files already formatted**
- Full suite `uv run pytest tests/` → **900 passed** (2 pre-existing unrelated mock warnings)

## Files changed

- `api/src/aerospike_cluster_manager_api/expression_builder.py`
- `api/tests/test_expression_builder.py`