### PR TITLE
fix(api): parse bare and bracketed IPv6 hosts in parse_host_port

### DIFF
--- a/api/src/aerospike_cluster_manager_api/utils.py
+++ b/api/src/aerospike_cluster_manager_api/utils.py
@@ -21,7 +21,31 @@ __all__ = ["parse_host_port"]
 
 
 def parse_host_port(host_str: str, default_port: int) -> tuple[str, int]:
-    """Parse a host string that may contain an optional ``:port`` suffix."""
+    """Parse a host string that may contain an optional ``:port`` suffix.
+
+    Handles IPv6 correctly so a bare IPv6 literal is never split on one of
+    its own colons (a naive ``rsplit(":", 1)`` turns ``"::1"`` into
+    ``(":", 1)``):
+
+    * Bracketed IPv6 (``[::1]``, ``[2001:db8::1]:3000``) -- strip brackets,
+      take the optional trailing ``:port``.
+    * Bare IPv6 literal (2+ colons, unbracketed) -- the whole string is the
+      host; ``default_port`` is used (there is no unambiguous port suffix).
+    * ``host:port`` (single colon) -- split on the last colon.
+    * Bare host (no colon) -- host with ``default_port``.
+
+    A non-integer port falls back to ``default_port``.
+    """
+    if host_str.startswith("["):  # bracketed IPv6, optional :port
+        host, _, port_str = host_str[1:].partition("]")
+        if port_str.startswith(":"):
+            try:
+                return (host, int(port_str[1:]))
+            except ValueError:
+                return (host, default_port)
+        return (host, default_port)
+    if host_str.count(":") >= 2:  # bare IPv6 literal -- no port suffix
+        return (host_str, default_port)
     if ":" in host_str:
         host, port_str = host_str.rsplit(":", 1)
         try:

--- a/api/tests/test_connections_router.py
+++ b/api/tests/test_connections_router.py
@@ -510,6 +510,22 @@ class TestConnectionSSRF:
         assert response.json()["success"] is False
         mock_cls.assert_not_called()
 
+    async def test_loopback_bare_ipv6_rejected(self, client: AsyncClient):
+        """Bare (unbracketed) IPv6 loopback ``::1`` must trip the SSRF
+        gate just like the bracketed ``[::1]`` form. Regression for the
+        parse_host_port last-colon split that mangled ``::1`` -> ``":"``
+        and slipped past _is_blocked_target."""
+        with patch(
+            "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
+        ) as mock_cls:
+            response = await client.post(
+                "/api/connections/test",
+                json={"hosts": ["::1"], "port": 3000},
+            )
+        assert response.status_code == 200
+        assert response.json()["success"] is False
+        mock_cls.assert_not_called()
+
     async def test_loopback_allowed_when_env_override_set(self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch):
         """``ACM_CONNECTION_TEST_ALLOW_PRIVATE=true`` lets dev deployments
         target the loopback Aerospike running alongside the API."""

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -1,0 +1,26 @@
+"""Unit tests for shared utility helpers."""
+
+import pytest
+
+from aerospike_cluster_manager_api.utils import parse_host_port
+
+
+@pytest.mark.parametrize(
+    ("host_str", "expected"),
+    [
+        ("localhost", ("localhost", 3000)),
+        ("host.example:3100", ("host.example", 3100)),
+        ("127.0.0.1", ("127.0.0.1", 3000)),
+        ("127.0.0.1:4000", ("127.0.0.1", 4000)),
+        # Bare IPv6 literals: must stay intact, never split on their own colons.
+        ("::1", ("::1", 3000)),
+        ("2001:db8::1", ("2001:db8::1", 3000)),
+        ("0:0:0:0:0:0:0:1", ("0:0:0:0:0:0:0:1", 3000)),
+        # Bracketed IPv6: strip brackets, honor optional :port.
+        ("[::1]", ("::1", 3000)),
+        ("[::1]:3100", ("::1", 3100)),
+        ("[2001:db8::1]:3000", ("2001:db8::1", 3000)),
+    ],
+)
+def test_parse_host_port(host_str: str, expected: tuple[str, int]):
+    assert parse_host_port(host_str, 3000) == expected


### PR DESCRIPTION
## Problem

`parse_host_port` in `api/src/aerospike_cluster_manager_api/utils.py` split on the **last** colon unconditionally. That is correct for `host:port`, but it corrupts bare IPv6 literals, which legitimately contain multiple colons.

## Root cause

`host_str.rsplit(":", 1)` applied to an IPv6 literal mangles host and port:

| Input | Old (buggy) result |
|-------|--------------------|
| `::1` | `(":", 1)` |
| `2001:db8::1` | `("2001:db8:", 1)` |
| `0:0:0:0:0:0:0:1` | `("0:0:0:0:0:0:0:", 1)` |

## Security note (SSRF gate bypass)

`services/connections_service.py::test_connection` feeds `parse_host_port`'s host part into `_is_blocked_target`, a default-deny SSRF gate that rejects loopback / link-local literals before any network syscall. Because the bare IPv6 host was mangled (`::1` -> `":"`), `ipaddress.ip_address(":")` raised `ValueError` and the gate let it through. So bare `::1` and `0:0:0:0:0:0:0:1` **evaded** the loopback block that the bracketed `[::1]` form correctly triggers — re-opening the authenticated SSRF probe surface for the loopback case.

## Fix

`parse_host_port` now handles, in order:

1. **Bracketed IPv6** (`[::1]`, `[::1]:3100`, `[2001:db8::1]:3000`) — strip brackets, take the optional trailing `:port`.
2. **Bare IPv6 literal** (2+ colons, unbracketed) — whole string is the host, `default_port` (no unambiguous port suffix).
3. **Normal `host:port`** (single colon) — `rsplit` on the last colon.
4. **Bare host** (no colon) — host with `default_port`.

Non-integer port still falls back to `default_port`. Dependency-free, single file (~25 LOC).

## Tests

- `api/tests/test_utils.py` — new parametrized `test_parse_host_port` covering all bare/bracketed/normal/loopback cases (10 cases).
- `api/tests/test_connections_router.py` — new `test_loopback_bare_ipv6_rejected` in `TestConnectionSSRF`, mirroring the existing `test_loopback_ipv6_rejected` but with the bare `::1` form; asserts `success=False` and that the Aerospike client is never constructed.

## Verification

Run from `api/`:

```
uv run ruff format src/aerospike_cluster_manager_api/utils.py   # 1 file left unchanged
uv run ruff check src/                                          # All checks passed!
uv run ruff format --check src/                                 # 82 files already formatted
uv run pytest tests/test_utils.py tests/test_connections_router.py -v --tb=short   # 50 passed
uv run pytest tests/ -q                                         # 921 passed
```