### PR TITLE
fix(copilot): reliably invoke tools + inject connection/cluster context (open-model reliability)

### DIFF
--- a/ui/src/app/copilotkit/[[...slug]]/route.ts
+++ b/ui/src/app/copilotkit/[[...slug]]/route.ts
@@ -46,16 +46,21 @@ What you can do:
 - Read (no confirmation): inspect connections, cluster topology, metrics,
   secondary indexes and records, run read queries, and list/get ACKO clusters
   (list_acko_clusters, get_acko_cluster).
-- Control plane — each opens a confirmation card the user must approve before
-  anything is applied; never claim success until the tool returns status "ok":
+- Control plane — call the tool directly; it renders the approval card:
   create_acko_cluster, scale_acko_cluster (change node count), and
   delete_acko_cluster (destructive). Stay within CE limits (max 8 nodes, max 2
   namespaces). For advanced cluster config (storage devices, multiple
   namespaces, racks), use the Create Cluster wizard at
   [Create Cluster](/clusters/new) or the cluster edit dialog.
-- Data plane — also confirmation-gated: put_record / delete_record and
-  generate_sample_data (for "create a sample set"). These accept a connection
-  id OR name directly.
+- Data plane — put_record / delete_record and generate_sample_data (for
+  "create a sample set"). These accept a connection id OR name directly.
+- CRITICAL — how approval works: every mutating tool above renders its OWN
+  confirmation card with Approve/Cancel buttons; calling the tool IS how you
+  ask for approval. So when the user asks to create/scale/delete a cluster or
+  write data, CALL THE TOOL IMMEDIATELY with the parameters. NEVER write your
+  own "confirmation card" in text, never describe what the card would look
+  like, and never ask the user to reply "yes"/"예" to confirm — that is the
+  card's job, not yours. Only claim success after the tool returns status "ok".
 - IMPORTANT: do NOT call a read/list tool (list_connections, list_acko_clusters)
   in the same turn right before a confirmation-gated tool — pass the name or id
   straight into that tool (the tool resolves names itself), or ask the user.

--- a/ui/src/components/copilot/CopilotAppContext.tsx
+++ b/ui/src/components/copilot/CopilotAppContext.tsx
@@ -1,30 +1,61 @@
 "use client"
 
 /**
- * Shares the user's current position in the app with the copilot on every
- * run: which connection is selected and which page is open. Lets the model
- * resolve "this cluster" / "this set" without asking.
+ * Shares app state with the copilot on every run: the user's current location,
+ * the selected connection, AND the full list of connection profiles + ACKO
+ * clusters. Giving the model the ids/names up front lets it call a
+ * confirmation-gated tool directly (by id or name) instead of first calling
+ * list_connections / list_acko_clusters — chaining a read into a
+ * confirmation-gated tool can abort the run in the CopilotKit runtime, and
+ * forces the model to guess connection names ("localhost") when it can't list.
  */
 
 import { useAgentContext } from "@copilotkit/react-core/v2"
 import { usePathname } from "next/navigation"
+import * as React from "react"
 
 import { useConnectionStore } from "@/stores/connection-store"
+import { useK8sClusterStore } from "@/stores/k8s-cluster-store"
 
 export function CopilotAppContext() {
   const pathname = usePathname()
   const currentConnId = useConnectionStore((state) => state.currentConnId)
   const connections = useConnectionStore((state) => state.connections)
+  const clusters = useK8sClusterStore((state) => state.clusters)
+  const fetchClusters = useK8sClusterStore((state) => state.fetchClusters)
   const current = connections.find((conn) => conn.id === currentConnId)
+
+  // Ensure the agent always has the ACKO cluster list in context, even on
+  // pages that never load it. Best-effort — the store swallows errors (e.g.
+  // when K8s management is disabled), leaving the list empty.
+  React.useEffect(() => {
+    void fetchClusters()
+  }, [fetchClusters])
 
   useAgentContext({
     description:
-      "The user's current location in the Aerospike Cluster Manager UI and " +
-      "the currently selected connection",
+      "The user's current location in the Aerospike Cluster Manager UI, the " +
+      "selected connection, and the available connection profiles and " +
+      "ACKO-managed clusters. Use these ids/names to call tools directly — " +
+      "do not call list_connections or list_acko_clusters first.",
     value: {
       route: pathname,
       selectedConnectionId: currentConnId,
       selectedConnectionName: current?.name ?? null,
+      // Resolve a named connection (including an ACKO cluster's auto-created
+      // "[K8s] <name>" profile) without calling list_connections.
+      connections: connections.map((conn) => ({
+        id: conn.id,
+        name: conn.name,
+        clusterName: conn.clusterName ?? null,
+      })),
+      // Resolve a cluster's k8s namespace/name for scale/delete without
+      // calling list_acko_clusters.
+      ackoClusters: clusters.map((cluster) => ({
+        namespace: cluster.namespace,
+        name: cluster.name,
+        phase: cluster.phase,
+      })),
     },
   })
 


### PR DESCRIPTION
## Summary

Two reliability fixes for the embedded ACKO Agent with open-weights models
(e.g. Qwen3-Next), both verified on kind.

### 1. Always invoke the mutating tool (don't narrate a text confirmation)

The model sometimes printed its own "confirmation card" in markdown and asked
the user to reply "yes/예" instead of calling `create_acko_cluster`, so the real
Approve/Cancel card never rendered. The prompt now states that **calling the
tool IS the approval step** — call it immediately with parameters; never write a
text confirmation card or ask the user to reply to confirm.

### 2. Inject connection + cluster lists into agent context

The agent only had the *currently selected* connection, so for a named target
("create a sample set in my-aerospike-cluster-test2") it chained
`list_connections` / `list_acko_clusters` before the mutation — which can abort
the run (`RUN_FINISHED while tool calls are still active`) — or guessed a
connection name like `localhost`. `CopilotAppContext` now exposes the full
connection profiles (id/name/clusterName) and ACKO clusters
(namespace/name/phase) via `useAgentContext`, so the model calls the tool
directly with the right target — no read-tool chain.

## Verification (kind)

- "create a cluster" → invokes `create_acko_cluster`, real **Approve & create**
  card renders (no text narration).
- "my-aerospike-cluster-test2 에 sample_set 생성" → `generate_sample_data` card
  with `connection=my-aerospike-cluster-test2` (not `localhost`), single-step,
  no abort; approving wrote **50 records** (API-confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
