### PR TITLE
fix(info-parser): keep multi-node info keys reported only by non-first nodes

### DIFF
--- a/api/src/aerospike_cluster_manager_api/info_parser.py
+++ b/api/src/aerospike_cluster_manager_api/info_parser.py
@@ -77,7 +77,14 @@ def aggregate_node_kv(
 
     * Keys in *keys_to_sum* are summed as integers across nodes.
     * Keys in *keys_to_min* take the minimum value across nodes.
-    * All other keys use the first node's value.
+    * All other keys use the first node that *reported that key*.
+
+    Nodes can legitimately report different key sets (version skew,
+    feature flags, per-node-only stats). Each passthrough key is taken
+    from the first node that carries it -- using the *first node's whole
+    response* would silently drop any key absent from that one node, and
+    because ``info_all()`` results are unordered the dropped set would be
+    nondeterministic across calls.
 
     Error responses (``err is not None``) are silently skipped.
     """
@@ -89,9 +96,11 @@ def aggregate_node_kv(
         if err:
             continue
         kv = parse_kv_pairs(resp)
-        if not merged:
-            merged.update(kv)
         for k, v in kv.items():
+            # Passthrough keys: keep the first-seen value across all nodes
+            # so a key present only on a later node is not lost.
+            if k not in keys_to_sum and k not in keys_to_min and k not in merged:
+                merged[k] = v
             if k in keys_to_sum:
                 sum_accum[k] = sum_accum.get(k, 0) + safe_int(v)
             elif k in keys_to_min:

--- a/api/tests/test_info_parser.py
+++ b/api/tests/test_info_parser.py
@@ -276,6 +276,52 @@ class TestAggregateNodeKv:
         merged = aggregate_node_kv(results, keys_to_sum={"objects"})
         assert merged["objects"] == "10"
 
+    def test_passthrough_key_only_on_later_node_is_kept(self):
+        # A passthrough key present only on a non-first node must not be
+        # dropped just because the first responder lacked it. ``info_all()``
+        # results are unordered, so losing such keys would be a
+        # nondeterministic regression in the merged cluster view.
+        results = [
+            self._make_result("node1", "objects=100;cluster_size=3"),
+            self._make_result("node2", "objects=200;cluster_size=3;edition=Community"),
+        ]
+        merged = aggregate_node_kv(results, keys_to_sum={"objects"})
+        assert merged["objects"] == "300"
+        assert merged["cluster_size"] == "3"
+        assert merged["edition"] == "Community"
+
+    def test_passthrough_first_seen_value_wins_when_first_node_lacks_key(self):
+        # When the key is absent from the first node, the first node that
+        # actually reports it owns the value (first-seen, not last-seen).
+        results = [
+            self._make_result("node1", "objects=100"),
+            self._make_result("node2", "build=6.4.0.1"),
+            self._make_result("node3", "build=6.4.0.9"),
+        ]
+        merged = aggregate_node_kv(results)
+        assert merged["build"] == "6.4.0.1"
+
+    def test_passthrough_first_node_value_still_wins(self):
+        # Regression guard: when every node reports the key, the first
+        # node's value must still win (documented contract).
+        results = [
+            self._make_result("node1", "version=6.0"),
+            self._make_result("node2", "version=6.1"),
+        ]
+        merged = aggregate_node_kv(results)
+        assert merged["version"] == "6.0"
+
+    def test_passthrough_key_missing_from_first_responding_node(self):
+        # The first node errors; the key only appears on the second
+        # (first *responding*) node and must be present.
+        results = [
+            self._make_error("node1"),
+            self._make_result("node2", "edition=Community;objects=50"),
+        ]
+        merged = aggregate_node_kv(results, keys_to_sum={"objects"})
+        assert merged["edition"] == "Community"
+        assert merged["objects"] == "50"
+
 
 # ---- aggregate_set_records --------------------------------------------------
 


### PR DESCRIPTION
## Summary

`aggregate_node_kv()` merges `info_all()` key/value responses from every node into one cluster-wide view. It seeded the merged dict from the **first responding node's entire response** and then only folded in `keys_to_sum` / `keys_to_min` from later nodes:

```python
if not merged:
    merged.update(kv)      # whole first-node dict
for k, v in kv.items():
    if k in keys_to_sum: ...
    elif k in keys_to_min: ...
```

Any **passthrough** key that was absent from that first node was silently dropped, even if every other node reported it.

## Why it matters

`info_all()` does not return nodes in a stable order, so the set of dropped keys was **nondeterministic across calls**. A key reported only by some nodes — `edition`, `build`, a per-node-only stat, a feature flag on a node mid-rolling-upgrade — could appear or vanish from the merged result depending on which node happened to answer first.

This function backs the cluster stats, namespace stats, and metrics aggregation paths (`clusters_service`, `metrics_service`, `connections.py`, `records_service`), so the flicker surfaced directly in the UI / API responses.

### Reproduction (before the fix)

```python
results = [
    ("node1", None, "objects=100;cluster_size=3"),
    ("node2", None, "objects=200;cluster_size=3;edition=Community"),
]
aggregate_node_kv(results, keys_to_sum={"objects"})
# -> {"objects": "300", "cluster_size": "3"}   # 'edition' dropped
```

## Fix

Merge each node's keys individually, keeping the **first-seen** value for passthrough keys (preserving the documented "first node wins" contract) while ensuring keys reported only by later nodes survive. Sum/min keys are unchanged.

## Tests

Added regression tests in `tests/test_info_parser.py`:

- `test_passthrough_key_only_on_later_node_is_kept` — later-node-only key survives (failed before, passes after)
- `test_passthrough_first_seen_value_wins_when_first_node_lacks_key` — first node that reports a key owns its value (failed before, passes after)
- `test_passthrough_first_node_value_still_wins` — documented first-node-wins contract guard
- `test_passthrough_key_missing_from_first_responding_node` — error-node skip + first-responder key

## Local verification

- `uv run ruff check` — passed
- `uv run ruff format --check` — passed
- `uv run pytest tests/test_info_parser.py tests/test_clusters_service.py tests/test_query_service.py` — passed
- `uv run pytest -k "info_parser or metrics or connections_router or records_service"` — passed

No version bump (auto-release handles it). No public model/type changes.