### PR TITLE
fix(security): replace SSE JWT query param with single-use stream ticket

### DIFF
--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -116,6 +116,16 @@ SSE_ENABLED: bool = os.getenv("SSE_ENABLED", "true").lower() in ("true", "1", "y
 SSE_HEARTBEAT_INTERVAL: int = _get_int("SSE_HEARTBEAT_INTERVAL", 15)  # seconds between heartbeat pings
 SSE_MAX_CONNECTIONS: int = _get_int("SSE_MAX_CONNECTIONS", 50)  # max concurrent SSE subscribers
 
+# Single-use SSE stream tickets (issue #345 — the JWT must never appear in a
+# URL). ``POST /api/v1/events/ticket`` mints an opaque ticket that the
+# EventSource presents as ``?ticket=...``; the middleware burns it on first
+# use. TTL only needs to cover the gap between mint and connect (one round
+# trip), so keep it short.
+SSE_TICKET_TTL_SECONDS: int = _get_int("SSE_TICKET_TTL_SECONDS", 30)
+# Upper bound on outstanding (minted, not yet redeemed/expired) tickets —
+# guards the in-memory table against a misbehaving authenticated client loop.
+SSE_TICKET_MAX_PENDING: int = _get_int("SSE_TICKET_MAX_PENDING", 1024)
+
 # CM_SSE_BROADCAST_PER_CONNECTION gates the per-connection broadcast loops in
 # ``events.collector`` (cluster.metrics, connection.health, k8s.cluster.*).
 # Default ``false`` because the broker has no per-subscriber owner filter --

--- a/api/src/aerospike_cluster_manager_api/events/tickets.py
+++ b/api/src/aerospike_cluster_manager_api/events/tickets.py
@@ -1,0 +1,121 @@
+"""Single-use, short-TTL opaque tickets for authenticating SSE streams.
+
+Browsers' native ``EventSource`` cannot send an ``Authorization`` header, and
+placing the JWT in the URL query string leaks it into ingress access logs,
+browser history, and Referer headers (issue #345, ADR-0040 follow-up).
+
+Instead, the SPA first calls ``POST /api/v1/events/ticket`` with the normal
+``Authorization: Bearer <jwt>`` header. The endpoint mints a short-lived
+(``SSE_TICKET_TTL_SECONDS``, default 30s), single-use opaque ticket bound to
+the verified token's claims. The EventSource then connects with
+``?ticket=<opaque>`` and :class:`~.oidc_auth.OIDCAuthMiddleware` redeems —
+and thereby *burns* — the ticket on first use. A ticket value that leaks
+into an access log is therefore already worthless by the time anyone can
+read it, and the long-lived JWT never appears in a URL at all.
+
+The store is process-local (a dict on the event loop; all operations are
+synchronous, so no locking is needed). Multi-replica API deployments must
+route the mint request and the subsequent stream connect to the same replica
+(session affinity on ``/api/*``) or replace this store with a shared one.
+The ADR-0040 topology runs one API instance per operator cluster, where this
+is a non-issue.
+"""
+
+from __future__ import annotations
+
+import secrets
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+from aerospike_cluster_manager_api import config
+
+
+class TicketCapacityError(Exception):
+    """Raised when the pending-ticket table is full (mint flood guard)."""
+
+
+@dataclass
+class _PendingTicket:
+    expires_at: float
+    claims: dict[str, Any] = field(default_factory=dict)
+
+
+class SSETicketStore:
+    """In-memory single-use ticket table.
+
+    * ``issue()`` mints a 256-bit urlsafe token and remembers the caller's
+      verified claims until the TTL elapses.
+    * ``redeem()`` pops the entry (single use) and returns the claims, or
+      ``None`` when the ticket is unknown, already used, or expired.
+
+    Expired entries are purged opportunistically on every ``issue()`` —
+    tickets share a uniform TTL, so no background sweeper is required.
+    """
+
+    def __init__(
+        self,
+        ttl_seconds: int = 30,
+        max_pending: int = 1024,
+    ) -> None:
+        self.ttl_seconds = ttl_seconds
+        self.max_pending = max_pending
+        self._pending: dict[str, _PendingTicket] = {}
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._pending)
+
+    def issue(self, claims: dict[str, Any] | None = None) -> tuple[str, int]:
+        """Mint a new ticket bound to ``claims``.
+
+        Returns ``(ticket, expires_in_seconds)``.
+
+        Raises:
+            TicketCapacityError: when ``max_pending`` unexpired tickets are
+                already outstanding. Minting requires an authenticated
+                request, so hitting this cap means either a misbehaving
+                client loop or an abuse attempt — reject rather than evict.
+        """
+        now = time.time()
+        self._purge_expired(now)
+        if len(self._pending) >= self.max_pending:
+            raise TicketCapacityError(f"Too many pending SSE tickets (max {self.max_pending})")
+        ticket = secrets.token_urlsafe(32)
+        self._pending[ticket] = _PendingTicket(
+            expires_at=now + self.ttl_seconds,
+            claims=dict(claims or {}),
+        )
+        return ticket, self.ttl_seconds
+
+    def redeem(self, ticket: str) -> dict[str, Any] | None:
+        """Consume ``ticket`` and return its claims, or ``None`` if invalid.
+
+        The entry is removed unconditionally (``dict.pop``), so a ticket can
+        only ever be redeemed once — a replayed URL fails even inside the
+        TTL window.
+        """
+        entry = self._pending.pop(ticket, None)
+        if entry is None:
+            return None
+        if time.time() >= entry.expires_at:
+            return None
+        return entry.claims
+
+    def clear(self) -> None:
+        """Drop all pending tickets — testing/shutdown helper."""
+        self._pending.clear()
+
+    def _purge_expired(self, now: float) -> None:
+        expired = [t for t, entry in self._pending.items() if now >= entry.expires_at]
+        for t in expired:
+            del self._pending[t]
+
+
+# Module singleton — shared by the mint endpoint (routers/events.py) and the
+# redeeming middleware (middleware/oidc_auth.py). Sized from config at import
+# time, matching how the rest of the config surface is consumed.
+ticket_store = SSETicketStore(
+    ttl_seconds=config.SSE_TICKET_TTL_SECONDS,
+    max_pending=config.SSE_TICKET_MAX_PENDING,
+)

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -229,11 +229,14 @@ app.add_middleware(
 # Request logging middleware
 # ---------------------------------------------------------------------------
 
-# Matches ``access_token=...`` (and a few common JWT-like query keys) in a
-# URL query string. We log the path + (optionally) query, and SSE clients
-# pass JWTs as ``?access_token=`` because EventSource cannot send Authorization
-# headers — masking before logging keeps tokens out of access logs.
-_SENSITIVE_QS_RE = re.compile(r"(access_token|id_token|token)=[^&\s]+", re.IGNORECASE)
+# Matches credential-bearing query keys in a URL query string before the
+# request line is logged. ``?access_token=`` is no longer *accepted* by the
+# API (issue #345 replaced it with single-use SSE tickets), but old or
+# misconfigured clients may still send it — keep masking so a rejected
+# request doesn't persist the JWT either. ``ticket`` values are single-use
+# and short-lived, but masking them too keeps even a burned credential out
+# of the logs.
+_SENSITIVE_QS_RE = re.compile(r"(access_token|id_token|ticket|token)=[^&\s]+", re.IGNORECASE)
 
 
 def _mask_query_string(qs: str) -> str:

--- a/api/src/aerospike_cluster_manager_api/middleware/__init__.py
+++ b/api/src/aerospike_cluster_manager_api/middleware/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from aerospike_cluster_manager_api.middleware.oidc_auth import (
-    SSE_QUERY_TOKEN_PATHS,
+    SSE_TICKET_PATHS,
     OIDCAuthMiddleware,
 )
 from aerospike_cluster_manager_api.middleware.trace_id import (
@@ -15,7 +15,7 @@ from aerospike_cluster_manager_api.middleware.trace_id import (
 
 __all__ = [
     "REQUEST_ID_HEADER",
-    "SSE_QUERY_TOKEN_PATHS",
+    "SSE_TICKET_PATHS",
     "OIDCAuthMiddleware",
     "RequestIDFilter",
     "TraceIDMiddleware",

--- a/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
+++ b/api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py
@@ -48,12 +48,18 @@ from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 from starlette.types import ASGIApp
 
+from aerospike_cluster_manager_api.events.tickets import ticket_store
+
 logger = logging.getLogger(__name__)
 
-# SSE EventSource cannot send custom headers (HTML5 spec), so we accept the
-# token via ``?access_token=`` on the documented stream endpoints. Both the
-# legacy /api/... and versioned /api/v1/... aliases are listed.
-SSE_QUERY_TOKEN_PATHS: frozenset[str] = frozenset(
+# SSE EventSource cannot send custom headers (HTML5 spec). Instead of
+# accepting the raw JWT via query string (removed — issue #345: it leaked
+# into ingress access logs, browser history, and Referer headers), these
+# stream endpoints accept a single-use, short-TTL opaque ticket minted by
+# ``POST /api[/v1]/events/ticket`` (which itself requires normal
+# Authorization-header auth). Both the legacy /api/... and versioned
+# /api/v1/... aliases are listed.
+SSE_TICKET_PATHS: frozenset[str] = frozenset(
     {
         "/api/events/stream",
         "/api/v1/events/stream",
@@ -195,7 +201,9 @@ class OIDCAuthMiddleware(BaseHTTPMiddleware):
         if request.method == "OPTIONS":
             return await call_next(request)
 
-        token = self._extract_token(request, path)
+        token = self._extract_token(request)
+        if token is None and path in SSE_TICKET_PATHS:
+            return await self._dispatch_sse_ticket(request, call_next)
         if token is None:
             return _unauthorized("Missing bearer token")
 
@@ -204,30 +212,75 @@ class OIDCAuthMiddleware(BaseHTTPMiddleware):
         except _AuthError as exc:
             return _unauthorized(exc.detail)
 
-        if self.required_roles:
-            roles = _extract_realm_roles(claims)
-            if not (self.required_roles & roles):
-                return _forbidden(
-                    f"Token lacks required role(s): {sorted(self.required_roles)}",
-                )
+        role_failure = self._role_failure(claims)
+        if role_failure is not None:
+            return role_failure
 
         request.state.user_claims = claims
         return await call_next(request)
+
+    async def _dispatch_sse_ticket(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        """Authenticate an SSE stream request via a single-use ticket.
+
+        Reached only when the request carries no Authorization header (a
+        valid header always takes precedence, so curl-style clients keep
+        working). The historical ``?access_token=<jwt>`` escape hatch is
+        rejected outright with a pointer at the replacement flow — issue
+        #345 removed it because the JWT persisted in ingress access logs.
+        """
+        if "access_token" in request.query_params:
+            return _unauthorized(
+                "The access_token query parameter is no longer accepted: "
+                "mint a single-use ticket via POST /api/v1/events/ticket "
+                "(Authorization header) and connect with ?ticket=<value>.",
+            )
+
+        ticket = request.query_params.get("ticket")
+        if not ticket:
+            return _unauthorized("Missing bearer token")
+
+        claims = ticket_store.redeem(ticket)
+        if claims is None:
+            return _unauthorized("Invalid, expired, or already-used SSE ticket")
+
+        role_failure = self._role_failure(claims)
+        if role_failure is not None:
+            return role_failure
+
+        request.state.user_claims = claims
+        return await call_next(request)
+
+    def _role_failure(self, claims: dict[str, Any]) -> Response | None:
+        """Return a 403 response when ``claims`` lack the required roles."""
+        if not self.required_roles:
+            return None
+        roles = _extract_realm_roles(claims)
+        if self.required_roles & roles:
+            return None
+        return _forbidden(
+            f"Token lacks required role(s): {sorted(self.required_roles)}",
+        )
 
     # ------------------------------------------------------------------
     # JWT verification
     # ------------------------------------------------------------------
     @staticmethod
-    def _extract_token(request: Request, path: str) -> str | None:
+    def _extract_token(request: Request) -> str | None:
+        """Extract the bearer JWT from the Authorization header.
+
+        Header-only by design: the ``?access_token=`` query fallback was
+        removed (issue #345) — SSE clients authenticate via single-use
+        tickets instead (see ``_dispatch_sse_ticket``).
+        """
         header = request.headers.get("authorization") or request.headers.get("Authorization")
         if header:
             parts = header.split(None, 1)
             if len(parts) == 2 and parts[0].lower() == "bearer" and parts[1].strip():
                 return parts[1].strip()
-        if path in SSE_QUERY_TOKEN_PATHS:
-            qs_token = request.query_params.get("access_token")
-            if qs_token:
-                return qs_token
         return None
 
     async def _verify(self, token: str) -> dict[str, Any]:

--- a/api/src/aerospike_cluster_manager_api/routers/events.py
+++ b/api/src/aerospike_cluster_manager_api/routers/events.py
@@ -3,6 +3,11 @@
 Clients connect to ``GET /api/v1/events/stream`` and receive a continuous
 stream of server-sent events.  An optional ``types`` query parameter
 filters which event types are delivered.
+
+When OIDC is enabled, browser clients first mint a single-use ticket via
+``POST /api/v1/events/ticket`` (Authorization header) and connect with
+``?ticket=<opaque>`` — the JWT itself is never placed in the URL (issue
+#345). See :mod:`aerospike_cluster_manager_api.events.tickets`.
 """
 
 from __future__ import annotations
@@ -15,15 +20,24 @@ from collections.abc import AsyncGenerator
 
 from fastapi import APIRouter, Query, Request
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
 
 from aerospike_cluster_manager_api import config
 from aerospike_cluster_manager_api.events.broker import broker
+from aerospike_cluster_manager_api.events.tickets import TicketCapacityError, ticket_store
 from aerospike_cluster_manager_api.rate_limit import limiter
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/events", tags=["events"])
+
+
+class SSETicketResponse(BaseModel):
+    """Single-use handshake ticket for the SSE stream (issue #345)."""
+
+    ticket: str
+    expires_in: int
 
 
 async def _event_generator(
@@ -54,6 +68,34 @@ async def _event_generator(
                 yield {"comment": f"ping {int(time.time() * 1000)}"}
     finally:
         await broker.unsubscribe(subscriber_id)
+
+
+@router.post(
+    "/ticket",
+    summary="Mint a single-use SSE stream ticket",
+    description="Exchange a normal Authorization-header credential for a "
+    "short-lived, single-use opaque ticket. Native EventSource cannot send "
+    "headers, so the stream is opened with `?ticket=<value>` instead of ever "
+    "placing the JWT in the URL. The ticket is burned on first use.",
+    response_model=SSETicketResponse,
+)
+async def mint_stream_ticket(request: Request) -> SSETicketResponse | JSONResponse:
+    """Mint a single-use ticket for ``GET /events/stream``.
+
+    Authentication is enforced by ``OIDCAuthMiddleware`` (Authorization
+    header only — this path never accepts query-string credentials). The
+    verified claims are carried over to the ticket so the stream request
+    inherits the same identity and role checks.
+    """
+    if not config.SSE_ENABLED:
+        return JSONResponse(status_code=404, content={"detail": "SSE streaming is disabled"})
+
+    claims = getattr(request.state, "user_claims", None) or {}
+    try:
+        ticket, expires_in = ticket_store.issue(claims)
+    except TicketCapacityError:
+        return JSONResponse(status_code=429, content={"detail": "Too many pending SSE tickets"})
+    return SSETicketResponse(ticket=ticket, expires_in=expires_in)
 
 
 @router.get(

--- a/api/tests/test_oidc_auth.py
+++ b/api/tests/test_oidc_auth.py
@@ -22,10 +22,20 @@ from fastapi.responses import PlainTextResponse
 from httpx import ASGITransport, AsyncClient
 from jwt.algorithms import RSAAlgorithm
 
+from aerospike_cluster_manager_api.events.tickets import ticket_store
 from aerospike_cluster_manager_api.middleware.oidc_auth import OIDCAuthMiddleware
+from aerospike_cluster_manager_api.routers.events import router as events_router
 
 ISSUER = "https://kc.example.com/realms/acko"
 AUDIENCE = "acko-api"
+
+
+@pytest.fixture(autouse=True)
+def _clean_ticket_store():
+    """The SSE ticket store is a module singleton — isolate tests from each other."""
+    ticket_store.clear()
+    yield
+    ticket_store.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -138,6 +148,12 @@ def _build_app(
     async def stream() -> PlainTextResponse:
         return PlainTextResponse("event:hello\n\n")
 
+    # Mount the real events router so ticket-mint tests exercise the actual
+    # POST /api/v1/events/ticket endpoint. The fake /api/v1/events/stream
+    # above is registered first and therefore shadows the real streaming
+    # endpoint (which never terminates and would hang a plain GET).
+    app.include_router(events_router, prefix="/api/v1")
+
     app.add_middleware(
         OIDCAuthMiddleware,
         enabled=enabled,
@@ -234,8 +250,16 @@ async def test_excluded_path_skips_auth():
     assert mock.jwks_calls == 0
 
 
+# ---------------------------------------------------------------------------
+# SSE auth — single-use ticket flow (issue #345). The raw JWT must never be
+# accepted via the URL query string; streams authenticate with a short-lived
+# opaque ticket minted through the Authorization-header path.
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
-async def test_sse_query_token_accepted():
+async def test_sse_raw_jwt_in_query_is_rejected():
+    """A perfectly valid JWT in ?access_token= must be rejected (issue #345)."""
     priv, jwk = _rsa_keypair()
     mock = _JWKSMock([jwk])
     app = _build_app(http_client=_client_for(mock))
@@ -243,7 +267,151 @@ async def test_sse_query_token_accepted():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
         resp = await ac.get(f"/api/v1/events/stream?access_token={token}")
+    assert resp.status_code == 401
+    assert "no longer accepted" in resp.json()["detail"]
+    # The rejected token must not even be verified — no JWKS traffic.
+    assert mock.well_known_calls == 0
+    assert mock.jwks_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_sse_stream_authorization_header_still_works():
+    """Non-browser clients (curl, ackoctl) keep using the header on the stream."""
+    priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    app = _build_app(http_client=_client_for(mock))
+    token = _sign(priv, jwk["kid"])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get(
+            "/api/v1/events/stream",
+            headers={"Authorization": f"Bearer {token}"},
+        )
     assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_sse_ticket_mint_requires_auth():
+    """POST /events/ticket must be behind normal header auth — no token, no ticket."""
+    priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    app = _build_app(http_client=_client_for(mock))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.post("/api/v1/events/ticket")
+        assert resp.status_code == 401
+
+        # Query-string credentials must not work on the mint path either.
+        token = _sign(priv, jwk["kid"])
+        resp = await ac.post(f"/api/v1/events/ticket?access_token={token}")
+        assert resp.status_code == 401
+    assert ticket_store.pending_count == 0
+
+
+@pytest.mark.asyncio
+async def test_sse_ticket_full_flow_mint_then_stream():
+    """Header-auth mint → ?ticket= connect succeeds, without a JWT in any URL."""
+    priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    app = _build_app(http_client=_client_for(mock))
+    token = _sign(priv, jwk["kid"])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        minted = await ac.post(
+            "/api/v1/events/ticket",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert minted.status_code == 200
+        body = minted.json()
+        assert body["ticket"]
+        assert body["expires_in"] > 0
+        # Opaque ticket — must not be (or contain) the JWT.
+        assert token not in body["ticket"]
+
+        resp = await ac.get(f"/api/v1/events/stream?ticket={body['ticket']}")
+        assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_sse_ticket_is_single_use():
+    """A replayed ticket URL (e.g. from an access log) must be rejected."""
+    priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    app = _build_app(http_client=_client_for(mock))
+    token = _sign(priv, jwk["kid"])
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        minted = await ac.post(
+            "/api/v1/events/ticket",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        ticket = minted.json()["ticket"]
+        first = await ac.get(f"/api/v1/events/stream?ticket={ticket}")
+        assert first.status_code == 200
+        replay = await ac.get(f"/api/v1/events/stream?ticket={ticket}")
+        assert replay.status_code == 401
+        assert "ticket" in replay.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_sse_expired_ticket_is_rejected(monkeypatch):
+    """A ticket older than its TTL must be rejected even if never used."""
+    _priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    app = _build_app(http_client=_client_for(mock))
+    monkeypatch.setattr(ticket_store, "ttl_seconds", 0)
+    ticket, _expires_in = ticket_store.issue({"sub": "user-1"})
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get(f"/api/v1/events/stream?ticket={ticket}")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_sse_bogus_ticket_is_rejected():
+    _priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    app = _build_app(http_client=_client_for(mock))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/v1/events/stream?ticket=not-a-real-ticket")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_sse_stream_without_any_credential_is_rejected():
+    _priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    app = _build_app(http_client=_client_for(mock))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/v1/events/stream")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_sse_ticket_inherits_role_check():
+    """Tickets carry the minting token's claims; the stream re-applies RBAC."""
+    priv, jwk = _rsa_keypair()
+    mock = _JWKSMock([jwk])
+    app = _build_app(required_roles=["acko:dev"], http_client=_client_for(mock))
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        # Token WITH the role: mint + stream both pass.
+        token = _sign(priv, jwk["kid"], realm_roles=["acko:dev"])
+        minted = await ac.post(
+            "/api/v1/events/ticket",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+        assert minted.status_code == 200
+        resp = await ac.get(f"/api/v1/events/stream?ticket={minted.json()['ticket']}")
+        assert resp.status_code == 200
+
+        # Ticket whose claims lack the role (defense-in-depth: can only
+        # happen if the role requirement changed between mint and redeem).
+        ticket, _ = ticket_store.issue({"realm_access": {"roles": ["other"]}})
+        resp = await ac.get(f"/api/v1/events/stream?ticket={ticket}")
+        assert resp.status_code == 403
 
 
 @pytest.mark.asyncio
@@ -541,6 +709,9 @@ def test_request_logging_masks_access_token_query():
     assert _mask_query_string("Access_Token=secret") == "Access_Token=***"
     # Other JWT-shaped query keys also get masked
     assert _mask_query_string("id_token=abc&token=xyz") == "id_token=***&token=***"
+    # Single-use SSE tickets are short-lived but still credentials — masked too
+    assert _mask_query_string("ticket=abc123") == "ticket=***"
+    assert _mask_query_string("cluster=dev&ticket=abc123&types=a,b") == "cluster=dev&ticket=***&types=a,b"
     # No-op when no token is present
     assert _mask_query_string("foo=bar") == "foo=bar"
     assert _mask_query_string("") == ""

--- a/api/tests/test_sse_tickets.py
+++ b/api/tests/test_sse_tickets.py
@@ -1,0 +1,172 @@
+"""Tests for the single-use SSE ticket store and the mint endpoint.
+
+The middleware-level flow (mint via Authorization header → connect with
+``?ticket=`` → burned on first use) is covered in ``test_oidc_auth.py``;
+this module unit-tests the store itself and the router endpoint wiring in
+``main.app`` (OIDC disabled — mint still works so non-OIDC deployments keep
+a single client code path).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from aerospike_cluster_manager_api.events.tickets import (
+    SSETicketStore,
+    TicketCapacityError,
+    ticket_store,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_ticket_store():
+    ticket_store.clear()
+    yield
+    ticket_store.clear()
+
+
+# ---------------------------------------------------------------------------
+# SSETicketStore unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_issue_and_redeem_roundtrip():
+    store = SSETicketStore(ttl_seconds=30)
+    ticket, expires_in = store.issue({"sub": "user-1"})
+    assert expires_in == 30
+    assert store.pending_count == 1
+    assert store.redeem(ticket) == {"sub": "user-1"}
+    assert store.pending_count == 0
+
+
+def test_redeem_is_single_use():
+    store = SSETicketStore()
+    ticket, _ = store.issue({"sub": "user-1"})
+    assert store.redeem(ticket) is not None
+    assert store.redeem(ticket) is None
+
+
+def test_redeem_unknown_ticket_returns_none():
+    store = SSETicketStore()
+    assert store.redeem("no-such-ticket") is None
+
+
+def test_expired_ticket_is_rejected():
+    store = SSETicketStore(ttl_seconds=0)
+    ticket, _ = store.issue({"sub": "user-1"})
+    assert store.redeem(ticket) is None
+
+
+def test_issue_purges_expired_entries():
+    store = SSETicketStore(ttl_seconds=0)
+    store.issue()
+    assert store.pending_count == 1
+    # The previous (instantly-expired) entry is swept on the next mint, so
+    # the table never accumulates dead tickets.
+    store.issue()
+    assert store.pending_count == 1
+
+
+def test_capacity_cap_rejects_when_full():
+    store = SSETicketStore(ttl_seconds=60, max_pending=2)
+    first, _ = store.issue()
+    store.issue()
+    with pytest.raises(TicketCapacityError):
+        store.issue()
+    # Redeeming frees a slot, so minting works again.
+    assert store.redeem(first) is not None
+    ticket, _ = store.issue()
+    assert ticket
+
+
+def test_claims_are_copied_not_aliased():
+    store = SSETicketStore()
+    claims = {"sub": "user-1"}
+    ticket, _ = store.issue(claims)
+    claims["sub"] = "tampered"
+    assert store.redeem(ticket) == {"sub": "user-1"}
+
+
+def test_none_claims_issue_empty_dict():
+    store = SSETicketStore()
+    ticket, _ = store.issue(None)
+    assert store.redeem(ticket) == {}
+
+
+def test_tickets_are_unique_and_high_entropy():
+    store = SSETicketStore()
+    t1, _ = store.issue()
+    t2, _ = store.issue()
+    assert t1 != t2
+    # 32 random bytes urlsafe-encode to 43 chars — opaque, not a JWT.
+    assert len(t1) >= 43
+    assert t1.count(".") == 0
+
+
+def test_clear_drops_all_pending():
+    store = SSETicketStore()
+    store.issue()
+    store.issue()
+    store.clear()
+    assert store.pending_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Mint endpoint wiring through main.app (OIDC disabled)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+async def client(init_test_db):
+    """Test client against the real app with SSE enabled."""
+    with (
+        patch("aerospike_cluster_manager_api.config.SSE_ENABLED", True),
+        patch("aerospike_cluster_manager_api.routers.events.config.SSE_ENABLED", True),
+    ):
+        from aerospike_cluster_manager_api.main import app
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            yield ac
+
+
+async def test_mint_ticket_endpoint_returns_single_use_ticket(client: AsyncClient) -> None:
+    resp = await client.post("/api/v1/events/ticket")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body["ticket"], str) and body["ticket"]
+    assert body["expires_in"] > 0
+    # The minted ticket is registered and redeems exactly once.
+    assert ticket_store.redeem(body["ticket"]) is not None
+    assert ticket_store.redeem(body["ticket"]) is None
+
+
+async def test_mint_ticket_legacy_alias(client: AsyncClient) -> None:
+    """The unversioned /api alias mints too (mounted alongside /api/v1)."""
+    resp = await client.post("/api/events/ticket")
+    assert resp.status_code == 200
+    assert resp.json()["ticket"]
+
+
+async def test_mint_ticket_returns_404_when_sse_disabled(init_test_db) -> None:
+    with (
+        patch("aerospike_cluster_manager_api.config.SSE_ENABLED", False),
+        patch("aerospike_cluster_manager_api.routers.events.config.SSE_ENABLED", False),
+    ):
+        from aerospike_cluster_manager_api.main import app
+
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            resp = await ac.post("/api/v1/events/ticket")
+            assert resp.status_code == 404
+            assert resp.json()["detail"] == "SSE streaming is disabled"
+
+
+async def test_mint_ticket_returns_429_at_capacity(client: AsyncClient) -> None:
+    with patch.object(ticket_store, "max_pending", 0):
+        resp = await client.post("/api/v1/events/ticket")
+    assert resp.status_code == 429
+    assert "Too many pending SSE tickets" in resp.json()["detail"]

--- a/ui/src/lib/api/events.test.ts
+++ b/ui/src/lib/api/events.test.ts
@@ -1,0 +1,242 @@
+/**
+ * subscribeEvents — SSE ticket handshake (issue #345).
+ *
+ * The JWT must never appear in the stream URL. When an access token is
+ * present, the client first mints a single-use ticket via an authenticated
+ * POST /api/events/ticket, then opens the EventSource with ?ticket=<opaque>.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+import { useAuthStore } from "@/stores/auth-store"
+import {
+  useClusterSelectorStore,
+  type ClusterRegistry,
+} from "@/stores/cluster-selector-store"
+
+import { subscribeEvents } from "./events"
+
+// keycloak-js pulls browser-crypto paths we don't want in unit tests; the
+// refresh path is exercised via this mock instead.
+vi.mock("@/lib/auth/keycloak", () => ({
+  refreshToken: vi.fn(),
+}))
+
+import { refreshToken } from "@/lib/auth/keycloak"
+
+const refreshTokenMock = vi.mocked(refreshToken)
+
+// ---------------------------------------------------------------------------
+// EventSource mock — jsdom does not implement EventSource.
+// ---------------------------------------------------------------------------
+
+class MockEventSource {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSED = 2
+  static instances: MockEventSource[] = []
+
+  url: string
+  readyState = MockEventSource.CONNECTING
+  listeners = new Map<string, Array<(ev: Event) => void>>()
+
+  constructor(url: string) {
+    this.url = url
+    MockEventSource.instances.push(this)
+  }
+
+  addEventListener(type: string, cb: (ev: Event) => void) {
+    const arr = this.listeners.get(type) ?? []
+    arr.push(cb)
+    this.listeners.set(type, arr)
+  }
+
+  close() {
+    this.readyState = MockEventSource.CLOSED
+  }
+
+  emit(type: string, ev: Event) {
+    for (const cb of this.listeners.get(type) ?? []) cb(ev)
+  }
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+/** Flush the event loop so subscribeEvents' async open settles. Each
+ *  setTimeout(0) turn drains all pending microtasks (fetch/json chains). */
+async function flush(turns = 3): Promise<void> {
+  for (let i = 0; i < turns; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 0))
+  }
+}
+
+const REGISTRY: ClusterRegistry = {
+  defaultClusterId: "dev",
+  clusters: [
+    {
+      id: "dev",
+      displayName: "Dev",
+      apiUrl: "https://dev-api.example.com",
+    },
+  ],
+}
+
+const JWT = "eyJ.fake.jwt-token"
+
+let fetchMock: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  MockEventSource.instances = []
+  vi.stubGlobal("EventSource", MockEventSource)
+  fetchMock = vi.fn()
+  vi.stubGlobal("fetch", fetchMock)
+  refreshTokenMock.mockReset()
+  refreshTokenMock.mockResolvedValue(undefined)
+  useAuthStore.setState({ accessToken: null, claims: null, refreshing: false })
+  useClusterSelectorStore.setState({
+    registry: null,
+    currentClusterId: null,
+    registryError: null,
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe("subscribeEvents — no auth token", () => {
+  it("connects directly without minting a ticket", async () => {
+    const sub = subscribeEvents()
+    await flush()
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(MockEventSource.instances).toHaveLength(1)
+    const url = MockEventSource.instances[0].url
+    expect(url).toBe("/api/events/stream")
+    sub.close()
+  })
+
+  it("appends types and the active cluster id", async () => {
+    useClusterSelectorStore.setState({
+      registry: REGISTRY,
+      currentClusterId: "dev",
+      registryError: null,
+    })
+    const sub = subscribeEvents({ types: ["cluster.status", "pod.status"] })
+    await flush()
+
+    const url = new URL(MockEventSource.instances[0].url)
+    expect(url.origin).toBe("https://dev-api.example.com")
+    expect(url.pathname).toBe("/api/events/stream")
+    expect(url.searchParams.get("types")).toBe("cluster.status,pod.status")
+    expect(url.searchParams.get("cluster")).toBe("dev")
+    expect(url.searchParams.has("ticket")).toBe(false)
+    sub.close()
+  })
+})
+
+describe("subscribeEvents — OIDC ticket handshake", () => {
+  beforeEach(() => {
+    useAuthStore.setState({
+      accessToken: JWT,
+      claims: null,
+      refreshing: false,
+    })
+    useClusterSelectorStore.setState({
+      registry: REGISTRY,
+      currentClusterId: "dev",
+      registryError: null,
+    })
+  })
+
+  it("mints a ticket via authenticated POST, then connects with ?ticket=", async () => {
+    fetchMock.mockResolvedValue(
+      jsonResponse({ ticket: "tkt-opaque-1", expires_in: 30 }),
+    )
+
+    const sub = subscribeEvents({ types: ["cluster.status"] })
+    await flush()
+
+    // Mint call: POST to the ticket endpoint with the Authorization header.
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+    const [mintUrl, mintInit] = fetchMock.mock.calls[0] as [string, RequestInit]
+    expect(mintUrl).toBe("https://dev-api.example.com/api/events/ticket")
+    expect(mintInit.method).toBe("POST")
+    expect(new Headers(mintInit.headers).get("Authorization")).toBe(
+      `Bearer ${JWT}`,
+    )
+
+    // Stream URL carries the opaque ticket — and NEVER the JWT.
+    expect(MockEventSource.instances).toHaveLength(1)
+    const url = new URL(MockEventSource.instances[0].url)
+    expect(url.searchParams.get("ticket")).toBe("tkt-opaque-1")
+    expect(url.searchParams.has("access_token")).toBe(false)
+    expect(MockEventSource.instances[0].url).not.toContain(JWT)
+    sub.close()
+  })
+
+  it("does not open the stream when the mint is rejected and refresh fails", async () => {
+    fetchMock.mockResolvedValue(jsonResponse({ detail: "expired" }, 401))
+    refreshTokenMock.mockResolvedValue(undefined)
+    const onError = vi.fn()
+
+    const sub = subscribeEvents({ onError })
+    await flush()
+
+    expect(MockEventSource.instances).toHaveLength(0)
+    expect(onError).toHaveBeenCalled()
+    sub.close()
+  })
+
+  it("refreshes the token once and retries the mint when the first mint fails", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ detail: "expired" }, 401))
+      .mockResolvedValueOnce(jsonResponse({ ticket: "tkt-2", expires_in: 30 }))
+    refreshTokenMock.mockResolvedValue("new-jwt")
+
+    const sub = subscribeEvents()
+    await flush()
+
+    expect(refreshTokenMock).toHaveBeenCalledTimes(1)
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    const [, secondInit] = fetchMock.mock.calls[1] as [string, RequestInit]
+    expect(new Headers(secondInit.headers).get("Authorization")).toBe(
+      "Bearer new-jwt",
+    )
+    expect(MockEventSource.instances).toHaveLength(1)
+    expect(
+      new URL(MockEventSource.instances[0].url).searchParams.get("ticket"),
+    ).toBe("tkt-2")
+    sub.close()
+  })
+
+  it("mints a fresh single-use ticket on auth-driven reconnect", async () => {
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse({ ticket: "tkt-a", expires_in: 30 }))
+      .mockResolvedValueOnce(jsonResponse({ ticket: "tkt-b", expires_in: 30 }))
+    refreshTokenMock.mockResolvedValue("refreshed-jwt")
+
+    const sub = subscribeEvents()
+    await flush()
+    expect(MockEventSource.instances).toHaveLength(1)
+    const first = MockEventSource.instances[0]
+    expect(new URL(first.url).searchParams.get("ticket")).toBe("tkt-a")
+
+    // Server hard-rejects (e.g. burned ticket after a proxy retry): the
+    // stream lands in CLOSED and the client reopens with a NEW ticket.
+    first.readyState = MockEventSource.CLOSED
+    first.emit("error", new Event("error"))
+    await flush()
+
+    expect(MockEventSource.instances).toHaveLength(2)
+    const second = MockEventSource.instances[1]
+    expect(new URL(second.url).searchParams.get("ticket")).toBe("tkt-b")
+    expect(second.url).not.toContain("tkt-a")
+    sub.close()
+  })
+})

--- a/ui/src/lib/api/events.ts
+++ b/ui/src/lib/api/events.ts
@@ -6,15 +6,22 @@
  * Each message's `data` field is a JSON string that we parse before
  * delivering to the consumer.
  *
- * Auth: `EventSource` cannot set headers, so the access token is appended as
- * `?access_token=<jwt>` and the active cluster id as `&cluster=<id>`. The
- * backend (Stream B) reads these and applies the same JWT verification as the
- * Authorization header path.
+ * Auth (issue #345, ADR-0040 follow-up): native `EventSource` cannot set an
+ * Authorization header, and putting the JWT in the URL leaks it into ingress
+ * access logs, browser history, and Referer headers. Instead, when an access
+ * token is present we first mint a short-lived, single-use opaque ticket via
+ * an authenticated `POST /api/events/ticket` (Authorization header), then
+ * connect with `?ticket=<opaque>`. The backend burns the ticket on first
+ * use, so a URL that leaks into an access log is already worthless — and the
+ * long-lived JWT never appears in any URL.
  */
 
 import { refreshToken } from "@/lib/auth/keycloak"
 import { useAuthStore } from "@/stores/auth-store"
-import { useClusterSelectorStore } from "@/stores/cluster-selector-store"
+import {
+  getActiveCluster,
+  type ClusterEntry,
+} from "@/stores/cluster-selector-store"
 
 import type { SSEEvent, SSEHandler } from "../types/events"
 import { API_PREFIX } from "./client"
@@ -41,66 +48,54 @@ export interface EventSubscription {
 const RECONNECT_INITIAL_MS = 1_000
 const RECONNECT_MAX_MS = 30_000
 
-function buildStreamUrl(types?: string[]): string {
+/** Resolve the active cluster's API origin ("" = same-origin / proxy mode). */
+function resolveBaseHost(active: ClusterEntry | null): string {
+  return active?.apiUrl?.replace(/\/+$/, "") ?? ""
+}
+
+/**
+ * Exchange the in-memory access token for a single-use SSE stream ticket.
+ * Returns `null` when the backend rejects the mint (expired token, SSE
+ * disabled, ...) — callers decide whether to refresh and retry or back off.
+ * Uses raw `fetch` (not apiFetch) so a failing background stream never
+ * triggers apiFetch's login redirect side effect.
+ */
+async function mintStreamTicket(
+  baseHost: string,
+  token: string,
+): Promise<string | null> {
+  const res = await fetch(`${baseHost}${API_PREFIX}/events/ticket`, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+  })
+  if (!res.ok) return null
+  try {
+    const body = (await res.json()) as { ticket?: unknown }
+    return typeof body.ticket === "string" && body.ticket.length > 0
+      ? body.ticket
+      : null
+  } catch {
+    return null
+  }
+}
+
+function buildStreamUrl(
+  active: ClusterEntry | null,
+  types?: string[],
+  ticket?: string | null,
+): string {
   const params = new URLSearchParams()
   if (types && types.length > 0) params.set("types", types.join(","))
-
-  // Multi-cluster + OIDC mode: append cluster id and JWT so SSE works across
-  // origins without an Authorization header (EventSource limitation).
-  //
-  // SECURITY: the access token appears in the request URL. This means the
-  // token can leak via (a) upstream ingress access logs, (b) browser dev
-  // tools, (c) Referer headers if the SSE response page links elsewhere.
-  // Mitigations: short token TTL, mandatory access-log masking on every
-  // ingress that sits in front of the API (documented in
-  // aerospike-ce-kubernetes-operator/docs/multi-cluster-keycloak.md), and
-  // logging middleware on the API masks `access_token`/`id_token` query
-  // params before persisting them. See ADR-0040 follow-up: the long-term
-  // fix is per-stream signed nonces or transport upgrades that allow
-  // header-based auth on subscriptions.
-  const selector = useClusterSelectorStore.getState()
-  const active =
-    selector.registry?.clusters.find(
-      (c) => c.id === selector.currentClusterId,
-    ) ??
-    selector.registry?.clusters.find(
-      (c) => c.id === selector.registry?.defaultClusterId,
-    ) ??
-    null
+  // Multi-cluster mode: pin the stream to the active cluster.
   if (active) params.set("cluster", active.id)
-  const token = useAuthStore.getState().accessToken
-  const baseHost = active?.apiUrl?.replace(/\/+$/, "") ?? ""
-  if (token) {
-    // TODO(ADR-0040 follow-up): replace with per-stream signed nonce or
-    // cookie-based auth so the token does not appear in the URL. EventSource
-    // does not support custom headers in stock browsers, so this remains the
-    // workaround until the broker grows a dedicated handshake endpoint.
-    //
-    // Until that lands, refuse to open the stream against a plain-http
-    // origin: the JWT would travel as cleartext in the URL and end up in
-    // every reverse-proxy access log on the path. Operators must serve the
-    // API over https before SSE+OIDC can be used.
-    if (active?.apiUrl && /^http:\/\//i.test(active.apiUrl)) {
-      throw new Error(
-        "[events.ts] refusing to open SSE stream over plain http://: " +
-          "the access_token query param would leak via access logs. " +
-          "Configure the cluster apiUrl to use https://. " +
-          "Tracking: ADR-0040 follow-up.",
-      )
-    }
-    if (process.env.NODE_ENV !== "production") {
-      // eslint-disable-next-line no-console
-      console.warn(
-        "[events.ts] access_token is being sent in the SSE URL query " +
-          "string. Ensure the ingress masks `access_token` from access logs. " +
-          "Tracking: ADR-0040 follow-up.",
-      )
-    }
-    params.set("access_token", token)
-  }
+  // Single-use handshake ticket — never the JWT itself (issue #345).
+  if (ticket) params.set("ticket", ticket)
 
   const qs = params.toString()
-  return `${baseHost}${API_PREFIX}/events/stream${qs ? `?${qs}` : ""}`
+  return `${resolveBaseHost(active)}${API_PREFIX}/events/stream${qs ? `?${qs}` : ""}`
 }
 
 /**
@@ -111,9 +106,10 @@ function buildStreamUrl(types?: string[]): string {
  * Auth-aware reconnect: when the EventSource transitions to ``CLOSED`` (the
  * only state we can observe — ``EventSource`` does not surface HTTP status
  * codes), we treat it as a likely 401/expired-token and try to refresh the
- * access token before re-opening the stream. We back off exponentially
- * (1s → 30s) on repeated failures so a permanently-broken auth doesn't melt
- * the API into a reconnect storm.
+ * access token before re-opening the stream. Every (re)open mints a fresh
+ * single-use ticket — tickets are burned server-side on first connect. We
+ * back off exponentially (1s → 30s) on repeated failures so a permanently-
+ * broken auth doesn't melt the API into a reconnect storm.
  */
 export function subscribeEvents<T = unknown>(
   options: SubscribeEventsOptions<T> = {},
@@ -165,7 +161,35 @@ export function subscribeEvents<T = unknown>(
       source = null
     }
 
-    const url = buildStreamUrl(types)
+    const active = getActiveCluster()
+
+    // OIDC mode: exchange the access token for a single-use stream ticket.
+    // The JWT itself must never be placed in the URL (issue #345).
+    let ticket: string | null = null
+    const token = useAuthStore.getState().accessToken
+    if (token) {
+      try {
+        ticket = await mintStreamTicket(resolveBaseHost(active), token)
+        if (!ticket && !closed) {
+          // Mint rejected — most likely an expired token. Refresh once and
+          // retry before falling back to the backoff loop.
+          const newToken = await refreshToken()
+          if (newToken && !closed) {
+            ticket = await mintStreamTicket(resolveBaseHost(active), newToken)
+          }
+        }
+      } catch {
+        ticket = null
+      }
+      if (closed) return
+      if (!ticket) {
+        onError?.(new Event("error"))
+        scheduleReconnect()
+        return
+      }
+    }
+
+    const url = buildStreamUrl(active, types, ticket)
     const next = new EventSource(url)
     source = next
 
@@ -181,13 +205,16 @@ export function subscribeEvents<T = unknown>(
       onError?.(ev)
       // EventSource auto-reconnects on transient errors but stays in CLOSED
       // when the server hard-rejected the request (e.g. 401). In that case,
-      // attempt a token refresh and re-open ourselves, otherwise leave the
-      // browser's reconnect to do its job.
+      // attempt a token refresh and re-open ourselves (which mints a fresh
+      // ticket), otherwise leave the browser's reconnect to do its job.
+      // NOTE: the browser's own auto-reconnect replays the same URL — with a
+      // burned single-use ticket that replay is rejected and lands here as a
+      // CLOSED stream, funnelling all reconnects through openConnection().
       if (next.readyState === EventSource.CLOSED) {
         next.close()
         if (closed) return
         // Attempt a one-shot token refresh; on success we immediately reopen
-        // with the new token, otherwise we fall back to backoff so we don't
+        // with a fresh ticket, otherwise we fall back to backoff so we don't
         // hammer the API while auth is permanently broken.
         void refreshToken()
           .then((newToken) => {


### PR DESCRIPTION
Fixes #345

## Problem (P0)

`EventSource` cannot send an `Authorization` header, so the SSE stream authenticated with the raw JWT in the URL (`?access_token=<jwt>`). The long-lived bearer token therefore persisted in ingress access logs (NGINX/HAProxy/Traefik default formats), browser history, Referer headers, and any intermediate proxy/WAF logs — see issue #345 (ADR-0040 follow-up, `TODO` marker at the old `ui/src/lib/api/events.ts:99`).

## Design implemented — single-use signed-out opaque ticket (issue option 2)

Option 1 (path-scoped `SameSite=Strict` cookie) was **not** chosen: in the ADR-0040 multi-cluster topology the SPA on the common cluster fans out cross-origin to `api.dev.example.com` / `api.prod.example.com`, and a `SameSite=Strict` cookie is never sent on those cross-site requests. The nonce/ticket flow works identically same-origin and cross-origin.

Flow:

1. `POST /api[/v1]/events/ticket` — requires normal `Authorization: Bearer <jwt>` (enforced by `OIDCAuthMiddleware`; query credentials are never accepted on this path). Mints a 256-bit opaque `secrets.token_urlsafe(32)` ticket bound to the verified claims. TTL 30s (`SSE_TICKET_TTL_SECONDS`), pending-table cap 1024 (`SSE_TICKET_MAX_PENDING`, 429 when full), 404 when SSE is disabled.
2. `GET /api[/v1]/events/stream?ticket=<opaque>` — middleware redeems and **burns** the ticket on first use (replay ⇒ 401), re-applies `OIDC_REQUIRED_ROLES` against the ticket's claims, and injects them as `request.state.user_claims`.
3. The JWT-in-query path is **removed entirely**: `?access_token=` on the stream is rejected with a 401 + migration hint and is never verified (no JWKS traffic for it). `Authorization`-header streaming still works for non-browser clients (curl, ackoctl).
4. UI (`subscribeEvents`) mints a ticket before opening the `EventSource` and mints a fresh one on every auth-driven reconnect. On mint failure it refreshes the token once, then falls back to the existing exponential backoff. The `http://` hard-refusal that existed only to guard the JWT-in-URL workaround is removed together with the workaround.
5. Defense in depth: the request-logging masker now also masks `?ticket=` (on top of the existing `access_token`/`id_token`/`token` masking).

## Files changed

- `api/src/aerospike_cluster_manager_api/events/tickets.py` — new `SSETicketStore` (issue/redeem/purge/cap) + module singleton
- `api/src/aerospike_cluster_manager_api/routers/events.py` — new `POST /events/ticket`
- `api/src/aerospike_cluster_manager_api/middleware/oidc_auth.py` — ticket redemption path, header-only `_extract_token`, explicit `access_token` rejection, `SSE_QUERY_TOKEN_PATHS` → `SSE_TICKET_PATHS`
- `api/src/aerospike_cluster_manager_api/config.py` — `SSE_TICKET_TTL_SECONDS`, `SSE_TICKET_MAX_PENDING`
- `api/src/aerospike_cluster_manager_api/main.py` — mask `ticket` in request logs
- `ui/src/lib/api/events.ts` — mint-then-connect flow; JWT never in URL
- Tests: `api/tests/test_sse_tickets.py` (new), `api/tests/test_oidc_auth.py` (ticket flow: mint requires auth, single-use, expiry, bogus, RBAC inheritance, raw-JWT-in-query rejected), `ui/src/lib/api/events.test.ts` (new)

## Test results

- `api`: `uv run pytest tests/` — **999 passed**; `ruff check` / `ruff format --check` / `pyright src/` clean
- `ui`: `npm run test` — **102 passed (18 files)**; `next lint`, `tsc --noEmit`, `prettier --check`, `next build` all clean

## Residual risk

- The ticket store is process-local: multi-replica API deployments need session affinity on `/api/*` (or a shared store) so mint and connect hit the same replica. The ADR-0040 topology runs one API per operator cluster, where this is a non-issue; noted in the module docstring.
- A leaked *unused* ticket is valid for up to 30s — but it is single-use, opaque, and grants only a stream subscription; on redemption the normal RBAC check re-applies.
- ADR-0040 amendment (documenting this flow) lives in project-hub and is not part of this repo's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)