### PR TITLE
refactor(ui): migrate to Tailwind CSS v4

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -51,6 +51,7 @@
       },
       "devDependencies": {
         "@tailwindcss/forms": "^0.5.10",
+        "@tailwindcss/postcss": "^4.3.0",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -67,7 +68,7 @@
         "postcss": "^8.5.15",
         "prettier": "^3.6.2",
         "prettier-plugin-tailwindcss": "^0.8.0",
-        "tailwindcss": "^3.4.18",
+        "tailwindcss": "^4.3.0",
         "typescript": "^5.9.3",
         "vitest": "^2.1.9"
       }
@@ -538,6 +539,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
       "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -2334,6 +2336,7 @@
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
       "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2355,6 +2358,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
       "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
@@ -2364,12 +2368,14 @@
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.31",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
       "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -3129,6 +3135,7 @@
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
@@ -3142,6 +3149,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 8"
@@ -3151,6 +3159,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
@@ -4936,6 +4945,289 @@
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
       }
     },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.21.0",
+        "jiti": "^2.6.1",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.1",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.0.tgz",
+      "integrity": "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "postcss": "^8.5.10",
+        "tailwindcss": "4.3.0"
+      }
+    },
     "node_modules/@tanstack/devtools-event-client": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@tanstack/devtools-event-client/-/devtools-event-client-0.4.3.tgz",
@@ -6654,43 +6946,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
-      "license": "MIT"
-    },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/anymatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/arg": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
-      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
-      "license": "MIT"
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -7027,18 +7282,6 @@
         "node": "*"
       }
     },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/body-parser": {
       "version": "1.20.5",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
@@ -7116,18 +7359,6 @@
       },
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "license": "MIT",
-      "dependencies": {
-        "fill-range": "^7.1.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/browserslist": {
@@ -7282,15 +7513,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camelcase-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
-      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001788",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
@@ -7404,42 +7626,6 @@
         "node": ">= 16"
       }
     },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/clarinet": {
       "version": "0.12.6",
       "resolved": "https://registry.npmjs.org/clarinet/-/clarinet-0.12.6.tgz",
@@ -7540,15 +7726,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/commander": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/compare-versions": {
@@ -7665,18 +7842,6 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "license": "MIT",
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/cssstyle": {
       "version": "4.6.0",
@@ -8465,6 +8630,16 @@
         "npm": "1.2.8000 || >= 1.4.16"
       }
     },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -8484,12 +8659,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/didyoumean": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "license": "Apache-2.0"
-    },
     "node_modules/diff": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
@@ -8498,12 +8667,6 @@
       "engines": {
         "node": ">=0.3.1"
       }
-    },
-    "node_modules/dlv": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -8619,6 +8782,20 @@
       "license": "MIT",
       "dependencies": {
         "once": "^1.4.0"
+      }
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
+      "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/entities": {
@@ -9662,34 +9839,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/fast-glob": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.8"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-patch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
@@ -9736,6 +9885,7 @@
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
       "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -9745,6 +9895,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -9792,18 +9943,6 @@
       },
       "engines": {
         "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "node_modules/fill-range": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "license": "MIT",
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/finalhandler": {
@@ -9969,6 +10108,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -10202,6 +10342,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
       "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
@@ -11686,18 +11827,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-boolean-object": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
@@ -11765,6 +11894,7 @@
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
@@ -11825,6 +11955,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -11880,6 +12011,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
@@ -11934,15 +12066,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-number-object": {
@@ -12247,12 +12370,13 @@
       }
     },
     "node_modules/jiti": {
-      "version": "1.21.7",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
-      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
       "license": "MIT",
       "bin": {
-        "jiti": "bin/jiti.js"
+        "jiti": "lib/jiti-cli.mjs"
       }
     },
     "node_modules/jose": {
@@ -12618,23 +12742,278 @@
       "integrity": "sha512-NdB6O6QvlGMCoG003m0YIKG2+Xw7DjmCZhmc1RH+K6HncADUbRf8TZeLegxBBN1VFyPHcNpPTKpIhYLXzJVy1Q==",
       "license": "MIT"
     },
-    "node_modules/lilconfig": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-      "integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-      "license": "MIT",
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
       "engines": {
-        "node": ">=14"
+        "node": ">= 12.0.0"
       },
       "funding": {
-        "url": "https://github.com/sponsors/antonk52"
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "license": "MIT"
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/lit": {
       "version": "3.3.3",
@@ -18006,15 +18385,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/mermaid": {
       "version": "11.15.0",
       "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.15.0.tgz",
@@ -19567,31 +19937,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/micromatch": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "license": "MIT",
-      "dependencies": {
-        "braces": "^3.0.3",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/mime": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
@@ -19702,17 +20047,6 @@
       "license": "MIT",
       "bin": {
         "mustache": "bin/mustache"
-      }
-    },
-    "node_modules/mz": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
-      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0",
-        "object-assign": "^4.0.1",
-        "thenify-all": "^1.0.0"
       }
     },
     "node_modules/nanoid": {
@@ -19961,15 +20295,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/nwsapi": {
       "version": "2.2.23",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
@@ -19984,15 +20309,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -20403,6 +20719,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/path-scurry": {
@@ -20461,21 +20778,13 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
-    "node_modules/pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/pino": {
@@ -20540,15 +20849,6 @@
       "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
       "license": "MIT"
     },
-    "node_modules/pirates": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/pkce-challenge": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
@@ -20588,6 +20888,7 @@
       "version": "8.5.15",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
       "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -20611,155 +20912,6 @@
       "engines": {
         "node": "^10 || ^12 || >=14"
       }
-    },
-    "node_modules/postcss-import": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "license": "MIT",
-      "dependencies": {
-        "postcss-value-parser": "^4.0.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/postcss-import/node_modules/resolve": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
-      "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/postcss-js": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
-      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "camelcase-css": "^2.0.1"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >= 16"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.21"
-      }
-    },
-    "node_modules/postcss-load-config": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
-      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "lilconfig": "^3.1.1"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "peerDependencies": {
-        "jiti": ">=1.21.0",
-        "postcss": ">=8.0.9",
-        "tsx": "^4.8.1",
-        "yaml": "^2.4.2"
-      },
-      "peerDependenciesMeta": {
-        "jiti": {
-          "optional": true
-        },
-        "postcss": {
-          "optional": true
-        },
-        "tsx": {
-          "optional": true
-        },
-        "yaml": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/postcss-nested": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
-      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "postcss-selector-parser": "^6.1.1"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.14"
-      }
-    },
-    "node_modules/postcss-selector-parser": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
-      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
-      "license": "MIT",
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -20999,6 +21151,7 @@
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -21291,15 +21444,6 @@
         "react-dom": ">=16.6.0"
       }
     },
-    "node_modules/read-cache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "license": "MIT",
-      "dependencies": {
-        "pify": "^2.3.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
@@ -21314,30 +21458,6 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/real-require": {
@@ -22415,6 +22535,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -22591,6 +22712,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -24213,28 +24335,6 @@
       "integrity": "sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==",
       "license": "MIT"
     },
-    "node_modules/sucrase": {
-      "version": "3.35.1",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
-      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
-      "license": "MIT",
-      "dependencies": {
-        "@jridgewell/gen-mapping": "^0.3.2",
-        "commander": "^4.0.0",
-        "lines-and-columns": "^1.1.6",
-        "mz": "^2.7.0",
-        "pirates": "^4.0.1",
-        "tinyglobby": "^0.2.11",
-        "ts-interface-checker": "^0.1.9"
-      },
-      "bin": {
-        "sucrase": "bin/sucrase",
-        "sucrase-node": "bin/sucrase-node"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -24251,6 +24351,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -24296,61 +24397,23 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "3.4.19",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
-      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "arg": "^5.0.2",
-        "chokidar": "^3.6.0",
-        "didyoumean": "^1.2.2",
-        "dlv": "^1.1.3",
-        "fast-glob": "^3.3.2",
-        "glob-parent": "^6.0.2",
-        "is-glob": "^4.0.3",
-        "jiti": "^1.21.7",
-        "lilconfig": "^3.1.3",
-        "micromatch": "^4.0.8",
-        "normalize-path": "^3.0.0",
-        "object-hash": "^3.0.0",
-        "picocolors": "^1.1.1",
-        "postcss": "^8.4.47",
-        "postcss-import": "^15.1.0",
-        "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
-        "postcss-nested": "^6.2.0",
-        "postcss-selector-parser": "^6.1.2",
-        "resolve": "^1.22.8",
-        "sucrase": "^3.35.0"
-      },
-      "bin": {
-        "tailwind": "lib/cli.js",
-        "tailwindcss": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "license": "MIT"
     },
-    "node_modules/tailwindcss/node_modules/resolve": {
-      "version": "1.22.12",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
-      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
-      },
       "engines": {
-        "node": ">= 0.4"
+        "node": ">=6"
       },
       "funding": {
-        "url": "https://github.com/sponsors/ljharb"
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/test-exclude": {
@@ -24446,27 +24509,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/thenify": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
-      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
-      "license": "MIT",
-      "dependencies": {
-        "any-promise": "^1.0.0"
-      }
-    },
-    "node_modules/thenify-all": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
-      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
-      "license": "MIT",
-      "dependencies": {
-        "thenify": ">= 3.1.0 < 4"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/thread-stream": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.2.0.tgz",
@@ -24500,6 +24542,7 @@
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
       "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -24561,18 +24604,6 @@
       "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "license": "MIT",
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -24650,12 +24681,6 @@
       "engines": {
         "node": ">=6.10"
       }
-    },
-    "node_modules/ts-interface-checker": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
-      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
-      "license": "Apache-2.0"
     },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
@@ -25258,12 +25283,6 @@
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",

--- a/ui/package.json
+++ b/ui/package.json
@@ -61,6 +61,7 @@
   },
   "devDependencies": {
     "@tailwindcss/forms": "^0.5.10",
+    "@tailwindcss/postcss": "^4.3.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
@@ -77,7 +78,7 @@
     "postcss": "^8.5.15",
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.8.0",
-    "tailwindcss": "^3.4.18",
+    "tailwindcss": "^4.3.0",
     "typescript": "^5.9.3",
     "vitest": "^2.1.9"
   }

--- a/ui/postcss.config.mjs
+++ b/ui/postcss.config.mjs
@@ -1,7 +1,7 @@
 /** @type {import('postcss-load-config').Config} */
 const config = {
   plugins: {
-    tailwindcss: {},
+    "@tailwindcss/postcss": {},
   },
 }
 

