### PR TITLE
fix(api): tolerate per-namespace info failures in GET /connections/{conn_id}/health

### DIFF
--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -173,12 +173,37 @@ async def get_connection_health(conn_id: str = Depends(_get_verified_connection)
             # across nodes for an accurate cluster-wide total. Sampling a single
             # random node and multiplying by node_count is wrong on an
             # unbalanced cluster.
+            #
+            # ``return_exceptions=True`` so a transient ``info_all`` failure on a
+            # single namespace does not abandon the whole aggregation loop. Without
+            # it, gather() re-raises the first failure, the broad ``except`` below
+            # swallows it at debug level, and the health card reports
+            # memory/disk = 0 for the ENTIRE cluster even though every node and the
+            # other namespaces are healthy. We skip the failed namespace and sum the
+            # ones that did respond — same per-namespace partial-failure convention
+            # as GET /metrics/{conn_id} (#431) and GET /clusters/{conn_id} (#430).
             if namespaces:
-                ns_infos = await asyncio.gather(*[client.info_all(f"namespace/{ns_name}") for ns_name in namespaces])
+                ns_infos = await asyncio.gather(
+                    *[client.info_all(f"namespace/{ns_name}") for ns_name in namespaces],
+                    return_exceptions=True,
+                )
             else:
                 ns_infos = []
 
-            for ns_info in ns_infos:
+            for ns_name, ns_info in zip(namespaces, ns_infos, strict=True):
+                # Skip a namespace whose namespace/<ns> info call raised.
+                # Aggregating against the BaseException placeholder gather()
+                # inserted would itself crash, so drop it and carry on with the
+                # healthy namespaces instead of zeroing the whole summary.
+                if isinstance(ns_info, BaseException):
+                    logger.warning(
+                        "Failed to fetch namespace info for namespace %s on connection '%s'; "
+                        "omitting from health summary",
+                        ns_name,
+                        conn_id,
+                        exc_info=ns_info,
+                    )
+                    continue
                 kv = aggregate_node_kv(ns_info, keys_to_sum=NS_SUM_KEYS)
                 # CE 8 uses unified data_used_bytes/data_total_bytes for both memory and device.
                 # Fall back to legacy memory_used_bytes/memory-size for older versions.

--- a/api/tests/test_connections_router.py
+++ b/api/tests/test_connections_router.py
@@ -497,6 +497,46 @@ class TestConnectionHealth:
         assert body["connected"] is True
         assert body["tendHealthy"] is True
 
+    async def test_one_namespace_info_failure_keeps_other_namespace_stats(self, client: AsyncClient, sample_connection):
+        """One namespace's info_all() failure must not zero the whole summary.
+
+        Regression: the per-namespace fan-out used asyncio.gather WITHOUT
+        return_exceptions=True, so a single namespace's info_all() failure
+        re-raised, the broad except swallowed it, and memory/disk reported 0
+        for the ENTIRE cluster even though the other namespace was healthy.
+        Mirrors the partial-failure convention from #431 (metrics) / #430
+        (clusters). Healthy namespace 'test' must still contribute its stats.
+        """
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+
+        mock_as_client = self._make_reachable_client()
+        mock_as_client.ping = AsyncMock(return_value=True)
+
+        async def info_all_side_effect(cmd: str):
+            # Healthy namespace contributes real size stats; the other raises.
+            if cmd == "namespace/test":
+                return [
+                    ("node1", None, "data_used_bytes=1000;data_total_bytes=4000;device_used_bytes=0"),
+                ]
+            raise AerospikeError("transient info failure on namespace/bar")
+
+        mock_as_client.info_all.side_effect = info_all_side_effect
+
+        with patch(
+            "aerospike_cluster_manager_api.routers.connections.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.get(f"/api/connections/{sample_connection.id}/health")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["connected"] is True
+        # Before the fix these were 0 (the failing namespace aborted the loop).
+        assert body["memoryUsed"] == 1000
+        assert body["memoryTotal"] == 4000
+
     async def test_profile_deleted_mid_health_check_returns_disconnected(self, client: AsyncClient, sample_connection):
         """TOCTOU: profile vanishes between the dependency check and get_client().
 


### PR DESCRIPTION
## Summary

The per-namespace fan-out that PR #431 hardened in `metrics_service` has a twin in `GET /connections/{conn_id}/health` (`routers/connections.py`). There the per-namespace `asyncio.gather([client.info_all("namespace/<ns>") ...])` was missing `return_exceptions=True`. If a single namespace's `info_all()` failed (transient blip, one node down for that namespace), gather re-raised, the broad `except Exception` swallowed it at debug level, and the **entire** memory/disk aggregation loop was abandoned — so the health card reported `memoryUsed/memoryTotal/diskUsed/diskTotal = 0` for the whole cluster even though every node and the other namespace(s) were healthy.

## Fix

Mirrors #431 one-to-one: `return_exceptions=True`, skip + `logger.warning(..., exc_info=...)` the failed namespace, sum the ones that responded. `connected`/`build`/`edition` and the `ConnectionStatus` wire shape are untouched.

## Tests

Regression test `test_one_namespace_info_failure_keeps_other_namespace_stats` — fails before the fix (`assert 0 == 1000`), passes after.

## Verification

- New test passes; `TestConnectionHealth` 4/4 pass
- `uv run pytest tests/test_connections_router.py` → 44 passed
- Related suites (connections/clusters service + 500-regressions) → 111 passed
- `uv run ruff check` ✅  `uv run ruff format --check` ✅ (both CI gates)

Low risk: only the partial-failure path changes (previously zeroed all stats; now returns healthy namespaces' stats + logged warning). Total unreachability still surfaces via the unguarded `info_random_node` calls outside this block. No version bump, no wire-shape change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)