### PR TITLE
fix(api): render /api/docs offline by serving swagger-ui 5.x

### DIFF
--- a/api/pyproject.toml
+++ b/api/pyproject.toml
@@ -17,7 +17,6 @@ dependencies = [
     "pyyaml>=6.0",
     "slowapi>=0.1.9",
     "sse-starlette>=2.0.0",
-    "swagger-ui-bundle>=1.1.0",
     "uvicorn[standard]>=0.34.0",
     # OpenTelemetry — disabled at runtime via OTEL_SDK_DISABLED=true (default).
     # All exporter/sampler/resource configuration goes through OTel SDK
@@ -37,6 +36,7 @@ dependencies = [
     # for Fernet at-rest encryption of stored connection passwords.
     "pyjwt[crypto]>=2.9",
     "cryptography>=42",
+    "fastapi-offline>=1.7.7",
 ]
 
 [tool.uv]

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -3,7 +3,9 @@ import re
 import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from pathlib import Path
 
+import fastapi_offline
 from fastapi import APIRouter, FastAPI, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.openapi.docs import get_swagger_ui_html
@@ -14,7 +16,6 @@ from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from starlette.middleware.base import RequestResponseEndpoint
 from starlette.responses import Response
-from swagger_ui_bundle import swagger_ui_path  # type: ignore[import-untyped]
 
 from aerospike_cluster_manager_api import config, db
 from aerospike_cluster_manager_api.client_manager import client_manager
@@ -123,11 +124,15 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
-# Serve swagger-ui-dist files vendored by the swagger-ui-bundle package so
-# /api/docs has no public-internet egress requirement.
+# Serve swagger-ui-dist files vendored by the fastapi-offline package so
+# /api/docs has no public-internet egress requirement. fastapi-offline ships
+# swagger-ui 5.x, which parses the OpenAPI 3.1 documents FastAPI emits; the
+# previously used swagger-ui-bundle package is stale at swagger-ui 4.15.5,
+# which rejects 3.1 specs outright and left /api/docs blank (#250).
+_SWAGGER_UI_STATIC_DIR = Path(fastapi_offline.__file__).parent / "static"
 app.mount(
     "/api/docs/static",
-    StaticFiles(directory=str(swagger_ui_path)),
+    StaticFiles(directory=str(_SWAGGER_UI_STATIC_DIR)),
     name="swagger-ui-static",
 )
 
@@ -144,7 +149,7 @@ _SWAGGER_UI_HTML = """\
 <head>
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link type="text/css" rel="stylesheet" href="/api/docs/static/swagger-ui.css">
-<link rel="shortcut icon" href="/api/docs/static/favicon-32x32.png">
+<link rel="shortcut icon" href="/api/docs/static/favicon.png">
 <title>Aerospike Cluster Manager API - Swagger UI</title>
 </head>
 <body>
@@ -155,6 +160,13 @@ _SWAGGER_UI_HTML = """\
 </html>
 """
 
+# NOTE: no SwaggerUIStandalonePreset here (#250). swagger-ui-dist 4.x/5.x
+# bundles do not expose it as a SwaggerUIBundle property (it lives in the
+# separate swagger-ui-standalone-preset.js, which defines a window global
+# instead), so referencing SwaggerUIBundle.SwaggerUIStandalonePreset passes
+# `undefined` as a preset. The preset only supplies StandaloneLayout + the top
+# bar, which `layout: 'BaseLayout'` never uses, so the correct fix is to omit
+# it rather than load an extra unused asset.
 _SWAGGER_INIT_JS = """\
 window.ui = SwaggerUIBundle({
     url: '/api/openapi.json',
@@ -165,7 +177,6 @@ window.ui = SwaggerUIBundle({
     showCommonExtensions: true,
     presets: [
         SwaggerUIBundle.presets.apis,
-        SwaggerUIBundle.SwaggerUIStandalonePreset,
     ],
 });
 """
@@ -177,13 +188,14 @@ async def custom_swagger_ui() -> HTMLResponse:
 
     With CSP_ENABLED=true (default): self-hosted assets + external
     swagger-init.js so the page renders under strict `script-src 'self'`
-    (#238). The vendored swagger-ui is 4.15.5 and does not parse OpenAPI 3.1.
+    (#238). The assets are swagger-ui 5.x vendored by fastapi-offline, so
+    the OpenAPI 3.1 documents FastAPI emits render fully offline (#250).
 
     With CSP_ENABLED=false: FastAPI's default helper which loads swagger-ui
-    5.x from cdn.jsdelivr.net — full OpenAPI 3.1 support and no init.js
-    indirection (#241). Browsers fetch the assets directly, so this works
-    whenever the operator's workstation has internet egress, regardless of
-    whether the cluster's pods do.
+    5.x from cdn.jsdelivr.net with no init.js indirection (#241). Browsers
+    fetch the assets directly, so this works whenever the operator's
+    workstation has internet egress, regardless of whether the cluster's
+    pods do.
     """
     if not config.CSP_ENABLED:
         return get_swagger_ui_html(

--- a/api/tests/test_security_headers.py
+++ b/api/tests/test_security_headers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from unittest.mock import patch
 
 import pytest
@@ -90,6 +91,60 @@ async def test_swagger_init_js_is_served_with_js_mime(client: AsyncClient):
     assert resp.status_code == 200
     assert resp.headers["Content-Type"].startswith("application/javascript")
     assert "SwaggerUIBundle({" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# Swagger UI actually renders from the self-hosted assets (#250)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.anyio
+async def test_swagger_docs_references_only_served_assets(client: AsyncClient):
+    """Every asset referenced by the /api/docs HTML must actually be served (#250).
+
+    A dangling reference (renamed static file, wrong mount path) produces the
+    exact all-assets-404-or-page-blank failure mode this suite exists to catch.
+    """
+    resp = await client.get("/api/docs")
+    assert resp.status_code == 200
+    refs = re.findall(r'(?:src|href)="([^"]+)"', resp.text)
+    assert refs, "/api/docs must reference its scripts and stylesheets"
+    for ref in refs:
+        asset = await client.get(ref)
+        assert asset.status_code == 200, f"{ref} is referenced by /api/docs but not served"
+
+
+@pytest.mark.anyio
+async def test_swagger_init_js_does_not_reference_standalone_preset(client: AsyncClient):
+    """The init script must not reference SwaggerUIStandalonePreset (#250).
+
+    swagger-ui-bundle.js has not exposed it as a SwaggerUIBundle property since
+    4.x (it lives in the separate swagger-ui-standalone-preset.js and defines a
+    window global), so the old ``SwaggerUIBundle.SwaggerUIStandalonePreset``
+    reference silently passed ``undefined`` as a preset. It is also unnecessary:
+    the preset only provides StandaloneLayout, and the page uses BaseLayout.
+    """
+    resp = await client.get("/api/docs/swagger-init.js")
+    assert resp.status_code == 200
+    assert "SwaggerUIStandalonePreset" not in resp.text
+
+
+@pytest.mark.anyio
+async def test_vendored_swagger_ui_supports_openapi_31(client: AsyncClient):
+    """The self-hosted swagger-ui must be 5.x because FastAPI emits OpenAPI 3.1 (#250).
+
+    swagger-ui 4.x (vendored by the stale swagger-ui-bundle package) rejects
+    3.1 documents with "Unable to render this definition", leaving /api/docs
+    useless in airgapped deployments where the CDN fallback is unreachable.
+    """
+    spec = (await client.get("/api/openapi.json")).json()
+    assert spec["openapi"].startswith("3.1"), "precondition: FastAPI emits OpenAPI 3.1"
+    bundle = await client.get("/api/docs/static/swagger-ui-bundle.js")
+    assert bundle.status_code == 200
+    # swagger-ui stamps its build info into the bundle as PACKAGE_VERSION:"x.y.z".
+    match = re.search(r'PACKAGE_VERSION:"(\d+)\.\d+\.\d+"', bundle.text)
+    assert match, "swagger-ui-bundle.js must carry a PACKAGE_VERSION build stamp"
+    assert int(match.group(1)) >= 5, f"swagger-ui {match.group(0)} cannot render OpenAPI 3.1"
 
 
 # ---------------------------------------------------------------------------

--- a/api/uv.lock
+++ b/api/uv.lock
@@ -21,6 +21,7 @@ dependencies = [
     { name = "asyncpg" },
     { name = "cryptography" },
     { name = "fastapi" },
+    { name = "fastapi-offline" },
     { name = "httpx" },
     { name = "kubernetes" },
     { name = "opentelemetry-api" },
@@ -34,7 +35,6 @@ dependencies = [
     { name = "pyyaml" },
     { name = "slowapi" },
     { name = "sse-starlette" },
-    { name = "swagger-ui-bundle" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -56,6 +56,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "cryptography", specifier = ">=42" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "fastapi-offline", specifier = ">=1.7.7" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "kubernetes", specifier = ">=31.0.0" },
     { name = "opentelemetry-api", specifier = ">=1.30.0" },
@@ -69,7 +70,6 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sse-starlette", specifier = ">=2.0.0" },
-    { name = "swagger-ui-bundle", specifier = ">=1.1.0" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34.0" },
 ]
 
@@ -478,6 +478,18 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi-offline"
+version = "1.7.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastapi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/15/a5/f650b565354d38f98211683a7b5c3578d450848421444799cb51da8e562f/fastapi_offline-1.7.7.tar.gz", hash = "sha256:aeeabe67dd40f867ab0fe64dd8de742949e36ba5f3ac6aeb055baef274ed91d0", size = 777678, upload-time = "2026-06-19T20:43:28.938Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/de/808ff88dac73c97ad32c653f92f6751ea5a0a211ae1dffd471125e63a31e/fastapi_offline-1.7.7-py3-none-any.whl", hash = "sha256:60c8399fd7d3e3b01510e14468709e3dea1a0e773ef920372d057392d736a1f9", size = 777007, upload-time = "2026-06-19T20:43:27.767Z" },
+]
+
+[[package]]
 name = "googleapis-common-protos"
 version = "1.74.0"
 source = { registry = "https://pypi.org/simple" }
@@ -610,18 +622,6 @@ wheels = [
 ]
 
 [[package]]
-name = "jinja2"
-version = "3.1.6"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "markupsafe" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
-]
-
-[[package]]
 name = "kubernetes"
 version = "35.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -653,58 +653,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
-]
-
-[[package]]
-name = "markupsafe"
-version = "3.0.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
-    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
-    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
-    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
-    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
-    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
-    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
-    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
-    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
-    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
-    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
-    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
-    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
-    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
-    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
-    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
-    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
-    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
-    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
-    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
-    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
 ]
 
 [[package]]
@@ -1285,18 +1233,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
-]
-
-[[package]]
-name = "swagger-ui-bundle"
-version = "1.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "jinja2" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/01/e6/d8ae21087a42627c2a04a738c947825b78c26b18595704b94bd3227197a2/swagger_ui_bundle-1.1.0.tar.gz", hash = "sha256:20673c3431c8733d5d1615ecf79d9acf30cff75202acaf21a7d9c7f489714529", size = 2599741, upload-time = "2023-11-01T19:58:17.397Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/66/8fb11445940bde7ca328d6aa23dd36b6056197d862f4bd6bb51c820c50e5/swagger_ui_bundle-1.1.0-py3-none-any.whl", hash = "sha256:f7526f7bb99923e10594c54247265839bec97e96b0438561ac86faf40d40dd57", size = 2626591, upload-time = "2023-11-01T19:58:15.366Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Fixes #250

