### PR TITLE
fix(api): strip bad port suffix in parse_host_port so SSRF gate sees the bare host

### DIFF
--- a/api/src/aerospike_cluster_manager_api/utils.py
+++ b/api/src/aerospike_cluster_manager_api/utils.py
@@ -34,7 +34,12 @@ def parse_host_port(host_str: str, default_port: int) -> tuple[str, int]:
     * ``host:port`` (single colon) -- split on the last colon.
     * Bare host (no colon) -- host with ``default_port``.
 
-    A non-integer port falls back to ``default_port``.
+    A non-integer port falls back to ``default_port`` while still returning
+    the parsed host portion (never the raw ``host:badport`` string). This
+    matters because ``connections_service`` feeds ``host_only`` straight into
+    the SSRF loopback/link-local gate: returning ``"127.0.0.1:x"`` instead of
+    ``"127.0.0.1"`` makes ``ipaddress.ip_address`` raise, the gate treat the
+    target as a non-literal hostname, and the block silently no-op.
     """
     if host_str.startswith("["):  # bracketed IPv6, optional :port
         host, _, port_str = host_str[1:].partition("]")
@@ -51,5 +56,8 @@ def parse_host_port(host_str: str, default_port: int) -> tuple[str, int]:
         try:
             return (host, int(port_str))
         except ValueError:
-            return (host_str, default_port)
+            # Non-integer port: keep the parsed host, drop the bad suffix.
+            # Returning the raw ``host:badport`` here would defeat the SSRF
+            # gate that parses ``host_only`` as an IP literal.
+            return (host, default_port)
     return (host_str, default_port)

--- a/api/tests/test_connections_router.py
+++ b/api/tests/test_connections_router.py
@@ -581,6 +581,24 @@ class TestConnectionSSRF:
         assert response.json()["success"] is False
         mock_cls.assert_not_called()
 
+    async def test_loopback_with_bad_port_suffix_rejected(self, client: AsyncClient):
+        """A loopback target carrying a non-integer port suffix
+        (``127.0.0.1:abc``) must still trip the SSRF gate. Regression for
+        the ``parse_host_port`` non-integer-port fallback that returned the
+        raw ``host:badport`` string instead of the bare host -- the gate
+        then failed to parse it as an IP literal and let the loopback
+        target slip through."""
+        with patch(
+            "aerospike_cluster_manager_api.services.connections_service.aerospike_py.AsyncClient",
+        ) as mock_cls:
+            response = await client.post(
+                "/api/connections/test",
+                json={"hosts": ["127.0.0.1:abc"], "port": 3000},
+            )
+        assert response.status_code == 200
+        assert response.json()["success"] is False
+        mock_cls.assert_not_called()
+
     async def test_loopback_allowed_when_env_override_set(self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch):
         """``ACM_CONNECTION_TEST_ALLOW_PRIVATE=true`` lets dev deployments
         target the loopback Aerospike running alongside the API."""

--- a/api/tests/test_utils.py
+++ b/api/tests/test_utils.py
@@ -20,6 +20,15 @@ from aerospike_cluster_manager_api.utils import parse_host_port
         ("[::1]", ("::1", 3000)),
         ("[::1]:3100", ("::1", 3100)),
         ("[2001:db8::1]:3000", ("2001:db8::1", 3000)),
+        # Non-integer / empty port on a single-colon host: fall back to the
+        # default port but keep ONLY the host part. Returning the raw
+        # "host:badport" string would defeat the SSRF gate in
+        # connections_service, which parses host_only as an IP literal.
+        ("127.0.0.1:abc", ("127.0.0.1", 3000)),
+        ("127.0.0.1:", ("127.0.0.1", 3000)),
+        ("host.example:notaport", ("host.example", 3000)),
+        # Bracketed IPv6 with a bad port already strips correctly — pin it.
+        ("[::1]:abc", ("::1", 3000)),
     ],
 )
 def test_parse_host_port(host_str: str, expected: tuple[str, int]):


### PR DESCRIPTION
## Problem

`parse_host_port()` (in `api/src/aerospike_cluster_manager_api/utils.py`) is reused by `connections_service` as the host extractor for the **SSRF gate** on `POST /api/connections/test`:

```python
host_only, _ = parse_host_port(host_str, req.port)
if _is_blocked_target(host_only):   # blocks loopback / link-local
    ...
```

A target carrying a **non-integer port suffix** (e.g. `127.0.0.1:abc`) slipped past the loopback/link-local block.

## Root cause

In the single-colon `host:port` branch, a non-integer port fell back to returning the **raw** `host_str` rather than the parsed host:

```python
except ValueError:
    return (host_str, default_port)   # -> ("127.0.0.1:abc", 3000)
```

Downstream, `_is_blocked_target("127.0.0.1:abc")` calls `ipaddress.ip_address("127.0.0.1:abc")`, which raises `ValueError`. The gate interprets that as "not a bare IP literal" and **lets the target through** — silently no-opping the SSRF block for any loopback/link-local IP with a malformed port suffix.

This also:
- contradicted the function's own docstring ("a non-integer port falls back to `default_port`"), and
- was inconsistent with the **bracketed-IPv6 branch**, which already returns just the host on a bad port.

## Fix

Return `(host, default_port)` — the parsed host with the bad suffix dropped — matching the bracketed-IPv6 branch and the documented contract. One-line change in the `except ValueError` path, plus a clarifying docstring note about the SSRF coupling.

## Tests

- `tests/test_utils.py`: added parametrized cases `127.0.0.1:abc`, `127.0.0.1:`, `host.example:notaport`, and `[::1]:abc`.
- `tests/test_connections_router.py`: added `TestConnectionSSRF::test_loopback_with_bad_port_suffix_rejected`, asserting `127.0.0.1:abc` trips the gate (`success: false`) with **no Aerospike client constructed**.

Both new tests fail without the source change (verified by reverting only `utils.py`).

## Verification

```
$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
133 files already formatted

$ uv run pytest
971 passed, 6 warnings   # was 966; +5 new tests
```

## Risk / scope

- 1 source line changed (the bad-port fallback) + docstring; 2 test files.
- No public type / Pydantic alias / wire-format change. No version bump.
- Behavior change is strictly narrowing: previously-returned `host:badport` strings now return the clean host. The only callers are the SSRF gate (now correctly blocks) and the test-connection client config (a `host:badport` host string would have failed DNS resolution anyway).