### PR TITLE
fix: filter/query 500-hardening + idempotent index delete

### DIFF
--- a/api/src/aerospike_cluster_manager_api/models/query.py
+++ b/api/src/aerospike_cluster_manager_api/models/query.py
@@ -68,6 +68,19 @@ class FilterOperator(StrEnum):
 # bin accessor. The condition's `bin` field is ignored (must be the placeholder).
 PK_OPERATORS: frozenset[FilterOperator] = frozenset({FilterOperator.PK_PREFIX, FilterOperator.PK_REGEX})
 
+# Operators that compare against the record without consuming a `value`. Every
+# other operator dereferences `value` (and BETWEEN also dereferences `value2`)
+# in expression_builder, so a missing value would raise ValueError/TypeError
+# deep in the builder. We reject those shapes up front instead.
+VALUELESS_OPERATORS: frozenset[FilterOperator] = frozenset(
+    {
+        FilterOperator.EXISTS,
+        FilterOperator.NOT_EXISTS,
+        FilterOperator.IS_TRUE,
+        FilterOperator.IS_FALSE,
+    }
+)
+
 
 class BinDataType(StrEnum):
     INTEGER = "integer"
@@ -107,6 +120,20 @@ class FilterCondition(BaseModel):
             raise ValueError(
                 f"PK operator {self.operator.value!r} requires a string value; got {type(self.value).__name__}"
             )
+        return self
+
+    @model_validator(mode="after")
+    def _validate_value_presence(self) -> FilterCondition:
+        # Value-bearing operators dereference `value` (and BETWEEN also
+        # `value2`) in expression_builder. Reject missing values here so the
+        # error surfaces as a 422 (body validation) / 400 (programmatic build)
+        # instead of a generic 500 from int(None) deep in the builder.
+        if self.operator in VALUELESS_OPERATORS:
+            return self
+        if self.value is None:
+            raise ValueError(f"operator {self.operator.value!r} requires a non-null value")
+        if self.operator == FilterOperator.BETWEEN and self.value2 is None:
+            raise ValueError(f"operator {self.operator.value!r} requires a non-null value2")
         return self
 
 

--- a/api/src/aerospike_cluster_manager_api/routers/indexes.py
+++ b/api/src/aerospike_cluster_manager_api/routers/indexes.py
@@ -122,13 +122,21 @@ async def delete_index(
 ) -> Response:
     """Remove a secondary index by name from the specified namespace.
 
+    DELETE is idempotent — if the index is already absent we still return 204,
+    mirroring ``delete_record``. Letting ``IndexNotFound`` propagate would
+    translate to 404 via the global handler and break common UI / CLI retry
+    patterns where the same DELETE is replayed after a network blip.
+
     Same idempotency guard as ``create_index`` (issue #260): if the drop call
-    raises but the index is already gone, treat the operation as successful.
+    raises a generic error but the index is already gone, treat the operation
+    as successful.
     """
     try:
         await client.index_remove(ns, name)
     except IndexNotFound:
-        raise
+        # Idempotent: the index is already absent, which is the desired
+        # post-condition of DELETE.
+        pass
     except AerospikeError:
         if await _index_exists(client, ns, name):
             raise

