### PR TITLE
fix(ui): 13 UI bug fixes — routing encoding, dead clicks, stale-data races, mobile layout

### DIFF
--- a/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/admin/page.tsx
@@ -21,7 +21,7 @@ import { mapApiError } from "@/lib/api/error-mapping"
 import { logFetchError } from "@/lib/api/log"
 import type { AerospikeRole, AerospikeUser } from "@/lib/types/admin"
 import { RiShieldKeyholeLine } from "@remixicon/react"
-import { useCallback, useEffect, useMemo, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 type PageProps = { params: { clusterId: string } }
 
@@ -43,7 +43,13 @@ export default function AdminPage({ params }: PageProps) {
   const [createRoleOpen, setCreateRoleOpen] = useState(false)
   const [userFilter, setUserFilter] = useState("")
 
+  // Sequence ref discards out-of-order responses: switching clusters while a
+  // load is in flight would otherwise let the previous cluster's result
+  // clobber this one's state — including falsely latching securityDisabled.
+  const loadSeqRef = useRef(0)
+
   const load = useCallback(async () => {
+    const seq = ++loadSeqRef.current
     setUsersState((s) => ({ ...s, loading: true, error: null }))
     setRolesState((s) => ({ ...s, loading: true, error: null }))
     setSecurityDisabled(false)
@@ -58,6 +64,7 @@ export default function AdminPage({ params }: PageProps) {
       listUsers(params.clusterId),
       listRoles(params.clusterId),
     ])
+    if (seq !== loadSeqRef.current) return
 
     const isAclGate = (err: unknown) => {
       const k = mapApiError(err).kind

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.test.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.test.tsx
@@ -228,3 +228,33 @@ describe("RecordBrowserPage — PK match mode (#287)", () => {
     expect(screen.getByRole("button", { name: /^search$/i })).toBeDisabled()
   })
 })
+
+describe("RecordBrowserPage — route param decoding", () => {
+  it("decodes percent-encoded namespace/set params before querying and rendering", async () => {
+    mockedFilter.mockResolvedValueOnce(fixtureResponse(0))
+
+    // App Router delivers params exactly as they appear in the URL —
+    // percent-encoded. A set named "my set" arrives as "my%20set".
+    render(
+      <RecordBrowserPage
+        params={{
+          clusterId: "conn-test",
+          namespace: "ns%2Fprod",
+          set: "my%20set",
+        }}
+      />,
+    )
+
+    expect(
+      await screen.findByText(/no records in this set/i),
+    ).toBeInTheDocument()
+    expect(mockedFilter).toHaveBeenCalledWith(
+      "conn-test",
+      expect.objectContaining({ namespace: "ns/prod", set: "my set" }),
+    )
+    // The heading shows the raw names, not their encoded forms.
+    expect(
+      screen.getByRole("heading", { name: "ns/prod.my set" }),
+    ).toBeInTheDocument()
+  })
+})

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
@@ -39,7 +39,7 @@ import { TableSkeleton } from "@/components/skeletons/TableSkeleton"
 import type { BinDataType } from "@/lib/types/query"
 import type { SecondaryIndex } from "@/lib/types/index"
 import type { AerospikeRecord } from "@/lib/types/record"
-import { cx } from "@/lib/utils"
+import { cx, safeDecodeURIComponent } from "@/lib/utils"
 import { RiRefreshLine, RiTimerLine } from "@remixicon/react"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
@@ -161,6 +161,10 @@ function indexTypeToBinDataType(idx: SecondaryIndex): BinDataType {
 }
 
 export default function RecordBrowserPage({ params }: PageProps) {
+  // App Router route params arrive percent-encoded; decode once and use the
+  // raw names for API calls, display, and hrefs (clusterSections re-encodes).
+  const namespace = safeDecodeURIComponent(params.namespace) ?? params.namespace
+  const set = safeDecodeURIComponent(params.set) ?? params.set
   const [records, setRecords] = useState<AerospikeRecord[] | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -181,10 +185,10 @@ export default function RecordBrowserPage({ params }: PageProps) {
     // Single-set lookup endpoint isn't exposed (the API surface is list /
     // upsert / delete), so this scans the namespace's notes — small in
     // practice and re-uses the route the recovery UI already calls.
-    const notes = await listSetNotes(params.clusterId, params.namespace)
-    const match = notes.find((n) => n.setName === params.set)
+    const notes = await listSetNotes(params.clusterId, namespace)
+    const match = notes.find((n) => n.setName === set)
     setSetNote(match?.note ?? null)
-  }, [params.clusterId, params.namespace, params.set])
+  }, [params.clusterId, namespace, set])
 
   // Initial mount swallows reload failures (a 503 from the metaDB
   // shouldn't block the record browser from rendering), but the post-save
