### PR TITLE
fix(ui): remove leaked AbortSignal listener in apiFetch

### DIFF
--- a/ui/src/lib/api/client.test.ts
+++ b/ui/src/lib/api/client.test.ts
@@ -129,6 +129,75 @@ describe("apiFetch (multi-cluster + auth)", () => {
     expect(retryHeaders.get("Authorization")).toBe("Bearer fresh")
   })
 
+  it("removes the external-signal abort listener after the request settles", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ ok: true }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const controller = new AbortController()
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener")
+
+    await apiFetch("/clusters", { signal: controller.signal })
+
+    // The listener bridged onto the caller's signal must be cleaned up so a
+    // long-lived signal reused across requests does not accumulate listeners
+    // (and keep dead controllers alive in their closures).
+    expect(removeSpy).toHaveBeenCalledWith("abort", expect.any(Function))
+  })
+
+  it("does not leak listeners on the external signal across the 401 retry", async () => {
+    useAuthStore.setState({
+      accessToken: "stale",
+      claims: null,
+      refreshing: false,
+    })
+
+    const keycloak = await import("@/lib/auth/keycloak")
+    vi.mocked(keycloak.refreshToken).mockResolvedValue("fresh")
+
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, 401))
+      .mockResolvedValueOnce(jsonResponse({ ok: true }))
+    vi.stubGlobal("fetch", fetchMock)
+
+    const controller = new AbortController()
+    const addSpy = vi.spyOn(controller.signal, "addEventListener")
+    const removeSpy = vi.spyOn(controller.signal, "removeEventListener")
+
+    await apiFetch("/clusters", { signal: controller.signal })
+
+    // executeRequest runs twice (original + retry); each add must be paired
+    // with a matching remove so nothing is left attached to the signal.
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const adds = addSpy.mock.calls.filter((c) => c[0] === "abort").length
+    const removes = removeSpy.mock.calls.filter((c) => c[0] === "abort").length
+    expect(adds).toBe(2)
+    expect(removes).toBe(2)
+  })
+
+  it("propagates an already-aborted external signal to the request", async () => {
+    // When the caller's signal is already aborted, the bridged controller
+    // must abort too, so fetch is invoked with an aborted signal and the
+    // request never hits the network for real.
+    const fetchMock = vi.fn((_url: string, init: RequestInit) => {
+      if (init.signal?.aborted) {
+        return Promise.reject(new DOMException("aborted", "AbortError"))
+      }
+      return Promise.resolve(jsonResponse({ ok: true }))
+    })
+    vi.stubGlobal("fetch", fetchMock)
+
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      apiFetch("/clusters", { signal: controller.signal }),
+    ).rejects.toMatchObject({ status: 0 })
+    expect((fetchMock.mock.calls[0][1] as RequestInit).signal?.aborted).toBe(
+      true,
+    )
+  })
+
   it("kicks off login redirect after permanent 401", async () => {
     useAuthStore.setState({
       accessToken: "stale",

--- a/ui/src/lib/api/client.ts
+++ b/ui/src/lib/api/client.ts
@@ -132,10 +132,18 @@ async function executeRequest(
 
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs)
+  // Bridge an externally-supplied signal into this request's controller.
+  // The listener must be removed in the `finally` below: `executeRequest`
+  // can run more than once per `apiFetch` (the 401 silent-refresh retry),
+  // and a caller that reuses one long-lived `AbortSignal` across many
+  // requests would otherwise accumulate one listener per request on that
+  // shared signal — each pinning a now-dead controller in a closure. The
+  // `{ once: true }` option does not help here because the signal usually
+  // never aborts, so the listener is never auto-removed.
+  const onExternalAbort = () => controller.abort()
   if (signal) {
     if (signal.aborted) controller.abort()
-    else
-      signal.addEventListener("abort", () => controller.abort(), { once: true })
+    else signal.addEventListener("abort", onExternalAbort)
   }
 
   const finalHeaders = new Headers(headers)
@@ -159,6 +167,7 @@ async function executeRequest(
     })
   } finally {
     clearTimeout(timeoutId)
+    if (signal) signal.removeEventListener("abort", onExternalAbort)
   }
 }
 


### PR DESCRIPTION
## What

`executeRequest` in `ui/src/lib/api/client.ts` bridges a caller-supplied `AbortSignal` into the request's own `AbortController` so an external cancel aborts the in-flight `fetch`:

```ts
signal.addEventListener("abort", () => controller.abort(), { once: true })
```

The listener was **never removed**. Since the bridged signal usually never aborts, the `{ once: true }` auto-removal never fires. A caller that reuses one long-lived `AbortSignal` across many `apiFetch` calls therefore accumulates one listener per request on that shared signal, and each listener closure keeps a now-dead `AbortController` reachable. The 401 silent-refresh retry path doubles the leak because it invokes `executeRequest` twice per `apiFetch`.

## Fix

Capture the listener in a named function and remove it in the existing `finally` block, next to `clearTimeout(timeoutId)`. The external-abort → controller bridge behavior is unchanged; only the cleanup is added.

## Tests

Added three cases to `client.test.ts`:
- the bridged `abort` listener is removed from the caller's signal after a request settles;
- across the 401 → refresh → retry path, `addEventListener`/`removeEventListener` calls for `abort` are paired (2 adds, 2 removes), so nothing is left attached;
- an already-aborted external signal still propagates an aborted signal to `fetch`.

## Verification

All run locally in `ui/`:
- `npx vitest run` — 61 passed (12 files), including the 8 in `client.test.ts`
- `npm run type-check` — clean
- `npm run lint` — no warnings/errors
- `npm run format:check` — clean

## Risk

Low. A 2-line behavioral change (remove a listener on completion) plus a clarifying comment; the cancel semantics callers rely on are untouched, and the existing 401/timeout tests still pass.