--- a/api/src/aerospike_cluster_manager_api/routers/records.py
+++ b/api/src/aerospike_cluster_manager_api/routers/records.py
@@ -343,9 +343,17 @@ async def get_filtered_records(
     """Scan records with optional expression filters and pagination."""
     try:
         result = await records_service.filter_records(client, body)
+    # ``InvalidPkPattern`` subclasses ``ValueError`` — keep it first so its
+    # dedicated message wins over the generic ValueError handler below.
+    except InvalidPkPattern as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except SetRequiredForPkLookup as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except InvalidPkPattern as exc:
+    except (ValueError, TypeError) as exc:
+        # Malformed filter conditions (e.g. binType=integer with a non-numeric
+        # value, BETWEEN missing value2) make build_expression/build_predicate
+        # raise ValueError/TypeError. Map them to 400 instead of a generic 500,
+        # mirroring routers/query.py's ValueError→400 handling.
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     models = [record_to_model(r) for r in result.records]

--- a/api/tests/test_filter_validation.py
+++ b/api/tests/test_filter_validation.py
@@ -1,0 +1,148 @@
+"""Regression tests for filter/query validation hardening (2026-05-30).
+
+Covers the 500→4xx hardening for the filtered-record scan and idempotent
+index delete:
+
+- Malformed filter condition (binType=integer with a non-numeric value) used to
+  500 — ``_val_accessor`` calls ``int("abc")`` deep in ``build_expression`` and
+  the resulting ``ValueError`` escaped to the generic 500 handler. Now mapped to
+  HTTP 400 by ``get_filtered_records``.
+- BETWEEN operator missing ``value2`` used to 500 via ``int(None)`` (TypeError).
+  Now rejected at the Pydantic layer (422) by ``FilterCondition`` and, for any
+  programmatic build path, mapped to 400 by the router handler.
+- DELETE /indexes for a non-existent index used to 404 despite the docstring
+  promising idempotency. Now returns 204, matching ``delete_record``.
+
+Mirrors the fixture/mocking style of ``test_api_500_regressions.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from aerospike_py.exception import IndexNotFound
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from aerospike_cluster_manager_api.main import app
+
+
+@asynccontextmanager
+async def _noop_lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    yield
+
+
+@pytest.fixture()
+async def http_client():
+    original_lifespan = app.router.lifespan_context
+    app.router.lifespan_context = _noop_lifespan
+    app.state.limiter.enabled = False
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.state.limiter.enabled = True
+    app.router.lifespan_context = original_lifespan
+
+
+def _patch_client(mock_client):
+    """Patch dependency resolution so router code receives *mock_client*."""
+    return (
+        patch(
+            "aerospike_cluster_manager_api.dependencies.db.get_connection",
+            AsyncMock(return_value={"id": "conn-test"}),
+        ),
+        patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            AsyncMock(return_value=mock_client),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Finding 1+3 — malformed filter condition → 400 (not 500)
+# ---------------------------------------------------------------------------
+
+
+class TestFilterValueCoercion:
+    async def test_integer_bin_with_non_numeric_value_returns_400(self, http_client: AsyncClient):
+        """binType=integer with value="abc" makes build_expression call
+        int("abc") → ValueError. The router must map that to 400, not 500."""
+        mock_client = AsyncMock()
+
+        db_patch, client_patch = _patch_client(mock_client)
+        with db_patch, client_patch:
+            response = await http_client.post(
+                "/api/v1/records/conn-test/filter",
+                json={
+                    "namespace": "test",
+                    "set": "demo",
+                    "filters": {
+                        "logic": "and",
+                        "conditions": [
+                            {"bin": "score", "operator": "eq", "binType": "integer", "value": "abc"},
+                        ],
+                    },
+                },
+            )
+
+        assert response.status_code == 400, response.text
+        # client.query must never have been reached — the bad value is caught
+        # while building the expression.
+        mock_client.query.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Finding 2 — BETWEEN missing value2 → 422/400 (not 500 via int(None))
+# ---------------------------------------------------------------------------
+
+
+class TestBetweenMissingValue2:
+    async def test_between_without_value2_is_rejected(self, http_client: AsyncClient):
+        """BETWEEN with no value2 previously crashed on int(None). It must be
+        rejected as a validation error (422 from the Pydantic model) or 400."""
+        mock_client = AsyncMock()
+
+        db_patch, client_patch = _patch_client(mock_client)
+        with db_patch, client_patch:
+            response = await http_client.post(
+                "/api/v1/records/conn-test/filter",
+                json={
+                    "namespace": "test",
+                    "set": "demo",
+                    "filters": {
+                        "logic": "and",
+                        "conditions": [
+                            {"bin": "score", "operator": "between", "binType": "integer", "value": 1},
+                        ],
+                    },
+                },
+            )
+
+        assert response.status_code in (400, 422), response.text
+        mock_client.query.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Finding 4 — DELETE /indexes is idempotent → 204 when index is absent
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteIndexIdempotent:
+    async def test_delete_nonexistent_index_returns_204(self, http_client: AsyncClient):
+        """IndexNotFound must be swallowed and return 204, matching the
+        docstring promise and ``delete_record`` behaviour."""
+        mock_client = AsyncMock()
+        mock_client.index_remove = AsyncMock(side_effect=IndexNotFound("no such index"))
+
+        db_patch, client_patch = _patch_client(mock_client)
+        with db_patch, client_patch:
+            response = await http_client.delete(
+                "/api/v1/indexes/conn-test",
+                params={"name": "ghost_idx", "ns": "test"},
+            )
+
+        assert response.status_code == 204, response.text
+        assert response.text == ""


### PR DESCRIPTION
## Summary

Hardens three 500-prone paths in the FastAPI backend (`api/`). Non-breaking: no Pydantic/TS type renames, no wire-format changes, no removed endpoints, no version edits.

## Findings & fixes

**Finding 1+3 (P1/P2)** — `routers/records.py` `get_filtered_records`
Only caught `SetRequiredForPkLookup` / `InvalidPkPattern`. Malformed filter conditions (e.g. `binType=integer, value="abc"`) make `build_expression` / `build_predicate` raise `ValueError` (`int("abc")`) / `TypeError`, which escaped to a generic HTTP 500. Added `except (ValueError, TypeError) -> 400` after the existing handlers (kept `InvalidPkPattern` first since it subclasses `ValueError`). Mirrors `routers/query.py`'s `ValueError->400` mapping.

**Finding 2 (P1)** — `models/query.py` `FilterCondition`
BETWEEN with a missing `value2` crashed on `int(None)` (TypeError). Added a `model_validator(mode="after")` requiring a non-null `value` for value-bearing operators and a non-null `value2` when `operator == BETWEEN`. Valueless operators (`exists`, `not_exists`, `is_true`, `is_false`) are exempt. Body validation now -> 422; any programmatic build path -> 400 via the Finding 1 handler.

**Finding 4 (P2)** — `routers/indexes.py` `delete_index`
Docstring promised idempotency but did `except IndexNotFound: raise` (404). Now swallows `IndexNotFound` and returns `Response(status_code=204)`, matching `delete_record`. Docstring updated. (`IndexNotFound` subclasses `AerospikeError`, and its `except` clause precedes the generic `AerospikeError` guard, so ordering is correct.)

## Tests

Added `api/tests/test_filter_validation.py` (matches `test_api_500_regressions.py` fixture/mock style):
- integer bin with non-numeric value -> 400 (and `client.query` never reached)
- BETWEEN missing value2 -> 400/422
- delete nonexistent index -> 204

## Verification

- `ruff format --check .` — 121 files already formatted
- `ruff check .` — all checks passed
- `pytest tests/test_filter_validation.py tests/test_api_500_regressions.py` — 11 passed
- Regression sweep `test_expression_builder.py test_query_service.py test_records_router.py test_records_service.py` — all passed