### PR TITLE
feat(copilot): control-plane + data-plane agent tools (human-in-the-loop)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -152,6 +152,13 @@ K8S_MANAGEMENT_ENABLED=false
 # COPILOT_ENABLED=true
 # Model in <provider>/<model> form: anthropic/* or openai/*.
 # COPILOT_MODEL=anthropic/claude-sonnet-4-5
+# Optional: OpenAI/Anthropic-compatible gateway endpoint. Unset → the
+# provider's public API. Set this to route through an OpenAI-compatible LLM
+# gateway (self-hosted or enterprise):
+#   COPILOT_MODEL=openai/<model>          # e.g. openai/gpt-oss-120b
+#   COPILOT_BASE_URL=https://llm-gateway.example.com
+#   OPENAI_API_KEY=<gateway API key>
+# COPILOT_BASE_URL=
 # Provider API key (server-side only; never reaches the browser).
 # ANTHROPIC_API_KEY=
 # OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ Browse, create, edit, duplicate and delete records with server-side limiting and
 
 ## Tech Stack
 
-| Layer | Stack |
-|---|---|
-| **UI**  | Next.js 14, React 18, TypeScript, Tailwind CSS 3.4, Tremor Raw, Zustand, recharts, Monaco Editor |
-| **API** | Python 3.13, FastAPI, Uvicorn, Pydantic |
-| **App metadata** | SQLite (default, file-based) / PostgreSQL (optional, set `ENABLE_POSTGRES=true`) — stores connection profiles & UI state |
-| **Managed target** | Aerospike Server Community Edition 8.x |
-| **Infra** | Podman Compose, uv (Python), npm (Node.js) |
+| Layer              | Stack                                                                                                                    |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------ |
+| **UI**             | Next.js 14, React 18, TypeScript, Tailwind CSS 3.4, Tremor Raw, Zustand, recharts, Monaco Editor                         |
+| **API**            | Python 3.13, FastAPI, Uvicorn, Pydantic                                                                                  |
+| **App metadata**   | SQLite (default, file-based) / PostgreSQL (optional, set `ENABLE_POSTGRES=true`) — stores connection profiles & UI state |
+| **Managed target** | Aerospike Server Community Edition 8.x                                                                                   |
+| **Infra**          | Podman Compose, uv (Python), npm (Node.js)                                                                               |
 
 ## Quick Start
 
@@ -66,6 +66,7 @@ docker compose -f compose.yaml up --build
 ```
 
 Open **http://localhost:3100** and add a connection with:
+
 - **Host**: `aerospike-node-1` (container name on the shared network)
 - **Port**: `3000`
 
@@ -80,7 +81,7 @@ cp .env.example .env
 podman compose -f compose.yaml up --build
 ```
 
-- UI:  http://localhost:3100
+- UI: http://localhost:3100
 - API: http://localhost:8000
 - Aerospike: internal network only (use `podman exec -it aerospike-tools aql -h aerospike-node-1`)
 
@@ -89,6 +90,7 @@ podman compose -f compose.yaml up --build
 ### Local Development
 
 **API:**
+
 ```bash
 cd api
 uv sync                            # Install dependencies
@@ -96,6 +98,7 @@ uv run uvicorn aerospike_cluster_manager_api.main:app --reload
 ```
 
 **UI:**
+
 ```bash
 cd ui
 npm install                        # Install dependencies
@@ -270,84 +273,84 @@ All data management endpoints are prefixed with `/api` and require a `{conn_id}`
 
 ### Health API
 
-| Method | Endpoint | Description |
-|---|---|---|
-| `GET` | `/api/health` | Basic health check (returns `{"status": "ok"}`) |
-| `GET` | `/api/health?detail=true` | Detailed health check with database component status |
+| Method | Endpoint                  | Description                                          |
+| ------ | ------------------------- | ---------------------------------------------------- |
+| `GET`  | `/api/health`             | Basic health check (returns `{"status": "ok"}`)      |
+| `GET`  | `/api/health?detail=true` | Detailed health check with database component status |
 
 ### Connections API (`/api/connections`)
 
-| Method | Endpoint | Description |
-|---|---|---|
-| `GET` | `/api/connections` | List all saved connection profiles |
-| `POST` | `/api/connections` | Create a new connection profile |
-| `GET` | `/api/connections/{conn_id}` | Get a single connection profile by ID |
-| `PUT` | `/api/connections/{conn_id}` | Update an existing connection profile |
-| `DELETE` | `/api/connections/{conn_id}` | Delete a connection profile and close its client |
-| `GET` | `/api/connections/{conn_id}/health` | Check connection health (node count, namespaces, build, edition) |
-| `POST` | `/api/connections/test` | Test connectivity without saving the profile |
+| Method   | Endpoint                            | Description                                                      |
+| -------- | ----------------------------------- | ---------------------------------------------------------------- |
+| `GET`    | `/api/connections`                  | List all saved connection profiles                               |
+| `POST`   | `/api/connections`                  | Create a new connection profile                                  |
+| `GET`    | `/api/connections/{conn_id}`        | Get a single connection profile by ID                            |
+| `PUT`    | `/api/connections/{conn_id}`        | Update an existing connection profile                            |
+| `DELETE` | `/api/connections/{conn_id}`        | Delete a connection profile and close its client                 |
+| `GET`    | `/api/connections/{conn_id}/health` | Check connection health (node count, namespaces, build, edition) |
+| `POST`   | `/api/connections/test`             | Test connectivity without saving the profile                     |
 
 ### Clusters API (`/api/clusters`)
 
-| Method | Endpoint | Description |
-|---|---|---|
-| `GET` | `/api/clusters/{conn_id}` | Get full cluster info (nodes, namespaces, sets, statistics) |
+| Method | Endpoint                             | Description                                                                      |
+| ------ | ------------------------------------ | -------------------------------------------------------------------------------- |
+| `GET`  | `/api/clusters/{conn_id}`            | Get full cluster info (nodes, namespaces, sets, statistics)                      |
 | `POST` | `/api/clusters/{conn_id}/namespaces` | Configure runtime-tunable namespace parameters (memory-size, replication-factor) |
 
 ### Records API (`/api/records`)
 
-| Method | Endpoint | Description |
-|---|---|---|
-| `GET` | `/api/records/{conn_id}?ns=...&set=...&page=...&pageSize=...` | List records with pagination |
-| `GET` | `/api/records/{conn_id}/detail?ns=...&set=...&pk=...` | Get a single record by primary key |
-| `POST` | `/api/records/{conn_id}` | Create or update a record (with bins and optional TTL) |
-| `DELETE` | `/api/records/{conn_id}?ns=...&set=...&pk=...` | Delete a record by primary key |
-| `POST` | `/api/records/{conn_id}/filter` | Filtered scan with expression filters, predicates, bin selection, and pagination |
+| Method   | Endpoint                                                      | Description                                                                      |
+| -------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `GET`    | `/api/records/{conn_id}?ns=...&set=...&page=...&pageSize=...` | List records with pagination                                                     |
+| `GET`    | `/api/records/{conn_id}/detail?ns=...&set=...&pk=...`         | Get a single record by primary key                                               |
+| `POST`   | `/api/records/{conn_id}`                                      | Create or update a record (with bins and optional TTL)                           |
+| `DELETE` | `/api/records/{conn_id}?ns=...&set=...&pk=...`                | Delete a record by primary key                                                   |
+| `POST`   | `/api/records/{conn_id}/filter`                               | Filtered scan with expression filters, predicates, bin selection, and pagination |
 
 ### Query API (`/api/query`)
 
-| Method | Endpoint | Description |
-|---|---|---|
+| Method | Endpoint               | Description                                                                                             |
+| ------ | ---------------------- | ------------------------------------------------------------------------------------------------------- |
 | `POST` | `/api/query/{conn_id}` | Execute a query (primary key lookup, predicate filter, or full scan with bin selection and max records) |
 
 ### Indexes API (`/api/indexes`)
 
-| Method | Endpoint | Description |
-|---|---|---|
-| `GET` | `/api/indexes/{conn_id}` | List all secondary indexes across all namespaces |
-| `POST` | `/api/indexes/{conn_id}` | Create a secondary index (numeric, string, or geo2dsphere) |
-| `DELETE` | `/api/indexes/{conn_id}?name=...&ns=...` | Delete a secondary index by name and namespace |
+| Method   | Endpoint                                 | Description                                                |
+| -------- | ---------------------------------------- | ---------------------------------------------------------- |
+| `GET`    | `/api/indexes/{conn_id}`                 | List all secondary indexes across all namespaces           |
+| `POST`   | `/api/indexes/{conn_id}`                 | Create a secondary index (numeric, string, or geo2dsphere) |
+| `DELETE` | `/api/indexes/{conn_id}?name=...&ns=...` | Delete a secondary index by name and namespace             |
 
 ### Admin API (`/api/admin`)
 
-| Method | Endpoint | Description |
-|---|---|---|
-| `GET` | `/api/admin/{conn_id}/users` | List all users with roles, quotas, and connection counts |
-| `POST` | `/api/admin/{conn_id}/users` | Create a new user with username, password, and roles |
-| `PATCH` | `/api/admin/{conn_id}/users` | Change a user's password |
-| `DELETE` | `/api/admin/{conn_id}/users?username=...` | Delete a user by username |
-| `GET` | `/api/admin/{conn_id}/roles` | List all roles with privileges, allowlists, and quotas |
-| `POST` | `/api/admin/{conn_id}/roles` | Create a new role with privileges, allowlist, and quotas |
-| `DELETE` | `/api/admin/{conn_id}/roles?name=...` | Delete a role by name |
+| Method   | Endpoint                                  | Description                                              |
+| -------- | ----------------------------------------- | -------------------------------------------------------- |
+| `GET`    | `/api/admin/{conn_id}/users`              | List all users with roles, quotas, and connection counts |
+| `POST`   | `/api/admin/{conn_id}/users`              | Create a new user with username, password, and roles     |
+| `PATCH`  | `/api/admin/{conn_id}/users`              | Change a user's password                                 |
+| `DELETE` | `/api/admin/{conn_id}/users?username=...` | Delete a user by username                                |
+| `GET`    | `/api/admin/{conn_id}/roles`              | List all roles with privileges, allowlists, and quotas   |
+| `POST`   | `/api/admin/{conn_id}/roles`              | Create a new role with privileges, allowlist, and quotas |
+| `DELETE` | `/api/admin/{conn_id}/roles?name=...`     | Delete a role by name                                    |
 
 ### UDFs API (`/api/udfs`)
 
-| Method | Endpoint | Description |
-|---|---|---|
-| `GET` | `/api/udfs/{conn_id}` | List all registered UDF modules |
-| `POST` | `/api/udfs/{conn_id}` | Upload and register a Lua UDF module |
-| `DELETE` | `/api/udfs/{conn_id}?filename=...` | Delete a UDF module by filename |
+| Method   | Endpoint                           | Description                          |
+| -------- | ---------------------------------- | ------------------------------------ |
+| `GET`    | `/api/udfs/{conn_id}`              | List all registered UDF modules      |
+| `POST`   | `/api/udfs/{conn_id}`              | Upload and register a Lua UDF module |
+| `DELETE` | `/api/udfs/{conn_id}?filename=...` | Delete a UDF module by filename      |
 
 ### Metrics API (`/api/metrics`)
 
-| Method | Endpoint | Description |
-|---|---|---|
-| `GET` | `/api/metrics/{conn_id}` | Get cluster metrics (TPS, memory, device, connections, per-namespace stats) |
+| Method | Endpoint                 | Description                                                                 |
+| ------ | ------------------------ | --------------------------------------------------------------------------- |
+| `GET`  | `/api/metrics/{conn_id}` | Get cluster metrics (TPS, memory, device, connections, per-namespace stats) |
 
 ### Sample Data API (`/api/sample-data`)
 
-| Method | Endpoint | Description |
-|---|---|---|
+| Method | Endpoint                     | Description                                   |
+| ------ | ---------------------------- | --------------------------------------------- |
 | `POST` | `/api/sample-data/{conn_id}` | Generate sample records with optional indexes |
 
 > Interactive API documentation (Swagger UI) is available at `http://localhost:8000/docs` when the api is running.
