### PR TITLE
fix(indexes): tolerate per-namespace sindex failures in GET /indexes

### DIFF
--- a/api/src/aerospike_cluster_manager_api/routers/indexes.py
+++ b/api/src/aerospike_cluster_manager_api/routers/indexes.py
@@ -45,7 +45,16 @@ async def get_indexes(client: AerospikeClient) -> list[SecondaryIndex]:
 
     indexes: list[SecondaryIndex] = []
     for ns in ns_names:
-        sindex_raw = await client.info_random_node(info_sindex(ns))
+        # Isolate per-namespace sindex failures so one bad namespace does not
+        # 500 the whole listing — return indexes from the healthy namespaces
+        # instead (matches the partial-failure convention from #257/#260 and
+        # sample_data_service). Total cluster-unreachability still surfaces via
+        # the unguarded INFO_NAMESPACES call above (ClusterError -> 503).
+        try:
+            sindex_raw = await client.info_random_node(info_sindex(ns))
+        except AerospikeError:
+            logger.warning("Failed to list secondary indexes for namespace %s", ns, exc_info=True)
+            continue
         for rec in parse_records(sindex_raw):
             raw_type = rec.get("type", rec.get("bin_type", "string")).lower()
             idx_type = cast(Literal["numeric", "string", "geo2dsphere"], _TYPE_MAP.get(raw_type, "string"))

--- a/api/tests/test_api_500_regressions.py
+++ b/api/tests/test_api_500_regressions.py
@@ -248,6 +248,61 @@ class TestIndexesIdempotency:
 
 
 # ---------------------------------------------------------------------------
+# GET /indexes must not 500 when one namespace's sindex info call raises
+# ---------------------------------------------------------------------------
+
+
+class TestGetIndexesPartialFailure:
+    async def test_returns_healthy_namespace_indexes_when_one_namespace_raises(
+        self,
+        http_client: AsyncClient,
+    ):
+        """sindex listing for "prod" raises, but "test" succeeds — the request
+        must return 200 with the indexes gathered from the healthy namespace
+        rather than 500-ing the whole listing."""
+
+        async def info_side_effect(command: str):
+            if command == "namespaces":
+                return "test;prod"
+            if "test" in command:
+                return "ns=test:indexname=qa_idx:set=demo:bin=score:type=numeric:state=RW"
+            raise AerospikeError("sindex info blew up for prod")
+
+        mock_client = AsyncMock()
+        mock_client.info_random_node = AsyncMock(side_effect=info_side_effect)
+
+        db_patch, client_patch = _patch_client(mock_client)
+        with db_patch, client_patch:
+            response = await http_client.get("/api/v1/indexes/conn-test")
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        names = {idx["name"] for idx in body}
+        namespaces = {idx["namespace"] for idx in body}
+        assert "qa_idx" in names
+        assert namespaces == {"test"}
+
+    async def test_returns_empty_list_when_all_namespaces_raise(self, http_client: AsyncClient):
+        """Every per-namespace sindex query raising must still yield 200 with an
+        empty list — not a 500."""
+
+        async def info_side_effect(command: str):
+            if command == "namespaces":
+                return "test;prod"
+            raise AerospikeError("sindex info blew up")
+
+        mock_client = AsyncMock()
+        mock_client.info_random_node = AsyncMock(side_effect=info_side_effect)
+
+        db_patch, client_patch = _patch_client(mock_client)
+        with db_patch, client_patch:
+            response = await http_client.get("/api/v1/indexes/conn-test")
+
+        assert response.status_code == 200, response.text
+        assert response.json() == []
+
+
+# ---------------------------------------------------------------------------
 # 500 handler — common ask in #257/#260: include requestId + error in body
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Problem

`get_indexes` (`api/src/aerospike_cluster_manager_api/routers/indexes.py`) loops over every namespace calling `await client.info_random_node(info_sindex(ns))` with no error isolation. If **one** namespace's sindex info call raises `AerospikeError`, the exception escapes to the global handler and the endpoint returns **HTTP 500 with zero indexes** — even when other namespaces returned valid indexes. This violates the team's established partial-failure convention (prior fixes #257 / #260 and `sample_data_service`).

## Fix

- Wrap the per-namespace sindex call in `try/except AerospikeError`, log `logger.warning(..., exc_info=True)`, and `continue` to the next namespace — returning indexes from the healthy namespaces.
- The initial `INFO_NAMESPACES` call stays **unguarded** so total cluster-unreachability still surfaces as 503 via the global `ClusterError` handler.
- Matches the exact import / logger / exception conventions already used in this file and `sample_data_service.py`.

Purely additive error isolation. **No breaking change** — no Pydantic / wire-alias rename, no removed endpoint, no response-shape change.

## Tests

Added to `tests/test_api_500_regressions.py` (`TestGetIndexesPartialFailure`):
- **Test A** — namespaces `["test","prod"]`; sindex succeeds for `test`, raises `AerospikeError` for `prod` → asserts 200 and `test` indexes present.
- **Test B** — all sindex queries raise → asserts 200 with empty list.

## Verification

- `pytest tests/test_api_500_regressions.py` → 10 passed (8 pre-existing + 2 new)
- `pytest tests/` (full suite) → 973 passed
- `ruff check .` → All checks passed
- `ruff format --check .` → 133 files already formatted