### PR TITLE
fix(api): validate GEO filter and predicate values to return 400 not 500

### DIFF
--- a/api/src/aerospike_cluster_manager_api/expression_builder.py
+++ b/api/src/aerospike_cluster_manager_api/expression_builder.py
@@ -227,6 +227,8 @@ def _build_condition(cond: FilterCondition) -> dict:
         return exp.eq(exp.bool_bin(bin_name), exp.bool_val(False))
 
     if op in {FilterOperator.GEO_WITHIN, FilterOperator.GEO_CONTAINS}:
+        if cond.value is None:
+            raise InvalidFilterValueError(f"Operator {op.value!r} requires a 'value'")
         geo_str = cond.value if isinstance(cond.value, str) else json.dumps(cond.value)
         return exp.geo_compare(exp.geo_bin(bin_name), exp.geo_val(geo_str))
 

--- a/api/src/aerospike_cluster_manager_api/predicate.py
+++ b/api/src/aerospike_cluster_manager_api/predicate.py
@@ -89,10 +89,18 @@ def build_predicate(pred: QueryPredicate) -> tuple[Any, ...]:
         return predicates.between(pred.bin, pred.value, pred.value2)
     if op == "contains":
         return predicates.contains(pred.bin, INDEX_TYPE_LIST, pred.value)
-    if op == "geo_within_region":
+    if op in ("geo_within_region", "geo_contains_point"):
+        # ``value`` must be GeoJSON: a str (already-serialised GeoJSON) or a
+        # dict/list that ``json.dumps`` can turn into one. Anything else (e.g.
+        # an int) serialises to a non-GeoJSON scalar like ``"5"`` that the
+        # aerospike-py builder rejects as an opaque 500; reject it here as 400.
+        if not isinstance(pred.value, str | dict | list):
+            raise InvalidPredicateValue(
+                f"predicate operator {op!r} requires a GeoJSON 'value' (str, dict, or list); "
+                f"got {type(pred.value).__name__}"
+            )
         geo = pred.value if isinstance(pred.value, str) else json.dumps(pred.value)
-        return predicates.geo_within_geojson_region(pred.bin, geo)
-    if op == "geo_contains_point":
-        geo = pred.value if isinstance(pred.value, str) else json.dumps(pred.value)
+        if op == "geo_within_region":
+            return predicates.geo_within_geojson_region(pred.bin, geo)
         return predicates.geo_contains_geojson_point(pred.bin, geo)
     raise UnknownPredicateOperator(op)

--- a/api/tests/test_expression_builder.py
+++ b/api/tests/test_expression_builder.py
@@ -346,3 +346,43 @@ class TestBoolFilterValueCoercion:
         )
         with pytest.raises(InvalidFilterValueError, match="not a valid boolean"):
             _build_condition(cond)
+
+
+class TestGeoFilterValueValidation:
+    """``FilterCondition.value`` defaults to ``None`` and the GEO_WITHIN /
+    GEO_CONTAINS branch passed it straight to ``json.dumps`` — ``None`` became
+    the literal ``"null"`` and reached ``exp.geo_val`` as a non-GeoJSON string,
+    surfacing as an opaque 500. A missing value must raise
+    ``InvalidFilterValueError`` (HTTP 400) like every other operator."""
+
+    @pytest.mark.parametrize("operator", [FilterOperator.GEO_WITHIN, FilterOperator.GEO_CONTAINS])
+    def test_missing_value_raises(self, operator: FilterOperator):
+        cond = FilterCondition(bin="loc", operator=operator, bin_type=BinDataType.GEO)
+        with pytest.raises(InvalidFilterValueError, match="requires a 'value'"):
+            _build_condition(cond)
+
+    def test_geojson_string_value_builds(self):
+        geojson = '{"type":"Point","coordinates":[0.0,0.0]}'
+        cond = FilterCondition(
+            bin="loc",
+            operator=FilterOperator.GEO_WITHIN,
+            value=geojson,
+            bin_type=BinDataType.GEO,
+        )
+        expr = _build_condition(cond)
+        expected = exp.geo_compare(exp.geo_bin("loc"), exp.geo_val(geojson))
+        assert expr == expected
+
+    def test_dict_value_is_json_serialised(self):
+        cond = FilterCondition(
+            bin="loc",
+            operator=FilterOperator.GEO_CONTAINS,
+            value={"type": "Point", "coordinates": [0.0, 0.0]},
+            bin_type=BinDataType.GEO,
+        )
+        expr = _build_condition(cond)
+        expected = exp.geo_compare(
+            exp.geo_bin("loc"),
+            exp.geo_val('{"type": "Point", "coordinates": [0.0, 0.0]}'),
+        )
+        assert expr == expected