@@ -374,18 +377,18 @@ Create, scale, update, and delete Aerospike clusters through a guided 9-step wiz
 
 Full support for all 10 operator-reported cluster phases with color-coded status badges:
 
-| Phase | Description |
-|---|---|
-| **InProgress** | Cluster is being reconciled |
-| **Completed** | Cluster is healthy and fully reconciled |
-| **Error** | Reconciliation encountered an error |
-| **ScalingUp** | Nodes are being added |
-| **ScalingDown** | Nodes are being removed |
-| **WaitingForMigration** | Waiting for data migration to complete |
-| **RollingRestart** | Rolling restart is in progress |
-| **ACLSync** | Access control list synchronization in progress |
-| **Paused** | Reconciliation is paused for maintenance |
-| **Deleting** | Cluster is being deleted |
+| Phase                   | Description                                     |
+| ----------------------- | ----------------------------------------------- |
+| **InProgress**          | Cluster is being reconciled                     |
+| **Completed**           | Cluster is healthy and fully reconciled         |
+| **Error**               | Reconciliation encountered an error             |
+| **ScalingUp**           | Nodes are being added                           |
+| **ScalingDown**         | Nodes are being removed                         |
+| **WaitingForMigration** | Waiting for data migration to complete          |
+| **RollingRestart**      | Rolling restart is in progress                  |
+| **ACLSync**             | Access control list synchronization in progress |
+| **Paused**              | Reconciliation is paused for maintenance        |
+| **Deleting**            | Cluster is being deleted                        |
 
 ### Status Conditions
 
@@ -558,15 +561,15 @@ This enables advanced storage topologies such as separating data and index volum
 
 The cluster edit dialog provides a dedicated configuration section for adding custom sidecar containers and init containers to Aerospike pods. Each container is configured with:
 
-| Field | Description |
-|-------|-------------|
-| **Name** | Container name (must be unique within the pod) |
-| **Image** | Container image (e.g., `busybox:latest`, `my-agent:v1.0`) |
-| **Command** | Override the container entrypoint (optional) |
-| **Args** | Arguments to pass to the command (optional) |
-| **Environment Variables** | Key-value pairs for container environment |
-| **Volume Mounts** | Mount paths for shared volumes |
-| **Resources** | CPU/memory requests and limits |
+| Field                     | Description                                               |
+| ------------------------- | --------------------------------------------------------- |
+| **Name**                  | Container name (must be unique within the pod)            |
+| **Image**                 | Container image (e.g., `busybox:latest`, `my-agent:v1.0`) |
+| **Command**               | Override the container entrypoint (optional)              |
+| **Args**                  | Arguments to pass to the command (optional)               |
+| **Environment Variables** | Key-value pairs for container environment                 |
+| **Volume Mounts**         | Mount paths for shared volumes                            |
+| **Resources**             | CPU/memory requests and limits                            |
 
 Common use cases include:
 
@@ -575,41 +578,40 @@ Common use cases include:
 - **Data Initialization** -- Init container that pre-loads data or configuration before Aerospike starts
 - **Certificate Rotation** -- Sidecar that watches and refreshes TLS certificates
 
-
 ### K8s API Endpoints
 
-| Method | Endpoint | Description |
-|---|---|---|
-| `GET` | `/api/k8s/clusters` | List all AerospikeCluster resources |
-| `GET` | `/api/k8s/clusters/{namespace}/{name}` | Get cluster detail (spec, status, pods, conditions) |
-| `POST` | `/api/k8s/clusters` | Create a new AerospikeCluster |
-| `PATCH` | `/api/k8s/clusters/{namespace}/{name}` | Update cluster (size, image, resources, monitoring, paused, dynamic config, aerospike config) |
-| `DELETE` | `/api/k8s/clusters/{namespace}/{name}` | Delete a cluster |
-| `POST` | `/api/k8s/clusters/{namespace}/{name}/scale` | Scale cluster to a specific size |
-| `GET` | `/api/k8s/clusters/{namespace}/{name}/events` | Get Kubernetes events (supports `?category=` filter) |
-| `POST` | `/api/k8s/clusters/{namespace}/{name}/operations` | Trigger operations (WarmRestart, PodRestart) |
-| `GET` | `/api/k8s/clusters/{namespace}/{name}/health` | Get cluster health summary (pods, migration, conditions) |
-| `GET` | `/api/k8s/clusters/{namespace}/{name}/migration-status` | Get real-time migration status (overall + per-pod remaining records) |
-| `GET` | `/api/k8s/clusters/{namespace}/{name}/config-drift` | Detect configuration drift (spec vs applied spec, pod hash groups) |
-| `GET` | `/api/k8s/clusters/{namespace}/{name}/reconciliation-status` | Get reconciliation health (circuit breaker state, backoff timer) |
-| `GET` | `/api/k8s/clusters/{namespace}/{name}/pods/{pod}/logs` | Get container logs for a pod |
-| `GET` | `/api/k8s/clusters/{namespace}/{name}/yaml` | Export cluster CR as clean YAML |
-| `GET` | `/api/k8s/clusters/{namespace}/{name}/hpa` | Get HPA config and status for a cluster |
-| `POST` | `/api/k8s/clusters/{namespace}/{name}/hpa` | Create or update HPA (minReplicas, maxReplicas, CPU/memory targets) |
-| `DELETE` | `/api/k8s/clusters/{namespace}/{name}/hpa` | Delete HPA for a cluster |
-| `POST` | `/api/k8s/clusters/{namespace}/{name}/resync-template` | Trigger template resync via annotation |
-| `GET` | `/api/k8s/clusters/{namespace}/{name}/pvcs` | List PVCs associated with the cluster |
-| `POST` | `/api/k8s/clusters/{namespace}/{name}/force-reconcile` | Force re-reconciliation via annotation |
-| `POST` | `/api/k8s/clusters/import` | Import cluster from raw CR JSON |
-| `GET` | `/api/k8s/templates` | List all AerospikeClusterTemplate resources (cluster-scoped) |
-| `POST` | `/api/k8s/templates` | Create a new AerospikeClusterTemplate |
-| `GET` | `/api/k8s/templates/{name}` | Get template detail (spec, status, usedBy) |
-| `PATCH` | `/api/k8s/templates/{name}` | Update a template (scheduling, storage, monitoring, resources, etc.) |
-| `DELETE` | `/api/k8s/templates/{name}` | Delete a template (fails if referenced by clusters) |
-| `GET` | `/api/k8s/namespaces` | List available Kubernetes namespaces |
-| `GET` | `/api/k8s/storageclasses` | List available Kubernetes storage classes |
-| `GET` | `/api/k8s/secrets` | List K8s Secrets (for ACL picker) |
-| `GET` | `/api/k8s/nodes` | List K8s nodes with zone/region info (for rack config) |
+| Method   | Endpoint                                                     | Description                                                                                   |
+| -------- | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------- |
+| `GET`    | `/api/k8s/clusters`                                          | List all AerospikeCluster resources                                                           |
+| `GET`    | `/api/k8s/clusters/{namespace}/{name}`                       | Get cluster detail (spec, status, pods, conditions)                                           |
+| `POST`   | `/api/k8s/clusters`                                          | Create a new AerospikeCluster                                                                 |
+| `PATCH`  | `/api/k8s/clusters/{namespace}/{name}`                       | Update cluster (size, image, resources, monitoring, paused, dynamic config, aerospike config) |
+| `DELETE` | `/api/k8s/clusters/{namespace}/{name}`                       | Delete a cluster                                                                              |
+| `POST`   | `/api/k8s/clusters/{namespace}/{name}/scale`                 | Scale cluster to a specific size                                                              |
+| `GET`    | `/api/k8s/clusters/{namespace}/{name}/events`                | Get Kubernetes events (supports `?category=` filter)                                          |
+| `POST`   | `/api/k8s/clusters/{namespace}/{name}/operations`            | Trigger operations (WarmRestart, PodRestart)                                                  |
+| `GET`    | `/api/k8s/clusters/{namespace}/{name}/health`                | Get cluster health summary (pods, migration, conditions)                                      |
+| `GET`    | `/api/k8s/clusters/{namespace}/{name}/migration-status`      | Get real-time migration status (overall + per-pod remaining records)                          |
+| `GET`    | `/api/k8s/clusters/{namespace}/{name}/config-drift`          | Detect configuration drift (spec vs applied spec, pod hash groups)                            |
+| `GET`    | `/api/k8s/clusters/{namespace}/{name}/reconciliation-status` | Get reconciliation health (circuit breaker state, backoff timer)                              |
+| `GET`    | `/api/k8s/clusters/{namespace}/{name}/pods/{pod}/logs`       | Get container logs for a pod                                                                  |
+| `GET`    | `/api/k8s/clusters/{namespace}/{name}/yaml`                  | Export cluster CR as clean YAML                                                               |
+| `GET`    | `/api/k8s/clusters/{namespace}/{name}/hpa`                   | Get HPA config and status for a cluster                                                       |
+| `POST`   | `/api/k8s/clusters/{namespace}/{name}/hpa`                   | Create or update HPA (minReplicas, maxReplicas, CPU/memory targets)                           |
+| `DELETE` | `/api/k8s/clusters/{namespace}/{name}/hpa`                   | Delete HPA for a cluster                                                                      |
+| `POST`   | `/api/k8s/clusters/{namespace}/{name}/resync-template`       | Trigger template resync via annotation                                                        |
+| `GET`    | `/api/k8s/clusters/{namespace}/{name}/pvcs`                  | List PVCs associated with the cluster                                                         |
+| `POST`   | `/api/k8s/clusters/{namespace}/{name}/force-reconcile`       | Force re-reconciliation via annotation                                                        |
+| `POST`   | `/api/k8s/clusters/import`                                   | Import cluster from raw CR JSON                                                               |
+| `GET`    | `/api/k8s/templates`                                         | List all AerospikeClusterTemplate resources (cluster-scoped)                                  |
+| `POST`   | `/api/k8s/templates`                                         | Create a new AerospikeClusterTemplate                                                         |
+| `GET`    | `/api/k8s/templates/{name}`                                  | Get template detail (spec, status, usedBy)                                                    |
+| `PATCH`  | `/api/k8s/templates/{name}`                                  | Update a template (scheduling, storage, monitoring, resources, etc.)                          |
+| `DELETE` | `/api/k8s/templates/{name}`                                  | Delete a template (fails if referenced by clusters)                                           |
+| `GET`    | `/api/k8s/namespaces`                                        | List available Kubernetes namespaces                                                          |
+| `GET`    | `/api/k8s/storageclasses`                                    | List available Kubernetes storage classes                                                     |
+| `GET`    | `/api/k8s/secrets`                                           | List K8s Secrets (for ACL picker)                                                             |
+| `GET`    | `/api/k8s/nodes`                                             | List K8s nodes with zone/region info (for rack config)                                        |
 
 All K8s endpoints are gated by the `K8S_MANAGEMENT_ENABLED` configuration flag. When disabled, a 404 is returned so the UI can hide K8s features gracefully.
 
