### PR TITLE
fix(ui): unwrap cascade layers in the copilot stylesheet, switch to sidebar

### DIFF
--- a/ui/scripts/copy-copilot-css.mjs
+++ b/ui/scripts/copy-copilot-css.mjs
@@ -3,19 +3,28 @@
  * plain static asset, loaded only when the copilot is enabled.
  *
  * Why not `import "@copilotkit/react-core/v2/styles.css"`: that file is
- * compiled with Tailwind v4 (native CSS cascade layers). Importing it routes
- * it through this app's Tailwind v3 PostCSS pipeline, which intercepts the
- * `@layer base` rules and fails the build ("`@layer base` is used but no
- * matching `@tailwind base` directive is present"). Serving it untouched
- * sidesteps the pipeline and keeps disabled deployments from downloading it
- * at all.
+ * compiled with Tailwind v4 and routed through this app's Tailwind v3
+ * PostCSS pipeline it fails the build ("`@layer base` is used but no
+ * matching `@tailwind base` directive is present").
+ *
+ * Why the @layer unwrapping: every rule in the file sits inside CSS cascade
+ * layers (properties/theme/base/utilities). Per the cascade spec, layered
+ * rules ALWAYS lose to un-layered rules of the same origin — and this app's
+ * own Tailwind v3 globals are un-layered, so they override CopilotKit's
+ * styling and the chat renders half-unstyled. Unwrapping is safe because
+ * the rules are already scoped: `base` targets [data-copilotkit] subtrees
+ * and `utilities` uses `.cpk\:`-prefixed classes. The one global rule (the
+ * `@layer properties` custom-property fallback on `*`) is re-scoped under
+ * [data-copilotkit] so it cannot leak into the app.
  *
  * Runs from the `prebuild` / `predev` npm hooks. Output is gitignored.
  */
 
-import { copyFileSync, mkdirSync } from "node:fs"
+import { readFileSync, mkdirSync, writeFileSync } from "node:fs"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
+
+import postcss from "postcss"
 
 const uiRoot = join(dirname(fileURLToPath(import.meta.url)), "..")
 const source = join(
@@ -25,6 +34,36 @@ const source = join(
 const targetDir = join(uiRoot, "public/copilot")
 const target = join(targetDir, "copilot-styles.css")
 
+function scopeSelector(selector) {
+  return selector
+    .split(",")
+    .map((part) => {
+      const sel = part.trim()
+      if (sel === "*") return "[data-copilotkit], [data-copilotkit] *"
+      // ::before / ::backdrop etc. on the universal selector
+      return `[data-copilotkit] ${sel}, [data-copilotkit]${sel}`
+    })
+    .join(", ")
+}
+
+const root = postcss.parse(readFileSync(source, "utf8"))
+
+root.walkAtRules("layer", (atRule) => {
+  if (!atRule.nodes) {
+    // bare `@layer components;` statement — drop it
+    atRule.remove()
+    return
+  }
+  if (atRule.params === "properties") {
+    // The custom-property fallback block targets `*` — scope it to
+    // CopilotKit subtrees before unwrapping so it cannot leak.
+    atRule.walkRules((rule) => {
+      rule.selector = scopeSelector(rule.selector)
+    })
+  }
+  atRule.replaceWith(atRule.nodes)
+})
+
 mkdirSync(targetDir, { recursive: true })
-copyFileSync(source, target)
-console.log(`[copy-copilot-css] ${source} -> ${target}`)
+writeFileSync(target, root.toString())
+console.log(`[copy-copilot-css] ${source} -> ${target} (layers unwrapped)`)

--- a/ui/src/components/copilot/CopilotShell.tsx
+++ b/ui/src/components/copilot/CopilotShell.tsx
@@ -6,7 +6,7 @@
  * tool/context/suggestion registrations.
  */
 
-import { CopilotKit, CopilotPopup } from "@copilotkit/react-core/v2"
+import { CopilotKit, CopilotSidebar } from "@copilotkit/react-core/v2"
 import * as React from "react"
 
 import { logCopilotError } from "@/lib/copilot/log"
@@ -75,7 +75,8 @@ export function CopilotShell({ children }: { children: React.ReactNode }) {
       <CopilotReadTools />
       <CopilotRenderTools />
       {children}
-      <CopilotPopup
+      <CopilotSidebar
+        width={440}
         labels={{
           modalHeaderTitle: "ACKO Agent",
           chatInputPlaceholder: "Ask ACKO Agent about your Aerospike clusters…",


### PR DESCRIPTION
Follow-up to #439. The Tailwind-v4-compiled CopilotKit stylesheet puts every rule in CSS cascade layers, which always lose to this app's un-layered Tailwind v3 globals — the chat rendered half-unstyled (reported via screenshot). The copy script now unwraps the layers with postcss (rules are already `[data-copilotkit]`/`.cpk:` scoped; the universal custom-property fallback is re-scoped so nothing leaks). Also switches the chat from `CopilotPopup` to `CopilotSidebar` (width 440). Verified on kind: official CopilotKit look restored, sidebar renders correctly, 87 tests green.