### PR TITLE
fix(api): tolerate per-namespace info failures in GET /metrics/{conn_id}

### DIFF
--- a/api/src/aerospike_cluster_manager_api/services/metrics_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/metrics_service.py
@@ -95,10 +95,17 @@ async def build_cluster_metrics(client, conn_id: str) -> ClusterMetrics:
 
         total_nodes = len(stats_all)
 
-        # All per-namespace info calls in parallel
+        # All per-namespace info calls in parallel. ``return_exceptions=True`` so a
+        # transient ``info_all`` failure on a single namespace does not blow up the
+        # whole metrics view. Without this, gather() re-raises the first failure, the
+        # broad ``except`` below turns it into an all-zeros disconnected payload, and
+        # the dashboard goes blank even though the cluster and the other namespaces
+        # are perfectly healthy. We isolate the per-namespace failure in the loop
+        # below and return the namespaces that did respond — same partial-failure
+        # convention as GET /clusters/{conn_id} (#430).
         if ns_names:
             ns_tasks = [client.info_all(info_namespace(ns_name)) for ns_name in ns_names]
-            ns_results = await asyncio.gather(*ns_tasks)
+            ns_results = await asyncio.gather(*ns_tasks, return_exceptions=True)
         else:
             ns_results = []
 
@@ -113,6 +120,19 @@ async def build_cluster_metrics(client, conn_id: str) -> ClusterMetrics:
 
         for i, ns_name in enumerate(ns_names):
             ns_all = ns_results[i]
+
+            # Skip a namespace whose namespace/<ns> info call raised. Aggregating
+            # against the BaseException placeholder gather() inserted would itself
+            # crash, so drop the namespace from the metrics and carry on with the
+            # healthy ones instead of zeroing the entire dashboard.
+            if isinstance(ns_all, BaseException):
+                logger.warning(
+                    "Failed to fetch namespace info for namespace %s; omitting from metrics",
+                    ns_name,
+                    exc_info=ns_all,
+                )
+                continue
+
             ns_stats = aggregate_node_kv(ns_all, keys_to_sum=NS_SUM_KEYS)
 
             replication_factor = safe_int(ns_stats.get("replication-factor"), 1)

--- a/api/tests/test_api_500_regressions.py
+++ b/api/tests/test_api_500_regressions.py
@@ -330,3 +330,61 @@ class TestInternalErrorBody:
         assert body["error"] == "Internal server error"
         assert "boom" not in str(body)
         assert response.headers.get("X-Request-ID") == "abcd1234abcd1234abcd1234abcd1234"
+
+
+# ---------------------------------------------------------------------------
+# GET /metrics must not blank the whole dashboard when one namespace's
+# info call raises — partial-failure parity with GET /clusters (#430)
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsPartialFailure:
+    async def test_returns_healthy_namespace_metrics_when_one_namespace_raises(
+        self,
+        http_client: AsyncClient,
+    ):
+        """``info_all("namespace/prod")`` raises but "test" succeeds — the metrics
+        endpoint must return 200 with connected=true and the healthy namespace,
+        rather than letting the failure degrade the whole payload to all-zeros."""
+
+        async def info_all_side_effect(command: str):
+            if command == "statistics":
+                return [("node1", None, "cluster_size=1;client_connections=5;uptime=3600")]
+            if command == "namespace/test":
+                return [("node1", None, "objects=100;replication-factor=1;data_used_bytes=1000;data_total_bytes=4000")]
+            raise AerospikeError("namespace info blew up for prod")
+
+        mock_client = AsyncMock()
+        mock_client.info_all = AsyncMock(side_effect=info_all_side_effect)
+        mock_client.info_random_node = AsyncMock(return_value="test;prod")
+
+        db_patch, client_patch = _patch_client(mock_client)
+        with db_patch, client_patch:
+            response = await http_client.get("/api/v1/metrics/conn-test")
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["connected"] is True
+        ns_names = {ns["namespace"] for ns in body["namespaces"]}
+        assert ns_names == {"test"}
+
+    async def test_returns_no_namespaces_when_all_namespaces_raise(self, http_client: AsyncClient):
+        """Every per-namespace info call raising must still yield 200 with an
+        empty namespace list — not a degraded/500 response."""
+
+        async def info_all_side_effect(command: str):
+            if command == "statistics":
+                return [("node1", None, "cluster_size=1;client_connections=5;uptime=3600")]
+            raise AerospikeError("namespace info blew up")
+
+        mock_client = AsyncMock()
+        mock_client.info_all = AsyncMock(side_effect=info_all_side_effect)
+        mock_client.info_random_node = AsyncMock(return_value="test;prod")
+
+        db_patch, client_patch = _patch_client(mock_client)
+        with db_patch, client_patch:
+            response = await http_client.get("/api/v1/metrics/conn-test")
+
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["namespaces"] == []


### PR DESCRIPTION
## Problem

`build_cluster_metrics` fetches every namespace's `info_all()` in parallel via `asyncio.gather(*ns_tasks)` **without** `return_exceptions=True`. If a single namespace's info call fails (transient network error, one node down mid-poll), `gather` re-raises the first exception, the broad `except` in the service catches it and returns an **all-zeros, `connected=false`** `ClusterMetrics`. The metrics dashboard then goes blank for the *entire* cluster even though every node and the other namespaces are perfectly healthy.

This is the exact failure mode that was already fixed for `GET /clusters/{conn_id}` in #430 — `GET /metrics/{conn_id}` had the same latent bug.

## Fix

- `asyncio.gather(*ns_tasks, return_exceptions=True)` so one namespace's failure no longer aborts the whole view.
- In the aggregation loop, skip any namespace whose result is a `BaseException`, log a warning (`exc_info`), and continue with the healthy namespaces — partial data beats no data.

No wire-format change: the `ClusterMetrics` / `NamespaceMetrics` schema is untouched. Failed namespaces are simply omitted from `namespaces[]`, identical to the `GET /clusters` convention.

## Tests

Added `TestMetricsPartialFailure` to `tests/test_api_500_regressions.py`:
- one namespace raises → 200, `connected=true`, only the healthy namespace returned.
- all namespaces raise → 200 with empty `namespaces[]` (not a degraded/500 response).

Local validation: full `test_api_500_regressions.py` green, `ruff check` clean, `ruff format --check` clean.

🤖 Generated as part of an automated ecosystem code-improvement pass.