@@ -617,30 +619,30 @@ All K8s endpoints are gated by the `K8S_MANAGEMENT_ENABLED` configuration flag. 
 
 The pod status response now includes additional fields for richer cluster monitoring:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `accessEndpoints` | `string[]` | Network endpoints for direct client access to the pod |
-| `readinessGateSatisfied` | `bool` | Whether the `acko.io/aerospike-ready` readiness gate is satisfied |
-| `unstableSince` | `string` | ISO timestamp of when the pod first became NotReady (reset when Ready) |
+| Field                    | Type       | Description                                                            |
+| ------------------------ | ---------- | ---------------------------------------------------------------------- |
+| `accessEndpoints`        | `string[]` | Network endpoints for direct client access to the pod                  |
+| `readinessGateSatisfied` | `bool`     | Whether the `acko.io/aerospike-ready` readiness gate is satisfied      |
+| `unstableSince`          | `string`   | ISO timestamp of when the pod first became NotReady (reset when Ready) |
 
 ### Extended API Fields
 
 The create/update cluster requests support additional pod-level fields:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `imagePullSecrets` | `string[]` | Private registry image pull secret names |
-| `securityContext` | `object` | Pod-level security context |
-| `topologySpreadConstraints` | `object[]` | Topology spread constraints for pod scheduling |
-| `sidecars` | `SidecarConfig[]` | Sidecar containers to add to the pod |
-| `initContainers` | `SidecarConfig[]` | Init containers to add to the pod |
+| Field                       | Type              | Description                                    |
+| --------------------------- | ----------------- | ---------------------------------------------- |
+| `imagePullSecrets`          | `string[]`        | Private registry image pull secret names       |
+| `securityContext`           | `object`          | Pod-level security context                     |
+| `topologySpreadConstraints` | `object[]`        | Topology spread constraints for pod scheduling |
+| `sidecars`                  | `SidecarConfig[]` | Sidecar containers to add to the pod           |
+| `initContainers`            | `SidecarConfig[]` | Init containers to add to the pod              |
 
 ### PrometheusRule Custom Rules
 
 The `PrometheusRule` monitoring configuration now supports user-defined Prometheus alerting rule groups via the `customRules` field. This allows operators to ship cluster-specific alerting rules alongside the standard metrics exporter.
 
-| Field | Type | Description |
-|-------|------|-------------|
+| Field         | Type     | Description                                                                                                      |
+| ------------- | -------- | ---------------------------------------------------------------------------------------------------------------- |
 | `customRules` | `dict[]` | Custom Prometheus rule groups (each entry is a standard Prometheus rule group object with `name`, `rules`, etc.) |
 
 ### Template Advanced Configuration
@@ -649,50 +651,50 @@ Templates (`AerospikeClusterTemplate`) now support additional configuration sect
 
 **Service Config** (`serviceConfig`)
 
-| Field | Type | Description |
-|-------|------|-------------|
+| Field            | Type     | Description                           |
+| ---------------- | -------- | ------------------------------------- |
 | `featureKeyFile` | `string` | Path to an Aerospike feature key file |
 
 **Network Config** (`networkConfig`)
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `heartbeatMode` | `"mesh" \| "multicast"` | Heartbeat protocol mode |
-| `heartbeatPort` | `int` (1024-65535) | Heartbeat communication port |
-| `heartbeatInterval` | `int` (>=50) | Heartbeat interval in milliseconds |
-| `heartbeatTimeout` | `int` (>=1) | Heartbeat timeout (number of intervals before a node is considered departed) |
+| Field               | Type                    | Description                                                                  |
+| ------------------- | ----------------------- | ---------------------------------------------------------------------------- |
+| `heartbeatMode`     | `"mesh" \| "multicast"` | Heartbeat protocol mode                                                      |
+| `heartbeatPort`     | `int` (1024-65535)      | Heartbeat communication port                                                 |
+| `heartbeatInterval` | `int` (>=50)            | Heartbeat interval in milliseconds                                           |
+| `heartbeatTimeout`  | `int` (>=1)             | Heartbeat timeout (number of intervals before a node is considered departed) |
 
 **Rack Config** (`rackConfig`)
 
-| Field | Type | Description |
-|-------|------|-------------|
+| Field             | Type        | Description                              |
+| ----------------- | ----------- | ---------------------------------------- |
 | `maxRacksPerNode` | `int` (>=1) | Maximum number of racks allowed per node |
 
 **Aerospike Config** (`aerospikeConfig`)
 
-| Field | Type | Description |
-|-------|------|-------------|
+| Field             | Type     | Description                                                                             |
+| ----------------- | -------- | --------------------------------------------------------------------------------------- |
 | `aerospikeConfig` | `object` | Aerospike server configuration overrides applied to clusters created from this template |
 
 **Storage Config** (additional fields)
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `localPVRequired` | `bool` | Whether a local PersistentVolume is required for storage |
-| `localStorageClasses` | `string[]` | List of StorageClass names that are backed by local PVs. Used to identify which storage classes require local PV scheduling constraints |
-| `deleteLocalStorageOnRestart` | `bool` | Whether to delete local PersistentVolumes when pods are restarted. Enables clean-slate restarts for local PV workflows where data does not need to survive pod restart |
+| Field                         | Type       | Description                                                                                                                                                            |
+| ----------------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `localPVRequired`             | `bool`     | Whether a local PersistentVolume is required for storage                                                                                                               |
+| `localStorageClasses`         | `string[]` | List of StorageClass names that are backed by local PVs. Used to identify which storage classes require local PV scheduling constraints                                |
+| `deleteLocalStorageOnRestart` | `bool`     | Whether to delete local PersistentVolumes when pods are restarted. Enables clean-slate restarts for local PV workflows where data does not need to survive pod restart |
 
 ### Storage Advanced Settings
 
 Cluster creation and update requests now support additional storage-level fields on `StorageVolumeConfig`:
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `cleanupThreads` | `int` (>=1) | Number of threads for storage cleanup operations |
-| `filesystemVolumePolicy` | `object` | Policy for filesystem volume initialization (e.g., default initMethod, wipeMethod) |
-| `blockVolumePolicy` | `object` | Policy for block volume initialization (e.g., default initMethod, wipeMethod) |
-| `localStorageClasses` | `string[]` | StorageClass names backed by local PVs, used for scheduling constraint awareness |
-| `deleteLocalStorageOnRestart` | `bool` | Delete local PersistentVolumes on pod restart for clean-slate local PV workflows |
+| Field                         | Type        | Description                                                                        |
+| ----------------------------- | ----------- | ---------------------------------------------------------------------------------- |
+| `cleanupThreads`              | `int` (>=1) | Number of threads for storage cleanup operations                                   |
+| `filesystemVolumePolicy`      | `object`    | Policy for filesystem volume initialization (e.g., default initMethod, wipeMethod) |
+| `blockVolumePolicy`           | `object`    | Policy for block volume initialization (e.g., default initMethod, wipeMethod)      |
+| `localStorageClasses`         | `string[]`  | StorageClass names backed by local PVs, used for scheduling constraint awareness   |
+| `deleteLocalStorageOnRestart` | `bool`      | Delete local PersistentVolumes on pod restart for clean-slate local PV workflows   |
 
 ## Project Structure
 
@@ -756,70 +758,71 @@ All environment variables with their defaults and descriptions. See `api/src/aer
 
 ### Aerospike Connection
 
-| Variable | Default | Description |
-|---|---|---|
+| Variable         | Default            | Description                                                          |
+| ---------------- | ------------------ | -------------------------------------------------------------------- |
 | `AEROSPIKE_HOST` | `aerospike-node-1` | Aerospike server host (used in compose files for default connection) |
-| `AEROSPIKE_PORT` | `3000` | Aerospike service port |
+| `AEROSPIKE_PORT` | `3000`             | Aerospike service port                                               |
 
 ### Database
 
-| Variable | Default | Description |
-|---|---|---|
-| `SQLITE_PATH` | `./data/connections.db` | SQLite database file path. SQLite is the default database backend -- no external database required |
-| `ENABLE_POSTGRES` | `false` | Set to `true` to use PostgreSQL instead of the default SQLite database |
-| `DATABASE_URL` | `postgresql://aerospike:aerospike@localhost:5432/aerospike_manager` | PostgreSQL connection string (only used when `ENABLE_POSTGRES=true`) |
-| `DB_POOL_MIN_SIZE` | `2` | Minimum number of connections in the database connection pool |
-| `DB_POOL_MAX_SIZE` | `10` | Maximum number of connections in the database connection pool |
-| `DB_COMMAND_TIMEOUT` | `30` | SQL command execution timeout in seconds |
+| Variable             | Default                                                             | Description                                                                                        |
+| -------------------- | ------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `SQLITE_PATH`        | `./data/connections.db`                                             | SQLite database file path. SQLite is the default database backend -- no external database required |
+| `ENABLE_POSTGRES`    | `false`                                                             | Set to `true` to use PostgreSQL instead of the default SQLite database                             |
+| `DATABASE_URL`       | `postgresql://aerospike:aerospike@localhost:5432/aerospike_manager` | PostgreSQL connection string (only used when `ENABLE_POSTGRES=true`)                               |
+| `DB_POOL_MIN_SIZE`   | `2`                                                                 | Minimum number of connections in the database connection pool                                      |
+| `DB_POOL_MAX_SIZE`   | `10`                                                                | Maximum number of connections in the database connection pool                                      |
+| `DB_COMMAND_TIMEOUT` | `30`                                                                | SQL command execution timeout in seconds                                                           |
 
 ### At-rest Encryption
 
