### PR TITLE
fix(api): add response_model to POST /connections/test endpoint

### DIFF
--- a/api/src/aerospike_cluster_manager_api/models/connection.py
+++ b/api/src/aerospike_cluster_manager_api/models/connection.py
@@ -110,6 +110,18 @@ class TestConnectionRequest(BaseModel):
     password: str | None = None
 
 
+class TestConnectionResponse(BaseModel):
+    """Result of ``POST /connections/test`` — connectivity probe outcome.
+
+    ``message`` is normalised to a generic string on failure so the REST
+    surface never leaks host/port or driver internals (see the router
+    docstring); the original detail lives in the operator log only.
+    """
+
+    success: bool
+    message: str
+
+
 class ConnectionProfileResponse(BaseModel):
     """Connection profile without password — used in API responses.
 

--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -16,6 +16,7 @@ from aerospike_cluster_manager_api.models.connection import (
     ConnectionStatus,
     CreateConnectionRequest,
     TestConnectionRequest,
+    TestConnectionResponse,
     UpdateConnectionRequest,
 )
 from aerospike_cluster_manager_api.rate_limit import limiter
@@ -252,6 +253,7 @@ def _disconnected_health(error: str, error_type: str) -> Response:
 
 @router.post(
     "/test",
+    response_model=TestConnectionResponse,
     summary="Test connection",
     description="Test connectivity to an Aerospike cluster without saving the profile.",
 )
@@ -260,7 +262,7 @@ async def test_connection(
     request: Request,
     body: TestConnectionRequest,
     caller_owner_id: CallerOwnerId,
-) -> dict[str, bool | str]:
+) -> TestConnectionResponse:
     """Test connectivity to an Aerospike cluster without saving the profile.
 
     Failure messages are normalised to a generic ``"connection failed"``
@@ -279,8 +281,8 @@ async def test_connection(
             body.port,
             result.message,
         )
-        return {"success": False, "message": "connection failed"}
-    return {"success": True, "message": result.message}
+        return TestConnectionResponse(success=False, message="connection failed")
+    return TestConnectionResponse(success=True, message=result.message)
 
 
 @router.delete(

--- a/api/tests/test_connections_router.py
+++ b/api/tests/test_connections_router.py
@@ -312,6 +312,39 @@ class TestTestConnection:
         assert body["success"] is True
         assert body["message"] == "Connected successfully"
 
+    async def test_response_schema(self, client: AsyncClient):
+        """Response conforms to the TestConnectionResponse model.
+
+        Guards the response_model contract (follow-up to #413/#414): the
+        body carries exactly ``success`` (bool) and ``message`` (str) and
+        OpenAPI advertises that typed schema rather than ``Any``.
+        """
+        mock_client = AsyncMock()
+        mock_client.connect = AsyncMock()
+        mock_client.is_connected = lambda: True
+        mock_client.close = AsyncMock()
+
+        with patch(
+            "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
+            return_value=mock_client,
+        ):
+            response = await client.post(
+                "/api/connections/test",
+                json={"hosts": ["localhost"], "port": 3000},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert set(body) == {"success", "message"}
+        assert isinstance(body["success"], bool)
+        assert isinstance(body["message"], str)
+
+        paths = app.openapi()["paths"]
+        path_key = next(p for p in paths if p.endswith("/connections/test"))
+        schema = paths[path_key]["post"]
+        ref = schema["responses"]["200"]["content"]["application/json"]["schema"]["$ref"]
+        assert ref.endswith("/TestConnectionResponse")
+
     async def test_failure(self, client: AsyncClient):
         """Test connection endpoint when connection fails.
 


### PR DESCRIPTION
## Summary

Follow-up to [#413](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/413) / [#414](https://github.com/aerospike-ce-ecosystem/aerospike-cluster-manager/pull/414). Both PRs swept the connections/workspaces/etc. routers to declare `response_model=` on typed POST handlers, but **explicitly skipped** `POST /connections/test` because it returned a plain `dict[str, bool | str]` ("intentionally untyped"). This PR closes that last gap by giving the endpoint a proper Pydantic model.

## The gap

`test_connection` returned a bare `dict[str, bool | str]` with no `response_model`, so:

- FastAPI skipped response validation/coercion for this handler.
- OpenAPI / Swagger / ReDoc reported the 200 response as `Any` instead of a typed shape.
- Downstream codegen consumers (UI types, ackoctl) fell back to `Any`.

## The fix

- New `TestConnectionResponse(BaseModel)` in `models/connection.py` with `success: bool` and `message: str` — matches the exact dict shape the handler already returned (no wire-key renames, fully backward compatible).
- `routers/connections.py`: added `response_model=TestConnectionResponse` to the decorator, changed the return annotation, and returns the model instance instead of a raw dict. Failure path still normalises to the generic `"connection failed"` message (P1-1 leak hardening preserved).

This is a purely additive contract change: same JSON keys (`success`, `message`), same types — the only observable effect is that FastAPI now enforces the type at serialization time and OpenAPI advertises `TestConnectionResponse`.

## Test plan

- New `TestTestConnection::test_response_schema` asserts the body carries exactly `{success, message}` with correct types **and** that OpenAPI advertises a `$ref` to `TestConnectionResponse` (not `Any`).
- `uv run pytest tests/test_connections_router.py tests/test_connections_service.py -q` — all pass.
- `uv run ruff check src tests` — clean.
- `uv run ruff format --check src tests` — 133 files already formatted (CI gate satisfied).