@@ -213,8 +217,8 @@ export default function RecordBrowserPage({ params }: PageProps) {
         const pk = target.pk.trim()
         const filters = draftToFilterConditions(target)
         const resp = await filterRecords(params.clusterId, {
-          namespace: params.namespace,
-          set: params.set,
+          namespace,
+          set,
           pageSize: size,
           pkPattern: pk || null,
           pkMatchMode: target.pkMatchMode,
@@ -235,7 +239,7 @@ export default function RecordBrowserPage({ params }: PageProps) {
         if (seq === fetchSeqRef.current) setLoading(false)
       }
     },
-    [params.clusterId, params.namespace, params.set],
+    [params.clusterId, namespace, set],
   )
 
   // Initial load + reload on set change.
@@ -283,8 +287,8 @@ export default function RecordBrowserPage({ params }: PageProps) {
     const byBin = new Map<string, SecondaryIndex>()
     for (const idx of indexes) {
       if (
-        idx.namespace === params.namespace &&
-        idx.set === params.set &&
+        idx.namespace === namespace &&
+        idx.set === set &&
         idx.state === "ready"
       ) {
         byBin.set(idx.bin, idx)
@@ -293,7 +297,7 @@ export default function RecordBrowserPage({ params }: PageProps) {
     return Array.from(byBin.entries())
       .sort(([a], [b]) => a.localeCompare(b))
       .map(([name, idx]) => ({ name, type: indexTypeToBinDataType(idx) }))
-  }, [indexes, params.namespace, params.set])
+  }, [indexes, namespace, set])
 
   const dirty = useMemo(() => !draftEquals(draft, applied), [draft, applied])
 
@@ -338,12 +342,10 @@ export default function RecordBrowserPage({ params }: PageProps) {
         </Link>
         <span aria-hidden="true">/</span>
         <span className="font-mono text-gray-900 dark:text-gray-50">
-          {params.namespace}
+          {namespace}
         </span>
         <span aria-hidden="true">/</span>
-        <span className="font-mono text-gray-900 dark:text-gray-50">
-          {params.set}
-        </span>
+        <span className="font-mono text-gray-900 dark:text-gray-50">{set}</span>
       </nav>
 
       <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
@@ -352,7 +354,7 @@ export default function RecordBrowserPage({ params }: PageProps) {
             Records
           </span>
           <h1 className="mt-1 font-mono text-lg font-semibold text-gray-900 sm:text-xl dark:text-gray-50">
-            {params.namespace}.{params.set}
+            {namespace}.{set}
           </h1>
           <p className="mt-1 text-sm text-gray-500 dark:text-gray-500">
             {records
@@ -388,13 +390,13 @@ export default function RecordBrowserPage({ params }: PageProps) {
         title="Set note"
         note={setNote}
         onSave={async (next) => {
-          await upsertSetNote(params.clusterId, params.namespace, params.set, {
+          await upsertSetNote(params.clusterId, namespace, set, {
             note: next,
           })
           await reloadSetNote()
         }}
         onDelete={async () => {
-          await deleteSetNote(params.clusterId, params.namespace, params.set)
+          await deleteSetNote(params.clusterId, namespace, set)
           await reloadSetNote()
         }}
       />
@@ -487,9 +489,9 @@ export default function RecordBrowserPage({ params }: PageProps) {
                         <Link
                           href={clusterSections.record(
                             params.clusterId,
-                            params.namespace,
-                            params.set,
-                            encodeURIComponent(r.key.pk),
+                            namespace,
+                            set,
+                            r.key.pk,
                           )}
                           className="text-primary-40 dark:text-primary-65 hover:underline"
                         >
@@ -524,9 +526,9 @@ export default function RecordBrowserPage({ params }: PageProps) {
                           <Link
                             href={clusterSections.record(
                               params.clusterId,
-                              params.namespace,
-                              params.set,
-                              encodeURIComponent(r.key.pk),
+                              namespace,
+                              set,
+                              r.key.pk,
                             )}
                           >
                             Open
@@ -555,19 +557,14 @@ export default function RecordBrowserPage({ params }: PageProps) {
         open={createOpen}
         onOpenChange={setCreateOpen}
         connId={params.clusterId}
-        namespace={params.namespace}
-        set={params.set}
+        namespace={namespace}
+        set={set}
         onSuccess={(pk) => {
           // Navigate to the freshly-written record so the user can add more
           // bins / edit metadata. The detail page re-fetches on mount, so
           // the new row is immediately visible.
           router.push(
-            clusterSections.record(
-              params.clusterId,
-              params.namespace,
-              params.set,
-              encodeURIComponent(pk),
-            ),
+            clusterSections.record(params.clusterId, namespace, set, pk),
           )
         }}
       />

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
@@ -523,7 +523,9 @@ export default function RecordDetailPage({ params }: PageProps) {
           </span>
         </Link>
         <span aria-hidden="true">/</span>
-        <span className="font-mono text-gray-900 dark:text-gray-50">{pk}</span>
+        <span className="font-mono break-all text-gray-900 dark:text-gray-50">
+          {pk}
+        </span>
       </nav>
 
       <header className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/records/[key]/page.tsx
@@ -13,6 +13,7 @@ import { logFetchError } from "@/lib/api/log"
 import { deleteRecordNote, upsertRecordNote } from "@/lib/api/notes"
 import { deleteRecord, getRecordDetail, putRecord } from "@/lib/api/records"
 import type { AerospikeRecord, BinValue, PkType } from "@/lib/types/record"
+import { safeDecodeURIComponent } from "@/lib/utils"
 import Link from "next/link"
 import { useRouter } from "next/navigation"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
@@ -243,20 +244,16 @@ function buildInitialDraft(record: AerospikeRecord): BinDraft[] {
   })
 }
 
-const safeDecode = (s: string): string | null => {
-  try {
-    return decodeURIComponent(s)
-  } catch {
-    return null
-  }
-}
-
 // ---------------------------------------------------------------------------
 // Page
 // ---------------------------------------------------------------------------
 export default function RecordDetailPage({ params }: PageProps) {
   const router = useRouter()
-  const pk = safeDecode(params.key)
+  // App Router route params arrive percent-encoded; decode before using them
+  // for API calls, display, and hrefs (clusterSections re-encodes).
+  const pk = safeDecodeURIComponent(params.key)
+  const namespace = safeDecodeURIComponent(params.namespace) ?? params.namespace
+  const set = safeDecodeURIComponent(params.set) ?? params.set
 
   const [record, setRecord] = useState<AerospikeRecord | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -275,8 +272,8 @@ export default function RecordDetailPage({ params }: PageProps) {
       setIsLoading(true)
       setError(null)
       return getRecordDetail(params.clusterId, {
-        ns: params.namespace,
-        set: params.set,
+        ns: namespace,
+        set,
         pk,
         pk_type: "auto" as PkType,
       })
@@ -294,7 +291,7 @@ export default function RecordDetailPage({ params }: PageProps) {
           if (!signal?.cancelled) setIsLoading(false)
         })
     },
-    [params.clusterId, params.namespace, params.set, pk],
+    [params.clusterId, namespace, set, pk],
   )
 
   // Keep the latest cancellation signal in a ref so handleSave's
@@ -322,7 +319,7 @@ export default function RecordDetailPage({ params }: PageProps) {
     return () => {
       signal.cancelled = true
     }
-  }, [params.clusterId, params.namespace, params.set, pk, loadRecord])
+  }, [params.clusterId, namespace, set, pk, loadRecord])
 
   const handleDelete = async () => {
     if (!record || pk === null) return
@@ -330,14 +327,12 @@ export default function RecordDetailPage({ params }: PageProps) {
     setDeleting(true)
     try {
       await deleteRecord(params.clusterId, {
-        ns: params.namespace,
-        set: params.set,
+        ns: namespace,
+        set,
         pk,
         pk_type: "auto" as PkType,
       })
-      router.push(
-        clusterSections.set(params.clusterId, params.namespace, params.set),
-      )
+      router.push(clusterSections.set(params.clusterId, namespace, set))
     } catch (err) {
       logFetchError("record-delete", err)
       if (err instanceof ApiError) setError(err.detail || err.message)
@@ -450,7 +445,7 @@ export default function RecordDetailPage({ params }: PageProps) {
     setSaving(true)
     try {
       await putRecord(params.clusterId, {
-        key: { namespace: params.namespace, set: params.set, pk },
+        key: { namespace, set, pk },
         bins,
         ttl,
         pkType: "auto" as PkType,
@@ -491,15 +486,11 @@ export default function RecordDetailPage({ params }: PageProps) {
           </Link>
           <span aria-hidden="true">/</span>
           <Link
-            href={clusterSections.set(
-              params.clusterId,
-              params.namespace,
-              params.set,
-            )}
+            href={clusterSections.set(params.clusterId, namespace, set)}
             className="hover:text-gray-900 dark:hover:text-gray-50"
           >
             <span className="font-mono">
-              {params.namespace}.{params.set}
+              {namespace}.{set}
             </span>
           </Link>
         </nav>
@@ -524,15 +515,11 @@ export default function RecordDetailPage({ params }: PageProps) {
         </Link>
         <span aria-hidden="true">/</span>
         <Link
-          href={clusterSections.set(
-            params.clusterId,
-            params.namespace,
-            params.set,
-          )}
+          href={clusterSections.set(params.clusterId, namespace, set)}
           className="hover:text-gray-900 dark:hover:text-gray-50"
         >
           <span className="font-mono">
-            {params.namespace}.{params.set}
+            {namespace}.{set}
           </span>
         </Link>
         <span aria-hidden="true">/</span>
@@ -657,21 +644,18 @@ export default function RecordDetailPage({ params }: PageProps) {
             note={record.note}
             disabled={isEditing || deleting || saving}
             onSave={async (next) => {
-              await upsertRecordNote(
-                params.clusterId,
-                params.namespace,
-                params.set,
-                pk,
-                { note: next, pkType: "auto" },
-              )
+              await upsertRecordNote(params.clusterId, namespace, set, pk, {
+                note: next,
+                pkType: "auto",
+              })
               // Reload to pick up updatedAt / updatedBy from the server.
               await loadRecordRef.current(loadSignalRef.current)
             }}
             onDelete={async () => {
               await deleteRecordNote(
                 params.clusterId,
-                params.namespace,
-                params.set,
+                namespace,
+                set,
                 pk,
                 "auto",
               )

--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -26,6 +26,13 @@ layer(base);
   ::file-selector-button {
     border-color: var(--color-gray-200, currentcolor);
   }
+
+  /* Tailwind CSS v4 preflight switched buttons to `cursor: default`; the UI
+     was designed against the v3 behavior where buttons show a pointer. */
+  button:not(:disabled),
+  [role="button"]:not(:disabled) {
+    cursor: pointer;
+  }
 }
 
 /* =====================================================================

--- a/ui/src/app/siteConfig.test.ts
+++ b/ui/src/app/siteConfig.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest"
+
+import { clusterSections } from "./siteConfig"
+
+// Aerospike namespace/set names and record keys are user-controlled and may
+// contain characters that are unsafe inside a URL path. The builders must
+// encode each dynamic segment, otherwise a set named "a/b" adds a path
+// segment and every link into it 404s.
+describe("clusterSections URL builders", () => {
+  it("passes through names that need no encoding", () => {
+    expect(clusterSections.set("conn-1", "test", "sample_set")).toBe(
+      "/clusters/conn-1/sets/test/sample_set",
+    )
+    expect(clusterSections.record("conn-1", "test", "sample_set", "pk-1")).toBe(
+      "/clusters/conn-1/sets/test/sample_set/records/pk-1",
+    )
+  })
+
+  it("encodes reserved characters in namespace, set, and key segments", () => {
+    expect(clusterSections.set("conn-1", "ns/prod", "my set")).toBe(
+      "/clusters/conn-1/sets/ns%2Fprod/my%20set",
+    )
+    expect(
+      clusterSections.record("conn-1", "test", "orders", "user#42?x=1"),
+    ).toBe("/clusters/conn-1/sets/test/orders/records/user%2342%3Fx%3D1")
+  })
+
+  it("round-trips a key through encode → decodeURIComponent unchanged", () => {
+    const key = "región/№7 100%"
+    const href = clusterSections.record("conn-1", "test", "orders", key)
+    const lastSegment = href.split("/records/")[1]
+    expect(decodeURIComponent(lastSegment)).toBe(key)
+  })
+})

--- a/ui/src/app/siteConfig.ts
+++ b/ui/src/app/siteConfig.ts
@@ -10,13 +10,18 @@ export const siteConfig = {
   },
 } as const
 
+// namespace / set / key are user-controlled Aerospike names and may contain
+// characters that are unsafe inside a URL path ("/", "?", "#", "%", spaces).
+// Callers always pass raw (decoded) values; the builders encode each segment.
+// Pages reading these segments back from route params must decode them
+// (safeDecodeURIComponent) before use — App Router params arrive encoded.
 export const clusterSections = {
   overview: (clusterId: string) => `/clusters/${clusterId}`,
   sets: (clusterId: string) => `/clusters/${clusterId}/sets`,
   set: (clusterId: string, namespace: string, set: string) =>
-    `/clusters/${clusterId}/sets/${namespace}/${set}`,
+    `/clusters/${clusterId}/sets/${encodeURIComponent(namespace)}/${encodeURIComponent(set)}`,
   record: (clusterId: string, namespace: string, set: string, key: string) =>
-    `/clusters/${clusterId}/sets/${namespace}/${set}/records/${key}`,
+    `/clusters/${clusterId}/sets/${encodeURIComponent(namespace)}/${encodeURIComponent(set)}/records/${encodeURIComponent(key)}`,
   admin: (clusterId: string) => `/clusters/${clusterId}/admin`,
   secondaryIndexes: (clusterId: string) =>
     `/clusters/${clusterId}/secondary-indexes`,

--- a/ui/src/components/Dialog.tsx
+++ b/ui/src/components/Dialog.tsx
@@ -58,7 +58,7 @@ const DialogContent = React.forwardRef<
           ref={forwardedRef}
           className={cx(
             // base
-            "fixed top-1/2 left-1/2 z-50 w-[95vw] max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-md border p-6 shadow-lg",
+            "fixed top-1/2 left-1/2 z-50 max-h-[85vh] w-[95vw] max-w-lg -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-md border p-6 shadow-lg",
             // border color
             "border-gray-200 dark:border-gray-900",
             // background color

--- a/ui/src/components/TabNavigation.tsx
+++ b/ui/src/components/TabNavigation.tsx
@@ -33,7 +33,7 @@ const TabNavigation = React.forwardRef<
     <NavigationMenuPrimitives.List
       className={cx(
         // base
-        "flex scrollbar-none items-center justify-start border-b whitespace-nowrap [&::-webkit-scrollbar]:hidden",
+        "flex scrollbar-none items-center justify-start overflow-x-auto border-b whitespace-nowrap [&::-webkit-scrollbar]:hidden",
         // border color
         "border-gray-200 dark:border-gray-800",
         className,

--- a/ui/src/components/clusters/ClusterCard.tsx
+++ b/ui/src/components/clusters/ClusterCard.tsx
@@ -26,11 +26,13 @@ export function ClusterCard({
     Object.keys(row.labels).filter((k) => k !== ENV_LABEL_KEY).length > 0
 
   // To keep the whole card clickable while still allowing nested interactive
-  // elements (the Edit button and the AddressCopyCell copy button), we render
-  // the navigation as an absolutely-positioned anchor *behind* the interactive
-  // controls (`relative` card + `absolute inset-0` link with `z-0`). All
-  // interactive children opt in with `relative z-10`. This avoids the invalid
-  // `<a><button></a>` nesting that the previous implementation produced.
+  // elements, we render the navigation as an absolutely-positioned anchor
+  // (`relative` card + `absolute inset-0` link). The link paints above static
+  // content (positioned z-0 beats in-flow text in hit-testing), so clicks on
+  // the name/status/body navigate; only genuinely interactive children (Edit
+  // button, copy cell, note tooltip, labels) opt out with `relative z-10`.
+  // This avoids the invalid `<a><button></a>` nesting that the previous
+  // implementation produced.
   return (
     <Card
       className={cx(
@@ -49,7 +51,7 @@ export function ClusterCard({
           )}
         />
       )}
-      <div className="relative z-10 flex items-start gap-3">
+      <div className="flex items-start gap-3">
         <span
           aria-hidden="true"
           className="mt-1 h-6 w-1 shrink-0 rounded-sm"
@@ -87,7 +89,7 @@ export function ClusterCard({
               triggerAsChild
               className="max-w-md"
             >
-              <p className="mt-1 cursor-help truncate text-xs text-gray-500 dark:text-gray-500">
+              <p className="relative z-10 mt-1 cursor-help truncate text-xs text-gray-500 dark:text-gray-500">
                 {row.note}
               </p>
             </Tooltip>
@@ -110,14 +112,14 @@ export function ClusterCard({
         />
       </div>
 
-      <div className="relative z-10 mt-auto flex items-center justify-between gap-2 border-t border-gray-200 pt-3 dark:border-gray-800">
+      <div className="mt-auto flex items-center justify-between gap-2 border-t border-gray-200 pt-3 dark:border-gray-800">
         <span className="text-xs text-gray-500 dark:text-gray-500">
           {row.managedBy === "ACKO" ? "ACKO" : "Manual"}
         </span>
         {row.profile ? (
           <Button
             variant="ghost"
-            className="h-7 px-2 text-xs"
+            className="relative z-10 h-7 px-2 text-xs"
             onClick={(event) => {
               event.preventDefault()
               event.stopPropagation()

--- a/ui/src/components/ui/navigation/Sidebar.tsx
+++ b/ui/src/components/ui/navigation/Sidebar.tsx
@@ -13,7 +13,7 @@ import { useK8sClusters } from "@/hooks/use-k8s-clusters"
 import { getCluster } from "@/lib/api/clusters"
 import type { ConnectionProfileResponse } from "@/lib/types/connection"
 import type { K8sClusterSummary } from "@/lib/types/k8s"
-import { cx, focusRing } from "@/lib/utils"
+import { cx, focusRing, safeDecodeURIComponent } from "@/lib/utils"
 import { useUiStore } from "@/stores/ui-store"
 import * as AccordionPrimitives from "@radix-ui/react-accordion"
 import {
@@ -29,7 +29,7 @@ import {
 import Image from "next/image"
 import Link from "next/link"
 import { useParams, usePathname } from "next/navigation"
-import { useEffect, useMemo, useState } from "react"
+import { useEffect, useMemo, useRef, useState } from "react"
 import { ClusterSelector } from "./ClusterSelector"
 import MobileSidebar from "./MobileSidebar"
 import { UserProfileDesktop, UserProfileMobile } from "./UserProfile"
@@ -108,21 +108,39 @@ function buildClusterList(
 
 export function Sidebar() {
   const pathname = usePathname()
-  const params = useParams<{ clusterId?: string }>()
+  const params = useParams<{
+    clusterId?: string
+    namespace?: string
+    set?: string
+  }>()
   const conn = useConnections()
   const k8s = useK8sClusters()
   const nsByConn = useClusterNamespaces(params?.clusterId ?? null)
   const currentWorkspaceId = useUiStore((s) => s.currentWorkspaceId)
   const setCurrentWorkspaceId = useUiStore((s) => s.setCurrentWorkspaceId)
 
+  // Route params arrive percent-encoded; decode them so they compare equal to
+  // the raw namespace/set names returned by the API.
+  const routeNamespace = params?.namespace
+    ? safeDecodeURIComponent(params.namespace)
+    : null
+  const routeSet = params?.set ? safeDecodeURIComponent(params.set) : null
+
   // When the user navigates directly to a cluster URL whose connection lives
   // in a different workspace than the one currently selected (e.g. opening a
   // shared link), follow the URL: switch the persisted workspace so the
-  // cluster is visible in the sidebar drill-down.
+  // cluster is visible in the sidebar drill-down. Follow at most once per
+  // cluster visit — otherwise this effect re-runs when currentWorkspaceId
+  // changes and instantly reverts a manual switch made in WorkspacesDropdown
+  // while a cluster page is open.
+  const followedClusterIdRef = useRef<string | null>(null)
   useEffect(() => {
     if (!params?.clusterId || !conn.data) return
+    if (followedClusterIdRef.current === params.clusterId) return
     const target = conn.data.find((c) => c.id === params.clusterId)
-    if (target && target.workspaceId !== currentWorkspaceId) {
+    if (!target) return
+    followedClusterIdRef.current = params.clusterId
+    if (target.workspaceId !== currentWorkspaceId) {
       setCurrentWorkspaceId(target.workspaceId)
     }
   }, [params?.clusterId, conn.data, currentWorkspaceId, setCurrentWorkspaceId])
@@ -214,8 +232,9 @@ export function Sidebar() {
                     <ClusterNode
                       key={c.id}
                       cluster={c}
-                      pathname={pathname}
                       isActive={isActive}
+                      routeNamespace={routeNamespace}
+                      routeSet={routeSet}
                     />
                   ))}
                 </Accordion>
@@ -344,19 +363,21 @@ function GroupSection({
 
 function ClusterNode({
   cluster,
-  pathname,
   isActive,
+  routeNamespace,
+  routeSet,
 }: {
   cluster: ClusterSummary
-  pathname: string
   isActive: (href: string, exact?: boolean) => boolean
+  routeNamespace: string | null
+  routeSet: string | null
 }) {
   const clusterActive = isActive(`/clusters/${cluster.id}`)
-  const expandedNamespaces = cluster.namespaces
-    .filter((ns) =>
-      pathname.includes(`/clusters/${cluster.id}/sets/${ns.name}`),
-    )
-    .map((ns) => ns.name)
+  // Namespace/set params only describe this cluster when the URL is inside
+  // it — otherwise namespace "test" here would light up while browsing a
+  // namespace of the same name in another cluster.
+  const activeNamespace = clusterActive ? routeNamespace : null
+  const activeSet = clusterActive ? routeSet : null
   // Backend prepends "[K8s] " to connection names auto-created for ACKO
   // clusters. The ACKO badge already signals K8s origin, so drop the prefix
   // for display to avoid visual duplication (and give the name more width).
@@ -419,8 +440,8 @@ function ClusterNode({
               key={ns.name}
               clusterId={cluster.id}
               namespace={ns}
-              pathname={pathname}
-              defaultOpen={expandedNamespaces.includes(ns.name)}
+              active={activeNamespace === ns.name}
+              activeSet={activeNamespace === ns.name ? activeSet : null}
             />
           ))}
         </ul>
@@ -432,30 +453,31 @@ function ClusterNode({
 function NamespaceNode({
   clusterId,
   namespace,
-  pathname,
-  defaultOpen,
+  active,
+  activeSet,
 }: {
   clusterId: string
   namespace: NamespaceSummary
-  pathname: string
-  defaultOpen?: boolean
+  active: boolean
+  activeSet: string | null
 }) {
-  const nsActive = pathname.includes(
-    `/clusters/${clusterId}/sets/${namespace.name}`,
-  )
+  // Controlled accordion: defaultValue only applies on mount, so navigating
+  // into a set of this namespace from elsewhere (set chips, record links)
+  // would leave it collapsed. Force-open whenever the namespace becomes
+  // active while still letting the user toggle it manually.
+  const [open, setOpen] = useState<string>(active ? namespace.name : "")
+  useEffect(() => {
+    if (active) setOpen(namespace.name)
+  }, [active, namespace.name])
 
   return (
     <li>
-      <Accordion
-        type="single"
-        collapsible
-        defaultValue={defaultOpen || nsActive ? namespace.name : undefined}
-      >
+      <Accordion type="single" collapsible value={open} onValueChange={setOpen}>
         <AccordionItem value={namespace.name} className="border-none">
           <AccordionTrigger
             className={cx(
               "group flex items-center justify-between rounded-md py-1 pr-2 pl-3 text-sm hover:bg-gray-100 dark:hover:bg-gray-900",
-              nsActive
+              active
                 ? "text-primary-40 dark:text-primary-65"
                 : "text-gray-700 dark:text-gray-300",
             )}
@@ -491,8 +513,7 @@ function NamespaceNode({
                     namespace.name,
                     s.name,
                   )
-                  const active =
-                    pathname === href || pathname.startsWith(href + "/")
+                  const setActive = active && activeSet === s.name
                   if (s.objects === 0) {
                     return (
                       <li key={s.name}>
@@ -521,7 +542,7 @@ function NamespaceNode({
                         className={cx(
                           "relative flex items-center rounded-md py-1 pr-2 pl-10 font-mono text-sm transition",
                           "before:absolute before:top-1.5 before:left-[30px] before:h-4 before:w-0.5 before:rounded-sm",
-                          active
+                          setActive
                             ? "text-primary-40 before:bg-primary-45 dark:text-primary-65 font-medium"
                             : "text-gray-600 before:bg-transparent hover:bg-gray-100 hover:text-gray-900 dark:text-gray-400 dark:hover:bg-gray-900 dark:hover:text-gray-50",
                           focusRing,

--- a/ui/src/hooks/use-cluster.ts
+++ b/ui/src/hooks/use-cluster.ts
@@ -60,6 +60,12 @@ export function useCluster(
       return
     }
     let cancelled = false
+    // Wipe the previous cluster's data so pages can't render it under the
+    // new cluster's URL while loading — or permanently, if the new fetch
+    // fails. refetch() intentionally keeps stale data on failure; switching
+    // clusters must not.
+    setData(null)
+    setError(null)
     setIsLoading(true)
     ;(async () => {
       try {

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -77,6 +77,22 @@ export const formatters: { [key: string]: any } = {
 }
 
 /**
+ * Decode a percent-encoded URL segment. App Router route params arrive
+ * URL-encoded (`my%20set` for a set named `my set`), so pages must decode
+ * them before using the value for API calls, display, or comparisons.
+ *
+ * Returns ``null`` for malformed input (e.g. a lone ``%``) so callers can
+ * branch to an explicit invalid state instead of crashing the render.
+ */
+export function safeDecodeURIComponent(value: string): string | null {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return null
+  }
+}
+
+/**
  * Convert ``#RRGGBB`` (or ``RRGGBB``) to a CSS rgba() string at the given alpha.
  *
  * Returns ``null`` for malformed input so callers can branch and fall back —

--- a/ui/src/styles/theme.css
+++ b/ui/src/styles/theme.css
@@ -97,6 +97,9 @@
    ===================================================================== */
 .ace-page-head {
   display: flex;
+  /* Title + action slot must wrap on narrow viewports — without this the
+     buttons/search input push the page wider than the phone screen. */
+  flex-wrap: wrap;
   align-items: flex-start;
   justify-content: space-between;
   margin-bottom: 22px;

--- a/ui/tailwind.config.ts
+++ b/ui/tailwind.config.ts
@@ -45,6 +45,18 @@ const config: Config = {
           from: { opacity: "0", transform: "translateX(50%)" },
           to: { opacity: "1", transform: "translateX(0)" },
         },
+        drawerSlideRightAndFade: {
+          from: { opacity: "1", transform: "translateX(0)" },
+          to: { opacity: "0", transform: "translateX(100%)" },
+        },
+        accordionOpen: {
+          from: { height: "0px" },
+          to: { height: "var(--radix-accordion-content-height)" },
+        },
+        accordionClose: {
+          from: { height: "var(--radix-accordion-content-height)" },
+          to: { height: "0px" },
+        },
       },
       animation: {
         hide: "hide 150ms cubic-bezier(0.16, 1, 0.3, 1)",
@@ -57,6 +69,9 @@ const config: Config = {
           "slideRightAndFade 150ms cubic-bezier(0.16, 1, 0.3, 1)",
         drawerSlideLeftAndFade:
           "drawerSlideLeftAndFade 150ms cubic-bezier(0.16, 1, 0.3, 1)",
+        drawerSlideRightAndFade: "drawerSlideRightAndFade 150ms ease-in",
+        accordionOpen: "accordionOpen 150ms cubic-bezier(0.87, 0, 0.13, 1)",
+        accordionClose: "accordionClose 150ms cubic-bezier(0.87, 0, 0.13, 1)",
         dialogOverlayShow:
           "dialogOverlayShow 150ms cubic-bezier(0.16, 1, 0.3, 1)",
         dialogContentShow:


### PR DESCRIPTION
## Summary

13 UI bugs found in a frontend audit (navigation/routing, dead interactions, state races, responsive layout, Tailwind v4 migration fallout), each verified against the code before fixing.

## Commit 1 — routing & sidebar

### 1. `clusterSections.set/record` built hrefs from raw namespace/set/key names (P1)
Aerospike set names and record keys are user-controlled and may contain `/`, `?`, `#`, `%`, or spaces. The URL builders interpolated them raw, so e.g. a set named `a/b` produced an extra path segment and every link into it 404'd. The builders now `encodeURIComponent` each dynamic segment; caller-side `encodeURIComponent(pk)` was removed to avoid double encoding.

### 2. Record browser/detail pages used percent-encoded route params for API calls and display (P1)
App Router params arrive percent-encoded (`my%20set` for `my set`). Both pages passed them straight into API calls and rendered them in breadcrumbs/headings, so a populated set with an encodable name rendered empty, sindex filters never matched, and an edit could write to a wrongly-named set. Pages now decode params once via a shared `safeDecodeURIComponent` helper.

### 3. Sidebar namespace active/expand used substring matching (P2)
`pathname.includes(...)` meant namespace `test` highlighted and auto-expanded while browsing `test2`. Active state is now derived from decoded route params with exact comparison, scoped to the active cluster. The namespace accordion is also controlled now, so entering a set from the Sets page chips actually expands it.

### 4. Workspace switching snapped back while a cluster page was open (P1)
The Sidebar's workspace-follow effect re-ran whenever `currentWorkspaceId` changed and instantly reverted any manual switch made in WorkspacesDropdown. It now follows a cluster URL at most once per cluster visit (ref guard).

## Commit 2 — dead clicks, races, responsive, Tailwind v4

### 5. ClusterCard body clicks did nothing (P1)
The whole-card stretched link was `z-0` while every content wrapper was `relative z-10`, covering essentially the entire card — clicking the name/status/address never navigated. Only genuinely interactive children (Edit button, copy cell, note tooltip, labels) keep `z-10` now.

### 6. Cluster tabs forced page-wide horizontal panning on phones (P1)
`TabNavigation`'s list hid its scrollbar (`scrollbar-none`) but never declared `overflow-x-auto`, so the 5 cluster tabs overflowed the viewport instead of scrolling.

### 7. Tall dialogs were clipped with unreachable footers (P1)
`DialogContent` centers with `translate` and had `overflow-y-auto` but no max-height, so a dialog taller than the viewport clipped at both ends and never scrolled. Capped at `max-h-[85vh]`.

### 8. PageHead overflowed on phones (P1)
`.ace-page-head` was `display:flex` without `flex-wrap`, so the title row plus action buttons/search input pushed the page wider than the screen on /clusters, admin, secondary-indexes and udfs.

### 9. `useCluster` rendered the previous cluster's data under the new cluster (P1)
Switching clusters didn't clear `data`, so the old cluster's nodes/namespaces stayed visible while loading — permanently, if the new fetch failed. Data/error are now wiped on `connId` change (manual `refetch()` keeps its stale-data-on-failure behavior).

### 10. Admin page: stale responses could falsely latch "Security is not enabled" (P1)
`load()` had no out-of-order guard; switching clusters mid-flight let the previous cluster's `listUsers/listRoles` settle into the new cluster's state, including a false `securityDisabled` latch. Added a sequence guard (same pattern as the record browser).

### 11. Drawer close & sidebar accordion animations were dead (P2)
`animate-drawerSlideRightAndFade`, `animate-accordionOpen/Close` were referenced in components but their keyframes were never defined in `tailwind.config.ts`, so the utilities were never generated — drawer/accordion snapped shut. Added the missing keyframes.

### 12. Buttons lost the pointer cursor after the Tailwind v4 migration (P2)
v4 preflight switched buttons to `cursor: default`; the border-color compat layer was added during migration but not the cursor one. Restored pointer on enabled buttons.

### 13. Long record keys blew out the record-detail page width (P2)
Breadcrumb primary key had no `break-all` (the `h1` already did).

## Tests

- New `siteConfig.test.ts` (segment encoding, round-trip) and a record-browser regression test (encoded params decoded before querying/rendering)
- `npm run type-check` / `npm run lint` / `npm test` (91/91) / `npm run build` all pass on both commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)