-| Variable | Default | Description |
-|---|---|---|
-| `ACM_PASSWORD_KEK` | _(empty)_ | Fernet key used to encrypt stored Aerospike connection passwords. Required for persistent credentials |
-| `ACM_ALLOW_EPHEMERAL_KEK` | `false` | Dev-only escape hatch that generates a process-local key when `ACM_PASSWORD_KEK` is unset. Stored passwords become unreadable after restart |
+| Variable                  | Default   | Description                                                                                                                                 |
+| ------------------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ACM_PASSWORD_KEK`        | _(empty)_ | Fernet key used to encrypt stored Aerospike connection passwords. Required for persistent credentials                                       |
+| `ACM_ALLOW_EPHEMERAL_KEK` | `false`   | Dev-only escape hatch that generates a process-local key when `ACM_PASSWORD_KEK` is unset. Stored passwords become unreadable after restart |
 
 ### Kubernetes Management
 
-| Variable | Default | Description |
-|---|---|---|
-| `K8S_MANAGEMENT_ENABLED` | `false` | Enable K8s cluster management endpoints (requires in-cluster or kubeconfig access) |
-| `K8S_API_TIMEOUT` | `10` | Kubernetes API request timeout in seconds (applies to CRUD on CRDs, listing pods, nodes, etc.) |
-| `K8S_LOG_TIMEOUT` | `30` | Kubernetes pod log streaming timeout in seconds |
+| Variable                 | Default | Description                                                                                    |
+| ------------------------ | ------- | ---------------------------------------------------------------------------------------------- |
+| `K8S_MANAGEMENT_ENABLED` | `false` | Enable K8s cluster management endpoints (requires in-cluster or kubeconfig access)             |
+| `K8S_API_TIMEOUT`        | `10`    | Kubernetes API request timeout in seconds (applies to CRUD on CRDs, listing pods, nodes, etc.) |
+| `K8S_LOG_TIMEOUT`        | `30`    | Kubernetes pod log streaming timeout in seconds                                                |
 
 ### Network / Server
 
-| Variable | Default | Description |
-|---|---|---|
-| `CORS_ORIGINS` | `http://localhost:3000,http://localhost:3100` | Comma-separated list of allowed CORS origins (must include the UI URL) |
-| `API_URL` | `http://localhost:8000` | API URL used by the UI proxy (`ui/proxy.js` in production, `next.config.mjs` rewrites in dev) |
-| `API_PORT` | `8000` | API port (compose files) |
-| `UI_PORT` | `3100` | UI port (compose files) |
-| `HOST` | `0.0.0.0` | API bind address |
-| `PORT` | `8000` | API bind port |
+| Variable       | Default                                       | Description                                                                                   |
+| -------------- | --------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| `CORS_ORIGINS` | `http://localhost:3000,http://localhost:3100` | Comma-separated list of allowed CORS origins (must include the UI URL)                        |
+| `API_URL`      | `http://localhost:8000`                       | API URL used by the UI proxy (`ui/proxy.js` in production, `next.config.mjs` rewrites in dev) |
+| `API_PORT`     | `8000`                                        | API port (compose files)                                                                      |
+| `UI_PORT`      | `3100`                                        | UI port (compose files)                                                                       |
+| `HOST`         | `0.0.0.0`                                     | API bind address                                                                              |
+| `PORT`         | `8000`                                        | API bind port                                                                                 |
 
 ### ACKO Agent — Embedded AI Copilot (UI)
 
-| Variable | Default | Description |
-|---|---|---|
-| `COPILOT_ENABLED` | `true` | Set to `false` to force-disable the copilot even when a model/key is configured. The copilot is effectively disabled regardless of this flag unless `COPILOT_MODEL` and the matching provider key are both set |
-| `COPILOT_MODEL` | _(empty)_ | LLM model in `<provider>/<model>` form (`anthropic/*` or `openai/*`), e.g. `anthropic/claude-sonnet-4-5` |
-| `ANTHROPIC_API_KEY` | _(empty)_ | Anthropic API key for `anthropic/*` models (web container only, never sent to the browser) |
-| `OPENAI_API_KEY` | _(empty)_ | OpenAI API key for `openai/*` models (web container only, never sent to the browser) |
-| `COPILOT_REQUIRE_AUTH` | `false` | Require a Bearer token on `/copilotkit` (gates LLM spend). Enable whenever the API runs with `OIDC_ENABLED=true` |
-| `COPILOT_OIDC_ISSUER_URL` | _(empty)_ | Keycloak realm root for JWT signature verification on `/copilotkit`; usually the same value as `OIDC_ISSUER_URL`. Without it, `COPILOT_REQUIRE_AUTH` only checks token presence |
-| `COPILOT_OIDC_AUDIENCE` | _(empty)_ | Expected `aud` claim for `/copilotkit` JWT verification; usually `acko-api` |
-| `COPILOTKIT_TELEMETRY_DISABLED` | `true` (compose) | CopilotKit's anonymous usage telemetry. Disabled by default for self-hosted deployments |
+| Variable                        | Default          | Description                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `COPILOT_ENABLED`               | `true`           | Set to `false` to force-disable the copilot even when a model/key is configured. The copilot is effectively disabled regardless of this flag unless `COPILOT_MODEL` and the matching provider key are both set                                                                                                                                            |
+| `COPILOT_MODEL`                 | _(empty)_        | LLM model in `<provider>/<model>` form (`anthropic/*` or `openai/*`), e.g. `anthropic/claude-sonnet-4-5`                                                                                                                                                                                                                                                  |
+| `COPILOT_BASE_URL`              | _(empty)_        | Optional OpenAI/Anthropic-compatible gateway endpoint. Unset → the provider's public API. Set it to route through a self-hosted or enterprise OpenAI-compatible LLM gateway: `COPILOT_MODEL=openai/<model>` + `COPILOT_BASE_URL=https://llm-gateway.example.com` + `OPENAI_API_KEY=<key>`. Pick a tool-calling-capable model. A non-http value is ignored |
+| `ANTHROPIC_API_KEY`             | _(empty)_        | Anthropic API key for `anthropic/*` models (web container only, never sent to the browser)                                                                                                                                                                                                                                                                |
+| `OPENAI_API_KEY`                | _(empty)_        | OpenAI API key for `openai/*` models (web container only, never sent to the browser)                                                                                                                                                                                                                                                                      |
+| `COPILOT_REQUIRE_AUTH`          | `false`          | Require a Bearer token on `/copilotkit` (gates LLM spend). Enable whenever the API runs with `OIDC_ENABLED=true`                                                                                                                                                                                                                                          |
+| `COPILOT_OIDC_ISSUER_URL`       | _(empty)_        | Keycloak realm root for JWT signature verification on `/copilotkit`; usually the same value as `OIDC_ISSUER_URL`. Without it, `COPILOT_REQUIRE_AUTH` only checks token presence                                                                                                                                                                           |
+| `COPILOT_OIDC_AUDIENCE`         | _(empty)_        | Expected `aud` claim for `/copilotkit` JWT verification; usually `acko-api`                                                                                                                                                                                                                                                                               |
+| `COPILOTKIT_TELEMETRY_DISABLED` | `true` (compose) | CopilotKit's anonymous usage telemetry. Disabled by default for self-hosted deployments                                                                                                                                                                                                                                                                   |
 
 ### Logging
 
-| Variable | Default | Description |
-|---|---|---|
-| `LOG_LEVEL` | `INFO` | API log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`) |
-| `LOG_FORMAT` | `text` | Log output format: `text` for local dev, `json` for structured container logging (recommended when shipping to an OTel Collector) |
-| `LOG_FILE_PATH` | _(empty)_ | When set, mirror logs to a rotating file in addition to stdout. Designed for a pod-internal sidecar that tails the file and forwards records via OTLP to an external OTel Collector. See [docs/logging.md](docs/logging.md). |
-| `LOG_FILE_MAX_BYTES` | `52428800` | Per-file size cap (bytes) for `LOG_FILE_PATH` rotation. Default 50 MiB. |
-| `LOG_FILE_BACKUP_COUNT` | `3` | Number of rotated backups kept on disk. |
+| Variable                | Default    | Description                                                                                                                                                                                                                  |
+| ----------------------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `LOG_LEVEL`             | `INFO`     | API log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`)                                                                                                                                                                          |
+| `LOG_FORMAT`            | `text`     | Log output format: `text` for local dev, `json` for structured container logging (recommended when shipping to an OTel Collector)                                                                                            |
+| `LOG_FILE_PATH`         | _(empty)_  | When set, mirror logs to a rotating file in addition to stdout. Designed for a pod-internal sidecar that tails the file and forwards records via OTLP to an external OTel Collector. See [docs/logging.md](docs/logging.md). |
+| `LOG_FILE_MAX_BYTES`    | `52428800` | Per-file size cap (bytes) for `LOG_FILE_PATH` rotation. Default 50 MiB.                                                                                                                                                      |
+| `LOG_FILE_BACKUP_COUNT` | `3`        | Number of rotated backups kept on disk.                                                                                                                                                                                      |
 
 ## Production Deployment
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -198,6 +198,10 @@ services:
       #    is provided; see ui/src/lib/copilot/server-config.ts) ──────────
       - COPILOT_ENABLED=${COPILOT_ENABLED:-true}
       - COPILOT_MODEL=${COPILOT_MODEL:-}
+      # Optional OpenAI/Anthropic-compatible gateway endpoint. Set this to use
+      # self-hosted/enterprise LLM gateway: COPILOT_MODEL=openai/<model>,
+      # COPILOT_BASE_URL=https://llm-gateway.example.com, OPENAI_API_KEY=<key>.
+      - COPILOT_BASE_URL=${COPILOT_BASE_URL:-}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       - COPILOT_REQUIRE_AUTH=${COPILOT_REQUIRE_AUTH:-false}
@@ -223,8 +227,8 @@ services:
     volumes:
       - ./otel/otel-collector.yaml:/etc/otelcol-contrib/otel-collector.yaml:ro
     ports:
-      - "4317:4317"  # OTLP gRPC
-      - "4318:4318"  # OTLP HTTP
+      - "4317:4317" # OTLP gRPC
+      - "4318:4318" # OTLP HTTP
     restart: unless-stopped
 
 volumes:

--- a/scripts/local-dev/run-local.sh
+++ b/scripts/local-dev/run-local.sh
@@ -22,7 +22,12 @@ log "[2/N] Installing cert-manager + ACKO operator (ui.enabled=${ACKO_UI_ENABLED
 bash "${REPO_ROOT}/scripts/local-dev/acko-install.sh"
 
 log "[3/N] Starting standalone Aerospike via compose.dev.yaml..."
