### PR TITLE
fix(api): return disconnected health instead of 500 on TOCTOU profile deletion

### DIFF
--- a/api/src/aerospike_cluster_manager_api/models/connection.py
+++ b/api/src/aerospike_cluster_manager_api/models/connection.py
@@ -39,7 +39,7 @@ class ConnectionStatus(BaseModel):
     diskTotal: int = 0
     tendHealthy: bool | None = None
     error: str | None = None
-    errorType: str | None = None  # timeout | connection_refused | cluster_error | auth_error | unknown
+    errorType: str | None = None  # timeout | connection_refused | cluster_error | auth_error | unknown | not_found
 
 
 class ConnectionProfile(BaseModel):

--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -225,6 +225,12 @@ async def get_connection_health(conn_id: str = Depends(_get_verified_connection)
             diskTotal=disk_total,
             tendHealthy=tend_healthy,
         )
+    except ValueError as exc:
+        # Profile vanished between the route dependency check and the client
+        # fetch (TOCTOU) — get_client() raises a plain ValueError. Surface as
+        # the disconnected shape, not an opaque 500.
+        logger.warning("Connection '%s' disappeared during health check", conn_id, exc_info=True)
+        return _disconnected_health(str(exc), "not_found")
     except AerospikeTimeoutError as exc:
         logger.warning("Health check timed out for connection '%s'", conn_id, exc_info=True)
         return _disconnected_health(str(exc), "timeout")

--- a/api/tests/test_connections_router.py
+++ b/api/tests/test_connections_router.py
@@ -497,6 +497,28 @@ class TestConnectionHealth:
         assert body["connected"] is True
         assert body["tendHealthy"] is True
 
+    async def test_profile_deleted_mid_health_check_returns_disconnected(self, client: AsyncClient, sample_connection):
+        """TOCTOU: profile vanishes between the dependency check and get_client().
+
+        get_client() raises a plain ValueError, which is NOT an Aerospike/OS
+        error. Without an explicit handler it escapes to the global 500 handler
+        and breaks the documented "always HTTP 200 / connected=false" contract.
+        """
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+
+        with patch(
+            "aerospike_cluster_manager_api.routers.connections.client_manager.get_client",
+            side_effect=ValueError(f"Connection profile '{sample_connection.id}' not found"),
+        ):
+            resp = await client.get(f"/api/connections/{sample_connection.id}/health")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["connected"] is False
+        assert body["errorType"] == "not_found"
+
 
 class TestConnectionSSRF:
     """P1-1 regression: test_connection rejects loopback / link-local


### PR DESCRIPTION
## Bug

`GET /api/connections/{conn_id}/health` documents an "always HTTP 200 / `connected: false`" contract for unreachable clusters. The handler calls `client = await client_manager.get_client(conn_id)` directly (connections.py ~line 148).

On a TOCTOU race — the connection profile is deleted between the route dependency check (`_get_verified_connection`) and this `get_client()` call — `get_client()` raises a plain `ValueError`. That exception type is **not** covered by the existing except chain (`AerospikeTimeoutError`, `ConnectionRefusedError`, `ClusterError`, `(AerospikeError, OSError)`), so it escaped to the global 500 handler. This broke the documented contract and surfaced an opaque 500 to the Next.js health indicator.

## Fix (purely additive — no wire-field changes)

- **api/routers/connections.py**: add a `ValueError` branch (before the `AerospikeTimeoutError` handler) that logs a warning and returns the existing `_disconnected_health(str(exc), "not_found")` disconnected shape. Restores the HTTP 200 / `connected: false` contract.
- **api/models/connection.py**: append `| not_found` to the inline `errorType` allowed-values comment so docs stay accurate. `errorType` remains a free-form `str | None` — no schema change.
- **api/tests/test_connections_router.py**: new test in the health-robustness block patches `client_manager.get_client` to raise `ValueError(...)` and asserts HTTP 200 with `connected == false` and `errorType == "not_found"`.

No JSON wire field was renamed/removed/narrowed; the UI contract is unchanged.

## Verification

- `uv run pytest tests/test_connections_router.py -q` — **42 passed**
- `uv run ruff check` (3 changed files) — **All checks passed!**
- `uv run ruff format --check` (3 changed files) — **3 files already formatted**
- `pre-commit run --files <changed>` — ruff, ruff format, pyright, all hooks **Passed**