### PR TITLE
fix(api): reject non-GeoJSON scalar GEO filter values with 400 not 500

### DIFF
--- a/api/src/aerospike_cluster_manager_api/expression_builder.py
+++ b/api/src/aerospike_cluster_manager_api/expression_builder.py
@@ -114,6 +114,24 @@ def _validate_pattern(pattern: str) -> None:
         raise InvalidPkPatternError(f"Invalid regex pattern: {e}") from e
 
 
+def _geo_val(value: object, context: str) -> dict:
+    """Build a ``geo_val`` expression, rejecting non-GeoJSON scalar values.
+
+    GeoJSON arrives either already-serialised as a ``str`` or as a
+    ``dict`` / ``list`` that ``json.dumps`` can turn into one. A bare scalar
+    (``int`` / ``float`` / ``bool``) serialises to something like ``"5"`` or
+    ``"true"`` — valid JSON, but not GeoJSON — which ``exp.geo_val`` forwards
+    to the server as an opaque 500. Reject it here so the HTTP boundary maps
+    it to a 400, matching the predicate-path guard added in #417.
+    """
+    if not isinstance(value, str | dict | list):
+        raise InvalidFilterValueError(
+            f"{context} requires a GeoJSON value (str, dict, or list); got {type(value).__name__}"
+        )
+    geo_str = value if isinstance(value, str) else json.dumps(value)
+    return exp.geo_val(geo_str)
+
+
 def _bin_accessor(bin_name: str, bin_type: BinDataType) -> dict:
     """Return the correct typed bin accessor expression."""
     accessors = {
@@ -153,8 +171,7 @@ def _val_accessor(value: object, bin_type: BinDataType) -> dict:
     if bin_type == BinDataType.BOOL:
         return exp.bool_val(_coerce_bool(value))
     if bin_type == BinDataType.GEO:
-        geo_str = value if isinstance(value, str) else json.dumps(value)
-        return exp.geo_val(geo_str)
+        return _geo_val(value, f"bin_type={bin_type.value!r}")
     # LIST / MAP — fall back to string representation
     return exp.string_val(str(value))
 
@@ -229,8 +246,7 @@ def _build_condition(cond: FilterCondition) -> dict:
     if op in {FilterOperator.GEO_WITHIN, FilterOperator.GEO_CONTAINS}:
         if cond.value is None:
             raise InvalidFilterValueError(f"Operator {op.value!r} requires a 'value'")
-        geo_str = cond.value if isinstance(cond.value, str) else json.dumps(cond.value)
-        return exp.geo_compare(exp.geo_bin(bin_name), exp.geo_val(geo_str))
+        return exp.geo_compare(exp.geo_bin(bin_name), _geo_val(cond.value, op.value))
 
     raise ValueError(f"Unknown filter operator: {op}")
 

--- a/api/tests/test_expression_builder.py
+++ b/api/tests/test_expression_builder.py
@@ -405,3 +405,26 @@ class TestGeoFilterValueValidation:
             exp.geo_val('{"type": "Point", "coordinates": [0.0, 0.0]}'),
         )
         assert expr == expected
+
+    @pytest.mark.parametrize(
+        ("value", "geo_str"),
+        [
+            (
+                '{"type":"Point","coordinates":[0.0,0.0]}',
+                '{"type":"Point","coordinates":[0.0,0.0]}',
+            ),
+            (
+                {"type": "Point", "coordinates": [0.0, 0.0]},
+                '{"type": "Point", "coordinates": [0.0, 0.0]}',
+            ),
+        ],
+    )
+    def test_eq_on_geo_bin_with_geojson_value_builds(self, value: object, geo_str: str):
+        # EQ on a geo bin routes through _val_accessor -> _geo_val (not the
+        # geo_compare branch). A valid GeoJSON str or dict must build a geo_val
+        # comparison without raising — the rejection-path guard must not break
+        # the happy path through this call site.
+        cond = FilterCondition(bin="loc", operator=FilterOperator.EQ, value=value, bin_type=BinDataType.GEO)
+        expr = _build_condition(cond)
+        expected = exp.eq(exp.geo_bin("loc"), exp.geo_val(geo_str))
+        assert expr == expected

--- a/api/tests/test_expression_builder.py
+++ b/api/tests/test_expression_builder.py
@@ -361,6 +361,25 @@ class TestGeoFilterValueValidation:
         with pytest.raises(InvalidFilterValueError, match="requires a 'value'"):
             _build_condition(cond)
 