## Root cause — two stacked problems, not one

Issue #250 correctly observed that `swagger-init.js` references `SwaggerUIBundle.SwaggerUIStandalonePreset`, which the vendored `swagger-ui-bundle.js` 4.15.5 does not expose. That reference is real and wrong — but a live-browser A/B test showed it is **not** what blanks the page: swagger-ui 4.15.5 silently tolerates `undefined` entries in `presets`, and both the buggy and preset-fixed configs rendered byte-identical output.

The actual render blocker is a version mismatch the docstring already admitted: **FastAPI emits OpenAPI 3.1.0, and swagger-ui 4.15.5 (the newest version the stale `swagger-ui-bundle` PyPI package ships — last release Nov 2023) rejects 3.1 documents outright** with "Unable to render this definition". Under `CSP_ENABLED=true` the self-hosted docs page has therefore never rendered actual API docs; the issue's suggested one-line fix (adding the `swagger-ui-standalone-preset.js` script tag) would change nothing, since that file defines a `window` global and never attaches anything to `SwaggerUIBundle`.

## Fix

- **Swap `swagger-ui-bundle` → `fastapi-offline`** (MIT, actively maintained — latest release 2026-06) as the source of self-hosted swagger-ui assets. It vendors **swagger-ui 5.32.6**, which fully supports OpenAPI 3.1. The airgap/no-egress property (#234) and the CSP-safe external-init pattern (#238) are preserved — only the mounted static directory changes; we deliberately do not use its `FastAPIOffline` wrapper because it relies on inline `<script>` bootstrap that `script-src 'self'` blocks.
- **Drop the `SwaggerUIBundle.SwaggerUIStandalonePreset` reference** from `swagger-init.js` (the #250 finding). No 4.x/5.x bundle exposes it as a property, and the page uses `layout: 'BaseLayout'`, which never needs the standalone preset — so omitting it beats loading an extra unused asset.
- Favicon reference updated to the file fastapi-offline actually ships (`favicon.png`).
- `CSP_ENABLED=false` CDN fallback path (#241) is untouched.

## Verification

Real-browser check (Chrome via DevTools protocol) against a locally running backend with default `CSP_ENABLED=true`:

- **Before**: `#swagger-ui` contained only the SVG-assets shim + "Unable to render this definition. …Supported version fields are swagger: 2.0 and those that match openapi: 3.0.n" — with all assets 200, matching the blank-page report.
- **After**: page renders `Aerospike Cluster Manager API 0.1.0 OAS 3.1` with **50 operations across 16 tag sections**, zero console errors, CSP header still `script-src 'self'`.
- All referenced assets serve 200: `/api/docs`, `/api/docs/swagger-init.js`, `/api/docs/static/swagger-ui-bundle.js` (contains `PACKAGE_VERSION:"5.32.6"`), `/api/docs/static/swagger-ui.css`, `/api/docs/static/favicon.png`.
- Full API test suite: **980 passed**. Ruff lint + format clean.

## Regression tests added (`api/tests/test_security_headers.py`)

- every `src`/`href` asset referenced by the `/api/docs` HTML must return 200 (catches renamed static files / broken mounts);
- `swagger-init.js` must not reference `SwaggerUIStandalonePreset`;
- the self-hosted bundle must stamp `PACKAGE_VERSION` >= 5 while `/api/openapi.json` declares OpenAPI 3.1 (catches a future regression to a 3.1-incapable bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)