### PR TITLE
fix(errors): map Aerospike errors by result_code instead of message substrings

### DIFF
--- a/.github/workflows/agent-implement.yml
+++ b/.github/workflows/agent-implement.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -59,7 +59,7 @@ jobs:
             runner: ubuntu-24.04-arm
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Prepare names
         id: prep
@@ -107,7 +107,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: digests-${{ matrix.name }}-${{ steps.prep.outputs.platform_pair }}
           path: /tmp/digests/*
@@ -138,7 +138,7 @@ jobs:
           echo "IMAGE=ghcr.io/${REPO}${{ matrix.suffix }}" >> "$GITHUB_ENV"
 
       - name: Download digests
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v8.0.1
         with:
           path: /tmp/digests
           pattern: digests-${{ matrix.name }}-*

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
 
@@ -51,7 +51,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 
@@ -48,10 +48,10 @@ jobs:
       run:
         working-directory: api
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.3.2
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           enable-cache: true
 
@@ -78,7 +78,7 @@ jobs:
       run:
         working-directory: ui
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/daily-release.yml
+++ b/.github/workflows/daily-release.yml
@@ -16,7 +16,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/issue-planner.yml
+++ b/.github/workflows/issue-planner.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
 

--- a/.github/workflows/pr-reviewer.yml
+++ b/.github/workflows/pr-reviewer.yml
@@ -35,7 +35,7 @@ jobs:
           echo "ref=$PR_REF" >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ steps.pr-info.outputs.ref }}
           fetch-depth: 0

--- a/api/src/aerospike_cluster_manager_api/aerospike_errors.py
+++ b/api/src/aerospike_cluster_manager_api/aerospike_errors.py
@@ -1,0 +1,66 @@
+"""Structured detection of Aerospike server result codes on raised exceptions.
+
+The FastAPI global exception handlers map aerospike-py exceptions to HTTP
+responses. Historically some of that mapping keyed off substring matches of the
+human-readable exception message (e.g. ``"failforbidden" in str(exc).lower()``),
+which is brittle: message wording can change between aerospike-py releases and
+localisations, silently breaking the mapping.
+
+This module extracts the *numeric* Aerospike result code instead, which is
+stable across releases:
+
+1. First it reads a structured ``.result_code`` int attribute off the exception.
+   aerospike-py is adding this attribute (ADR-0011); when the installed build
+   exposes it we use it directly.
+2. If the attribute is absent (currently-released aerospike-py), it falls back
+   to parsing the code that aerospike-py already embeds in the message text,
+   which is rendered as ``AEROSPIKE_ERR (<code>): ...`` (see aerospike-py
+   ``rust/src/errors.rs``).
+
+The result-code constants mirror aerospike-py's ``AEROSPIKE_ERR_*`` values
+(``rust/src/constants.rs``).
+"""
+
+from __future__ import annotations
+
+import re
+
+# --- Aerospike server result codes (subset used by this API's error mapping) ---
+# Mirrors aerospike-py's ``AEROSPIKE_ERR_FAIL_FORBIDDEN`` (wire code 22). Raised,
+# for example, when setting a record TTL against a namespace without
+# ``nsup-period`` configured.
+RESULT_CODE_FAIL_FORBIDDEN = 22
+
+# aerospike-py renders server errors as ``AEROSPIKE_ERR (<code>): <detail>``
+# (and batch errors as ``AEROSPIKE_ERR (<code>) [batch_index=N]: ...``). The
+# code may be negative for client-side errors, so allow an optional sign.
+_AEROSPIKE_ERR_CODE_RE = re.compile(r"AEROSPIKE_ERR \((-?\d+)\)")
+
+
+def result_code_of(exc: BaseException) -> int | None:
+    """Return the Aerospike numeric result code carried by *exc*, or ``None``.
+
+    Detection order (robust now, forward-compatible with aerospike-py ADR-0011):
+
+    1. ``exc.result_code`` — the structured int attribute aerospike-py is
+       introducing. Used directly when present.
+    2. Otherwise, the numeric code embedded in ``str(exc)`` as
+       ``AEROSPIKE_ERR (<code>)``, which the currently-released aerospike-py
+       already emits.
+    """
+    # 1. Structured attribute (preferred once aerospike-py exposes it).
+    code = getattr(exc, "result_code", None)
+    # bool is an int subclass; a stray True/False must not be treated as a code.
+    if isinstance(code, int) and not isinstance(code, bool):
+        return code
+    if isinstance(code, str):
+        try:
+            return int(code.strip())
+        except ValueError:
+            pass
+
+    # 2. Fallback: parse the code aerospike-py embeds in the message.
+    match = _AEROSPIKE_ERR_CODE_RE.search(str(exc))
+    if match:
+        return int(match.group(1))
+    return None

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -18,6 +18,7 @@ from starlette.middleware.base import RequestResponseEndpoint
 from starlette.responses import Response
 
 from aerospike_cluster_manager_api import config, db
+from aerospike_cluster_manager_api.aerospike_errors import RESULT_CODE_FAIL_FORBIDDEN, result_code_of
 from aerospike_cluster_manager_api.client_manager import client_manager
 from aerospike_cluster_manager_api.events.broker import broker
 from aerospike_cluster_manager_api.events.collector import collector
@@ -413,9 +414,13 @@ try:
 
     @app.exception_handler(ServerError)
     async def _server_error(_req: Request, exc: ServerError) -> JSONResponse:
-        msg = str(exc)
-        # TODO: Replace string check with proper error code when aerospike-py exposes result_code
-        if "failforbidden" in msg.lower():
+        # Map by the stable numeric Aerospike result code rather than by
+        # matching substrings of the (release-dependent) message text.
+        # result_code_of prefers a structured ``exc.result_code`` attribute
+        # (aerospike-py ADR-0011) and falls back to the code embedded in the
+        # message ("AEROSPIKE_ERR (<code>)") for currently-released builds.
+        code = result_code_of(exc)
+        if code == RESULT_CODE_FAIL_FORBIDDEN:
             return JSONResponse(
                 status_code=403,
                 content={
@@ -423,7 +428,7 @@ try:
                     "If setting TTL, ensure the namespace has 'nsup-period' configured."
                 },
             )
-        logger.warning("Unrecognized ServerError: %s", msg)
+        logger.warning("Unrecognized ServerError (result_code=%s): %s", code, exc)
         return _internal_error_response()
 
     @app.exception_handler(AerospikeTimeoutError)

--- a/api/tests/test_aerospike_errors.py
+++ b/api/tests/test_aerospike_errors.py
@@ -1,0 +1,114 @@
+"""Tests for structured Aerospike result-code error mapping.
+
+Covers the migration of the ``ServerError`` -> HTTP mapping (``main.py``) away
+from brittle message-substring matching (``"failforbidden" in str(exc)``) to
+detection by the stable numeric Aerospike result code. Both detection paths are
+exercised:
+
+* a structured ``exc.result_code`` attribute (aerospike-py ADR-0011), and
+* the message-string fallback (``AEROSPIKE_ERR (<code>)``) emitted by
+  currently-released aerospike-py.
+"""
+
+from __future__ import annotations
+
+import pytest
+from aerospike_py.exception import ServerError
+from fastapi import Request
+
+from aerospike_cluster_manager_api.aerospike_errors import RESULT_CODE_FAIL_FORBIDDEN, result_code_of
+from aerospike_cluster_manager_api.main import app
+
+
+class _AttrError(Exception):
+    """Exception carrying a structured ``result_code`` attribute."""
+
+    def __init__(self, message: str, result_code: object) -> None:
+        super().__init__(message)
+        self.result_code = result_code
+
+
+# ---------------------------------------------------------------------------
+# result_code_of — pure extraction logic
+# ---------------------------------------------------------------------------
+
+
+class TestResultCodeOf:
+    def test_prefers_structured_attribute(self):
+        # No code in the message at all — only the structured attribute.
+        exc = _AttrError("something went wrong", RESULT_CODE_FAIL_FORBIDDEN)
+        assert result_code_of(exc) == RESULT_CODE_FAIL_FORBIDDEN
+
+    def test_structured_attribute_wins_over_message(self):
+        # Attribute says 22, message says 1 — the attribute must take priority.
+        exc = _AttrError("AEROSPIKE_ERR (1): Server error", RESULT_CODE_FAIL_FORBIDDEN)
+        assert result_code_of(exc) == RESULT_CODE_FAIL_FORBIDDEN
+
+    def test_message_fallback_when_no_attribute(self):
+        # Mirrors the currently-released aerospike-py rendering.
+        exc = Exception("AEROSPIKE_ERR (22): Server error: FailForbidden, In Doubt: false")
+        assert result_code_of(exc) == 22
+
+    def test_message_fallback_batch_format(self):
+        # Batch errors embed the code before the "[batch_index=N]" suffix.
+        exc = Exception("AEROSPIKE_ERR (22) [batch_index=3]: Server error")
+        assert result_code_of(exc) == 22
+
+    def test_message_fallback_negative_code(self):
+        exc = Exception("AEROSPIKE_ERR (-1): Server error: generic")
+        assert result_code_of(exc) == -1
+
+    def test_string_attribute_is_parsed(self):
+        exc = _AttrError("opaque", "22")
+        assert result_code_of(exc) == 22
+
+    def test_bool_attribute_is_ignored(self):
+        # bool is an int subclass; a stray True must not be read as code 1.
+        exc = _AttrError("AEROSPIKE_ERR (22): x", True)
+        assert result_code_of(exc) == 22
+
+    def test_returns_none_when_absent(self):
+        assert result_code_of(Exception("totally unrelated message")) is None
+
+
+# ---------------------------------------------------------------------------
+# ServerError -> HTTP handler behaviour (both detection paths)
+# ---------------------------------------------------------------------------
+
+
+def _make_request() -> Request:
+    # The handler does not read the request (it only reads the request-id
+    # ContextVar, which has a default), so a minimal scope is sufficient.
+    return Request({"type": "http", "method": "GET", "path": "/", "headers": []})
+
+
+@pytest.fixture()
+def server_error_handler():
+    handler = app.exception_handlers.get(ServerError)
+    assert handler is not None, "ServerError exception handler is not registered"
+    return handler
+
+
+class TestServerErrorHandler:
+    async def test_forbidden_via_result_code_attribute(self, server_error_handler):
+        # Structured attribute path (forward-compatible with aerospike-py ADR-0011).
+        # Message deliberately omits "failforbidden" so a substring check would miss it.
+        exc = ServerError("AEROSPIKE_ERR (22): Server error")
+        exc.result_code = RESULT_CODE_FAIL_FORBIDDEN
+        response = await server_error_handler(_make_request(), exc)
+        assert response.status_code == 403
+        assert b"nsup-period" in response.body
+
+    async def test_forbidden_via_message_fallback(self, server_error_handler):
+        # No structured attribute — detection relies solely on the embedded code.
+        exc = ServerError("AEROSPIKE_ERR (22): Server error: FailForbidden, In Doubt: false")
+        assert not hasattr(exc, "result_code")
+        response = await server_error_handler(_make_request(), exc)
+        assert response.status_code == 403
+        assert b"nsup-period" in response.body
+
+    async def test_other_server_error_maps_to_500(self, server_error_handler):
+        # A non-forbidden server error must still fall through to the generic 500.
+        exc = ServerError("AEROSPIKE_ERR (1): Server error: generic failure")
+        response = await server_error_handler(_make_request(), exc)
+        assert response.status_code == 500


### PR DESCRIPTION
## Summary

Two small, backend/CI-only hardening changes to the FastAPI backend.

### Task A — result-code-based error mapping (Item 1b)

The `ServerError` global exception handler in `api/.../main.py` decided whether to return **403 Forbidden** by matching a substring of the exception message: `if "failforbidden" in str(exc).lower()`. That is brittle — message wording can change between aerospike-py releases and silently break the mapping (the code carried a `# TODO: Replace string check with proper error code when aerospike-py exposes result_code`).

This replaces the substring check with structured detection by the stable **numeric Aerospike result code**, in a new `aerospike_errors.result_code_of()` helper:

1. **Preferred:** read `getattr(exc, "result_code", None)` — aerospike-py is adding a structured `.result_code` int attribute (**ADR-0011**). When the installed build exposes it, we use it directly (forward-compatible).
2. **Fallback:** parse the code aerospike-py already embeds in the message, rendered as `AEROSPIKE_ERR (<code>)` (see aerospike-py `rust/src/errors.rs`), via `AEROSPIKE_ERR \((-?\d+)\)`. This works against the **currently-released** aerospike-py.

**Codes mapped:** `FAIL_FORBIDDEN` (result code **22**) → **403** with the existing TTL / `nsup-period` guidance message. Behavior is identical for the currently-handled case; only detection is made robust. All other `ServerError`s continue to fall through to the generic 500 (now with the detected `result_code` in the log line). The resolved TODO is removed.

New tests (`api/tests/test_aerospike_errors.py`, 11 cases) cover both detection paths — a mock exception carrying `.result_code`, and message-string fallback with no attribute — asserting the correct HTTP behavior end-to-end through the registered handler (403 for code 22 via either path; 500 for other codes), plus edge cases (attribute-wins-over-message, batch-format message, negative code, string attribute, bool guard).

### Task B — GitHub Actions version alignment (Item 6)

Aligned action pins in `.github/workflows/*` with the org reference repo (aerospike-py), no ui build/node behavior touched (`actions/setup-node@v6` unchanged):

| Action | Before | After |
|---|---|---|
| `astral-sh/setup-uv` | `v8.3.2` | `v8.1.0` |
| `actions/checkout` | `v6` | `v7` |
| `actions/upload-artifact` | `v7` | `v7.0.1` |
| `actions/download-artifact` | `v8` | `v8.0.1` |

## Verification

- `uv run pytest tests/` → **1014 passed** (incl. 11 new)
- `uv run ruff check` + `uv run ruff format --check` → clean
- UI untouched — no changes under `ui/`

## Version policy

`fix:` change, no MAJOR bump, no `!` / BREAKING footer; app version untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)