### PR TITLE
fix(api): tolerate per-namespace info failures in GET /clusters/{conn_id}

### DIFF
--- a/api/src/aerospike_cluster_manager_api/services/clusters_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/clusters_service.py
@@ -287,7 +287,17 @@ async def get_cluster_info(client: aerospike_py.AsyncClient, conn_id: str) -> Cl
         for ns_name in ns_names:
             ns_tasks.append(client.info_all(info_namespace(ns_name)))
             ns_tasks.append(client.info_all(info_sets(ns_name)))
-        ns_results = await asyncio.gather(*ns_tasks)
+        # ``return_exceptions=True`` so a transient ``info_all`` failure on a
+        # single namespace does not blow up the whole cluster view. Without
+        # this, gather() re-raises the first failure, the global AerospikeError
+        # handler turns it into a 500, and the dashboard goes blank even though
+        # every node and the other namespace are perfectly healthy. We isolate
+        # the per-namespace failure below and return the namespaces that did
+        # respond — same partial-failure convention as GET /indexes (#429) and
+        # sample_data_service (#257). Total cluster-unreachability still
+        # surfaces via the unguarded list_namespaces() / get_nodes() calls
+        # above (ClusterError -> 503).
+        ns_results = await asyncio.gather(*ns_tasks, return_exceptions=True)
     else:
         ns_results = []
 
@@ -295,6 +305,19 @@ async def get_cluster_info(client: aerospike_py.AsyncClient, conn_id: str) -> Cl
     for i, ns_name in enumerate(ns_names):
         ns_all = ns_results[i * 2]
         sets_all = ns_results[i * 2 + 1]
+
+        # Skip a namespace whose namespace/<ns> or sets/<ns> info call raised.
+        # Aggregating against the BaseException placeholder gather() inserted
+        # would itself crash, so drop the namespace from the listing and carry
+        # on with the healthy ones.
+        if isinstance(ns_all, BaseException) or isinstance(sets_all, BaseException):
+            failure = ns_all if isinstance(ns_all, BaseException) else sets_all
+            logger.warning(
+                "Failed to fetch namespace/set info for namespace %s; omitting from cluster view",
+                ns_name,
+                exc_info=failure,
+            )
+            continue
 
         ns_stats = aggregate_node_kv(ns_all, keys_to_sum=NS_SUM_KEYS)
 

--- a/api/tests/test_clusters_service.py
+++ b/api/tests/test_clusters_service.py
@@ -384,6 +384,58 @@ class TestGetClusterInfo:
         assert result.namespaces == []
         assert len(result.nodes) == 2
 
+    async def test_tolerates_per_namespace_info_failure(self):
+        """A transient ``info_all`` failure on one namespace must not 500 the
+        whole cluster view — the healthy namespace is still returned.
+
+        Regression: ``get_cluster_info`` used to ``asyncio.gather`` the
+        per-namespace info calls without ``return_exceptions=True``, so a single
+        failing namespace re-raised through gather and the global
+        AerospikeError handler turned the entire ``GET /clusters/{conn_id}``
+        dashboard endpoint into a 500. Mirrors the partial-failure convention
+        already enforced for GET /indexes (#429) and sample-data (#257).
+        """
+        from aerospike_py.exception import AerospikeError
+
+        client = _make_mock_client()
+        # Two namespaces: "good" responds normally, "bad" raises on its
+        # namespace/<ns> info call.
+        client.info_random_node.return_value = "good;bad"
+
+        good_ns_stats = (
+            "objects=200;tombstones=0;memory_used_bytes=1024;"
+            "memory-size=4096;device_used_bytes=0;device-total-bytes=0;"
+            "replication-factor=2;stop_writes=false;hwm_breached=false;"
+            "high-water-memory-pct=60;high-water-disk-pct=50;"
+            "nsup-period=120;default-ttl=0;allow-ttl-without-nsup=false"
+        )
+        sets_resp = "set=myset:objects=100:tombstones=0:memory_data_bytes=500:stop-writes-count=0"
+
+        def info_all_side_effect(cmd: str):
+            if cmd == "statistics":
+                return [_info_all_result("node1", "cluster_size=2;uptime=3600")]
+            if cmd in ("build", "edition", "service"):
+                return [_info_all_result("node1", "x")]
+            if cmd == "namespace/good":
+                return [_info_all_result("node1", good_ns_stats)]
+            if cmd == "namespace/bad":
+                # Simulate a transient per-namespace info failure.
+                raise AerospikeError("namespace info temporarily unavailable")
+            if cmd.startswith("sets/"):
+                return [_info_all_result("node1", sets_resp)]
+            return []
+
+        client.info_all.side_effect = info_all_side_effect
+
+        result = await clusters_service.get_cluster_info(client, "conn-test-1")
+
+        # The bad namespace is omitted; the good one survives. Node listing is
+        # unaffected (it comes from get_node_names() + the statistics fan-out,
+        # not the per-namespace calls).
+        ns_names = [ns.name for ns in result.namespaces]
+        assert ns_names == ["good"]
+        assert len(result.nodes) == 2
+
 
 # ---------------------------------------------------------------------------
 # configure_namespace


### PR DESCRIPTION
## Issue

`GET /clusters/{conn_id}` (the main dashboard endpoint) used to return **HTTP 500** whenever a *single* namespace's `namespace/<ns>` or `sets/<ns>` info call hit a transient failure — even when every node and the cluster's other namespace were perfectly healthy.

Root cause is in `services/clusters_service.py::get_cluster_info`:

```python
ns_tasks = [...]  # 2 info_all calls per namespace
ns_results = await asyncio.gather(*ns_tasks)   # no return_exceptions=True
```

`asyncio.gather` without `return_exceptions=True` re-raises the first failing task. That `AerospikeError` bubbles to the global `AerospikeError` exception handler in `main.py`, which collapses it into a generic 500. The whole dashboard goes blank on a transient blip affecting just one namespace.

## Root Cause

Missing partial-failure isolation. The codebase already established the convention that one bad namespace must not 500 a whole cluster-wide listing — see `GET /indexes` (#429) and `sample_data_service` (#257) — but `get_cluster_info` predated/missed that hardening.

## Fix

- Fan out with `asyncio.gather(*ns_tasks, return_exceptions=True)`.
- Skip any namespace whose `namespace/<ns>` or `sets/<ns>` call returned a `BaseException` placeholder: log a warning (`exc_info=`) and `continue`, omitting just that namespace.
- Healthy namespaces are still returned.
- Total cluster-unreachability is unchanged: the unguarded `list_namespaces()` / `get_nodes()` calls earlier in the function still surface `ClusterError` → 503 via the global handler.

This mirrors the exact pattern used by the #429 indexes fix.

## Verification

- New regression test `TestGetClusterInfo::test_tolerates_per_namespace_info_failure` — two namespaces, one raises `AerospikeError` on its info call; asserts the healthy namespace is returned and nodes are intact. **Confirmed it fails without the service fix** (raw `AerospikeError` propagates) and passes with it.
- `uv run pytest` — **974 passed**.
- `uv run ruff check .` — All checks passed.
- `uv run ruff format --check .` — 133 files already formatted.

## Scope

2 files, +76/-1 lines. No public API / wire-format / version changes.