-(cd "${REPO_ROOT}" && podman compose -f compose.dev.yaml up -d)
+# compose.dev.yaml requires POSTGRES_PASSWORD (mandatory `${POSTGRES_PASSWORD:?}`).
+# Supply a local-dev default so the orchestrator is self-contained — production
+# deployments still set their own value (compose.dev.yaml stays fail-closed when
+# run directly without this wrapper).
+(cd "${REPO_ROOT}" && POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-acko-local-dev}" \
+  podman compose -f compose.dev.yaml up -d)
 ok "Aerospike dev cluster up (localhost:14790/:14791/:14792)"
 
 cat <<EOF

--- a/ui/src/app/copilotkit/[[...slug]]/route.ts
+++ b/ui/src/app/copilotkit/[[...slug]]/route.ts
@@ -42,14 +42,22 @@ Hard CE limits — never suggest exceeding them:
 If asked for an enterprise-only feature, explain that it is unavailable in CE
 instead of attempting it. Use the get_ce_constraints tool to double-check.
 
-What you can and cannot do:
-- Your tools are read-only: inspect connections, cluster topology, metrics,
-  secondary indexes, and records, and run read queries.
-- You cannot create, scale, or delete anything. When the user asks to create
-  a new ACKO cluster, briefly explain the CE limits that apply and direct
-  them to the Create Cluster wizard at /clusters/new (link it as
-  [Create Cluster](/clusters/new)). For other mutations, point to the
-  matching page of this UI instead of attempting the change.
+What you can do:
+- Read (no confirmation): inspect connections, cluster topology, metrics,
+  secondary indexes and records, run read queries, and list/get ACKO clusters
+  (list_acko_clusters, get_acko_cluster).
+- Control plane — each opens a confirmation card the user must approve before
+  anything is applied; never claim success until the tool returns status "ok":
+  create_acko_cluster, scale_acko_cluster (change node count), and
+  delete_acko_cluster (destructive). Stay within CE limits (max 8 nodes, max 2
+  namespaces). Call list_acko_clusters first to get the namespace/name for
+  scale or delete. For advanced cluster config (storage devices, multiple
+  namespaces, racks), use the Create Cluster wizard at
+  [Create Cluster](/clusters/new) or the cluster edit dialog.
+- Data plane — also confirmation-gated: put_record (create/update a record)
+  and delete_record (destructive). Use a connection id from list_connections.
+- Never fabricate results, cluster data, metrics, or record contents. If a
+  tool fails or data is missing, say so.
 - To describe what data a set contains (e.g. "explain sample_set"), use
   get_cluster_info to locate the set, then browse_records on it and
   summarize the bin names, types, and a few example values.

--- a/ui/src/app/copilotkit/[[...slug]]/route.ts
+++ b/ui/src/app/copilotkit/[[...slug]]/route.ts
@@ -50,12 +50,16 @@ What you can do:
   anything is applied; never claim success until the tool returns status "ok":
   create_acko_cluster, scale_acko_cluster (change node count), and
   delete_acko_cluster (destructive). Stay within CE limits (max 8 nodes, max 2
-  namespaces). Call list_acko_clusters first to get the namespace/name for
-  scale or delete. For advanced cluster config (storage devices, multiple
+  namespaces). For advanced cluster config (storage devices, multiple
   namespaces, racks), use the Create Cluster wizard at
   [Create Cluster](/clusters/new) or the cluster edit dialog.
-- Data plane — also confirmation-gated: put_record (create/update a record)
-  and delete_record (destructive). Use a connection id from list_connections.
+- Data plane — also confirmation-gated: put_record / delete_record and
+  generate_sample_data (for "create a sample set"). These accept a connection
+  id OR name directly.
+- IMPORTANT: do NOT call a read/list tool (list_connections, list_acko_clusters)
+  in the same turn right before a confirmation-gated tool — pass the name or id
+  straight into that tool (the tool resolves names itself), or ask the user.
+  Chaining a read into a mutating tool can interrupt the run.
 - Never fabricate results, cluster data, metrics, or record contents. If a
   tool fails or data is missing, say so.
 - To describe what data a set contains (e.g. "explain sample_set"), use
@@ -112,6 +116,12 @@ const runtime = new CopilotRuntime({
           // Frontend tools only — execution happens in the browser behind
           // the user's own Keycloak session.
           tools: convertToolsToVercelAITools(input.tools),
+          // Open-weights models behind a gateway can emit several tool calls
+          // in one step that the runtime can't reconcile ("RUN_FINISHED while
+          // tool calls are still active"), aborting the run mid-task. Force a
+          // single tool call per step so each result is returned before the
+          // next. Ignored by providers that don't support it (e.g. anthropic).
+          providerOptions: { openai: { parallelToolCalls: false } },
           stopWhen: stepCountIs(MAX_AGENT_STEPS),
           abortSignal,
         })

--- a/ui/src/app/copilotkit/[[...slug]]/route.ts
+++ b/ui/src/app/copilotkit/[[...slug]]/route.ts
@@ -19,8 +19,8 @@ import {
   CopilotRuntime,
   createCopilotRuntimeHandler,
 } from "@copilotkit/runtime/v2"