--- a/api/tests/test_predicate.py
+++ b/api/tests/test_predicate.py
@@ -55,3 +55,36 @@ class TestBuildPredicateValidation:
         catch ValueError (e.g. the query router) keep working."""
         assert issubclass(PredicateError, ValueError)
         assert issubclass(InvalidPredicateValue, PredicateError)
+
+
+class TestBuildPredicateGeoValidation:
+    """The geo branches ``json.dumps`` any non-str value with no shape check,
+    so a scalar like ``5`` became ``"5"`` and reached the aerospike-py builder
+    as non-GeoJSON, surfacing as an opaque 500. Only str/dict/list (the shapes
+    that can serialise to GeoJSON) are accepted; anything else is a 400."""
+
+    @pytest.mark.parametrize("operator", ["geo_within_region", "geo_contains_point"])
+    def test_non_geojson_scalar_value_raises(self, operator: str):
+        pred = QueryPredicate(bin="loc", operator=operator, value=5)
+        with pytest.raises(InvalidPredicateValue, match="GeoJSON"):
+            build_predicate(pred)
+
+    @pytest.mark.parametrize("operator", ["geo_within_region", "geo_contains_point"])
+    def test_geojson_string_value_builds_ok(self, operator: str):
+        pred = QueryPredicate(
+            bin="loc",
+            operator=operator,
+            value='{"type":"Point","coordinates":[0.0,0.0]}',
+        )
+        result = build_predicate(pred)
+        assert isinstance(result, tuple)
+
+    @pytest.mark.parametrize("operator", ["geo_within_region", "geo_contains_point"])
+    def test_geojson_dict_value_builds_ok(self, operator: str):
+        pred = QueryPredicate(
+            bin="loc",
+            operator=operator,
+            value={"type": "Point", "coordinates": [0.0, 0.0]},
+        )
+        result = build_predicate(pred)
+        assert isinstance(result, tuple)


### PR DESCRIPTION
## Problem

Two GEO code paths let malformed input slip past API-side validation and reach aerospike-core, where it surfaces as an opaque **500** — unlike every other filter/predicate operator, which raises a **400**.

### A. `expression_builder.py` — `GEO_WITHIN` / `GEO_CONTAINS` branch

`FilterCondition.value` defaults to `None`. The geo branch did `json.dumps(cond.value)` with **no `None` guard** (every sibling branch — EQ/BETWEEN/CONTAINS/REGEX — has one). A geo filter sent with no value produced `json.dumps(None) == "null"`, which became `exp.geo_val("null")` and an opaque server error.

**Fix:** raise `InvalidFilterValueError` (already mapped to HTTP 400 in `routers/records.py`) when `cond.value is None`, mirroring the existing CONTAINS/REGEX guards.

### B. `predicate.py` — `geo_within_region` / `geo_contains_point` branch

`json.dumps(pred.value)` ran for any non-`str` value with no shape check. A non-GeoJSON scalar (e.g. `int 5`) serialised to `"5"`, reaching the aerospike-py builder as non-GeoJSON → opaque server error.

**Fix:** when `pred.value` is not a `str`, `dict`, or `list`, raise `InvalidPredicateValue` (this module's existing 400-mapped error). `str`/`dict`/`list` are accepted exactly as before; the two branches were merged so they share the single guard.

## The footgun

Both were silent **500s** for what is plainly bad client input — inconsistent with the rest of the filter/predicate surface and hard to diagnose from the opaque error.

## New coverage

This area had **zero** geo tests. Added:

- `tests/test_expression_builder.py::TestGeoFilterValueValidation` — missing value (both geo operators) raises `InvalidFilterValueError`; valid GeoJSON string and dict build the expected `exp.geo_compare(exp.geo_bin, exp.geo_val(...))`.
- `tests/test_predicate.py::TestBuildPredicateGeoValidation` — non-GeoJSON scalar raises `InvalidPredicateValue`; valid GeoJSON str and dict build the predicate tuple.

## Verification

- `ruff check` (4 changed files) — All checks passed
- `ruff format --check` (4 changed files) — already formatted
- `pytest tests/test_expression_builder.py tests/test_predicate.py` — 67 passed

Non-breaking: only adds validation that converts previously-opaque 500s into clean 400s. No version bump.