### PR TITLE
fix(api): map unparseable pk_type on filter endpoint to 400 not 500

### DIFF
--- a/api/src/aerospike_cluster_manager_api/routers/records.py
+++ b/api/src/aerospike_cluster_manager_api/routers/records.py
@@ -371,6 +371,15 @@ async def get_filtered_records(
         # ``ValueError`` catch, otherwise the more accurate 422 would
         # silently degrade to 400.
         raise HTTPException(status_code=422, detail=f"Invalid predicate: {exc}") from exc
+    except ValueError as exc:
+        # Explicit pk_type with an unparseable pk → resolve_pk raises a plain
+        # ValueError (e.g. pkType=int with primaryKey="abc", or pkType=bytes
+        # with invalid hex). That is a client error, so map it to 400 to match
+        # the records-detail and query endpoints. Without this catch the bare
+        # ValueError escaped to the global handler as an opaque HTTP 500. This
+        # branch MUST stay last so the more specific ValueError subclasses
+        # above keep their dedicated status codes.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     models = [record_to_model(r) for r in result.records]
     # Filter scans always carry a set scope (SetRequiredForPkLookup is

--- a/api/tests/test_records_router.py
+++ b/api/tests/test_records_router.py
@@ -567,6 +567,41 @@ class TestFilteredRecordsPkMatchMode:
         # The predicate is rejected before the scan executes.
         mock_client.query.return_value.results.assert_not_called()
 
+    async def test_explicit_int_pk_type_with_non_integer_pk_returns_400(self, client: AsyncClient):
+        """An exact PK lookup with ``pkType=int`` but a non-integer pk must
+        surface as 400, not the opaque 500 the bare ``resolve_pk`` ValueError
+        used to produce. This aligns the filter endpoint with the records-
+        detail and query endpoints, which already map this client error to
+        400."""
+        mock_client = _build_query_mock()
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test/filter",
+                json={
+                    "namespace": "test",
+                    "set": "demo",
+                    "pkPattern": "not-a-number",
+                    "pkMatchMode": "exact",
+                    "pkType": "int",
+                },
+            )
+
+        assert resp.status_code == 400, resp.text
+        assert "int" in resp.json()["detail"]
+        # The bad pk is rejected before any client call (get or scan) runs.
+        mock_client.get.assert_not_called()
+        mock_client.query.assert_not_called()
+
 
 class TestPutRecordRouter:
     """POST /records/{conn_id} — record write path."""


### PR DESCRIPTION
## Problem

`POST /records/{conn_id}/filter` (`get_filtered_records`) translated several domain exceptions to HTTP status codes — `SetRequiredForPkLookup`, `InvalidPkPattern`, `InvalidFilterValueError`, and `PredicateError` — but had no catch for a plain `ValueError`.

When a client sends an **exact PK lookup with an explicit `pkType`** whose value cannot be parsed (for example `pkType=int` with `primaryKey="abc"`, or `pkType=bytes` with invalid hex), `resolve_pk` raises a bare `ValueError`. That exception escaped every `except` clause in the handler and fell through to the global exception handler, which returns an opaque **HTTP 500 "An internal server error occurred"**.

## Root cause

`resolve_pk` (in `pk.py`) raises a plain `ValueError` for an explicit `pkType` it cannot coerce. The sibling endpoints `get_record_detail` (`GET /records/{conn_id}/detail`) and `execute_query` (`POST /query/{conn_id}`) already catch this `ValueError` and map it to **400**. The filter endpoint was the odd one out, so the same class of client error produced a 500 there.

## Fix

Add a trailing `except ValueError -> HTTPException(400)` to `get_filtered_records`, ordered **after** the more specific `ValueError` subclass catches (`SetRequiredForPkLookup`, `InvalidPkPattern`, `InvalidFilterValueError`, `PredicateError`) so each keeps its dedicated status code. This aligns the filter endpoint with the detail and query endpoints.

- No public type / route / wire-alias changes (not a MAJOR change).
- No version fields touched.

## Verification

- New regression test `test_explicit_int_pk_type_with_non_integer_pk_returns_400` in `tests/test_records_router.py`. Confirmed it **fails** (bare `ValueError` propagates) on `origin/main` and **passes** with this fix, asserting 400 and that no client `get`/`query` call is made.
- `uv run pytest tests/` — **922 passed**.
- `uv run ruff check src/` — clean.
- `uv run ruff format --check src/` — clean.

These are exactly the backend gates the CI `api` job runs.