### PR TITLE
fix(api): pass through real K8s API error statuses instead of collapsing to 500

### DIFF
--- a/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
@@ -161,9 +161,22 @@ class DeleteResponse(BaseModel):
 
 
 def _map_k8s_error(e: K8sApiError) -> HTTPException:
-    """Map K8sApiError status codes to appropriate HTTPException responses."""
-    status_map = {400: 400, 401: 401, 403: 403, 404: 404, 408: 408, 409: 409, 422: 422, 429: 429, 503: 503}
-    http_status = status_map.get(e.status, 500)
+    """Map a :class:`K8sApiError` status to an :class:`HTTPException`.
+
+    ``K8sApiError.status`` already carries the real HTTP status the Kubernetes
+    API server returned (``_wrap_api_exception`` passes the ``ApiException``
+    status through verbatim). Surface any genuine client/server error status
+    (4xx/5xx) transparently so the operator and UI see the actual cause —
+    e.g. ``410 Gone`` (stale resourceVersion), ``412 Precondition Failed``
+    (optimistic-concurrency conflict on update), or ``502``/``504`` from an
+    aggregated/proxied API server. The previous identity allowlist collapsed
+    every status outside a fixed set to a generic ``500 Failed to <op>``,
+    hiding the real failure.
+
+    Anything that is not a valid HTTP error status (e.g. ``0`` for a connection
+    failure, or an out-of-range value) defaults to ``500``.
+    """
+    http_status = e.status if 400 <= e.status <= 599 else 500
     return HTTPException(status_code=http_status, detail=e.message or e.reason)
 
 

--- a/api/tests/test_k8s_error_mapping.py
+++ b/api/tests/test_k8s_error_mapping.py
@@ -1,0 +1,58 @@
+"""Tests for ``_map_k8s_error`` status pass-through.
+
+``K8sApiError.status`` already carries the real HTTP status the Kubernetes
+API server returned (``K8sClient._wrap_api_exception`` forwards the
+``ApiException`` status verbatim). ``_map_k8s_error`` must surface that
+status transparently for any genuine 4xx/5xx error, rather than collapsing
+unexpected-but-valid statuses (410, 412, 502, 504, ...) to a misleading 500.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aerospike_cluster_manager_api.k8s_client import K8sApiError
+from aerospike_cluster_manager_api.routers.k8s_clusters import _map_k8s_error
+
+
+@pytest.mark.parametrize(
+    "status",
+    [400, 401, 403, 404, 408, 409, 422, 429, 503],
+)
+def test_known_statuses_pass_through(status: int) -> None:
+    """The statuses the old allowlist handled still map to themselves."""
+    exc = _map_k8s_error(K8sApiError(status=status, reason="r", message="m"))
+    assert exc.status_code == status
+
+
+@pytest.mark.parametrize(
+    "status",
+    [410, 412, 415, 502, 504, 451, 423],
+)
+def test_other_valid_http_error_statuses_pass_through(status: int) -> None:
+    """Real K8s API statuses outside the old allowlist must not collapse to 500.
+
+    410 Gone (stale resourceVersion), 412 Precondition Failed (optimistic
+    concurrency on update), and 502/504 from an aggregated/proxied API server
+    are all real responses that previously became an opaque ``500``.
+    """
+    exc = _map_k8s_error(K8sApiError(status=status, reason="r", message="m"))
+    assert exc.status_code == status
+
+
+@pytest.mark.parametrize("status", [0, -1, 200, 302, 399, 600, 700])
+def test_invalid_or_non_error_statuses_default_to_500(status: int) -> None:
+    """Anything that is not a valid HTTP error status defaults to 500.
+
+    ``0`` is what ``_wrap_api_exception`` would carry for a connection failure
+    if it were not already normalized; success/redirect/out-of-range values
+    have no meaningful error mapping.
+    """
+    exc = _map_k8s_error(K8sApiError(status=status, reason="r", message="m"))
+    assert exc.status_code == 500
+
+
+def test_detail_prefers_message_then_reason() -> None:
+    """Detail uses ``message`` when present, falling back to ``reason``."""
+    assert _map_k8s_error(K8sApiError(status=404, reason="NotFound", message="gone")).detail == "gone"
+    assert _map_k8s_error(K8sApiError(status=404, reason="NotFound", message="")).detail == "NotFound"


### PR DESCRIPTION
## Problem

`_map_k8s_error` in `api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py` used an **identity allowlist** to translate a `K8sApiError` into an `HTTPException`:

```python
status_map = {400: 400, 401: 401, 403: 403, 404: 404, 408: 408, 409: 409, 422: 422, 429: 429, 503: 503}
http_status = status_map.get(e.status, 500)
```

Every entry maps a status to itself, so the dict is really just an allowlist — any status outside it collapses to a generic `500 Failed to <operation>`.

But `K8sClient._wrap_api_exception` already forwards the **real** Kubernetes API server status verbatim (`status = raw_status if raw_status else 500`). So genuine, actionable errors were being hidden:

- **410 Gone** — stale `resourceVersion` on a list/watch
- **412 Precondition Failed** — optimistic-concurrency conflict on an update (the K8s client even raises 409 for some of these, but the API server itself returns 412)
- **502 / 504** — from an aggregated or proxied API server
- **415**, **451**, etc.

All of these reached the client as an opaque `500`, so operators and the UI lost the real cause.

## Fix

Pass through any valid HTTP error status (400–599) transparently, defaulting only invalid/non-error values (`0` for a connection failure, out-of-range numbers) to `500`:

```python
http_status = e.status if 400 <= e.status <= 599 else 500
```

Behavior for every status the old allowlist handled is **unchanged** (each was an identity mapping). This is strictly additive: previously-hidden statuses now surface correctly.

## Verification

```
cd api
uv run ruff check src tests            # All checks passed!
uv run ruff format --check src tests   # 133 files already formatted
uv run pytest tests/test_k8s_error_mapping.py -q   # 24 passed
uv run pytest tests/test_k8s_pods_list_endpoint.py tests/test_clone_endpoint.py \
              tests/test_k8s_migration_status.py tests/test_k8s_workspace_toctou_guard.py -q  # passed
```

Adds `api/tests/test_k8s_error_mapping.py` covering: previously-allowlisted statuses still map 1:1, newly passed-through statuses (410/412/415/502/504/451/423), invalid-status fallback to 500, and `detail` precedence (message then reason).

## Scope

- 2 files, ~25 lines changed.
- No public Pydantic/TS type renamed; no version bump.