--- a/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
@@ -170,7 +170,7 @@ function SecurityDisabledState() {
         href="https://aerospike.com/docs/server/operations/configure/security"
         target="_blank"
         rel="noopener noreferrer"
-        className="text-xs font-medium text-primary-40 hover:underline dark:text-primary-65"
+        className="text-primary-40 dark:text-primary-65 text-xs font-medium hover:underline"
       >
         See Aerospike security docs →
       </a>
@@ -271,7 +271,7 @@ function UsersSection({
                     <TableCell className="text-right tabular-nums">
                       {u.writeQuota === 0 ? "—" : u.writeQuota.toLocaleString()}
                     </TableCell>
-                    <TableCell className="text-right tabular-nums text-gray-500">
+                    <TableCell className="text-right text-gray-500 tabular-nums">
                       {u.connections ?? 0}
                     </TableCell>
                     <TableCell className="text-right">

--- a/ui/src/app/(main)/clusters/[clusterId]/error.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/error.tsx
@@ -22,7 +22,7 @@ export default function ClusterError({ error, reset }: ErrorProps) {
     <main className="flex flex-col gap-6">
       <Card className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
-          <span className="text-xs font-medium uppercase tracking-wider text-red-600 dark:text-red-400">
+          <span className="text-xs font-medium tracking-wider text-red-600 uppercase dark:text-red-400">
             Cluster error
           </span>
           <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-50">

--- a/ui/src/app/(main)/clusters/[clusterId]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/page.tsx
@@ -79,11 +79,11 @@ export default function ClusterOverview({ params }: PageProps) {
       {ackoInfo && (
         <section
           aria-label="ACKO overview"
-          className="bg-primary-95/50 dark:border-primary-30/40 dark:bg-primary-10/30 flex flex-col gap-4 rounded-lg border border-primary-95 p-4"
+          className="bg-primary-95/50 dark:border-primary-30/40 dark:bg-primary-10/30 border-primary-95 flex flex-col gap-4 rounded-lg border p-4"
         >
           <div className="flex items-start justify-between gap-4">
             <div>
-              <span className="text-xs font-medium uppercase tracking-wider text-primary-40 dark:text-primary-80">
+              <span className="text-primary-40 dark:text-primary-80 text-xs font-medium tracking-wider uppercase">
                 Managed by ACKO
               </span>
               <h2 className="mt-1 text-base font-semibold text-gray-900 dark:text-gray-50">
@@ -121,7 +121,7 @@ export default function ClusterOverview({ params }: PageProps) {
       <section aria-label="Nodes" className="flex flex-col gap-3">
         <div className="flex items-end justify-between">
           <div>
-            <span className="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-500">
+            <span className="text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-500">
               Nodes
             </span>
             <h2 className="mt-1 text-base font-semibold text-gray-900 dark:text-gray-50">
@@ -167,7 +167,7 @@ export default function ClusterOverview({ params }: PageProps) {
                       <p className="text-xs text-gray-500 dark:text-gray-500">
                         build {n.build}
                       </p>
-                      <p className="text-xs tabular-nums text-gray-500 dark:text-gray-500">
+                      <p className="text-xs text-gray-500 tabular-nums dark:text-gray-500">
                         uptime {formatUptime(n.uptime)}
                       </p>
                     </div>
@@ -191,7 +191,7 @@ function Metric({ label, value }: { label: string; value: string }) {
   return (
     <div>
       <dt className="text-xs text-gray-500 dark:text-gray-500">{label}</dt>
-      <dd className="font-medium tabular-nums text-gray-900 dark:text-gray-50">
+      <dd className="font-medium text-gray-900 tabular-nums dark:text-gray-50">
         {value}
       </dd>
     </div>

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
@@ -110,7 +110,7 @@ function detectBinKind(v: unknown, name: string): BinKind {
 function renderBin(v: unknown, name: string): React.ReactNode {
   const kind = detectBinKind(v, name)
   if (kind === "null")
-    return <span className="italic text-gray-400 dark:text-gray-600">null</span>
+    return <span className="text-gray-400 italic dark:text-gray-600">null</span>
   if (kind === "bool")
     return (
       <span className="font-mono text-xs">
@@ -119,7 +119,7 @@ function renderBin(v: unknown, name: string): React.ReactNode {
     )
   if (kind === "integer" || kind === "double")
     return (
-      <span className="font-mono text-xs tabular-nums text-primary-40 dark:text-primary-65">
+      <span className="text-primary-40 dark:text-primary-65 font-mono text-xs tabular-nums">
         {String(v)}
       </span>
     )
@@ -127,7 +127,7 @@ function renderBin(v: unknown, name: string): React.ReactNode {
     const label = typeof v === "string" ? v : JSON.stringify(v)
     return (
       <Badge variant="success">
-        <span className="max-w-[14rem] truncate font-mono text-[10px]">
+        <span className="max-w-56 truncate font-mono text-[10px]">
           geo · {label.length > 32 ? label.slice(0, 32) + "…" : label}
         </span>
       </Badge>
@@ -348,7 +348,7 @@ export default function RecordBrowserPage({ params }: PageProps) {
 
       <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <span className="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-500">
+          <span className="text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-500">
             Records
           </span>
           <h1 className="mt-1 font-mono text-lg font-semibold text-gray-900 sm:text-xl dark:text-gray-50">
@@ -491,7 +491,7 @@ export default function RecordBrowserPage({ params }: PageProps) {
                             params.set,
                             encodeURIComponent(r.key.pk),
                           )}
-                          className="text-primary-40 hover:underline dark:text-primary-65"
+                          className="text-primary-40 dark:text-primary-65 hover:underline"
                         >
                           {r.key.pk}
                         </Link>
@@ -500,7 +500,7 @@ export default function RecordBrowserPage({ params }: PageProps) {
                         // primary-key column; the detail route requires a pk
                         // path segment, so we render an inert digest stub
                         // instead of a broken empty-string link.
-                        <span className="text-xs italic text-gray-400">
+                        <span className="text-xs text-gray-400 italic">
                           digest:{r.key.digest?.slice(0, 8) ?? ""}…
                         </span>
                       )}
@@ -508,7 +508,7 @@ export default function RecordBrowserPage({ params }: PageProps) {
                     <TableCell className="text-right font-mono text-xs tabular-nums">
                       {r.meta.generation}
                     </TableCell>
-                    <TableCell className="text-right font-mono text-xs tabular-nums text-gray-500">
+                    <TableCell className="text-right font-mono text-xs text-gray-500 tabular-nums">
                       {formatTtl(r.meta.ttl)}
                     </TableCell>
                     {binColumns.map((b) => (
@@ -592,7 +592,7 @@ function StatusBar({
   return (
     <div className="flex flex-wrap items-center gap-3 text-xs">
       {meta.executionTimeMs > 0 && (
-        <span className="inline-flex items-center gap-1 rounded bg-emerald-50 px-1.5 py-0.5 font-mono text-[11px] font-semibold tabular-nums text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-400">
+        <span className="inline-flex items-center gap-1 rounded bg-emerald-50 px-1.5 py-0.5 font-mono text-[11px] font-semibold text-emerald-700 tabular-nums dark:bg-emerald-950/40 dark:text-emerald-400">
           <RiTimerLine className="size-3" aria-hidden="true" />
           {meta.executionTimeMs}ms
         </span>
@@ -603,7 +603,7 @@ function StatusBar({
         aria-hidden="true"
       />
 
-      <span className="font-mono tabular-nums text-gray-500 dark:text-gray-400">
+      <span className="font-mono text-gray-500 tabular-nums dark:text-gray-400">
         <span className="font-semibold text-gray-900 dark:text-gray-50">
           {returned}
         </span>

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
@@ -541,10 +541,10 @@ export default function RecordDetailPage({ params }: PageProps) {
 
       <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
         <div>
-          <span className="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-500">
+          <span className="text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-500">
             Record
           </span>
-          <h1 className="mt-1 break-all font-mono text-lg font-semibold text-gray-900 sm:text-xl dark:text-gray-50">
+          <h1 className="mt-1 font-mono text-lg font-semibold break-all text-gray-900 sm:text-xl dark:text-gray-50">
             {pk}
           </h1>
         </div>
@@ -610,13 +610,13 @@ export default function RecordDetailPage({ params }: PageProps) {
               <dt className="text-xs text-gray-500 dark:text-gray-500">
                 Generation
               </dt>
-              <dd className="font-mono text-sm font-medium tabular-nums text-gray-900 dark:text-gray-50">
+              <dd className="font-mono text-sm font-medium text-gray-900 tabular-nums dark:text-gray-50">
                 {meta?.generation ?? "—"}
               </dd>
             </div>
             <div>
               <dt className="text-xs text-gray-500 dark:text-gray-500">TTL</dt>
-              <dd className="font-mono text-sm font-medium tabular-nums text-gray-900 dark:text-gray-50">
+              <dd className="font-mono text-sm font-medium text-gray-900 tabular-nums dark:text-gray-50">
                 {isEditing ? (
                   <Input
                     value={ttlDraft}
@@ -646,7 +646,7 @@ export default function RecordDetailPage({ params }: PageProps) {
             </div>
             <div>
               <dt className="text-xs text-gray-500 dark:text-gray-500">Bins</dt>
-              <dd className="font-mono text-sm font-medium tabular-nums text-gray-900 dark:text-gray-50">
+              <dd className="font-mono text-sm font-medium text-gray-900 tabular-nums dark:text-gray-50">
                 {binCount}
               </dd>
             </div>
@@ -802,7 +802,7 @@ export default function RecordDetailPage({ params }: PageProps) {
                       </p>
                       <Badge variant="neutral">{detectBinType(value)}</Badge>
                     </div>
-                    <pre className="flex-1 overflow-x-auto whitespace-pre-wrap break-all rounded bg-gray-50 p-3 font-mono text-xs text-gray-800 dark:bg-gray-900 dark:text-gray-200">
+                    <pre className="flex-1 overflow-x-auto rounded bg-gray-50 p-3 font-mono text-xs break-all whitespace-pre-wrap text-gray-800 dark:bg-gray-900 dark:text-gray-200">
                       {formatBinValue(value)}
                     </pre>
                   </li>

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/page.tsx
@@ -76,7 +76,7 @@ export default function SetsPage({ params }: PageProps) {
         title="Namespaces & sets"
         sub="Browse per-namespace sets. Click a set to open the record browser."
       >
-        <span className="text-xs text-on-surface-muted">
+        <span className="text-on-surface-muted text-xs">
           {namespaces.length} / 2 max <span className="font-medium">(CE)</span>
         </span>
         <Button
@@ -230,7 +230,7 @@ function NamespaceCard({
               style={{ width: `${Math.max(memPct, 1)}%` }}
             />
           </div>
-          <span className="text-[10px] tabular-nums text-gray-500 dark:text-gray-500">
+          <span className="text-[10px] text-gray-500 tabular-nums dark:text-gray-500">
             {memPct}%
           </span>
         </div>
@@ -238,7 +238,7 @@ function NamespaceCard({
 
       <div className="flex flex-wrap items-center gap-1.5 border-t border-gray-200 px-5 py-3 dark:border-gray-800">
         {ns.sets.length === 0 && (
-          <span className="text-xs italic text-gray-400 dark:text-gray-600">
+          <span className="text-xs text-gray-400 italic dark:text-gray-600">
             No sets in this namespace yet.
           </span>
         )}
@@ -260,7 +260,7 @@ function NamespaceCard({
           type="button"
           onClick={onCreateSet}
           className={cx(
-            "inline-flex items-center gap-1 rounded-md border border-dashed border-primary-80 px-2.5 py-1.5 text-xs font-medium text-primary-40 transition",
+            "border-primary-80 text-primary-40 inline-flex items-center gap-1 rounded-md border border-dashed px-2.5 py-1.5 text-xs font-medium transition",
             "dark:border-primary-30/60 dark:hover:bg-primary-10/30 hover:border-primary-65 hover:bg-primary-95 dark:text-primary-65",
           )}
         >
@@ -308,7 +308,7 @@ function SetChip({
       href={clusterSections.set(clusterId, namespace, set.name)}
       className={cx(
         baseClass,
-        "hover:bg-primary-95/50 hover:dark:border-primary-30/60 hover:dark:bg-primary-10/20 border-gray-200 bg-white hover:border-primary-80 dark:border-gray-800 dark:bg-gray-950",
+        "hover:bg-primary-95/50 dark:hover:border-primary-30/60 dark:hover:bg-primary-10/20 hover:border-primary-80 border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950",
       )}
       title={set.note ?? undefined}
     >
@@ -321,13 +321,13 @@ function SetChip({
       {set.note && (
         <span
           aria-label="Set has an operator note"
-          className="dark:bg-primary-10/40 rounded bg-primary-95 px-1 py-0.5 font-mono text-[9px] uppercase tracking-wide text-primary-40 dark:text-primary-80"
+          className="dark:bg-primary-10/40 bg-primary-95 text-primary-40 dark:text-primary-80 rounded px-1 py-0.5 font-mono text-[9px] tracking-wide uppercase"
         >
           note
         </span>
       )}
       <RiArrowRightSLine
-        className="size-3.5 text-gray-300 transition group-hover:text-primary-45 dark:text-gray-700"
+        className="group-hover:text-primary-45 size-3.5 text-gray-300 transition dark:text-gray-700"
         aria-hidden="true"
       />
     </Link>
@@ -345,7 +345,7 @@ function Metric({
 }) {
   return (
     <div className="flex flex-col gap-0.5">
-      <span className="text-[9px] font-semibold uppercase tracking-[0.1em] text-gray-500 dark:text-gray-500">
+      <span className="text-[9px] font-semibold tracking-widest text-gray-500 uppercase dark:text-gray-500">
         {label}
       </span>
       <span

--- a/ui/src/app/(main)/clusters/page.tsx
+++ b/ui/src/app/(main)/clusters/page.tsx
@@ -86,7 +86,7 @@ export default function ClustersPage() {
       ) : (
         <>
           <div className="flex items-center justify-between">
-            <p className="text-xs text-on-surface-muted">
+            <p className="text-on-surface-muted text-xs">
               {rows.length} {rows.length === 1 ? "cluster" : "clusters"} ·{" "}
               {groups.length} env group{groups.length === 1 ? "" : "s"}
             </p>

--- a/ui/src/app/(main)/error.tsx
+++ b/ui/src/app/(main)/error.tsx
@@ -23,7 +23,7 @@ export default function MainError({ error, reset }: ErrorProps) {
     <main className="flex flex-col gap-6">
       <Card className="flex flex-col gap-4">
         <div className="flex flex-col gap-1">
-          <span className="text-xs font-medium uppercase tracking-wider text-red-600 dark:text-red-400">
+          <span className="text-xs font-medium tracking-wider text-red-600 uppercase dark:text-red-400">
             Error
           </span>
           <h1 className="text-lg font-semibold text-gray-900 dark:text-gray-50">

--- a/ui/src/app/(main)/guides/page.tsx
+++ b/ui/src/app/(main)/guides/page.tsx
@@ -68,7 +68,7 @@ export default function GuidesPage() {
         sub={
           <>
             Org/team policy for workspace{" "}
-            <span className="font-medium text-on-surface-variant">
+            <span className="text-on-surface-variant font-medium">
               {workspaceName}
             </span>{" "}
             — authored here, enforced everywhere.

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -1,13 +1,32 @@
 /* Pretendard Variable from CDN (Korean-friendly sans). */
-@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.css");
+@import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable.css")
+layer(base);
 
 /* Local design tokens + minimal base theme (Naver-green primary). */
-@import "../styles/tokens.css";
-@import "../styles/theme.css";
+@import "../styles/tokens.css" layer(base);
+@import "../styles/theme.css" layer(base);
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
+
+@config "../../tailwind.config.ts";
+
+/*
+  The default border color has changed to `currentcolor` in Tailwind CSS v4,
+  so we've added these compatibility styles to make sure everything still
+  looks the same as it did with Tailwind CSS v3.
+
+  If we ever want to remove these styles, we need to add an explicit border
+  color utility to any element that depends on these defaults.
+*/
+@layer base {
+  *,
+  ::after,
+  ::before,
+  ::backdrop,
+  ::file-selector-button {
+    border-color: var(--color-gray-200, currentcolor);
+  }
+}
 
 /* =====================================================================
    ACM shell layout

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -49,7 +49,7 @@ export default function RootLayout({
     <html lang="en" suppressHydrationWarning>
       <body
         data-app="ace"
-        className="antialiased selection:bg-primary-95 selection:text-primary-40 dark:bg-bg"
+        className="selection:bg-primary-95 selection:text-primary-40 dark:bg-bg antialiased"
       >
         <ThemeProvider defaultTheme="light" attribute="data-theme">
           <AuthProvider>

--- a/ui/src/app/not-found.tsx
+++ b/ui/src/app/not-found.tsx
@@ -10,7 +10,7 @@ export default function NotFound() {
       <Link href={siteConfig.baseLinks.home}>
         <DatabaseLogo className="mt-6 h-10" />
       </Link>
-      <p className="mt-6 text-4xl font-semibold text-primary-40 sm:text-5xl dark:text-primary-45">
+      <p className="text-primary-40 dark:text-primary-45 mt-6 text-4xl font-semibold sm:text-5xl">
         404
       </p>
       <h1 className="mt-4 text-2xl font-semibold text-gray-900 dark:text-gray-50">

--- a/ui/src/components/Accordion.tsx
+++ b/ui/src/components/Accordion.tsx
@@ -18,13 +18,13 @@ const AccordionTrigger = React.forwardRef<
     <AccordionPrimitives.Trigger
       className={cx(
         // base
-        "group flex flex-1 cursor-pointer items-center justify-between py-3 text-left text-sm font-medium leading-none",
+        "group flex flex-1 cursor-pointer items-center justify-between py-3 text-left text-sm leading-none font-medium",
         // text color
         "text-gray-900 dark:text-gray-50",
         // disabled
-        "data-[disabled]:cursor-default data-[disabled]:text-gray-400 dark:data-[disabled]:text-gray-600",
+        "data-disabled:cursor-default data-disabled:text-gray-400 dark:data-disabled:text-gray-600",
         //focus
-        "focus-visible:z-10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-blue-500",
+        "focus-visible:z-10 focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:outline-hidden focus-visible:ring-inset",
         className,
       )}
       {...props}
@@ -34,11 +34,11 @@ const AccordionTrigger = React.forwardRef<
       <RiArrowDownSLine
         className={cx(
           // base
-          "size-5 shrink-0 transition-transform duration-150 ease-[cubic-bezier(0.87,_0,_0.13,_1)] group-data-[state=open]:rotate-180",
+          "size-5 shrink-0 transition-transform duration-150 ease-[cubic-bezier(0.87,0,0.13,1)] group-data-[state=open]:rotate-180",
           // text color
           "text-gray-400 dark:text-gray-600",
           // disabled
-          "group-data-[disabled]:text-gray-300 group-data-[disabled]:dark:text-gray-700",
+          "group-data-disabled:text-gray-300 dark:group-data-disabled:text-gray-700",
         )}
         aria-hidden="true"
         focusable="false"

--- a/ui/src/components/AuthProvider.tsx
+++ b/ui/src/components/AuthProvider.tsx
@@ -102,7 +102,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         <div className="flex flex-col items-center gap-3">
           <div
             aria-label="Loading"
-            className="size-8 animate-spin rounded-full border-2 border-gray-200 border-t-primary-45"
+            className="border-t-primary-45 size-8 animate-spin rounded-full border-2 border-gray-200"
           />
           <p className="text-sm text-gray-500 dark:text-gray-400">
             Signing you in…
@@ -128,7 +128,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // login redirect). Render the loading shell rather than a blank page.
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <div className="size-8 animate-spin rounded-full border-2 border-gray-200 border-t-primary-45" />
+        <div className="border-t-primary-45 size-8 animate-spin rounded-full border-2 border-gray-200" />
       </div>
     )
   }

--- a/ui/src/components/Badge.tsx
+++ b/ui/src/components/Badge.tsx
@@ -7,7 +7,7 @@ import { cx } from "@/lib/utils"
 
 const badgeVariants = tv({
   base: cx(
-    "inline-flex items-center gap-x-1 whitespace-nowrap rounded px-1.5 py-0.5 text-xs font-semibold ring-1",
+    "inline-flex items-center gap-x-1 rounded px-1.5 py-0.5 text-xs font-semibold whitespace-nowrap ring-1",
   ),
   variants: {
     variant: {

--- a/ui/src/components/Button.tsx
+++ b/ui/src/components/Button.tsx
@@ -10,7 +10,7 @@ import { cx, focusRing } from "@/lib/utils"
 const buttonVariants = tv({
   base: [
     // base
-    "relative inline-flex items-center justify-center whitespace-nowrap rounded-md border px-3 py-2 text-center text-sm font-medium shadow-sm transition-all duration-100 ease-in-out",
+    "relative inline-flex items-center justify-center rounded-md border px-3 py-2 text-center text-sm font-medium whitespace-nowrap shadow-sm transition-all duration-100 ease-in-out",
     // disabled
     "disabled:pointer-events-none disabled:shadow-none",
     // focus
@@ -36,7 +36,7 @@ const buttonVariants = tv({
       ],
       ghost: [
         "border-transparent shadow-none",
-        "bg-transparent text-on-surface",
+        "text-on-surface bg-transparent",
         "hover:bg-surface-container-low",
         "disabled:text-on-surface-disabled",
       ],

--- a/ui/src/components/Calendar.tsx
+++ b/ui/src/components/Calendar.tsx
@@ -44,19 +44,19 @@ const NavigationButton = React.forwardRef<
         type="button"
         disabled={disabled}
         className={cx(
-          "flex size-8 shrink-0 select-none items-center justify-center rounded border p-1 outline-none transition sm:size-[30px]",
+          "flex size-8 shrink-0 items-center justify-center rounded border p-1 outline-hidden transition select-none sm:size-[30px]",
           // text color
           "text-gray-600 hover:text-gray-800",
-          "dark:text-gray-400 hover:dark:text-gray-200",
+          "dark:text-gray-400 dark:hover:text-gray-200",
           // border color
           "border-gray-300 dark:border-gray-800",
           // background color
           "hover:bg-gray-50 active:bg-gray-100",
-          "hover:dark:bg-gray-900 active:dark:bg-gray-800",
+          "dark:hover:bg-gray-900 dark:active:bg-gray-800",
           // disabled
           "disabled:pointer-events-none",
-          "disabled:border-gray-200 disabled:dark:border-gray-800",
-          "disabled:text-gray-400 disabled:dark:text-gray-600",
+          "disabled:border-gray-200 dark:disabled:border-gray-800",
+          "disabled:text-gray-400 dark:disabled:text-gray-600",
           focusRing,
         )}
         onClick={onClick}
@@ -123,7 +123,7 @@ const Calendar = ({
         ),
         day: cx(
           "size-9 rounded text-sm text-gray-900 focus:z-10 dark:text-gray-50",
-          "hover:bg-gray-200 hover:dark:bg-gray-700",
+          "hover:bg-gray-200 dark:hover:bg-gray-700",
           focusRing,
         ),
         day_today: "font-semibold",
@@ -133,15 +133,15 @@ const Calendar = ({
           "dark:aria-selected:bg-primary-45 dark:aria-selected:text-gray-50",
         ),
         day_disabled:
-          "!text-gray-300 dark:!text-gray-700 line-through disabled:hover:bg-transparent",
+          "text-gray-300! dark:text-gray-700! line-through disabled:hover:bg-transparent",
         day_outside: "text-gray-400 dark:text-gray-600",
         day_range_middle: cx(
-          "!rounded-none",
-          "aria-selected:!bg-gray-100 aria-selected:!text-gray-900",
-          "dark:aria-selected:!bg-gray-900 dark:aria-selected:!text-gray-50",
+          "rounded-none!",
+          "aria-selected:bg-gray-100! aria-selected:text-gray-900!",
+          "dark:aria-selected:bg-gray-900! dark:aria-selected:text-gray-50!",
         ),
-        day_range_start: "rounded-r-none !rounded-l",
-        day_range_end: "rounded-l-none !rounded-r",
+        day_range_start: "rounded-r-none rounded-l!",
+        day_range_end: "rounded-l-none rounded-r!",
         day_hidden: "invisible",
         ...classNames,
       }}
@@ -221,7 +221,7 @@ const Calendar = ({
               <div
                 role="presentation"
                 aria-live="polite"
-                className="text-sm font-medium capitalize tabular-nums text-gray-900 dark:text-gray-50"
+                className="text-sm font-medium text-gray-900 capitalize tabular-nums dark:text-gray-50"
               >
                 {format(props.displayMonth, "LLLL yyy", { locale })}
               </div>
@@ -295,8 +295,8 @@ const Calendar = ({
                     "absolute inset-x-1/2 bottom-1.5 h-0.5 w-4 -translate-x-1/2 rounded-[2px]",
                     {
                       "bg-blue-500 dark:bg-blue-500": !selected,
-                      "!bg-white dark:!bg-gray-950": selected,
-                      "!bg-gray-400 dark:!bg-gray-600":
+                      "bg-white! dark:bg-gray-950!": selected,
+                      "bg-gray-400! dark:bg-gray-600!":
                         selected && range_middle,
                       "bg-gray-400 text-gray-400 dark:bg-gray-400 dark:text-gray-600":
                         disabled,

--- a/ui/src/components/Checkbox.tsx
+++ b/ui/src/components/Checkbox.tsx
@@ -16,7 +16,7 @@ const Checkbox = React.forwardRef<
       checked={checked}
       className={cx(
         // base
-        "relative inline-flex size-4 shrink-0 appearance-none items-center justify-center rounded shadow-sm outline-none ring-1 ring-inset transition duration-100 enabled:cursor-pointer",
+        "relative inline-flex size-4 shrink-0 appearance-none items-center justify-center rounded shadow-sm ring-1 outline-hidden transition duration-100 ring-inset enabled:cursor-pointer",
         // text color
         "text-white dark:text-gray-50",
         // background color
@@ -24,8 +24,8 @@ const Checkbox = React.forwardRef<
         // ring color
         "ring-gray-300 dark:ring-gray-800",
         // disabled
-        "data-[disabled]:bg-gray-100 data-[disabled]:text-gray-400 data-[disabled]:ring-gray-300",
-        "data-[disabled]:dark:bg-gray-800 data-[disabled]:dark:text-gray-500 data-[disabled]:dark:ring-gray-700",
+        "data-disabled:bg-gray-100 data-disabled:text-gray-400 data-disabled:ring-gray-300",
+        "dark:data-disabled:bg-gray-800 dark:data-disabled:text-gray-500 dark:data-disabled:ring-gray-700",
         // checked and enabled
         "enabled:data-[state=checked]:bg-primary-50 enabled:data-[state=checked]:ring-0 enabled:data-[state=checked]:ring-transparent",
         // indeterminate

--- a/ui/src/components/CommandBar.tsx
+++ b/ui/src/components/CommandBar.tsx
@@ -6,7 +6,7 @@ import * as React from "react"
 import { cx, focusRing } from "@/lib/utils"
 
 const shortcutStyles = cx(
-  "hidden h-6 select-none items-center justify-center rounded-md bg-gray-800 px-2 font-mono text-xs text-gray-400 ring-1 ring-inset ring-gray-700 transition sm:flex",
+  "hidden h-6 items-center justify-center rounded-md bg-gray-800 px-2 font-mono text-xs text-gray-400 ring-1 ring-gray-700 transition select-none ring-inset sm:flex",
 )
 
 interface CommandBarProps extends React.PropsWithChildren {
@@ -65,7 +65,7 @@ const CommandBarValue = React.forwardRef<
     <div
       ref={ref}
       className={cx(
-        "px-3 py-2.5 text-sm tabular-nums text-gray-300",
+        "px-3 py-2.5 text-sm text-gray-300 tabular-nums",
         className,
       )}
       {...props}
@@ -152,7 +152,7 @@ const CommandBarCommand = React.forwardRef<HTMLButtonElement, CommandProps>(
     return (
       <span
         className={cx(
-          "flex items-center gap-x-2 rounded-lg bg-gray-900 p-1 text-base font-medium text-gray-50 outline-none transition focus:z-10 sm:text-sm",
+          "flex items-center gap-x-2 rounded-lg bg-gray-900 p-1 text-base font-medium text-gray-50 outline-hidden transition focus:z-10 sm:text-sm",
           "sm:last-of-type:-mr-1",
           className,
         )}

--- a/ui/src/components/DatePicker.tsx
+++ b/ui/src/components/DatePicker.tsx
@@ -61,7 +61,7 @@ const TimeSegment = ({ segment, state }: TimeSegmentProps) => {
       ref={ref}
       className={cx(
         // base
-        "relative block w-full appearance-none rounded-md border px-2.5 py-1.5 text-left uppercase tabular-nums shadow-sm outline-none transition sm:text-sm",
+        "relative block w-full appearance-none rounded-md border px-2.5 py-1.5 text-left uppercase tabular-nums shadow-sm outline-hidden transition sm:text-sm",
         // border color
         "border-gray-300 dark:border-gray-800",
         // text color
@@ -71,14 +71,14 @@ const TimeSegment = ({ segment, state }: TimeSegmentProps) => {
         // focus
         focusInput,
         // invalid (optional)
-        "invalid:border-red-500 invalid:ring-2 invalid:ring-red-200 group-aria-[invalid=true]/time-input:border-red-500 group-aria-[invalid=true]/time-input:ring-2 group-aria-[invalid=true]/time-input:ring-red-200 group-aria-[invalid=true]/time-input:dark:ring-red-400/20",
+        "group-aria-invalid/time-input:border-red-500 group-aria-invalid/time-input:ring-2 group-aria-invalid/time-input:ring-red-200 invalid:border-red-500 invalid:ring-2 invalid:ring-red-200 dark:group-aria-invalid/time-input:ring-red-400/20",
         {
-          "!w-fit border-none bg-transparent px-0 text-gray-400 shadow-none":
+          "w-fit! border-none bg-transparent px-0 text-gray-400 shadow-none":
             isDecorator,
           hidden: isSpace,
           "border-gray-300 bg-gray-100 text-gray-400 dark:border-gray-700 dark:bg-gray-800 dark:text-gray-500":
             state.isDisabled,
-          "!bg-transparent !text-gray-400": !segment.isEditable,
+          "bg-transparent! text-gray-400!": !segment.isEditable,
         },
       )}
     >
@@ -155,7 +155,7 @@ TimeInput.displayName = "TimeInput"
 const triggerStyles = tv({
   base: [
     // base
-    "peer flex w-full cursor-pointer appearance-none items-center gap-x-2 truncate rounded-md border px-3 py-2 shadow-sm outline-none transition-all sm:text-sm",
+    "peer flex w-full cursor-pointer appearance-none items-center gap-x-2 truncate rounded-md border px-3 py-2 shadow-sm outline-hidden transition-all sm:text-sm",
     // background color
     "bg-white dark:bg-gray-950",
     // border color
@@ -165,15 +165,15 @@ const triggerStyles = tv({
     // placeholder color
     "placeholder-gray-400 dark:placeholder-gray-500",
     // hover
-    "hover:bg-gray-50 hover:dark:bg-gray-950/50",
+    "hover:bg-gray-50 dark:hover:bg-gray-950/50",
     // disabled
     "disabled:pointer-events-none",
     "disabled:bg-gray-100 disabled:text-gray-400",
-    "disabled:dark:border-gray-800 disabled:dark:bg-gray-800 disabled:dark:text-gray-500",
+    "dark:disabled:border-gray-800 dark:disabled:bg-gray-800 dark:disabled:text-gray-500",
     // focus
     focusInput,
     // invalid (optional)
-    // "aria-[invalid=true]:dark:ring-red-400/20 aria-[invalid=true]:ring-2 aria-[invalid=true]:ring-red-200 aria-[invalid=true]:border-red-500 invalid:ring-2 invalid:ring-red-200 invalid:border-red-500"
+    // "dark:aria-invalid:ring-red-400/20 aria-invalid:ring-2 aria-invalid:ring-red-200 aria-invalid:border-red-500 invalid:ring-2 invalid:ring-red-200 invalid:border-red-500"
   ],
   variants: {
     hasError: {
@@ -200,7 +200,7 @@ const Trigger = React.forwardRef<HTMLButtonElement, TriggerProps>(
           {...props}
         >
           <RiCalendar2Fill className="size-5 shrink-0 text-gray-400 dark:text-gray-600" />
-          <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-left text-gray-900 dark:text-gray-50">
+          <span className="flex-1 overflow-hidden text-left text-ellipsis whitespace-nowrap text-gray-900 dark:text-gray-50">
             {children ? (
               children
             ) : placeholder ? (
@@ -235,9 +235,9 @@ const CalendarPopover = React.forwardRef<
         onOpenAutoFocus={(e) => e.preventDefault()}
         className={cx(
           // base
-          "relative z-50 w-fit rounded-md border text-sm shadow-xl shadow-black/[2.5%]",
+          "relative z-50 w-fit rounded-md border text-sm shadow-xl shadow-black/2.5",
           // widths
-          "min-w-[calc(var(--radix-select-trigger-width)-2px)] max-w-[95vw]",
+          "max-w-[95vw] min-w-[calc(var(--radix-select-trigger-width)-2px)]",
           // border color
           "border-gray-200 dark:border-gray-800",
           // background color
@@ -368,7 +368,7 @@ const PresetContainer = <TPreset extends Preset, TValue>({
               title={preset.label}
               className={cx(
                 // base
-                "relative w-full overflow-hidden text-ellipsis whitespace-nowrap rounded border px-2.5 py-1.5 text-left text-base shadow-sm outline-none transition-all sm:border-none sm:py-2 sm:text-sm sm:shadow-none",
+                "relative w-full overflow-hidden rounded border px-2.5 py-1.5 text-left text-base text-ellipsis whitespace-nowrap shadow-sm outline-hidden transition-all sm:border-none sm:py-2 sm:text-sm sm:shadow-none",
                 // text color
                 "text-gray-700 dark:text-gray-300",
                 // border color
@@ -376,8 +376,8 @@ const PresetContainer = <TPreset extends Preset, TValue>({
                 // focus
                 focusRing,
                 // background color
-                "focus-visible:bg-gray-100 focus-visible:dark:bg-gray-900",
-                "hover:bg-gray-100 hover:dark:bg-gray-900",
+                "focus-visible:bg-gray-100 dark:focus-visible:bg-gray-900",
+                "hover:bg-gray-100 dark:hover:bg-gray-900",
                 {
                   "bg-gray-100 dark:bg-gray-900": matchesCurrent(preset),
                 },
@@ -624,7 +624,7 @@ const SingleDatePicker = ({
               <div
                 className={cx(
                   "relative flex h-14 w-full items-center sm:h-full sm:w-40",
-                  "border-b border-gray-200 sm:border-b-0 sm:border-r dark:border-gray-800",
+                  "border-b border-gray-200 sm:border-r sm:border-b-0 dark:border-gray-800",
                   "overflow-auto",
                 )}
               >
@@ -926,7 +926,7 @@ const RangeDatePicker = ({
               <div
                 className={cx(
                   "relative flex h-16 w-full items-center sm:h-full sm:w-40",
-                  "border-b border-gray-200 sm:border-b-0 sm:border-r dark:border-gray-800",
+                  "border-b border-gray-200 sm:border-r sm:border-b-0 dark:border-gray-800",
                   "overflow-auto",
                 )}
               >
@@ -988,7 +988,7 @@ const RangeDatePicker = ({
                 </div>
               )}
               <div className="border-t border-gray-200 p-3 sm:flex sm:items-center sm:justify-between dark:border-gray-800">
-                <p className="tabular-nums text-gray-900 dark:text-gray-50">
+                <p className="text-gray-900 tabular-nums dark:text-gray-50">
                   <span className="text-gray-700 dark:text-gray-300">
                     {translations?.range ?? "Range"}:
                   </span>{" "}

--- a/ui/src/components/Dialog.tsx
+++ b/ui/src/components/Dialog.tsx
@@ -58,7 +58,7 @@ const DialogContent = React.forwardRef<
           ref={forwardedRef}
           className={cx(
             // base
-            "fixed left-1/2 top-1/2 z-50 w-[95vw] max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-md border p-6 shadow-lg",
+            "fixed top-1/2 left-1/2 z-50 w-[95vw] max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-md border p-6 shadow-lg",
             // border color
             "border-gray-200 dark:border-gray-900",
             // background color

--- a/ui/src/components/Divider.tsx
+++ b/ui/src/components/Divider.tsx
@@ -24,7 +24,7 @@ const Divider = React.forwardRef<HTMLDivElement, DividerProps>(
           <div
             className={cx(
               // base
-              "h-[1px] w-full",
+              "h-px w-full",
               // background color
               "bg-gray-200 dark:bg-gray-800",
             )}
@@ -33,7 +33,7 @@ const Divider = React.forwardRef<HTMLDivElement, DividerProps>(
           <div
             className={cx(
               // base
-              "h-[1px] w-full",
+              "h-px w-full",
               // background color
               "bg-gray-200 dark:bg-gray-800",
             )}
@@ -43,7 +43,7 @@ const Divider = React.forwardRef<HTMLDivElement, DividerProps>(
         <div
           className={cx(
             // base
-            "h-[1px] w-full",
+            "h-px w-full",
             // background color
             "bg-gray-200 dark:bg-gray-800",
           )}

--- a/ui/src/components/Drawer.tsx
+++ b/ui/src/components/Drawer.tsx
@@ -77,7 +77,7 @@ const DrawerContent = React.forwardRef<
           ref={forwardedRef}
           className={cx(
             // base
-            "fixed inset-y-2 mx-auto flex w-[95vw] flex-1 flex-col overflow-y-auto rounded-md border p-4 shadow-lg focus:outline-none max-sm:inset-x-2 sm:inset-y-2 sm:right-2 sm:max-w-lg sm:p-6",
+            "fixed inset-y-2 mx-auto flex w-[95vw] flex-1 flex-col overflow-y-auto rounded-md border p-4 shadow-lg focus:outline-hidden max-sm:inset-x-2 sm:inset-y-2 sm:right-2 sm:max-w-lg sm:p-6",
             // border color
             "border-gray-200 dark:border-gray-900",
             // background color
@@ -112,7 +112,7 @@ const DrawerHeader = React.forwardRef<
       <DrawerPrimitives.Close asChild>
         <Button
           variant="ghost"
-          className="aspect-square p-1 hover:bg-gray-100 hover:dark:bg-gray-400/10"
+          className="aspect-square p-1 hover:bg-gray-100 dark:hover:bg-gray-400/10"
         >
           <RiCloseLine className="size-6" aria-hidden="true" />
         </Button>

--- a/ui/src/components/Dropdown.tsx
+++ b/ui/src/components/Dropdown.tsx
@@ -36,15 +36,15 @@ const DropdownMenuSubMenuTrigger = React.forwardRef<
     ref={forwardedRef}
     className={cx(
       // base
-      "relative flex cursor-default select-none items-center rounded py-1.5 pl-2 pr-1 outline-none transition-colors data-[state=checked]:font-semibold sm:text-sm",
+      "relative flex cursor-default items-center rounded py-1.5 pr-1 pl-2 outline-hidden transition-colors select-none data-[state=checked]:font-semibold sm:text-sm",
       // text color
       "text-gray-900 dark:text-gray-50",
       // disabled
-      "data-[disabled]:pointer-events-none data-[disabled]:text-gray-400 data-[disabled]:hover:bg-none dark:data-[disabled]:text-gray-600",
+      "data-disabled:pointer-events-none data-disabled:text-gray-400 data-disabled:hover:bg-none dark:data-disabled:text-gray-600",
       // focus
-      "focus-visible:bg-gray-100 data-[state=open]:bg-gray-100 focus-visible:dark:bg-gray-900 data-[state=open]:dark:bg-gray-900",
+      "focus-visible:bg-gray-100 data-[state=open]:bg-gray-100 dark:focus-visible:bg-gray-900 dark:data-[state=open]:bg-gray-900",
       // hover
-      "hover:bg-gray-100 hover:dark:bg-gray-900",
+      "hover:bg-gray-100 dark:hover:bg-gray-900",
       //
       className,
     )}
@@ -69,11 +69,11 @@ const DropdownMenuSubMenuContent = React.forwardRef<
       collisionPadding={collisionPadding}
       className={cx(
         // base
-        "relative z-50 overflow-hidden rounded-md border p-1 shadow-xl shadow-black/[2.5%]",
+        "relative z-50 overflow-hidden rounded-md border p-1 shadow-xl shadow-black/2.5",
         // widths
         "min-w-32",
         // heights
-        "max-h-[var(--radix-popper-available-height)]",
+        "max-h-(--radix-popper-available-height)",
         // background color
         "bg-white dark:bg-gray-950",
         // text color
@@ -113,11 +113,11 @@ const DropdownMenuContent = React.forwardRef<
         ref={forwardedRef}
         className={cx(
           // base
-          "relative z-50 overflow-hidden rounded-md border p-1 shadow-xl shadow-black/[2.5%]",
+          "relative z-50 overflow-hidden rounded-md border p-1 shadow-xl shadow-black/2.5",
           // widths
           "min-w-[calc(var(--radix-dropdown-menu-trigger-width))]",
           // heights
-          "max-h-[var(--radix-popper-available-height)]",
+          "max-h-(--radix-popper-available-height)",
           // background color
           "bg-white dark:bg-gray-950",
           // text color
@@ -152,15 +152,15 @@ const DropdownMenuItem = React.forwardRef<
     ref={forwardedRef}
     className={cx(
       // base
-      "group/DropdownMenuItem relative flex cursor-pointer select-none items-center rounded py-1.5 pl-2 pr-1 outline-none transition-colors data-[state=checked]:font-semibold sm:text-sm",
+      "group/DropdownMenuItem relative flex cursor-pointer items-center rounded py-1.5 pr-1 pl-2 outline-hidden transition-colors select-none data-[state=checked]:font-semibold sm:text-sm",
       // text color
       "text-gray-900 dark:text-gray-50",
       // disabled
-      "data-[disabled]:pointer-events-none data-[disabled]:text-gray-400 data-[disabled]:hover:bg-none dark:data-[disabled]:text-gray-600",
+      "data-disabled:pointer-events-none data-disabled:text-gray-400 data-disabled:hover:bg-none dark:data-disabled:text-gray-600",
       // focus
-      "focus-visible:bg-gray-100 focus-visible:dark:bg-gray-900",
+      "focus-visible:bg-gray-100 dark:focus-visible:bg-gray-900",
       // hover
-      "hover:bg-gray-100 hover:dark:bg-gray-900",
+      "hover:bg-gray-100 dark:hover:bg-gray-900",
       className,
     )}
     {...props}
@@ -199,15 +199,15 @@ const DropdownMenuCheckboxItem = React.forwardRef<
       ref={forwardedRef}
       className={cx(
         // base
-        "relative flex cursor-pointer select-none items-center gap-x-2 rounded py-1.5 pl-8 pr-1 outline-none transition-colors data-[state=checked]:font-semibold sm:text-sm",
+        "relative flex cursor-pointer items-center gap-x-2 rounded py-1.5 pr-1 pl-8 outline-hidden transition-colors select-none data-[state=checked]:font-semibold sm:text-sm",
         // text color
         "text-gray-900 dark:text-gray-50",
         // disabled
-        "data-[disabled]:pointer-events-none data-[disabled]:text-gray-400 data-[disabled]:hover:bg-none dark:data-[disabled]:text-gray-600",
+        "data-disabled:pointer-events-none data-disabled:text-gray-400 data-disabled:hover:bg-none dark:data-disabled:text-gray-600",
         // focus
-        "focus-visible:bg-gray-100 focus-visible:dark:bg-gray-900",
+        "focus-visible:bg-gray-100 dark:focus-visible:bg-gray-900",
         // hover
-        "hover:bg-gray-100 hover:dark:bg-gray-900",
+        "hover:bg-gray-100 dark:hover:bg-gray-900",
         className,
       )}
       checked={checked}
@@ -261,15 +261,15 @@ const DropdownMenuRadioItem = React.forwardRef<
       ref={forwardedRef}
       className={cx(
         // base
-        "group/DropdownMenuRadioItem relative flex cursor-pointer select-none items-center gap-x-2 rounded py-1.5 pl-8 pr-1 outline-none transition-colors data-[state=checked]:font-semibold sm:text-sm",
+        "group/DropdownMenuRadioItem relative flex cursor-pointer items-center gap-x-2 rounded py-1.5 pr-1 pl-8 outline-hidden transition-colors select-none data-[state=checked]:font-semibold sm:text-sm",
         // text color
         "text-gray-900 dark:text-gray-50",
         // disabled
-        "data-[disabled]:pointer-events-none data-[disabled]:text-gray-400 data-[disabled]:hover:bg-none dark:data-[disabled]:text-gray-600",
+        "data-disabled:pointer-events-none data-disabled:text-gray-400 data-disabled:hover:bg-none dark:data-disabled:text-gray-600",
         // focus
-        "focus-visible:bg-gray-100 focus-visible:dark:bg-gray-900",
+        "focus-visible:bg-gray-100 dark:focus-visible:bg-gray-900",
         // hover
-        "hover:bg-gray-100 hover:dark:bg-gray-900",
+        "hover:bg-gray-100 dark:hover:bg-gray-900",
         className,
       )}
       {...props}
@@ -282,7 +282,7 @@ const DropdownMenuRadioItem = React.forwardRef<
           />
           <RiCheckboxBlankCircleLine
             aria-hidden="true"
-            className="size-full shrink-0 text-gray-300 group-data-[state=unchecked]/DropdownMenuRadioItem:flex group-data-[state=checked]/DropdownMenuRadioItem:hidden dark:text-gray-700"
+            className="size-full shrink-0 text-gray-300 group-data-[state=checked]/DropdownMenuRadioItem:hidden group-data-[state=unchecked]/DropdownMenuRadioItem:flex dark:text-gray-700"
           />
         </span>
       ) : iconType === "check" ? (
@@ -360,7 +360,7 @@ const DropdownMenuIconWrapper = ({
         // text color
         "text-gray-600 dark:text-gray-400",
         // disabled
-        "group-data-[disabled]/DropdownMenuItem:text-gray-400 group-data-[disabled]/DropdownMenuItem:dark:text-gray-700",
+        "group-data-disabled/DropdownMenuItem:text-gray-400 dark:group-data-disabled/DropdownMenuItem:text-gray-700",
         className,
       )}
       {...props}

--- a/ui/src/components/GuideMarkdown.tsx
+++ b/ui/src/components/GuideMarkdown.tsx
@@ -75,7 +75,7 @@ function renderInline(text: string, keyPrefix: string): React.ReactNode[] {
             href={lm[2]}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-primary-40 underline hover:text-primary-30 dark:text-primary-65 dark:hover:text-primary-80"
+            className="text-primary-40 hover:text-primary-30 dark:text-primary-65 dark:hover:text-primary-80 underline"
           >
             {lm[1]}
           </a>,
@@ -193,7 +193,7 @@ function renderBlocks(md: string): React.ReactNode[] {
       blocks.push(
         <blockquote
           key={key++}
-          className="mt-3 border-l-2 border-primary-80 pl-3 text-sm italic text-gray-600 dark:border-primary-40 dark:text-gray-400"
+          className="border-primary-80 dark:border-primary-40 mt-3 border-l-2 pl-3 text-sm text-gray-600 italic dark:text-gray-400"
         >
           {renderInline(quote.join(" "), `bq${key}`)}
         </blockquote>,
@@ -316,7 +316,7 @@ export function GuideMarkdown({
 }) {
   if (!content.trim()) {
     return (
-      <p className="text-sm italic text-gray-400 dark:text-gray-600">(empty)</p>
+      <p className="text-sm text-gray-400 italic dark:text-gray-600">(empty)</p>
     )
   }
   return <div className={className}>{renderBlocks(content)}</div>

--- a/ui/src/components/InfoBanner.tsx
+++ b/ui/src/components/InfoBanner.tsx
@@ -11,7 +11,7 @@ export function InfoBanner({ title, children }: InfoBannerProps) {
   return (
     <div
       role="status"
-      className="dark:border-primary-30/50 dark:bg-primary-10/40 flex gap-2 rounded border border-primary-90 bg-primary-95 px-3 py-2 text-xs text-primary-40 dark:text-primary-80"
+      className="dark:border-primary-30/50 dark:bg-primary-10/40 border-primary-90 bg-primary-95 text-primary-40 dark:text-primary-80 flex gap-2 rounded border px-3 py-2 text-xs"
     >
       <RiInformationLine
         className="mt-0.5 size-3.5 shrink-0"

--- a/ui/src/components/Input.tsx
+++ b/ui/src/components/Input.tsx
@@ -10,7 +10,7 @@ import { cx, focusInput, focusRing, hasErrorInput } from "@/lib/utils"
 const inputStyles = tv({
   base: [
     // base
-    "relative block w-full appearance-none truncate rounded-md border px-2.5 py-2 shadow-sm outline-none transition sm:text-sm",
+    "relative block w-full appearance-none truncate rounded-md border px-2.5 py-2 shadow-sm outline-hidden transition sm:text-sm",
     // border color
     "border-gray-300 dark:border-gray-800",
     // text color
@@ -21,18 +21,18 @@ const inputStyles = tv({
     "bg-white dark:bg-gray-950",
     // disabled
     "disabled:border-gray-300 disabled:bg-gray-100 disabled:text-gray-400",
-    "disabled:dark:border-gray-700 disabled:dark:bg-gray-800 disabled:dark:text-gray-500",
+    "dark:disabled:border-gray-700 dark:disabled:bg-gray-800 dark:disabled:text-gray-500",
     // file
     [
-      "file:-my-2 file:-ml-2.5 file:cursor-pointer file:rounded-l-[5px] file:rounded-r-none file:border-0 file:px-3 file:py-2 file:outline-none focus:outline-none disabled:pointer-events-none file:disabled:pointer-events-none",
-      "file:border-solid file:border-gray-300 file:bg-gray-50 file:text-gray-500 file:hover:bg-gray-100 file:dark:border-gray-800 file:dark:bg-gray-950 file:hover:dark:bg-gray-900/20 file:disabled:dark:border-gray-700",
-      "file:[border-inline-end-width:1px] file:[margin-inline-end:0.75rem]",
-      "file:disabled:bg-gray-100 file:disabled:text-gray-500 file:disabled:dark:bg-gray-800",
+      "file:-my-2 file:-ml-2.5 file:cursor-pointer file:rounded-l-[5px] file:rounded-r-none file:border-0 file:px-3 file:py-2 file:outline-hidden focus:outline-hidden disabled:pointer-events-none file:disabled:pointer-events-none",
+      "file:border-solid file:border-gray-300 file:bg-gray-50 file:text-gray-500 file:hover:bg-gray-100 dark:file:border-gray-800 dark:file:bg-gray-950 dark:file:hover:bg-gray-900/20 dark:file:disabled:border-gray-700",
+      "file:me-[0.75rem] file:[border-inline-end-width:1px]",
+      "file:disabled:bg-gray-100 file:disabled:text-gray-500 dark:file:disabled:bg-gray-800",
     ],
     // focus
     focusInput,
     // invalid (optional)
-    // "aria-[invalid=true]:dark:ring-red-400/20 aria-[invalid=true]:ring-2 aria-[invalid=true]:ring-red-200 aria-[invalid=true]:border-red-500 invalid:ring-2 invalid:ring-red-200 invalid:border-red-500"
+    // "dark:aria-invalid:ring-red-400/20 aria-invalid:ring-2 aria-invalid:ring-red-200 aria-invalid:border-red-500 invalid:ring-2 invalid:ring-red-200 invalid:border-red-500"
     // remove search cancel button (optional)
     "[&::--webkit-search-cancel-button]:hidden [&::-webkit-search-cancel-button]:hidden [&::-webkit-search-decoration]:hidden",
   ],
@@ -96,27 +96,24 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
               "text-gray-400 dark:text-gray-600",
             )}
           >
-            <RiSearchLine
-              className="size-[1.125rem] shrink-0"
-              aria-hidden="true"
-            />
+            <RiSearchLine className="size-4.5 shrink-0" aria-hidden="true" />
           </div>
         )}
         {isPassword && (
           <div
             className={cx(
-              "absolute bottom-0 right-0 flex h-full items-center justify-center px-3",
+              "absolute right-0 bottom-0 flex h-full items-center justify-center px-3",
             )}
           >
             <button
               aria-label="Change password visibility"
               className={cx(
                 // base
-                "h-fit w-fit rounded-sm outline-none transition-all",
+                "h-fit w-fit rounded-sm outline-hidden transition-all",
                 // text
                 "text-gray-400 dark:text-gray-600",
                 // hover
-                "hover:text-gray-500 hover:dark:text-gray-500",
+                "hover:text-gray-500 dark:hover:text-gray-500",
                 focusRing,
               )}
               type="button"

--- a/ui/src/components/LineChart.tsx
+++ b/ui/src/components/LineChart.tsx
@@ -56,7 +56,7 @@ const LegendItem = ({
     <li
       className={cx(
         // base
-        "group inline-flex flex-nowrap items-center gap-1.5 whitespace-nowrap rounded px-2 py-1 transition",
+        "group inline-flex flex-nowrap items-center gap-1.5 rounded px-2 py-1 whitespace-nowrap transition",
         hasOnValueChange
           ? "bg-transpaent cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-800"
           : "cursor-default",
@@ -77,7 +77,7 @@ const LegendItem = ({
       <p
         className={cx(
           // base
-          "truncate whitespace-nowrap text-xs",
+          "truncate text-xs whitespace-nowrap",
           // text color
           "text-gray-700 dark:text-gray-300",
           hasOnValueChange &&
@@ -267,7 +267,7 @@ const Legend = React.forwardRef<HTMLOListElement, LegendProps>((props, ref) => {
           "flex h-full",
           enableLegendSlider
             ? hasScroll?.right || hasScroll?.left
-              ? "snap-mandatory items-center overflow-auto pl-4 pr-12 [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+              ? "snap-mandatory scrollbar-none items-center overflow-auto pr-12 pl-4 [&::-webkit-scrollbar]:hidden"
               : ""
             : "flex-wrap",
         )}
@@ -287,7 +287,7 @@ const Legend = React.forwardRef<HTMLOListElement, LegendProps>((props, ref) => {
           <div
             className={cx(
               // base
-              "absolute bottom-0 right-0 top-0 flex h-full items-center justify-center pr-1",
+              "absolute top-0 right-0 bottom-0 flex h-full items-center justify-center pr-1",
               // background color
               "bg-white dark:bg-gray-950",
             )}
@@ -368,7 +368,7 @@ const ChartTooltipRow = ({ value, name, color }: ChartTooltipRowProps) => (
       <p
         className={cx(
           // commmon
-          "whitespace-nowrap text-right",
+          "text-right whitespace-nowrap",
           // text color
           "text-gray-700 dark:text-gray-300",
         )}
@@ -379,7 +379,7 @@ const ChartTooltipRow = ({ value, name, color }: ChartTooltipRowProps) => (
     <p
       className={cx(
         // base
-        "whitespace-nowrap text-right font-medium tabular-nums",
+        "text-right font-medium whitespace-nowrap tabular-nums",
         // text color
         "text-gray-900 dark:text-gray-50",
       )}

--- a/ui/src/components/Popover.tsx
+++ b/ui/src/components/Popover.tsx
@@ -71,7 +71,7 @@ const PopoverContent = React.forwardRef<
           avoidCollisions
           className={cx(
             // base
-            "z-50 max-h-[var(--radix-popper-available-height)] min-w-60 overflow-hidden rounded-md border p-2.5 text-sm shadow-md",
+            "z-50 max-h-(--radix-popper-available-height) min-w-60 overflow-hidden rounded-md border p-2.5 text-sm shadow-md",
             // border color
             "border-gray-200 dark:border-gray-800",
             // text color

--- a/ui/src/components/ProgressBar.tsx
+++ b/ui/src/components/ProgressBar.tsx
@@ -95,7 +95,7 @@ const ProgressBar = React.forwardRef<HTMLDivElement, ProgressBarProps>(
           <span
             className={cx(
               // base
-              "ml-2 whitespace-nowrap text-sm font-medium leading-none",
+              "ml-2 text-sm leading-none font-medium whitespace-nowrap",
               // text color
               "text-gray-900 dark:text-gray-50",
             )}

--- a/ui/src/components/RadioCard.tsx
+++ b/ui/src/components/RadioCard.tsx
@@ -27,17 +27,17 @@ const RadioCardGroupIndicator = React.forwardRef<
     <div
       className={cx(
         // base
-        "relative flex size-4 shrink-0 appearance-none items-center justify-center rounded-full border shadow-sm outline-none",
+        "relative flex size-4 shrink-0 appearance-none items-center justify-center rounded-full border shadow-sm outline-hidden",
         // border color
         "border-gray-300 dark:border-gray-800",
         // background color
         "bg-white dark:bg-gray-950",
         // checked
-        "group-data-[state=checked]:border-0 group-data-[state=checked]:border-transparent group-data-[state=checked]:bg-primary-50",
+        "group-data-[state=checked]:bg-primary-50 group-data-[state=checked]:border-0 group-data-[state=checked]:border-transparent",
         // disabled
-        "group-data-[disabled]:border",
-        "group-data-[disabled]:border-gray-300 group-data-[disabled]:bg-gray-100 group-data-[disabled]:text-gray-400",
-        "group-data-[disabled]:dark:border-gray-700 group-data-[disabled]:dark:bg-gray-800",
+        "group-data-disabled:border",
+        "group-data-disabled:border-gray-300 group-data-disabled:bg-gray-100 group-data-disabled:text-gray-400",
+        "dark:group-data-disabled:border-gray-700 dark:group-data-disabled:bg-gray-800",
         // focus
         focusRing,
         className,
@@ -55,7 +55,7 @@ const RadioCardGroupIndicator = React.forwardRef<
             // indicator
             "bg-white",
             // disabled
-            "group-data-[disabled]:bg-gray-400 group-data-[disabled]:dark:bg-gray-500",
+            "group-data-disabled:bg-gray-400 dark:group-data-disabled:bg-gray-500",
           )}
         />
       </RadioGroupPrimitives.Indicator>
@@ -73,12 +73,12 @@ const RadioCardItem = React.forwardRef<
       ref={forwardedRef}
       className={cx(
         // base
-        "group relative w-full rounded-md border p-4 text-left shadow-sm transition-all focus:outline-none",
+        "group relative w-full rounded-md border p-4 text-left shadow-sm transition-all focus:outline-hidden",
         // background color
         "bg-white dark:bg-gray-950",
         // border color
         "border-gray-200 dark:border-gray-800",
-        "data-[state=checked]:border-primary-50 data-[state=checked]:dark:border-primary-50",
+        "data-[state=checked]:border-primary-50 dark:data-[state=checked]:border-primary-50",
         focusInput,
         className,
       )}

--- a/ui/src/components/Searchbar.tsx
+++ b/ui/src/components/Searchbar.tsx
@@ -9,7 +9,7 @@ import { cx, focusInput, hasErrorInput } from "@/lib/utils"
 const inputStyles = tv({
   base: [
     // base
-    "relative block w-full appearance-none rounded-md border px-2.5 py-1.5 outline-none transition sm:text-sm",
+    "relative block w-full appearance-none rounded-md border px-2.5 py-1.5 outline-hidden transition sm:text-sm",
     // border color (border only used in dark mode for better aesthetics in filterbar)
     "border-transparent dark:border-gray-800",
     // text color
@@ -20,11 +20,11 @@ const inputStyles = tv({
     "bg-gray-100 dark:bg-gray-950",
     // disabled
     "disabled:border-gray-300 disabled:bg-gray-100 disabled:text-gray-400",
-    "disabled:dark:border-gray-700 disabled:dark:bg-gray-800 disabled:dark:text-gray-500",
+    "dark:disabled:border-gray-700 dark:disabled:bg-gray-800 dark:disabled:text-gray-500",
     // focus
     focusInput,
     // invalid (optional)
-    // "aria-[invalid=true]:dark:ring-red-400/20 aria-[invalid=true]:ring-2 aria-[invalid=true]:ring-red-200 aria-[invalid=true]:border-red-500 invalid:ring-2 invalid:ring-red-200 invalid:border-red-500"
+    // "dark:aria-invalid:ring-red-400/20 aria-invalid:ring-2 aria-invalid:ring-red-200 aria-invalid:border-red-500 invalid:ring-2 invalid:ring-red-200 invalid:border-red-500"
     // remove search cancel button (optional)
     "[&::--webkit-search-cancel-button]:hidden [&::-webkit-search-cancel-button]:hidden [&::-webkit-search-decoration]:hidden",
   ],
@@ -78,10 +78,7 @@ const Searchbar = React.forwardRef<HTMLInputElement, InputProps>(
             "text-gray-400 dark:text-gray-600",
           )}
         >
-          <RiSearchLine
-            className="size-[1.125rem] shrink-0"
-            aria-hidden="true"
-          />
+          <RiSearchLine className="size-4.5 shrink-0" aria-hidden="true" />
         </div>
       </div>
     )

--- a/ui/src/components/Select.tsx
+++ b/ui/src/components/Select.tsx
@@ -20,23 +20,23 @@ SelectValue.displayName = "SelectValue"
 const selectTriggerStyles = [
   cx(
     // base
-    "group/trigger flex w-full select-none items-center justify-between gap-2 truncate rounded-md border px-3 py-2 shadow-sm outline-none transition sm:text-sm",
+    "group/trigger flex w-full items-center justify-between gap-2 truncate rounded-md border px-3 py-2 shadow-sm outline-hidden transition select-none sm:text-sm",
     // border color
     "border-gray-300 dark:border-gray-800",
     // text color
     "text-gray-900 dark:text-gray-50",
     // placeholder
-    "data-[placeholder]:text-gray-500 data-[placeholder]:dark:text-gray-500",
+    "data-placeholder:text-gray-500 dark:data-placeholder:text-gray-500",
     // background color
     "bg-white dark:bg-gray-950",
     // hover
-    "hover:bg-gray-50 hover:dark:bg-gray-950/50",
+    "hover:bg-gray-50 dark:hover:bg-gray-950/50",
     // disabled
-    "data-[disabled]:bg-gray-100 data-[disabled]:text-gray-400",
-    "data-[disabled]:dark:border-gray-700 data-[disabled]:dark:bg-gray-800 data-[disabled]:dark:text-gray-500",
+    "data-disabled:bg-gray-100 data-disabled:text-gray-400",
+    "dark:data-disabled:border-gray-700 dark:data-disabled:bg-gray-800 dark:data-disabled:text-gray-500",
     focusInput,
     // invalid (optional)
-    // "aria-[invalid=true]:dark:ring-red-400/20 aria-[invalid=true]:ring-2 aria-[invalid=true]:ring-red-200 aria-[invalid=true]:border-red-500 invalid:ring-2 invalid:ring-red-200 invalid:border-red-500"
+    // "dark:aria-invalid:ring-red-400/20 aria-invalid:ring-2 aria-invalid:ring-red-200 aria-invalid:border-red-500 invalid:ring-2 invalid:ring-red-200 invalid:border-red-500"
   ),
 ]
 
@@ -65,7 +65,7 @@ const SelectTrigger = React.forwardRef<
             // text color
             "text-gray-400 dark:text-gray-600",
             // disabled
-            "group-data-[disabled]/trigger:text-gray-300 group-data-[disabled]/trigger:dark:text-gray-600",
+            "group-data-disabled/trigger:text-gray-300 dark:group-data-disabled/trigger:text-gray-600",
           )}
         />
       </SelectPrimitives.Icon>
@@ -130,11 +130,11 @@ const SelectContent = React.forwardRef<
         ref={forwardedRef}
         className={cx(
           // base
-          "relative z-50 overflow-hidden rounded-md border shadow-xl shadow-black/[2.5%]",
+          "relative z-50 overflow-hidden rounded-md border shadow-xl shadow-black/2.5",
           // widths
-          "min-w-[calc(var(--radix-select-trigger-width)-2px)] max-w-[95vw]",
+          "max-w-[95vw] min-w-[calc(var(--radix-select-trigger-width)-2px)]",
           // heights
-          "max-h-[--radix-select-content-available-height]",
+          "max-h-(--radix-select-content-available-height)",
           // background color
           "bg-white dark:bg-gray-950",
           // text color
@@ -158,7 +158,7 @@ const SelectContent = React.forwardRef<
           className={cx(
             "p-1",
             position === "popper" &&
-              "h-[var(--radix-select-trigger-height)] w-full min-w-[calc(var(--radix-select-trigger-width))]",
+              "h-(--radix-select-trigger-height) w-full min-w-[calc(var(--radix-select-trigger-width))]",
           )}
         >
           {children}
@@ -199,15 +199,15 @@ const SelectItem = React.forwardRef<
       ref={forwardedRef}
       className={cx(
         // base
-        "grid cursor-pointer grid-cols-[1fr_20px] gap-x-2 rounded px-3 py-2 outline-none transition-colors data-[state=checked]:font-semibold sm:text-sm",
+        "grid cursor-pointer grid-cols-[1fr_20px] gap-x-2 rounded px-3 py-2 outline-hidden transition-colors data-[state=checked]:font-semibold sm:text-sm",
         // text color
         "text-gray-900 dark:text-gray-50",
         // disabled
-        "data-[disabled]:pointer-events-none data-[disabled]:text-gray-400 data-[disabled]:hover:bg-none dark:data-[disabled]:text-gray-600",
+        "data-disabled:pointer-events-none data-disabled:text-gray-400 data-disabled:hover:bg-none dark:data-disabled:text-gray-600",
         // focus
-        "focus-visible:bg-gray-100 focus-visible:dark:bg-gray-900",
+        "focus-visible:bg-gray-100 dark:focus-visible:bg-gray-900",
         // hover
-        "hover:bg-gray-100 hover:dark:bg-gray-900",
+        "hover:bg-gray-100 dark:hover:bg-gray-900",
         className,
       )}
       {...props}
@@ -238,15 +238,15 @@ const SelectItemPeriod = React.forwardRef<
       ref={forwardedRef}
       className={cx(
         // base
-        "relative flex cursor-pointer items-center rounded py-2 pl-8 pr-3 outline-none transition-colors data-[state=checked]:font-semibold sm:text-sm",
+        "relative flex cursor-pointer items-center rounded py-2 pr-3 pl-8 outline-hidden transition-colors data-[state=checked]:font-semibold sm:text-sm",
         // text color
         "text-gray-900 dark:text-gray-50",
         // disabled
-        "data-[disabled]:pointer-events-none data-[disabled]:text-gray-400 data-[disabled]:hover:bg-none dark:data-[disabled]:text-gray-600",
+        "data-disabled:pointer-events-none data-disabled:text-gray-400 data-disabled:hover:bg-none dark:data-disabled:text-gray-600",
         // focus
-        "focus-visible:bg-gray-100 focus-visible:dark:bg-gray-900",
+        "focus-visible:bg-gray-100 dark:focus-visible:bg-gray-900",
         // hover
-        "hover:bg-gray-100 hover:dark:bg-gray-900",
+        "hover:bg-gray-100 dark:hover:bg-gray-900",
         className,
       )}
       {...props}
@@ -266,7 +266,7 @@ const SelectItemPeriod = React.forwardRef<
         </span>
         <span>
           {period?.from && period?.to && (
-            <span className="whitespace-nowrap font-normal text-gray-400">
+            <span className="font-normal whitespace-nowrap text-gray-400">
               {format(period.from, "MMM d, yyyy")} –{" "}
               {format(period.to, "MMM d, yyyy")}
             </span>

--- a/ui/src/components/Switch.tsx
+++ b/ui/src/components/Switch.tsx
@@ -10,36 +10,36 @@ const switchVariants = tv({
   slots: {
     root: [
       // base
-      "group relative isolate inline-flex shrink-0 cursor-pointer items-center rounded-full p-0.5 shadow-inner outline-none ring-1 ring-inset transition-all",
+      "group relative isolate inline-flex shrink-0 cursor-pointer items-center rounded-full p-0.5 shadow-inner ring-1 outline-hidden transition-all ring-inset",
       "bg-gray-200 dark:bg-gray-950",
       // ring color
       "ring-black/5 dark:ring-gray-800",
       // checked
-      "data-[state=checked]:bg-primary-50 data-[state=checked]:dark:bg-primary-50",
+      "data-[state=checked]:bg-primary-50 dark:data-[state=checked]:bg-primary-50",
       // disabled
-      "data-[disabled]:cursor-default",
+      "data-disabled:cursor-default",
       // disabled checked
-      "data-[disabled]:data-[state=checked]:bg-primary-90",
-      "data-[disabled]:data-[state=checked]:ring-gray-300",
+      "data-disabled:data-[state=checked]:bg-primary-90",
+      "data-disabled:data-[state=checked]:ring-gray-300",
       // disabled checked dark
-      "data-[disabled]:data-[state=checked]:dark:ring-gray-900",
-      "data-[disabled]:data-[state=checked]:dark:bg-primary-30",
+      "dark:data-disabled:data-[state=checked]:ring-gray-900",
+      "dark:data-disabled:data-[state=checked]:bg-primary-30",
       // disabled unchecked
-      "data-[disabled]:data-[state=unchecked]:ring-gray-300",
-      "data-[disabled]:data-[state=unchecked]:bg-gray-100",
+      "data-disabled:data-[state=unchecked]:ring-gray-300",
+      "data-disabled:data-[state=unchecked]:bg-gray-100",
       // disabled unchecked dark
-      "data-[disabled]:data-[state=unchecked]:dark:ring-gray-700",
-      "data-[disabled]:data-[state=unchecked]:dark:bg-gray-800",
+      "dark:data-disabled:data-[state=unchecked]:ring-gray-700",
+      "dark:data-disabled:data-[state=unchecked]:bg-gray-800",
       focusRing,
     ],
     thumb: [
       // base
-      "pointer-events-none relative inline-block transform appearance-none rounded-full border-none shadow-lg outline-none transition-all duration-150 ease-in-out focus:border-none focus:outline-none focus:outline-transparent",
+      "pointer-events-none relative inline-block transform appearance-none rounded-full border-none shadow-lg outline-hidden transition-all duration-150 ease-in-out focus:border-none focus:outline-hidden focus:outline-transparent",
       // background color
       "bg-white dark:bg-gray-50",
       // disabled
-      "group-data-[disabled]:shadow-none",
-      "group-data-[disabled]:bg-gray-50 group-data-[disabled]:dark:bg-gray-500",
+      "group-data-disabled:shadow-none",
+      "group-data-disabled:bg-gray-50 dark:group-data-disabled:bg-gray-500",
     ],
   },
   variants: {

--- a/ui/src/components/TabNavigation.tsx
+++ b/ui/src/components/TabNavigation.tsx
@@ -33,7 +33,7 @@ const TabNavigation = React.forwardRef<
     <NavigationMenuPrimitives.List
       className={cx(
         // base
-        "flex items-center justify-start whitespace-nowrap border-b [scrollbar-width:none] [&::-webkit-scrollbar]:hidden",
+        "flex scrollbar-none items-center justify-start border-b whitespace-nowrap [&::-webkit-scrollbar]:hidden",
         // border color
         "border-gray-200 dark:border-gray-800",
         className,
@@ -57,7 +57,7 @@ const TabNavigationLink = React.forwardRef<
     <NavigationMenuPrimitives.Link
       aria-disabled={disabled}
       className={cx(
-        "group relative flex shrink-0 select-none items-center justify-center",
+        "group relative flex shrink-0 items-center justify-center select-none",
         disabled ? "pointer-events-none" : "",
       )}
       ref={forwardedRef}
@@ -69,16 +69,16 @@ const TabNavigationLink = React.forwardRef<
         <span
           className={cx(
             // base
-            "-mb-px flex items-center justify-center whitespace-nowrap border-b-2 border-transparent px-3 pb-2 text-sm font-medium transition-all",
+            "-mb-px flex items-center justify-center border-b-2 border-transparent px-3 pb-2 text-sm font-medium whitespace-nowrap transition-all",
             // text color
             "text-gray-500 dark:text-gray-500",
             // hover
-            "group-hover:text-gray-700 group-hover:dark:text-gray-400",
+            "group-hover:text-gray-700 dark:group-hover:text-gray-400",
             // border hover
-            "group-hover:border-gray-300 group-hover:dark:border-gray-400",
+            "group-hover:border-gray-300 dark:group-hover:border-gray-400",
             // selected
-            "group-data-[active]:border-primary-50 group-data-[active]:text-primary-40",
-            "group-data-[active]:dark:border-primary-45 group-data-[active]:dark:text-primary-45",
+            "group-data-active:border-primary-50 group-data-active:text-primary-40",
+            "dark:group-data-active:border-primary-45 dark:group-data-active:text-primary-45",
             // disabled
             disabled
               ? "pointer-events-none text-gray-300 dark:text-gray-700"

--- a/ui/src/components/Tooltip.tsx
+++ b/ui/src/components/Tooltip.tsx
@@ -62,12 +62,12 @@ const Tooltip = React.forwardRef<
               align="center"
               className={cx(
                 // base — refined card-like surface (lifted, light background)
-                "z-50 max-w-md select-none rounded-lg px-3 py-2 text-xs leading-relaxed",
+                "z-50 max-w-md rounded-lg px-3 py-2 text-xs leading-relaxed select-none",
                 // typography
                 "font-medium text-gray-700 dark:text-gray-200",
                 // surface — white card in light, near-black in dark, with hairline border + ring + soft layered shadow
                 "border border-gray-200/80 bg-white dark:border-gray-800 dark:bg-gray-900",
-                "ring-1 ring-black/[0.04] dark:ring-white/[0.04]",
+                "ring-1 ring-black/4 dark:ring-white/4",
                 "shadow-[0_10px_30px_-10px_rgba(15,23,42,0.18),0_4px_6px_-4px_rgba(15,23,42,0.08)] dark:shadow-[0_10px_30px_-10px_rgba(0,0,0,0.6),0_4px_6px_-4px_rgba(0,0,0,0.4)]",
                 // transition
                 "will-change-[transform,opacity]",

--- a/ui/src/components/browser/RecordFilters.tsx
+++ b/ui/src/components/browser/RecordFilters.tsx
@@ -221,7 +221,7 @@ export function RecordFilters({
       <div className="flex flex-wrap items-center gap-2">
         {/* PK lookup */}
         <div className="flex min-w-[240px] items-center gap-1">
-          <span className="font-mono text-[10px] font-semibold uppercase tracking-wider text-gray-500 dark:text-gray-500">
+          <span className="font-mono text-[10px] font-semibold tracking-wider text-gray-500 uppercase dark:text-gray-500">
             PK
           </span>
           <Select
@@ -285,7 +285,7 @@ export function RecordFilters({
               )}
               <span>Add filter</span>
               {availableBins.length > 0 && (
-                <span className="dark:bg-primary-10/60 ml-1 rounded-full bg-primary-95 px-1.5 text-[10px] font-medium tabular-nums text-primary-40 dark:text-primary-80">
+                <span className="dark:bg-primary-10/60 bg-primary-95 text-primary-40 dark:text-primary-80 ml-1 rounded-full px-1.5 text-[10px] font-medium tabular-nums">
                   {availableBins.length}
                 </span>
               )}
@@ -403,7 +403,7 @@ function BinPicker({
           value={query}
           onChange={(e) => setQuery(e.target.value)}
           placeholder="Filter by..."
-          className="w-full bg-transparent text-xs outline-none placeholder:text-gray-400 dark:placeholder:text-gray-600"
+          className="w-full bg-transparent text-xs outline-hidden placeholder:text-gray-400 dark:placeholder:text-gray-600"
         />
       </div>
 
@@ -503,7 +503,7 @@ function ConditionChip({
           <button
             type="button"
             onClick={onToggleLogic}
-            className="inline-flex h-6 items-center rounded bg-gray-100 px-1.5 font-mono text-[10px] font-semibold uppercase tracking-wider text-gray-600 hover:bg-gray-200 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-gray-800"
+            className="inline-flex h-6 items-center rounded bg-gray-100 px-1.5 font-mono text-[10px] font-semibold tracking-wider text-gray-600 uppercase hover:bg-gray-200 dark:bg-gray-900 dark:text-gray-400 dark:hover:bg-gray-800"
           >
             {leadingLogic}
           </button>
@@ -712,7 +712,7 @@ function ConditionEditor({
           value={val}
           onChange={(e) => setVal(e.target.value)}
           placeholder='{"type":"AeroCircle","coordinates":[[lng,lat],radius]}'
-          className="dark:focus:ring-primary-40/30 min-h-[80px] w-full rounded-md border border-gray-300 bg-white p-2 font-mono text-xs outline-none transition focus:border-primary-45 focus:ring-2 focus:ring-primary-90 dark:border-gray-800 dark:bg-gray-950 dark:focus:border-primary-40"
+          className="dark:focus:ring-primary-40/30 focus:border-primary-45 focus:ring-primary-90 dark:focus:border-primary-40 min-h-[80px] w-full rounded-md border border-gray-300 bg-white p-2 font-mono text-xs outline-hidden transition focus:ring-2 dark:border-gray-800 dark:bg-gray-950"
         />
       )}
 

--- a/ui/src/components/clusters/ClusterCard.tsx
+++ b/ui/src/components/clusters/ClusterCard.tsx
@@ -36,7 +36,7 @@ export function ClusterCard({
       className={cx(
         "relative flex h-full flex-col gap-3 transition",
         row.connId &&
-          "hover:border-primary-80 hover:shadow-sm dark:hover:border-primary-40",
+          "hover:border-primary-80 dark:hover:border-primary-40 hover:shadow-sm",
       )}
     >
       {row.connId && (
@@ -44,7 +44,7 @@ export function ClusterCard({
           href={clusterSections.overview(row.connId)}
           aria-label={`Open ${row.displayName}`}
           className={cx(
-            "absolute inset-0 z-0 rounded-md focus-visible:outline-none",
+            "absolute inset-0 z-0 rounded-md focus-visible:outline-hidden",
             focusRing,
           )}
         />
@@ -61,11 +61,11 @@ export function ClusterCard({
               className={`size-2 rounded-full ${status.dot}`}
               aria-hidden="true"
             />
-            <span className="text-xs font-medium uppercase tracking-wider text-gray-500 dark:text-gray-500">
+            <span className="text-xs font-medium tracking-wider text-gray-500 uppercase dark:text-gray-500">
               {status.label}
             </span>
             {row.managedBy === "ACKO" && (
-              <span className="text-xs font-medium uppercase tracking-wider text-primary-40 dark:text-primary-65">
+              <span className="text-primary-40 dark:text-primary-65 text-xs font-medium tracking-wider uppercase">
                 · ACKO
               </span>
             )}
@@ -79,7 +79,7 @@ export function ClusterCard({
           {row.note && (
             <Tooltip
               content={
-                <div className="max-w-md whitespace-pre-wrap break-words text-xs">
+                <div className="max-w-md text-xs wrap-break-word whitespace-pre-wrap">
                   {row.note}
                 </div>
               }

--- a/ui/src/components/clusters/ClusterTable.tsx
+++ b/ui/src/components/clusters/ClusterTable.tsx
@@ -85,7 +85,7 @@ export function ClusterTable({
                   {r.note ? (
                     <Tooltip
                       content={
-                        <div className="max-w-md whitespace-pre-wrap break-words text-xs">
+                        <div className="max-w-md text-xs wrap-break-word whitespace-pre-wrap">
                           {r.note}
                         </div>
                       }
@@ -119,7 +119,7 @@ export function ClusterTable({
                   {r.managedBy === "ACKO" ? (
                     <Badge
                       variant="default"
-                      className="text-[10px] uppercase tracking-wider"
+                      className="text-[10px] tracking-wider uppercase"
                     >
                       ACKO
                     </Badge>

--- a/ui/src/components/clusters/ClustersEmptyState.tsx
+++ b/ui/src/components/clusters/ClustersEmptyState.tsx
@@ -9,10 +9,10 @@ export function ClustersEmptyState({
 }) {
   return (
     <Card className="flex flex-col items-center gap-2 py-10 text-center">
-      <h3 className="text-base font-semibold text-on-surface">
+      <h3 className="text-on-surface text-base font-semibold">
         No clusters yet
       </h3>
-      <p className="max-w-md text-sm text-on-surface-muted">
+      <p className="text-on-surface-muted max-w-md text-sm">
         Add a connection profile to manage an existing cluster, or create a new
         one via ACKO.
       </p>

--- a/ui/src/components/clusters/EnvSectionHeader.tsx
+++ b/ui/src/components/clusters/EnvSectionHeader.tsx
@@ -24,13 +24,13 @@ export function EnvSectionHeader({
       />
       <span
         className={cx(
-          "text-[11px] font-bold uppercase tracking-[0.22em]",
+          "text-[11px] font-bold tracking-[0.22em] uppercase",
           tone.headerText,
         )}
       >
         {env}
       </span>
-      <span className="font-mono text-[11px] tabular-nums text-gray-500 dark:text-gray-500">
+      <span className="font-mono text-[11px] text-gray-500 tabular-nums dark:text-gray-500">
         {count} {count === 1 ? "cluster" : "clusters"}
       </span>
       <span aria-hidden="true" className={cx("h-px flex-1", tone.rule)} />

--- a/ui/src/components/clusters/LabelsCell.tsx
+++ b/ui/src/components/clusters/LabelsCell.tsx
@@ -30,7 +30,7 @@ function Chip({ k, v, tone }: ChipProps) {
           tone.valueRing,
         )}
       >
-        <span className="border-r border-black/[0.06] bg-white px-1.5 py-1 font-mono text-[10px] font-medium uppercase tracking-wider text-gray-500 dark:border-white/[0.06] dark:bg-gray-950 dark:text-gray-500">
+        <span className="border-r border-black/6 bg-white px-1.5 py-1 font-mono text-[10px] font-medium tracking-wider text-gray-500 uppercase dark:border-white/6 dark:bg-gray-950 dark:text-gray-500">
           {k}
         </span>
         <span
@@ -47,7 +47,7 @@ function Chip({ k, v, tone }: ChipProps) {
   }
   return (
     <span className="inline-flex items-stretch overflow-hidden rounded-md text-[11px] leading-none shadow-[0_1px_0_rgb(0_0_0/0.02)] ring-1 ring-gray-200 dark:shadow-none dark:ring-gray-800">
-      <span className="border-r border-gray-200 bg-gray-50 px-1.5 py-1 font-mono text-[10px] font-medium uppercase tracking-wider text-gray-500 dark:border-gray-800 dark:bg-gray-900 dark:text-gray-500">
+      <span className="border-r border-gray-200 bg-gray-50 px-1.5 py-1 font-mono text-[10px] font-medium tracking-wider text-gray-500 uppercase dark:border-gray-800 dark:bg-gray-900 dark:text-gray-500">
         {k}
       </span>
       <span className="bg-white px-1.5 py-1 font-mono text-gray-800 dark:bg-gray-950 dark:text-gray-200">

--- a/ui/src/components/clusters/NameLink.tsx
+++ b/ui/src/components/clusters/NameLink.tsx
@@ -17,7 +17,7 @@ export function NameLink({ row }: { row: ClusterRow }) {
         href={clusterSections.overview(row.connId)}
         title={row.displayName}
         className={cx(
-          "block truncate font-mono font-medium text-gray-900 transition hover:text-primary-40 dark:text-gray-50 dark:hover:text-primary-80",
+          "hover:text-primary-40 dark:hover:text-primary-80 block truncate font-mono font-medium text-gray-900 transition dark:text-gray-50",
           focusRing,
         )}
       >

--- a/ui/src/components/clusters/ViewToggle.tsx
+++ b/ui/src/components/clusters/ViewToggle.tsx
@@ -45,7 +45,7 @@ export function ViewToggle({
               "flex size-7 items-center justify-center rounded transition",
               active
                 ? "dark:bg-primary-45/10 bg-primary-95 text-primary-40 dark:text-primary-65"
-                : "text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-500 hover:dark:bg-gray-900 hover:dark:text-gray-50",
+                : "text-gray-500 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-500 dark:hover:bg-gray-900 dark:hover:text-gray-50",
               focusRing,
             )}
           >

--- a/ui/src/components/clusters/envTone.ts
+++ b/ui/src/components/clusters/envTone.ts
@@ -12,7 +12,7 @@ export const ENV_TONES = {
   prod: {
     accent: "bg-rose-500",
     headerText: "text-rose-700 dark:text-rose-400",
-    rule: "bg-gradient-to-r from-rose-300/80 via-rose-200/40 to-transparent dark:from-rose-700/50 dark:via-rose-800/20",
+    rule: "bg-linear-to-r from-rose-300/80 via-rose-200/40 to-transparent dark:from-rose-700/50 dark:via-rose-800/20",
     valueBg: "bg-rose-50 dark:bg-rose-950/40",
     valueText: "text-rose-700 dark:text-rose-300",
     valueRing: "ring-rose-200 dark:ring-rose-900/60",
@@ -20,7 +20,7 @@ export const ENV_TONES = {
   stage: {
     accent: "bg-amber-500",
     headerText: "text-amber-700 dark:text-amber-400",
-    rule: "bg-gradient-to-r from-amber-300/80 via-amber-200/40 to-transparent dark:from-amber-700/50 dark:via-amber-800/20",
+    rule: "bg-linear-to-r from-amber-300/80 via-amber-200/40 to-transparent dark:from-amber-700/50 dark:via-amber-800/20",
     valueBg: "bg-amber-50 dark:bg-amber-950/40",
     valueText: "text-amber-800 dark:text-amber-300",
     valueRing: "ring-amber-200 dark:ring-amber-900/60",
@@ -28,7 +28,7 @@ export const ENV_TONES = {
   test: {
     accent: "bg-sky-500",
     headerText: "text-sky-700 dark:text-sky-400",
-    rule: "bg-gradient-to-r from-sky-300/80 via-sky-200/40 to-transparent dark:from-sky-700/50 dark:via-sky-800/20",
+    rule: "bg-linear-to-r from-sky-300/80 via-sky-200/40 to-transparent dark:from-sky-700/50 dark:via-sky-800/20",
     valueBg: "bg-sky-50 dark:bg-sky-950/40",
     valueText: "text-sky-700 dark:text-sky-300",
     valueRing: "ring-sky-200 dark:ring-sky-900/60",
@@ -36,7 +36,7 @@ export const ENV_TONES = {
   dev: {
     accent: "bg-emerald-500",
     headerText: "text-emerald-700 dark:text-emerald-400",
-    rule: "bg-gradient-to-r from-emerald-300/80 via-emerald-200/40 to-transparent dark:from-emerald-700/50 dark:via-emerald-800/20",
+    rule: "bg-linear-to-r from-emerald-300/80 via-emerald-200/40 to-transparent dark:from-emerald-700/50 dark:via-emerald-800/20",
     valueBg: "bg-emerald-50 dark:bg-emerald-950/40",
     valueText: "text-emerald-700 dark:text-emerald-300",
     valueRing: "ring-emerald-200 dark:ring-emerald-900/60",
@@ -44,7 +44,7 @@ export const ENV_TONES = {
   default: {
     accent: "bg-slate-400 dark:bg-slate-500",
     headerText: "text-slate-600 dark:text-slate-300",
-    rule: "bg-gradient-to-r from-slate-300/80 via-slate-200/40 to-transparent dark:from-slate-700/50 dark:via-slate-800/20",
+    rule: "bg-linear-to-r from-slate-300/80 via-slate-200/40 to-transparent dark:from-slate-700/50 dark:via-slate-800/20",
     valueBg: "bg-slate-100 dark:bg-slate-900",
     valueText: "text-slate-700 dark:text-slate-300",
     valueRing: "ring-slate-200 dark:ring-slate-800",

--- a/ui/src/components/copilot/tools/render-tools.tsx
+++ b/ui/src/components/copilot/tools/render-tools.tsx
@@ -40,7 +40,7 @@ function CardShell({ children }: { children: React.ReactNode }) {
 function PendingCard({ label }: { label: string }) {
   return (
     <CardShell>
-      <span className="animate-pulse text-on-surface-variant">{label}…</span>
+      <span className="text-on-surface-variant animate-pulse">{label}…</span>
     </CardShell>
   )
 }
@@ -120,7 +120,7 @@ function ClusterInfoCard({
       </ul>
       <Link
         href={`/clusters/${encodeURIComponent(connId)}`}
-        className="mt-2 inline-block text-primary-40 hover:underline"
+        className="text-primary-40 mt-2 inline-block hover:underline"
       >
         Open cluster page →
       </Link>
@@ -183,7 +183,7 @@ function RecordsMiniTable({
         </table>
       </div>
       {footer ? (
-        <p className="mt-1 text-xs text-on-surface-variant">{footer}</p>
+        <p className="text-on-surface-variant mt-1 text-xs">{footer}</p>
       ) : null}
     </CardShell>
   )
@@ -292,7 +292,7 @@ export function CopilotRenderTools() {
   useDefaultRenderTool(
     {
       render: ({ name, status }) => (
-        <p className="my-1 text-xs text-on-surface-variant">
+        <p className="text-on-surface-variant my-1 text-xs">
           {status === "complete" ? "✓" : "⏳"} {name}
         </p>
       ),

--- a/ui/src/components/dialogs/ConnectionFormFields.tsx
+++ b/ui/src/components/dialogs/ConnectionFormFields.tsx
@@ -18,10 +18,10 @@ interface ConnectionFormFieldsProps {
 }
 
 const SELECT_CLASSES =
-  "h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-primary-45 focus:outline-none focus:ring-1 focus:ring-primary-45 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+  "h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-primary-45 focus:outline-hidden focus:ring-1 focus:ring-primary-45 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
 
 const TEXTAREA_CLASSES =
-  "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-primary-45 focus:ring-2 focus:ring-primary-90 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-primary-65/20"
+  "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-hidden transition focus:border-primary-45 focus:ring-2 focus:ring-primary-90 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-primary-65/20"
 
 export function ConnectionFormFields({
   form,

--- a/ui/src/components/dialogs/CreateRecordDialog.tsx
+++ b/ui/src/components/dialogs/CreateRecordDialog.tsx
@@ -49,7 +49,7 @@ const PK_TYPES: ReadonlyArray<{ value: PkType; label: string }> = [
 ]
 
 const SELECT_CLASSES =
-  "h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-primary-45 focus:outline-none focus:ring-1 focus:ring-primary-45 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+  "h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-primary-45 focus:outline-hidden focus:ring-1 focus:ring-primary-45 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
 
 interface CreateRecordDialogProps {
   open: boolean

--- a/ui/src/components/dialogs/CreateRoleDialog.tsx
+++ b/ui/src/components/dialogs/CreateRoleDialog.tsx
@@ -303,7 +303,7 @@ export function CreateRoleDialog({
                       </span>
                     </label>
                     {checked && selected && (
-                      <div className="ml-6 mt-1 grid grid-cols-2 gap-2">
+                      <div className="mt-1 ml-6 grid grid-cols-2 gap-2">
                         <Input
                           aria-label={`${p.code} namespace scope`}
                           value={selected.ns}

--- a/ui/src/components/dialogs/GuideEditorDialog.tsx
+++ b/ui/src/components/dialogs/GuideEditorDialog.tsx
@@ -79,7 +79,7 @@ agents must read this guide before creating, scaling or deleting clusters.
 }
 
 const TEXTAREA_CLASS = cx(
-  "block w-full rounded-md border px-2.5 py-2 font-mono text-xs leading-relaxed shadow-sm outline-none transition",
+  "block w-full rounded-md border px-2.5 py-2 font-mono text-xs leading-relaxed shadow-sm outline-hidden transition",
   "border-gray-300 bg-white text-gray-900 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50",
   "placeholder-gray-400 dark:placeholder-gray-500",
   focusInput,
@@ -261,7 +261,7 @@ export function GuideEditorDialog({
                 placeholder="# Policy&#10;&#10;Write the guide in Markdown..."
               />
             ) : (
-              <div className="h-[26rem] overflow-y-auto rounded-md border border-gray-200 bg-white px-3 py-2 dark:border-gray-800 dark:bg-gray-950">
+              <div className="h-104 overflow-y-auto rounded-md border border-gray-200 bg-white px-3 py-2 dark:border-gray-800 dark:bg-gray-950">
                 <GuideMarkdown content={content} />
               </div>
             )}

--- a/ui/src/components/dialogs/RegisterUdfDialog.tsx
+++ b/ui/src/components/dialogs/RegisterUdfDialog.tsx
@@ -124,7 +124,7 @@ export function RegisterUdfDialog({
               onChange={(e) => setForm({ ...form, content: e.target.value })}
               rows={6}
               spellCheck={false}
-              className="dark:focus:ring-primary-65/20 block w-full rounded-md border border-gray-300 bg-white px-2.5 py-2 font-mono text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-primary-45 focus:ring-2 focus:ring-primary-90 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500"
+              className="dark:focus:ring-primary-65/20 focus:border-primary-45 focus:ring-primary-90 block w-full rounded-md border border-gray-300 bg-white px-2.5 py-2 font-mono text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-hidden transition focus:ring-2 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500"
               placeholder={`function example_fn(rec)\n  return rec.bin_name\nend`}
               required
             />

--- a/ui/src/components/dialogs/WorkspaceFormFields.tsx
+++ b/ui/src/components/dialogs/WorkspaceFormFields.tsx
@@ -12,7 +12,7 @@ interface WorkspaceFormFieldsProps {
 }
 
 const TEXTAREA_CLASSES =
-  "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-primary-45 focus:ring-2 focus:ring-primary-90 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-primary-65/20"
+  "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-hidden transition focus:border-primary-45 focus:ring-2 focus:ring-primary-90 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-primary-65/20"
 
 export function WorkspaceFormFields({
   form,

--- a/ui/src/components/k8s/create-cluster-wizard/StepBasic.tsx
+++ b/ui/src/components/k8s/create-cluster-wizard/StepBasic.tsx
@@ -20,7 +20,7 @@ interface StepBasicProps {
 }
 
 const SELECT_CLASSES =
-  "h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-primary-45 focus:outline-none focus:ring-1 focus:ring-primary-45 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+  "h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-primary-45 focus:outline-hidden focus:ring-1 focus:ring-primary-45 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
 
 export function StepBasic({
   form,
@@ -121,7 +121,7 @@ export function StepBasic({
               id="cluster-image"
               value={form.image ?? AEROSPIKE_IMAGES[0]}
               onChange={(e) => updateForm({ image: e.target.value })}
-              className="h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:border-primary-45 focus:outline-none focus:ring-1 focus:ring-primary-45 dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
+              className="focus:border-primary-45 focus:ring-primary-45 h-9 rounded-md border border-gray-300 bg-white px-3 text-sm text-gray-900 focus:ring-1 focus:outline-hidden dark:border-gray-700 dark:bg-gray-900 dark:text-gray-100"
             >
               {AEROSPIKE_IMAGES.map((img) => (
                 <option key={img} value={img}>

--- a/ui/src/components/notes/NoteSection.tsx
+++ b/ui/src/components/notes/NoteSection.tsx
@@ -12,7 +12,7 @@ const MAX_NOTE_LENGTH = 8192
 // Same Tailwind class set as ConnectionFormFields' textarea — keeps the
 // indigo focus ring consistent with other multi-line inputs in the app.
 const TEXTAREA_CLASSES =
-  "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-none transition focus:border-primary-45 focus:ring-2 focus:ring-primary-90 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-primary-65/20 disabled:cursor-not-allowed disabled:opacity-50"
+  "block w-full resize-y rounded-md border border-gray-300 bg-white px-2.5 py-2 text-sm text-gray-900 placeholder-gray-400 shadow-sm outline-hidden transition focus:border-primary-45 focus:ring-2 focus:ring-primary-90 dark:border-gray-800 dark:bg-gray-950 dark:text-gray-50 dark:placeholder-gray-500 dark:focus:ring-primary-65/20 disabled:cursor-not-allowed disabled:opacity-50"
 
 interface NoteSectionProps {
   title: string
@@ -194,7 +194,7 @@ export function NoteSection({
           Add note
         </Button>
       ) : (
-        <p className="whitespace-pre-wrap break-words text-sm text-gray-800 dark:text-gray-200">
+        <p className="text-sm wrap-break-word whitespace-pre-wrap text-gray-800 dark:text-gray-200">
           {initial}
         </p>
       )}

--- a/ui/src/components/ui/navigation/ClusterSelector.tsx
+++ b/ui/src/components/ui/navigation/ClusterSelector.tsx
@@ -191,7 +191,7 @@ export function ClusterSelector() {
               </span>
               {selected && (
                 <RiCheckLine
-                  className="size-4 shrink-0 text-primary-40 dark:text-primary-65"
+                  className="text-primary-40 dark:text-primary-65 size-4 shrink-0"
                   aria-hidden="true"
                 />
               )}

--- a/ui/src/components/ui/navigation/MobileSidebar.tsx
+++ b/ui/src/components/ui/navigation/MobileSidebar.tsx
@@ -47,7 +47,7 @@ export default function MobileSidebar() {
         <Button
           variant="ghost"
           aria-label="open sidebar"
-          className="group flex items-center rounded-md p-2 text-sm font-medium hover:bg-gray-100 data-[state=open]:bg-gray-100 hover:dark:bg-gray-400/10"
+          className="group flex items-center rounded-md p-2 text-sm font-medium hover:bg-gray-100 data-[state=open]:bg-gray-100 dark:hover:bg-gray-400/10"
         >
           <RiMenuLine
             className="size-6 shrink-0 sm:size-5"
@@ -87,8 +87,8 @@ export default function MobileSidebar() {
                       className={cx(
                         isActive(item.href)
                           ? "text-primary-40 dark:text-primary-65"
-                          : "text-gray-600 hover:text-gray-900 dark:text-gray-400 hover:dark:text-gray-50",
-                        "flex items-center gap-x-2.5 rounded-md px-2 py-1.5 text-base font-medium transition hover:bg-gray-100 sm:text-sm hover:dark:bg-gray-900",
+                          : "text-gray-600 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-50",
+                        "flex items-center gap-x-2.5 rounded-md px-2 py-1.5 text-base font-medium transition hover:bg-gray-100 sm:text-sm dark:hover:bg-gray-900",
                         focusRing,
                       )}
                     >

--- a/ui/src/components/ui/navigation/Sidebar.tsx
+++ b/ui/src/components/ui/navigation/Sidebar.tsx
@@ -183,10 +183,10 @@ export function Sidebar() {
                 <Link
                   href={siteConfig.baseLinks.guides}
                   className={cx(
-                    "flex items-center gap-x-2.5 rounded-md py-1.5 pl-2 pr-2 text-sm font-medium transition",
+                    "flex items-center gap-x-2.5 rounded-md py-1.5 pr-2 pl-2 text-sm font-medium transition",
                     isActive(siteConfig.baseLinks.guides)
                       ? "text-primary-40 dark:text-primary-65"
-                      : "text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 hover:dark:bg-gray-900 hover:dark:text-gray-50",
+                      : "text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-gray-50",
                     focusRing,
                   )}
                 >
@@ -220,12 +220,12 @@ export function Sidebar() {
                   ))}
                 </Accordion>
                 {loading && clusterList.length === 0 && (
-                  <span className="block py-1 pl-2 text-xs italic text-gray-400 dark:text-gray-600">
+                  <span className="block py-1 pl-2 text-xs text-gray-400 italic dark:text-gray-600">
                     Loading…
                   </span>
                 )}
                 {!loading && clusterList.length === 0 && (
-                  <span className="block py-1 pl-2 text-xs italic text-gray-400 dark:text-gray-600">
+                  <span className="block py-1 pl-2 text-xs text-gray-400 italic dark:text-gray-600">
                     No clusters yet
                   </span>
                 )}
@@ -235,10 +235,10 @@ export function Sidebar() {
                 <Link
                   href={siteConfig.baseLinks.ackoTemplates}
                   className={cx(
-                    "flex items-center gap-x-2.5 rounded-md py-1.5 pl-2 pr-2 text-sm font-medium transition",
+                    "flex items-center gap-x-2.5 rounded-md py-1.5 pr-2 pl-2 text-sm font-medium transition",
                     isActive(siteConfig.baseLinks.ackoTemplates)
                       ? "text-primary-40 dark:text-primary-65"
-                      : "text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 hover:dark:bg-gray-900 hover:dark:text-gray-50",
+                      : "text-gray-700 hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-gray-50",
                     focusRing,
                   )}
                 >
@@ -324,7 +324,7 @@ function GroupSection({
     <AccordionItem value={value} className="border-none">
       <AccordionTrigger
         className={cx(
-          "rounded-md px-2 py-2 text-sm font-semibold text-gray-900 hover:bg-gray-100 dark:text-gray-50 hover:dark:bg-gray-900",
+          "rounded-md px-2 py-2 text-sm font-semibold text-gray-900 hover:bg-gray-100 dark:text-gray-50 dark:hover:bg-gray-900",
           focusRing,
         )}
       >
@@ -333,7 +333,7 @@ function GroupSection({
           {label}
         </span>
       </AccordionTrigger>
-      <AccordionContent className="pb-1 pt-1">
+      <AccordionContent className="pt-1 pb-1">
         <div className="ml-[11px] flex flex-col border-l border-gray-200 pl-2 dark:border-gray-800">
           {children}
         </div>
@@ -369,7 +369,7 @@ function ClusterNode({
     <AccordionItem value={cluster.id} className="border-none">
       <AccordionPrimitives.Header
         className={cx(
-          "flex items-center rounded-md pr-1 hover:bg-gray-100 hover:dark:bg-gray-900",
+          "flex items-center rounded-md pr-1 hover:bg-gray-100 dark:hover:bg-gray-900",
           clusterActive
             ? "text-primary-40 dark:text-primary-65"
             : "text-gray-700 dark:text-gray-400",
@@ -388,7 +388,7 @@ function ClusterNode({
               {displayName}
             </span>
             {cluster.managedBy === "ACKO" && (
-              <span className="dark:bg-primary-10/40 shrink-0 rounded bg-primary-95 px-1.5 text-[10px] font-semibold uppercase tracking-wider text-primary-40 dark:text-primary-65">
+              <span className="dark:bg-primary-10/40 bg-primary-95 text-primary-40 dark:text-primary-65 shrink-0 rounded px-1.5 text-[10px] font-semibold tracking-wider uppercase">
                 ACKO
               </span>
             )}
@@ -397,7 +397,7 @@ function ClusterNode({
         <AccordionPrimitives.Trigger
           aria-label={`Toggle ${displayName} namespaces`}
           className={cx(
-            "group/chev flex size-6 shrink-0 items-center justify-center rounded-md text-gray-400 hover:bg-gray-200 hover:text-gray-900 dark:text-gray-500 hover:dark:bg-gray-800 hover:dark:text-gray-50",
+            "group/chev flex size-6 shrink-0 items-center justify-center rounded-md text-gray-400 hover:bg-gray-200 hover:text-gray-900 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-50",
             focusRing,
           )}
         >
@@ -410,7 +410,7 @@ function ClusterNode({
       <AccordionContent className="pt-1">
         <ul className="flex flex-col gap-0.5">
           {cluster.namespaces.length === 0 && (
-            <li className="py-1 pl-5 text-xs italic text-gray-400 dark:text-gray-600">
+            <li className="py-1 pl-5 text-xs text-gray-400 italic dark:text-gray-600">
               no namespaces
             </li>
           )}
@@ -454,7 +454,7 @@ function NamespaceNode({
         <AccordionItem value={namespace.name} className="border-none">
           <AccordionTrigger
             className={cx(
-              "group flex items-center justify-between rounded-md py-1 pl-3 pr-2 text-sm hover:bg-gray-100 hover:dark:bg-gray-900",
+              "group flex items-center justify-between rounded-md py-1 pr-2 pl-3 text-sm hover:bg-gray-100 dark:hover:bg-gray-900",
               nsActive
                 ? "text-primary-40 dark:text-primary-65"
                 : "text-gray-700 dark:text-gray-300",
@@ -475,7 +475,7 @@ function NamespaceNode({
           <AccordionContent className="pt-0.5">
             <ul className="flex flex-col gap-0.5">
               {namespace.sets.length === 0 && (
-                <li className="py-1 pl-10 text-xs italic text-gray-400 dark:text-gray-600">
+                <li className="py-1 pl-10 text-xs text-gray-400 italic dark:text-gray-600">
                   no sets
                 </li>
               )}
@@ -504,7 +504,7 @@ function NamespaceNode({
                           <span
                             aria-disabled="true"
                             className={cx(
-                              "relative flex cursor-not-allowed items-center rounded-md py-1 pl-10 pr-2 font-mono text-sm",
+                              "relative flex cursor-not-allowed items-center rounded-md py-1 pr-2 pl-10 font-mono text-sm",
                               "text-gray-400 opacity-70 dark:text-gray-600",
                             )}
                           >
@@ -519,11 +519,11 @@ function NamespaceNode({
                       <Link
                         href={href}
                         className={cx(
-                          "relative flex items-center rounded-md py-1 pl-10 pr-2 font-mono text-sm transition",
-                          "before:absolute before:left-[30px] before:top-1.5 before:h-4 before:w-0.5 before:rounded-sm",
+                          "relative flex items-center rounded-md py-1 pr-2 pl-10 font-mono text-sm transition",
+                          "before:absolute before:top-1.5 before:left-[30px] before:h-4 before:w-0.5 before:rounded-sm",
                           active
-                            ? "font-medium text-primary-40 before:bg-primary-45 dark:text-primary-65"
-                            : "text-gray-600 before:bg-transparent hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 hover:dark:bg-gray-900 hover:dark:text-gray-50",
+                            ? "text-primary-40 before:bg-primary-45 dark:text-primary-65 font-medium"
+                            : "text-gray-600 before:bg-transparent hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-gray-50",
                           focusRing,
                         )}
                       >

--- a/ui/src/components/ui/navigation/UserProfile.tsx
+++ b/ui/src/components/ui/navigation/UserProfile.tsx
@@ -59,7 +59,7 @@ export const UserProfileDesktop = () => {
         variant="ghost"
         className={cx(
           focusRing,
-          "group flex w-full items-center justify-between rounded-md p-2 text-sm font-medium text-gray-900 hover:bg-gray-100 data-[state=open]:bg-gray-100 data-[state=open]:bg-gray-400/10 hover:dark:bg-gray-400/10",
+          "group flex w-full items-center justify-between rounded-md p-2 text-sm font-medium text-gray-900 hover:bg-gray-100 data-[state=open]:bg-gray-100 data-[state=open]:bg-gray-400/10 dark:hover:bg-gray-400/10",
         )}
       >
         <span className="flex items-center gap-3">
@@ -72,7 +72,7 @@ export const UserProfileDesktop = () => {
           <span className="truncate">{display}</span>
         </span>
         <RiMore2Fill
-          className="size-4 shrink-0 text-gray-500 group-hover:text-gray-700 group-hover:dark:text-gray-400"
+          className="size-4 shrink-0 text-gray-500 group-hover:text-gray-700 dark:group-hover:text-gray-400"
           aria-hidden="true"
         />
       </Button>
@@ -88,7 +88,7 @@ export const UserProfileMobile = () => {
         aria-label="User settings"
         variant="ghost"
         className={cx(
-          "group flex items-center rounded-md p-1 text-sm font-medium text-gray-900 hover:bg-gray-100 data-[state=open]:bg-gray-100 data-[state=open]:bg-gray-400/10 hover:dark:bg-gray-400/10",
+          "group flex items-center rounded-md p-1 text-sm font-medium text-gray-900 hover:bg-gray-100 data-[state=open]:bg-gray-100 data-[state=open]:bg-gray-400/10 dark:hover:bg-gray-400/10",
         )}
       >
         <span

--- a/ui/src/components/ui/navigation/WorkspacesDropdown.tsx
+++ b/ui/src/components/ui/navigation/WorkspacesDropdown.tsx
@@ -162,7 +162,7 @@ export function WorkspacesDropdown() {
                 </span>
                 {selected && (
                   <RiCheckLine
-                    className="size-4 shrink-0 text-primary-40 dark:text-primary-65"
+                    className="text-primary-40 dark:text-primary-65 size-4 shrink-0"
                     aria-hidden="true"
                   />
                 )}
@@ -175,7 +175,7 @@ export function WorkspacesDropdown() {
                     setEditTarget(ws)
                   }}
                   className={cx(
-                    "ml-1 flex size-6 shrink-0 items-center justify-center rounded text-gray-400 hover:bg-gray-200 hover:text-gray-900 dark:text-gray-500 hover:dark:bg-gray-800 hover:dark:text-gray-50",
+                    "ml-1 flex size-6 shrink-0 items-center justify-center rounded text-gray-400 hover:bg-gray-200 hover:text-gray-900 dark:text-gray-500 dark:hover:bg-gray-800 dark:hover:text-gray-50",
                     focusRing,
                   )}
                 >
@@ -185,7 +185,7 @@ export function WorkspacesDropdown() {
             )
           })}
           {visible && visible.length === 0 && !isLoading && (
-            <div className="px-2 py-1.5 text-sm italic text-gray-400 dark:text-gray-600">
+            <div className="px-2 py-1.5 text-sm text-gray-400 italic dark:text-gray-600">
               No workspaces
             </div>
           )}

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -13,16 +13,16 @@ export const focusInput = [
   // base
   "focus:ring-2",
   // ring color
-  "focus:ring-primary-90 focus:dark:ring-primary-40/30",
+  "focus:ring-primary-90 dark:focus:ring-primary-40/30",
   // border color
-  "focus:border-primary-45 focus:dark:border-primary-40",
+  "focus:border-primary-45 dark:focus:border-primary-40",
 ]
 
 // Tremor Raw focusRing [v0.0.1]
 
 export const focusRing = [
   // base
-  "outline outline-offset-2 outline-0 focus-visible:outline-2",
+  "outline-solid outline-offset-2 outline-0 focus-visible:outline-2",
   // outline color
   "outline-primary-45 dark:outline-primary-45",
 ]


### PR DESCRIPTION
## Summary

Migrates the UI from Tailwind CSS 3.4 to **4.3** using the official `@tailwindcss/upgrade` tool, keeping the existing `tailwind.config.ts` + preset + token files via `@config` (no design-system rewrite).

## Changes

- `tailwindcss` 3.4 → 4.3, PostCSS plugin → `@tailwindcss/postcss`
- `globals.css`: `@tailwind` directives → `@import "tailwindcss"` + `@config '../../tailwind.config.ts'`; tool-added v3 compat layer for the border-color/placeholder default changes; token CSS imported into `layer(base)`
- Tool-applied class renames across 37 files (shadow/ring/outline scale changes)
- Copilot stylesheet pipeline (static copy + layer-unwrap, #440) intentionally unchanged — it stays independent of the app bundle so disabled deployments remain payload-free

## Verification

- `type-check` / `lint` / `format:check` / 87 tests / `next build` all green
- Deployed to kind (podman, ACKO chart): app pages and the ACKO Agent sidebar render identically to v3 — verified via computed styles (tokens, brand green, sidebar 440px) and screenshots