+    @pytest.mark.parametrize("operator", [FilterOperator.GEO_WITHIN, FilterOperator.GEO_CONTAINS])
+    @pytest.mark.parametrize("value", [5, 3.14, True])
+    def test_non_geojson_scalar_value_raises(self, operator: FilterOperator, value: object):
+        # A bare scalar serialises to valid JSON ("5", "3.14", "true") but not
+        # GeoJSON; exp.geo_val would forward it to the server as an opaque 500.
+        # Must be rejected as a 400-class InvalidFilterValueError instead — the
+        # #417 predicate-path guard now applies to the expression path too.
+        cond = FilterCondition(bin="loc", operator=operator, value=value, bin_type=BinDataType.GEO)
+        with pytest.raises(InvalidFilterValueError, match="GeoJSON"):
+            _build_condition(cond)
+
+    @pytest.mark.parametrize("value", [5, 3.14, True])
+    def test_comparison_op_on_geo_bin_with_scalar_value_raises(self, value: object):
+        # _val_accessor is the other path that json.dumps'd a bare scalar into
+        # a non-GeoJSON string for a geo bin (e.g. EQ on a geo bin).
+        cond = FilterCondition(bin="loc", operator=FilterOperator.EQ, value=value, bin_type=BinDataType.GEO)
+        with pytest.raises(InvalidFilterValueError, match="GeoJSON"):
+            _build_condition(cond)
+
     def test_geojson_string_value_builds(self):
         geojson = '{"type":"Point","coordinates":[0.0,0.0]}'
         cond = FilterCondition(


### PR DESCRIPTION
## Bug

A filtered-query request with a `geo` bin filter whose `value` is a bare scalar (int / float / bool) returns an **opaque HTTP 500** instead of a 400, even though the equivalent predicate-based path already returns 400.

```jsonc
// POST /api/.../filter
{
  "filters": {
    "conditions": [
      { "bin": "loc", "operator": "geo_within", "binType": "geo", "value": 5 }
    ]
  }
}
```

`json.dumps(5)` produces `"5"` — valid JSON, but **not** GeoJSON — which `exp.geo_val` forwards to the Aerospike server, surfacing as a generic 500 with no actionable signal for the user.

## Root cause

PR #417 (`fix(api): validate GEO filter and predicate values to return 400 not 500`) added the **full** `isinstance(value, str | dict | list)` shape check to `predicate.py`, but only added a **`None` guard** to the `expression_builder.py` GEO path. The non-GeoJSON-scalar case stayed unfixed in the expression path. Two spots were affected:

1. `_build_condition` — `GEO_WITHIN` / `GEO_CONTAINS` branch (`geo_compare`).
2. `_val_accessor` — `BinDataType.GEO` branch (used by `EQ` / `NE` / comparison ops on a geo bin).

## Fix

Extract a `_geo_val(value, context)` helper that applies the same `str | dict | list` guard used in `predicate.py`, and call it from both spots. Invalid scalars now raise `InvalidFilterValueError`, which the records/query router already maps to HTTP 400. No wire-contract or type changes.

## Tests

Added to `TestGeoFilterValueValidation`:
- `test_non_geojson_scalar_value_raises` — `int`/`float`/`bool` × `GEO_WITHIN`/`GEO_CONTAINS` now raise `InvalidFilterValueError` matching `GeoJSON`.
- `test_comparison_op_on_geo_bin_with_scalar_value_raises` — covers the `_val_accessor` path (`EQ` on a geo bin).

Existing valid str/dict GeoJSON tests still pass unchanged.

### Test evidence
- `uv run pytest tests/test_expression_builder.py tests/test_predicate.py -q` → all pass
- `uv run pytest tests/test_expression_builder.py tests/test_records_service.py tests/test_query_service.py tests/test_query_router.py tests/test_records_router.py tests/test_api_500_regressions.py -q` → 172 pass
- `uv run ruff check ...` → All checks passed
- `uv run ruff format --check ...` → already formatted

## Risk

**Low.** Only narrows behaviour for input that previously 500'd (an already-broken path) — turns an opaque 500 into a clear 400. Valid GeoJSON (str / dict / list) is unaffected. No public type or wire-format changes.