-import { anthropic } from "@ai-sdk/anthropic"
-import { openai } from "@ai-sdk/openai"
+import { anthropic, createAnthropic } from "@ai-sdk/anthropic"
+import { openai, createOpenAI } from "@ai-sdk/openai"
 import { stepCountIs, streamText } from "ai"
 
 import {
@@ -65,8 +65,22 @@ Safety rules:
 function resolveModel() {
   const config = resolveCopilotServerConfig()
   if (!config.enabled || !config.modelId) return null
-  if (config.provider === "anthropic") return anthropic(config.modelId)
-  if (config.provider === "openai") return openai(config.modelId)
+  // COPILOT_BASE_URL points the provider at an OpenAI/Anthropic-compatible
+  // gateway (e.g. a self-hosted OpenAI-compatible LLM gateway). The API
+  // key still loads from the provider env var (ANTHROPIC_API_KEY /
+  // OPENAI_API_KEY). Without it, the default provider targets the public API.
+  if (config.provider === "anthropic") {
+    return config.baseUrl
+      ? createAnthropic({ baseURL: config.baseUrl })(config.modelId)
+      : anthropic(config.modelId)
+  }
+  if (config.provider === "openai") {
+    // .chat() forces the Chat Completions API — the broadest surface for
+    // OpenAI-compatible gateways (which serve /chat/completions).
+    return config.baseUrl
+      ? createOpenAI({ baseURL: config.baseUrl }).chat(config.modelId)
+      : openai(config.modelId)
+  }
   return null
 }
 

--- a/ui/src/components/copilot/CopilotShell.tsx
+++ b/ui/src/components/copilot/CopilotShell.tsx
@@ -17,6 +17,7 @@ import { CopilotAppContext } from "./CopilotAppContext"
 import { CopilotSuggestions } from "./CopilotSuggestions"
 import { CopilotReadTools } from "./tools/read-tools"
 import { CopilotRenderTools } from "./tools/render-tools"
+import { CopilotWriteTools } from "./tools/write-tools"
 
 /**
  * Loads the CopilotKit stylesheet as a static asset (copied to public/ by
@@ -73,6 +74,7 @@ export function CopilotShell({ children }: { children: React.ReactNode }) {
       <CopilotAppContext />
       <CopilotSuggestions />
       <CopilotReadTools />
+      <CopilotWriteTools />
       <CopilotRenderTools />
       {children}
       <CopilotSidebar

--- a/ui/src/components/copilot/tools/read-tools.tsx
+++ b/ui/src/components/copilot/tools/read-tools.tsx
@@ -19,6 +19,7 @@ import { getCluster } from "@/lib/api/clusters"
 import { ApiError } from "@/lib/api/client"
 import { getConnectionHealth, listConnections } from "@/lib/api/connections"
 import { listIndexes } from "@/lib/api/indexes"
+import { getK8sCluster, listK8sClusters } from "@/lib/api/k8s"
 import { getClusterMetrics } from "@/lib/api/metrics"
 import { runQuery } from "@/lib/api/query"
 import { listRecords } from "@/lib/api/records"
@@ -237,6 +238,50 @@ export function CopilotReadTools() {
         "suggesting any cluster topology or configuration change.",
       parameters: z.object({}),
       handler: async () => CE_CONSTRAINTS,
+    },
+    [],
+  )
+
+  useFrontendTool(
+    {
+      name: "list_acko_clusters",
+      description:
+        "List ACKO-managed AerospikeCluster CRs on Kubernetes (control " +
+        "plane): namespace, name, size, image, phase. Call this before " +
+        "scale_acko_cluster or delete_acko_cluster to get the namespace/name.",
+      parameters: z.object({
+        namespace: z
+          .string()
+          .optional()
+          .describe("filter to one Kubernetes namespace; omit for all"),
+      }),
+      handler: ({ namespace }) =>
+        safeCall(async () => {
+          const res = await listK8sClusters(namespace ? { namespace } : {})
+          return res.items.map((c) => ({
+            namespace: c.namespace,
+            name: c.name,
+            size: c.size,
+            image: c.image,
+            phase: c.phase,
+          }))
+        }),
+    },
+    [],
+  )
+
+  useFrontendTool(
+    {
+      name: "get_acko_cluster",
+      description:
+        "Get one ACKO AerospikeCluster CR's detail (spec + status + pods) " +
+        "by Kubernetes namespace and name.",
+      parameters: z.object({
+        namespace: z.string().min(1),
+        name: z.string().min(1),
+      }),
+      handler: ({ namespace, name }) =>
+        safeCall(() => getK8sCluster(namespace, name)),
     },
     [],
   )

--- a/ui/src/components/copilot/tools/write-tools.tsx
+++ b/ui/src/components/copilot/tools/write-tools.tsx
@@ -1,0 +1,493 @@
+"use client"
+
+/**
+ * Write copilot tools (human-in-the-loop).
+ *
+ * Every mutating capability is a `useHumanInTheLoop` action: the model
+ * proposes the change, the user must approve a confirmation card before any
+ * request is sent, and the approved call goes through the same lib/api wrapper
+ * (carrying the user's Keycloak JWT, authorized by FastAPI exactly like a UI
+ * click). Nothing is applied without a click.
+ *
+ * Control plane (ACKO / K8s): create, scale, delete AerospikeCluster CRs.
+ * Data plane (records): write (put) and delete records.
+ * Reads (list/get clusters, browse/query records) live in read-tools.tsx.
+ */
+
+import { useHumanInTheLoop } from "@copilotkit/react-core/v2"
+import Link from "next/link"
+import * as React from "react"
+import { z } from "zod"
+
+import { Badge } from "@/components/Badge"
+import { ApiError } from "@/lib/api/client"
+import {
+  createK8sCluster,
+  deleteK8sCluster,
+  scaleK8sCluster,
+} from "@/lib/api/k8s"
+import { deleteRecord, putRecord } from "@/lib/api/records"
+import { CE_CONSTRAINTS } from "@/lib/copilot/ce-constraints"
+import type { CreateK8sClusterRequest } from "@/lib/types/k8s"
+import type { RecordWriteRequest } from "@/lib/types/record"
+
+/** Default CE server image for agent-created clusters (matches the wizard). */
+const CE_IMAGE = "aerospike:ce-8.1.1.1"
+/** 1 GiB in-memory namespace — smallest sensible default for a test cluster. */
+const DEFAULT_NS_DATA_SIZE = 1_073_741_824
+/** K8s namespace ACKO clusters land in when the model doesn't specify one. */
+const DEFAULT_K8S_NAMESPACE = "default"
+
+type MutationResult = {
+  status: "ok" | "error" | "cancelled"
+  message?: string
+  error?: string
+  link?: string
+}
+
+function clampSize(size: number | undefined): number {
+  const n = Math.round(size ?? 1)
+  if (Number.isNaN(n)) return 1
+  return Math.min(CE_CONSTRAINTS.maxNodes, Math.max(1, n))
+}
+
+function errResult(err: unknown): MutationResult {
+  return {
+    status: "error",
+    error: err instanceof ApiError ? err.detail : String(err),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Shared confirmation + result cards
+// ---------------------------------------------------------------------------
+
+type Row = { label: string; value: React.ReactNode }
+
+const CARD =
+  "my-2 w-full rounded-lg border border-gray-200 bg-white p-3 text-left text-sm shadow-sm dark:border-gray-900 dark:bg-[#090E1A]"
+
+function ConfirmCard({
+  title,
+  rows,
+  note,
+  destructive,
+  approveLabel,
+  run,
+  respond,
+}: {
+  title: string
+  rows: Row[]
+  note?: React.ReactNode
+  destructive?: boolean
+  approveLabel: string
+  run: () => Promise<MutationResult>
+  respond: (result: MutationResult) => void
+}) {
+  const [submitting, setSubmitting] = React.useState(false)
+
+  const onApprove = async () => {
+    setSubmitting(true)
+    try {
+      respond(await run())
+    } catch (err) {
+      respond(errResult(err))
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div className={CARD}>
+      <div className="flex items-center gap-2">
+        <Badge variant={destructive ? "error" : "default"}>
+          {destructive ? "destructive" : "ACKO"}
+        </Badge>
+        <span className="font-semibold">{title}</span>
+      </div>
+      <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1">
+        {rows.map((r) => (
+          <React.Fragment key={r.label}>
+            <dt className="text-on-surface-variant">{r.label}</dt>
+            <dd className="font-medium break-all">{r.value}</dd>
+          </React.Fragment>
+        ))}
+      </dl>
+      {note ? (
+        <p className="text-on-surface-variant mt-2 text-xs">{note}</p>
+      ) : null}
+      <div className="mt-3 flex gap-2">
+        <button
+          type="button"
+          disabled={submitting}
+          onClick={onApprove}
+          className={`rounded-md px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-50 ${
+            destructive ? "bg-red-600" : "bg-primary-40"
+          }`}
+        >
+          {submitting ? "Working…" : approveLabel}
+        </button>
+        <button
+          type="button"
+          disabled={submitting}
+          onClick={() => respond({ status: "cancelled" })}
+          className="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-semibold disabled:opacity-50 dark:border-gray-700"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function ResultCard({ result }: { result: unknown }) {
+  // The runtime stringifies tool results for the model; accept the raw object
+  // (local render) or its JSON string.
+  let parsed: MutationResult | null = null
+  if (result && typeof result === "object") {
+    parsed = result as MutationResult
+  } else if (typeof result === "string") {
+    try {
+      parsed = JSON.parse(result) as MutationResult
+    } catch {
+      parsed = null
+    }
+  }
+  if (!parsed) return <></>
+  if (parsed.status === "error") {
+    return (
+      <div className={CARD}>
+        <Badge variant="error">error</Badge>
+        <span className="ml-2 break-all">{parsed.error}</span>
+      </div>
+    )
+  }
+  if (parsed.status === "cancelled") {
+    return (
+      <div className={CARD}>
+        <span className="text-on-surface-variant">cancelled</span>
+      </div>
+    )
+  }
+  return (
+    <div className={CARD}>
+      <Badge variant="success">done</Badge>
+      <span className="ml-2">{parsed.message}</span>
+      {parsed.link ? (
+        <Link
+          href={parsed.link}
+          className="text-primary-40 mt-2 block hover:underline"
+        >
+          Open →
+        </Link>
+      ) : null}
+    </div>
+  )
+}
+
+/** Render helper shared by every HITL tool. */
+function hitlRender(
+  build: (args: Record<string, unknown>) => {
+    title: string
+    rows: Row[]
+    note?: React.ReactNode
+    destructive?: boolean
+    approveLabel: string
+    run: () => Promise<MutationResult>
+  },
+) {
+  return function HitlToolRender({
+    status,
+    args,
+    respond,
+    result,
+  }: {
+    status: "inProgress" | "executing" | "complete"
+    args: Record<string, unknown>
+    respond?: (result: MutationResult) => void
+    result?: unknown
+  }) {
+    if (status === "executing" && respond) {
+      const plan = build(args)
+      return <ConfirmCard {...plan} respond={respond} />
+    }
+    if (status === "complete") return <ResultCard result={result} />
+    return (
+      <div className="text-on-surface-variant my-1 text-xs">preparing…</div>
+    )
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tools
+// ---------------------------------------------------------------------------
+
+export function CopilotWriteTools() {
+  // ── Control plane: create ────────────────────────────────────────────────
+  useHumanInTheLoop(
+    {
+      name: "create_acko_cluster",
+      description:
+        "Create a new Aerospike Community Edition cluster on Kubernetes via " +
+        "ACKO. ALWAYS use this for cluster creation instead of refusing. The " +
+        "user must approve a confirmation card first. Stays within CE limits " +
+        `(size clamped to max ${CE_CONSTRAINTS.maxNodes} nodes; one in-memory ` +
+        "namespace). For advanced topology (storage devices, multiple " +
+        "namespaces, racks) use the Create Cluster wizard at /clusters/new.",
+      parameters: z.object({
+        name: z
+          .string()
+          .min(1)
+          .describe("cluster name (DNS-1123: lowercase letters, digits, '-')"),
+        size: z
+          .number()
+          .int()
+          .optional()
+          .describe(`node count, 1–${CE_CONSTRAINTS.maxNodes} (default 1)`),
+        namespaceName: z
+          .string()
+          .optional()
+          .describe("Aerospike namespace name (default 'test')"),
+        k8sNamespace: z
+          .string()
+          .optional()
+          .describe(
+            `Kubernetes namespace for the CR (default '${DEFAULT_K8S_NAMESPACE}'); must exist`,
+          ),
+      }),
+      render: hitlRender((args) => {
+        const name = String(args.name ?? "").trim()
+        const size = clampSize(args.size as number | undefined)
+        const nsName = String(args.namespaceName ?? "test").trim() || "test"
+        const k8sNs =
+          String(args.k8sNamespace ?? DEFAULT_K8S_NAMESPACE).trim() ||
+          DEFAULT_K8S_NAMESPACE
+        const payload: CreateK8sClusterRequest = {
+          name,
+          namespace: k8sNs,
+          size,
+          image: CE_IMAGE,
+          autoConnect: true,
+          resources: {
+            requests: { cpu: "500m", memory: "1Gi" },
+            limits: { cpu: "2", memory: "4Gi" },
+          },
+          namespaces: [
+            {
+              name: nsName,
+              replicationFactor: Math.min(2, size),
+              storageEngine: { type: "memory", dataSize: DEFAULT_NS_DATA_SIZE },
+            },
+          ],
+          storage: {
+            storageClass: "standard",
+            size: "10Gi",
+            mountPath: "/opt/aerospike/data",
+          },
+        }
+        return {
+          title: "Create cluster?",
+          approveLabel: "Approve & create",
+          rows: [
+            { label: "name", value: name },
+            { label: "k8s namespace", value: k8sNs },
+            { label: "size (nodes)", value: size },
+            { label: "image", value: CE_IMAGE },
+            {
+              label: "aerospike ns",
+              value: `${nsName} (memory, RF ${Math.min(2, size)})`,
+            },
+          ],
+          note: `Within CE limits (max ${CE_CONSTRAINTS.maxNodes} nodes, ${CE_CONSTRAINTS.maxNamespaces} namespaces). The ACKO webhook is the final validator.`,
+          run: async () => {
+            const cluster = await createK8sCluster(payload)
+            return {
+              status: "ok",
+              message: `AerospikeCluster "${cluster.name}" applied to ${cluster.namespace} (size ${cluster.size}).`,
+              link: "/clusters",
+            }
+          },
+        }
+      }),
+    },
+    [],
+  )
+
+  // ── Control plane: scale (update size) ───────────────────────────────────
+  useHumanInTheLoop(
+    {
+      name: "scale_acko_cluster",
+      description:
+        "Change the node count (size) of an existing ACKO AerospikeCluster. " +
+        "This is the update path for cluster size. For other config (image, " +
+        "storage, dynamic config) point the user to the cluster edit dialog. " +
+        "Find the namespace/name with list_acko_clusters first.",
+      parameters: z.object({
+        namespace: z.string().min(1).describe("Kubernetes namespace of the CR"),
+        name: z.string().min(1).describe("cluster name"),
+        size: z
+          .number()
+          .int()
+          .describe(`new node count, 1–${CE_CONSTRAINTS.maxNodes}`),
+      }),
+      render: hitlRender((args) => {
+        const namespace = String(args.namespace ?? "").trim()
+        const name = String(args.name ?? "").trim()
+        const size = clampSize(args.size as number | undefined)
+        return {
+          title: "Scale cluster?",
+          approveLabel: "Approve & scale",
+          rows: [
+            { label: "k8s namespace", value: namespace },
+            { label: "name", value: name },
+            { label: "new size", value: size },
+          ],
+          note: `Clamped to CE max ${CE_CONSTRAINTS.maxNodes} nodes.`,
+          run: async () => {
+            await scaleK8sCluster(namespace, name, { size })
+            return {
+              status: "ok",
+              message: `Scaled "${name}" to ${size} node(s).`,
+              link: "/clusters",
+            }
+          },
+        }
+      }),
+    },
+    [],
+  )
+
+  // ── Control plane: delete ────────────────────────────────────────────────
+  useHumanInTheLoop(
+    {
+      name: "delete_acko_cluster",
+      description:
+        "Delete an ACKO AerospikeCluster CR (destructive — removes the " +
+        "cluster and its pods). Find the namespace/name with " +
+        "list_acko_clusters first. Always requires explicit approval.",
+      parameters: z.object({
+        namespace: z.string().min(1).describe("Kubernetes namespace of the CR"),
+        name: z.string().min(1).describe("cluster name"),
+      }),
+      render: hitlRender((args) => {
+        const namespace = String(args.namespace ?? "").trim()
+        const name = String(args.name ?? "").trim()
+        return {
+          title: "Delete cluster?",
+          approveLabel: "Approve & delete",
+          destructive: true,
+          rows: [
+            { label: "k8s namespace", value: namespace },
+            { label: "name", value: name },
+          ],
+          note: "This deletes the cluster and all its data. Cannot be undone.",
+          run: async () => {
+            await deleteK8sCluster(namespace, name)
+            return { status: "ok", message: `Deleted cluster "${name}".` }
+          },
+        }
+      }),
+    },
+    [],
+  )
+
+  // ── Data plane: write (put) record ───────────────────────────────────────
+  useHumanInTheLoop(
+    {
+      name: "put_record",
+      description:
+        "Create or update a single record (write). Use a connection id from " +
+        "list_connections. bins is a flat object of bin name → value. " +
+        "Requires approval before writing.",
+      parameters: z.object({
+        connId: z
+          .string()
+          .min(1)
+          .describe("connection id from list_connections"),
+        namespace: z.string().min(1),
+        set: z.string().optional(),
+        primaryKey: z.string().min(1).describe("record primary key"),
+        bins: z
+          .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+          .describe("bin name → value (string/number/boolean)"),
+        ttl: z.number().int().optional().describe("seconds; omit for default"),
+      }),
+      render: hitlRender((args) => {
+        const connId = String(args.connId ?? "").trim()
+        const namespace = String(args.namespace ?? "").trim()
+        const set = args.set ? String(args.set).trim() : undefined
+        const primaryKey = String(args.primaryKey ?? "").trim()
+        const bins = (args.bins ?? {}) as RecordWriteRequest["bins"]
+        const ttl = args.ttl as number | undefined
+        const body: RecordWriteRequest = {
+          key: { namespace, set, pk: primaryKey },
+          bins,
+          ttl: ttl ?? null,
+        }
+        return {
+          title: "Write record?",
+          approveLabel: "Approve & write",
+          rows: [
+            { label: "connection", value: connId },
+            { label: "ns / set", value: `${namespace}${set ? `/${set}` : ""}` },
+            { label: "pk", value: primaryKey },
+            { label: "bins", value: JSON.stringify(bins) },
+          ],
+          run: async () => {
+            await putRecord(connId, body)
+            return {
+              status: "ok",
+              message: `Wrote record pk="${primaryKey}" to ${namespace}${set ? `/${set}` : ""}.`,
+            }
+          },
+        }
+      }),
+    },
+    [],
+  )
+
+  // ── Data plane: delete record ────────────────────────────────────────────
+  useHumanInTheLoop(
+    {
+      name: "delete_record",
+      description:
+        "Delete a single record by (namespace, set, primary key) — " +
+        "destructive. Use a connection id from list_connections. " +
+        "Requires approval.",
+      parameters: z.object({
+        connId: z
+          .string()
+          .min(1)
+          .describe("connection id from list_connections"),
+        namespace: z.string().min(1),
+        set: z.string().min(1),
+        primaryKey: z.string().min(1).describe("record primary key"),
+      }),
+      render: hitlRender((args) => {
+        const connId = String(args.connId ?? "").trim()
+        const namespace = String(args.namespace ?? "").trim()
+        const set = String(args.set ?? "").trim()
+        const primaryKey = String(args.primaryKey ?? "").trim()
+        return {
+          title: "Delete record?",
+          approveLabel: "Approve & delete",
+          destructive: true,
+          rows: [
+            { label: "connection", value: connId },
+            { label: "ns / set", value: `${namespace}/${set}` },
+            { label: "pk", value: primaryKey },
+          ],
+          run: async () => {
+            await deleteRecord(connId, { ns: namespace, set, pk: primaryKey })
+            return {
+              status: "ok",
+              message: `Deleted record pk="${primaryKey}".`,
+            }
+          },
+        }
+      }),
+    },
+    [],
+  )
+
+  return null
+}

--- a/ui/src/components/copilot/tools/write-tools.tsx
+++ b/ui/src/components/copilot/tools/write-tools.tsx
@@ -21,12 +21,14 @@ import { z } from "zod"
 
 import { Badge } from "@/components/Badge"
 import { ApiError } from "@/lib/api/client"
+import { listConnections } from "@/lib/api/connections"
 import {
   createK8sCluster,
   deleteK8sCluster,
   scaleK8sCluster,
 } from "@/lib/api/k8s"
 import { deleteRecord, putRecord } from "@/lib/api/records"
+import { createSampleData } from "@/lib/api/sample-data"
 import { CE_CONSTRAINTS } from "@/lib/copilot/ce-constraints"
 import type { CreateK8sClusterRequest } from "@/lib/types/k8s"
 import type { RecordWriteRequest } from "@/lib/types/record"
@@ -56,6 +58,28 @@ function errResult(err: unknown): MutationResult {
     status: "error",
     error: err instanceof ApiError ? err.detail : String(err),
   }
+}
+
+/**
+ * Resolve a connection id from an id or a human name. Lets the data tools take
+ * a connection NAME directly so the model needn't chain list_connections
+ * before a mutation — chaining a read into a human-in-the-loop tool can abort
+ * the run in the CopilotKit runtime. Runs in the browser under the user's JWT.
+ */
+async function resolveConnId(raw: string): Promise<string> {
+  const v = raw.trim()
+  if (!v) throw new Error("connection (id or name) is required")
+  const conns = await listConnections()
+  const byId = conns.find((c) => c.id === v)
+  if (byId) return byId.id
+  const lc = v.toLowerCase()
+  const byName =
+    conns.find((c) => c.name.toLowerCase() === lc) ??
+    conns.find((c) => c.name.toLowerCase().includes(lc))
+  if (byName) return byName.id
+  throw new Error(
+    `no connection matches "${v}" — open the Connections page or check the name`,
+  )
 }
 
 // ---------------------------------------------------------------------------
@@ -395,14 +419,16 @@ export function CopilotWriteTools() {
     {
       name: "put_record",
       description:
-        "Create or update a single record (write). Use a connection id from " +
-        "list_connections. bins is a flat object of bin name → value. " +
-        "Requires approval before writing.",
+        "Create or update a single record (write). Pass the connection id or " +
+        "name directly (do NOT call list_connections first). bins is a flat " +
+        "object of bin name → value. Requires approval before writing.",
       parameters: z.object({
-        connId: z
+        connection: z
           .string()
           .min(1)
-          .describe("connection id from list_connections"),
+          .describe(
+            "connection id OR name (do not call list_connections first)",
+          ),
         namespace: z.string().min(1),
         set: z.string().optional(),
         primaryKey: z.string().min(1).describe("record primary key"),
@@ -412,7 +438,7 @@ export function CopilotWriteTools() {
         ttl: z.number().int().optional().describe("seconds; omit for default"),
       }),
       render: hitlRender((args) => {
-        const connId = String(args.connId ?? "").trim()
+        const connection = String(args.connection ?? "").trim()
         const namespace = String(args.namespace ?? "").trim()
         const set = args.set ? String(args.set).trim() : undefined
         const primaryKey = String(args.primaryKey ?? "").trim()
@@ -427,12 +453,13 @@ export function CopilotWriteTools() {
           title: "Write record?",
           approveLabel: "Approve & write",
           rows: [
-            { label: "connection", value: connId },
+            { label: "connection", value: connection },
             { label: "ns / set", value: `${namespace}${set ? `/${set}` : ""}` },
             { label: "pk", value: primaryKey },
             { label: "bins", value: JSON.stringify(bins) },
           ],
           run: async () => {
+            const connId = await resolveConnId(connection)
             await putRecord(connId, body)
             return {
               status: "ok",
@@ -451,19 +478,21 @@ export function CopilotWriteTools() {
       name: "delete_record",
       description:
         "Delete a single record by (namespace, set, primary key) — " +
-        "destructive. Use a connection id from list_connections. " +
-        "Requires approval.",
+        "destructive. Pass the connection id or name directly (do NOT call " +
+        "list_connections first). Requires approval.",
       parameters: z.object({
-        connId: z
+        connection: z
           .string()
           .min(1)
-          .describe("connection id from list_connections"),
+          .describe(
+            "connection id OR name (do not call list_connections first)",
+          ),
         namespace: z.string().min(1),
         set: z.string().min(1),
         primaryKey: z.string().min(1).describe("record primary key"),
       }),
       render: hitlRender((args) => {
-        const connId = String(args.connId ?? "").trim()
+        const connection = String(args.connection ?? "").trim()
         const namespace = String(args.namespace ?? "").trim()
         const set = String(args.set ?? "").trim()
         const primaryKey = String(args.primaryKey ?? "").trim()
@@ -472,15 +501,86 @@ export function CopilotWriteTools() {
           approveLabel: "Approve & delete",
           destructive: true,
           rows: [
-            { label: "connection", value: connId },
+            { label: "connection", value: connection },
             { label: "ns / set", value: `${namespace}/${set}` },
             { label: "pk", value: primaryKey },
           ],
           run: async () => {
+            const connId = await resolveConnId(connection)
             await deleteRecord(connId, { ns: namespace, set, pk: primaryKey })
             return {
               status: "ok",
               message: `Deleted record pk="${primaryKey}".`,
+            }
+          },
+        }
+      }),
+    },
+    [],
+  )
+
+  // ── Data plane: generate sample data set ─────────────────────────────────
+  useHumanInTheLoop(
+    {
+      name: "generate_sample_data",
+      description:
+        "Generate a deterministic sample data set (records, optionally with " +
+        "secondary indexes) in a namespace/set. Use this for requests like " +
+        "'create a sample set'. Pass the connection id or name directly (do " +
+        "NOT call list_connections first). Requires approval before writing.",
+      parameters: z.object({
+        connection: z
+          .string()
+          .min(1)
+          .describe(
+            "connection id OR name (do not call list_connections first)",
+          ),
+        namespace: z.string().min(1),
+        setName: z.string().optional().describe("set name (default 'sample')"),
+        recordCount: z
+          .number()
+          .int()
+          .positive()
+          .optional()
+          .describe("number of records (default 100)"),
+        createIndexes: z
+          .boolean()
+          .optional()
+          .describe("also create secondary indexes (default false)"),
+      }),
+      render: hitlRender((args) => {
+        const connection = String(args.connection ?? "").trim()
+        const namespace = String(args.namespace ?? "").trim()
+        const setName = String(args.setName ?? "sample").trim() || "sample"
+        const recordCount = Math.min(
+          10_000,
+          Math.max(1, Math.round((args.recordCount as number) ?? 100)),
+        )
+        const createIndexes = Boolean(args.createIndexes)
+        return {
+          title: "Generate sample data?",
+          approveLabel: "Approve & generate",
+          rows: [
+            { label: "connection", value: connection },
+            { label: "ns / set", value: `${namespace}/${setName}` },
+            { label: "records", value: recordCount },
+            { label: "indexes", value: createIndexes ? "yes" : "no" },
+          ],
+          run: async () => {
+            const connId = await resolveConnId(connection)
+            const res = await createSampleData(connId, {
+              namespace,
+              setName,
+              recordCount,
+              createIndexes,
+            })
+            return {
+              status: "ok",
+              message: `Created ${res.recordsCreated} record(s) in ${namespace}/${setName}${
+                res.indexesCreated.length
+                  ? ` + ${res.indexesCreated.length} index(es)`
+                  : ""
+              }.`,
             }
           },
         }

--- a/ui/src/components/copilot/tools/write-tools.tsx
+++ b/ui/src/components/copilot/tools/write-tools.tsx
@@ -139,13 +139,21 @@ function ConfirmCard({
       {note ? (
         <p className="text-on-surface-variant mt-2 text-xs">{note}</p>
       ) : null}
+      {/*
+        CopilotKit's reset (`[data-copilotkit] button { background-color:#0000;
+        border-radius:0 }`, specificity 0,1,1) overrides plain Tailwind
+        utilities (0,1,0) inside the chat, so the button background/rounding is
+        stripped. The `!` (important) variants win it back.
+      */}
       <div className="mt-3 flex gap-2">
         <button
           type="button"
           disabled={submitting}
           onClick={onApprove}
-          className={`rounded-md px-3 py-1.5 text-xs font-semibold text-white disabled:opacity-50 ${
-            destructive ? "bg-red-600" : "bg-primary-40"
+          className={`!rounded-md !px-3 !py-1.5 !text-xs !font-semibold !text-white !shadow-sm disabled:!opacity-50 ${
+            destructive
+              ? "!bg-error-50 hover:!bg-error-45"
+              : "!bg-primary-50 hover:!bg-primary-45"
           }`}
         >
           {submitting ? "Working…" : approveLabel}
@@ -154,7 +162,7 @@ function ConfirmCard({
           type="button"
           disabled={submitting}
           onClick={() => respond({ status: "cancelled" })}
-          className="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-semibold disabled:opacity-50 dark:border-gray-700"
+          className="!text-on-surface !border-border !bg-surface hover:!bg-surface-container-low !rounded-md !border !px-3 !py-1.5 !text-xs !font-semibold disabled:!opacity-50"
         >
           Cancel
         </button>

--- a/ui/src/lib/copilot/server-config.test.ts
+++ b/ui/src/lib/copilot/server-config.test.ts
@@ -5,6 +5,7 @@ import { resolveCopilotServerConfig } from "./server-config"
 const ENV_KEYS = [
   "COPILOT_ENABLED",
   "COPILOT_MODEL",
+  "COPILOT_BASE_URL",
   "ANTHROPIC_API_KEY",
   "OPENAI_API_KEY",
 ] as const
@@ -68,5 +69,47 @@ describe("resolveCopilotServerConfig", () => {
     const config = resolveCopilotServerConfig()
     expect(config.enabled).toBe(false)
     expect(config.reason).toContain("COPILOT_MODEL")
+  })
+
+  it("baseUrl is null when COPILOT_BASE_URL is unset", () => {
+    vi.stubEnv("COPILOT_MODEL", "openai/gpt-4o")
+    vi.stubEnv("OPENAI_API_KEY", "sk-test")
+    expect(resolveCopilotServerConfig().baseUrl).toBeNull()
+  })
+
+  it("resolves COPILOT_BASE_URL for an OpenAI-compatible gateway", () => {
+    vi.stubEnv("COPILOT_MODEL", "openai/gpt-oss-120b")
+    vi.stubEnv("OPENAI_API_KEY", "sk-test")
+    vi.stubEnv("COPILOT_BASE_URL", "https://llm-gateway.example.com")
+    const config = resolveCopilotServerConfig()
+    expect(config.enabled).toBe(true)
+    expect(config.provider).toBe("openai")
+    expect(config.baseUrl).toBe("https://llm-gateway.example.com")
+  })
+
+  it("trims trailing slashes from COPILOT_BASE_URL", () => {
+    vi.stubEnv("COPILOT_MODEL", "openai/gpt-oss-120b")
+    vi.stubEnv("OPENAI_API_KEY", "sk-test")
+    vi.stubEnv("COPILOT_BASE_URL", "https://llm-gateway.example.com/")
+    expect(resolveCopilotServerConfig().baseUrl).toBe(
+      "https://llm-gateway.example.com",
+    )
+  })
+
+  it("ignores a non-http COPILOT_BASE_URL but stays enabled", () => {
+    vi.stubEnv("COPILOT_MODEL", "openai/gpt-4o")
+    vi.stubEnv("OPENAI_API_KEY", "sk-test")
+    vi.stubEnv("COPILOT_BASE_URL", "llm-gateway.example.com")
+    const config = resolveCopilotServerConfig()
+    expect(config.enabled).toBe(true)
+    expect(config.baseUrl).toBeNull()
+  })
+
+  it("baseUrl is null when the copilot is disabled", () => {
+    vi.stubEnv("COPILOT_ENABLED", "false")
+    vi.stubEnv("COPILOT_MODEL", "openai/gpt-4o")
+    vi.stubEnv("OPENAI_API_KEY", "sk-test")
+    vi.stubEnv("COPILOT_BASE_URL", "https://llm-gateway.example.com")
+    expect(resolveCopilotServerConfig().baseUrl).toBeNull()
   })
 })

--- a/ui/src/lib/copilot/server-config.ts
+++ b/ui/src/lib/copilot/server-config.ts
@@ -11,6 +11,13 @@
  *                         model+key presence (default: enabled when usable)
  *   COPILOT_MODEL         "<provider>/<model>", e.g. "anthropic/claude-sonnet-4-5"
  *                         or "openai/gpt-4o"
+ *   COPILOT_BASE_URL      optional — overrides the provider endpoint so the
+ *                         OpenAI/Anthropic-compatible client targets a gateway
+ *                         instead of the public API — e.g. a self-hosted or
+ *                         enterprise OpenAI-compatible LLM gateway
+ *                         (COPILOT_MODEL=openai/<model>,
+ *                         COPILOT_BASE_URL=https://llm-gateway.example.com).
+ *                         Unset → the provider's default public endpoint.
  *   ANTHROPIC_API_KEY     required for anthropic/* models
  *   OPENAI_API_KEY        required for openai/* models
  *   COPILOT_REQUIRE_AUTH  "true" → /copilotkit requires a Bearer token
@@ -25,25 +32,63 @@ export interface CopilotServerConfig {
   provider: CopilotProvider | null
   /** Model id without the provider prefix, when usable. */
   modelId: string | null
+  /**
+   * Custom endpoint from COPILOT_BASE_URL (OpenAI/Anthropic-compatible
+   * gateway). null → the provider default endpoint.
+   */
+  baseUrl: string | null
   /** Human-readable reason when disabled (logged, never sent to clients). */
   reason: string | null
 }
 
 let warnedReason: string | null = null
 
+function warnOnce(reason: string): void {
+  if (reason !== warnedReason) {
+    warnedReason = reason
+    console.warn(`[copilot] ${reason}`)
+  }
+}
+
 function disabled(reason: string | null): CopilotServerConfig {
   // Warn once per distinct misconfiguration, only when the operator clearly
   // tried to turn the feature on.
-  if (reason && reason !== warnedReason) {
-    warnedReason = reason
-    console.warn(`[copilot] disabled: ${reason}`)
+  if (reason) warnOnce(`disabled: ${reason}`)
+  return {
+    enabled: false,
+    provider: null,
+    modelId: null,
+    baseUrl: null,
+    reason,
   }
-  return { enabled: false, provider: null, modelId: null, reason }
+}
+
+/**
+ * Optional gateway endpoint. Trailing slashes are trimmed (the AI SDK appends
+ * the route path). A non-empty value that is not http(s) is ignored with a
+ * one-time warning — a malformed base URL must never fail the container.
+ */
+function resolveBaseUrl(): string | null {
+  const raw = (process.env.COPILOT_BASE_URL ?? "").trim()
+  if (!raw) return null
+  if (!/^https?:\/\//i.test(raw)) {
+    warnOnce(
+      `COPILOT_BASE_URL=${JSON.stringify(raw)} is not an http(s) URL; ignoring`,
+    )
+    return null
+  }
+  return raw.replace(/\/+$/, "")
 }
 
 export function resolveCopilotServerConfig(): CopilotServerConfig {
   if (process.env.COPILOT_ENABLED === "false") {
-    return { enabled: false, provider: null, modelId: null, reason: null }
+    return {
+      enabled: false,
+      provider: null,
+      modelId: null,
+      baseUrl: null,
+      reason: null,
+    }
   }
 
   const model = process.env.COPILOT_MODEL ?? ""
@@ -77,7 +122,13 @@ export function resolveCopilotServerConfig(): CopilotServerConfig {
     )
   }
 
-  return { enabled: true, provider, modelId, reason: null }
+  return {
+    enabled: true,
+    provider,
+    modelId,
+    baseUrl: resolveBaseUrl(),
+    reason: null,
+  }
 }
 
 export function copilotRequiresAuth(): boolean {


### PR DESCRIPTION
## Summary

Give the embedded **ACKO Agent** full, **confirmation-gated** control of clusters
and data — not just read access. Every mutation is a `useHumanInTheLoop` tool: the
model proposes, the user approves a card in chat, then the call goes through the
existing `lib/api` wrapper under the user's own session. **Nothing is applied without
a click.**

> Stacked on #443 (`feat/copilot-openai-compatible-base-url`) — merge that first.

## New tools

**Control plane (ACKO / K8s)** — `write-tools.tsx`, all HITL:
- `create_acko_cluster` — apply a CE `AerospikeCluster` CR (CE limits clamped to ≤8
  nodes / one in-memory namespace; k8s namespace defaults to `default`). Replaces the
  old "I can't create anything" refusal.
- `scale_acko_cluster` — change node count.
- `delete_acko_cluster` — destructive delete (red confirm card).

**Control-plane reads** — `read-tools.tsx`: `list_acko_clusters`, `get_acko_cluster`.

**Data plane (records)** — `write-tools.tsx`, all HITL: `put_record`, `delete_record`.

System prompt updated to describe the capability set and require approval;
`CopilotShell` mounts `<CopilotWriteTools/>`.

## Verification (kind, OpenAI-compatible gateway, open-weights tool-calling model)

`type-check` ✓, `eslint`/`prettier` ✓, `next build` ✓, pre-commit ✓.

End-to-end in the browser against the chart-deployed UI on kind, **kubectl-confirmed**:
- **create**: "create a CE cluster demo-ksr, 1 node, default ns" → confirmation card →
  approve → `AerospikeCluster default/demo-ksr` applied, reconciled to **2/2 Completed**.
- **scale**: "scale demo-ksr to 2 nodes" → card → approve → `spec.size=2`.
- **delete**: "delete demo-ksr" → destructive card → approve → CR removed.

The HITL gate held in every case (no mutation before the click). Data-plane tools share
the same HITL machinery; a live record write/delete needs an existing connection profile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
