### PR TITLE
docs: rewrite guides in plain language

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,27 +11,27 @@
   <a href="LICENSE"><img alt="Apache 2.0 license" src="https://img.shields.io/github/license/aerospike-ce-ecosystem/aerospike-cluster-manager?style=flat-square&amp;logo=apache&amp;logoColor=FFC72C&amp;labelColor=0B1F33&amp;color=647283"></a>
 </p>
 
-A web-based GUI management tool for Aerospike Community Edition.
+A web interface for managing Aerospike Community Edition.
 
-Provides cluster monitoring, record browsing, query execution, index management, user/role management, UDF management, and more.
+Use it to monitor clusters, browse records, run queries, and manage indexes, users, roles, and UDFs.
 
 ## Overview
 
 ### Cluster Management
 
-Manage multiple Aerospike cluster connections with color-coded profiles. Create, edit, test, import and export connections.
+Manage several Aerospike clusters with color-coded connection profiles. You can create, edit, test, import, and export each connection.
 
 ![Cluster Management](docs/images/01-clusters.png)
 
 ### Cluster Dashboard
 
-Real-time monitoring with live TPS charts, client connections, read/write success rates, and uptime tracking.
+Monitor live TPS, client connections, read and write success rates, and uptime.
 
 ![Cluster Dashboard](docs/images/02-overview-dashboard.png)
 
 ### Namespaces & Sets
 
-Browse namespaces with memory/device usage, replication factor, HWM thresholds, and navigate into sets.
+Review each namespace's memory and device usage, replication factor, and HWM thresholds. Open a namespace to browse its sets.
 
 ![Namespaces](docs/images/04-namespaces.png)
 
@@ -39,7 +39,7 @@ Browse namespaces with memory/device usage, replication factor, HWM thresholds, 
 
 ### Record Browser
 
-Browse, create, edit, duplicate and delete records with server-side limiting and reload.
+Browse, create, edit, duplicate, and delete records. Server-side limits keep large result sets manageable.
 
 ![Record Browser](docs/images/03-record-browser.png)
 
@@ -57,7 +57,7 @@ Browse, create, edit, duplicate and delete records with server-side limiting and
 
 ### Compose Stack (Quickest)
 
-Run Aerospike Cluster Manager with the checked-in Compose stack. It builds separate API and web containers from `Dockerfile.api` and `Dockerfile.web`. Connection profiles are stored in SQLite — no separate database required.
+The checked-in Compose stack runs Aerospike Cluster Manager with separate API and web containers. It builds them from `Dockerfile.api` and `Dockerfile.web`. SQLite stores connection profiles, so you do not need a separate database.
 
 **Step 1 — Start the stack**
 
@@ -77,9 +77,9 @@ Open **http://localhost:3100** and add a connection with:
 - **Host**: `aerospike-node-1` (container name on the shared network)
 - **Port**: `3000`
 
-Connection profiles are persisted in the Compose `app-data` volume.
+The Compose `app-data` volume keeps connection profiles across restarts.
 
-> **macOS / Windows — connecting to an external Aerospike** — if your Aerospike is running on the host (not in this network), use `host.containers.internal` (Podman) or `host.docker.internal` (Docker) as the host when adding the connection in the UI.
+> **macOS / Windows — connecting to an external Aerospike:** If Aerospike runs on the host instead of the Compose network, enter `host.containers.internal` for Podman or `host.docker.internal` for Docker when you add the connection.
 
 ### Podman Compose (Recommended)
 
@@ -116,19 +116,19 @@ npm run dev                        # http://localhost:3100
 
 ### Local K8s / ACKO Development
 
-To exercise the K8s / ACKO UI (`/k8s/clusters`, `/k8s/templates`) against a real operator without deploying anything to a shared cluster, use `make run-local`:
+Use `make run-local` to test the K8s / ACKO UI (`/k8s/clusters`, `/k8s/templates`) against a real operator without deploying to a shared cluster:
 
 ```bash
 make run-local          # kind (podman) + cert-manager + ACKO operator + Aerospike (compose.dev.yaml)
 ```
 
-The command is idempotent and prints the exact api/ui start commands to run in separate terminals. It sets up:
+You can run this command more than once. It prints the exact API and UI commands for separate terminals and sets up:
 
 - kind cluster named `kind` → kubectl context `kind-kind` (1 control-plane + 3 workers with `topology.kubernetes.io/zone=zone-a/b/c`)
 - cert-manager and the ACKO operator via Helm (CRDs: `aerospikeclusters.acko.io`, `aerospikeclustertemplates.acko.io`)
 - Standalone Aerospike nodes on `localhost:14790/:14791/:14792` (for the non-K8s connection UI)
 
-Start the api with `K8S_MANAGEMENT_ENABLED=true` and the ui as usual; the api's Kubernetes client picks up `~/.kube/config` automatically. Teardown with `make run-local-down`.
+Start the API with `K8S_MANAGEMENT_ENABLED=true`, then start the UI as usual. The API reads `~/.kube/config` automatically. Run `make run-local-down` when you are done.
 
 Related targets: `make kind-up/down/status`, `make acko-install/uninstall/verify`.
 
@@ -198,11 +198,11 @@ Related targets: `make kind-up/down/status`, `make acko-install/uninstall/verify
 
 ## Aerospike Data Management
 
-Beyond Kubernetes cluster lifecycle management, the Aerospike Cluster Manager provides a comprehensive set of tools for interacting with Aerospike data directly from the browser.
+Cluster Manager handles more than the Kubernetes cluster lifecycle. It also lets you work with Aerospike data directly in the browser.
 
 ### Connection Management
 
-Manage multiple Aerospike cluster connections with color-coded profiles. Each connection profile stores the host(s), port, optional cluster name, and credentials. Features include:
+Use color-coded profiles to manage several Aerospike connections. Each profile stores hosts, a port, an optional cluster name, and credentials. You can:
 
 - **Create / Edit / Delete** profiles for different clusters or environments
 - **Test Connection** — Validate connectivity without saving the profile
@@ -276,7 +276,7 @@ Generate deterministic sample data sets for testing and demonstration:
 
 ## Aerospike Data Management API Reference
 
-All data management endpoints are prefixed with `/api` and require a `{conn_id}` parameter identifying the connection profile to use.
+Every data management endpoint starts with `/api`. Pass `{conn_id}` to identify the connection profile for the request.
 
 ### Health API
 
@@ -360,11 +360,11 @@ All data management endpoints are prefixed with `/api` and require a `{conn_id}`
 | ------ | ---------------------------- | --------------------------------------------- |
 | `POST` | `/api/sample-data/{conn_id}` | Generate sample records with optional indexes |
 
-> Interactive API documentation (Swagger UI) is available at `http://localhost:8000/docs` when the api is running.
+> When the API is running, open `http://localhost:8000/docs` for interactive Swagger UI documentation.
 
 ## K8s Cluster Management
 
-When running inside a Kubernetes cluster (or with `K8S_MANAGEMENT_ENABLED=true`), the Aerospike Cluster Manager provides a full GUI for managing `AerospikeCluster` custom resources (`acko.io/v1alpha1`) deployed by the [Aerospike CE Kubernetes Operator](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator).
+When Cluster Manager runs inside Kubernetes, or when `K8S_MANAGEMENT_ENABLED=true`, it can manage `AerospikeCluster` custom resources (`acko.io/v1alpha1`) from the [Aerospike CE Kubernetes Operator](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator).
 
 ### Cluster Lifecycle
 
@@ -437,7 +437,7 @@ When a WarmRestart or PodRestart operation is active, the cluster detail page di
 - **Failed Pods** — Count of pods that encountered errors during the operation, enabling quick identification of issues.
 - **Operation Type** — Indicates whether the active operation is a WarmRestart or PodRestart.
 
-The progress display appears automatically when an operation is in progress and disappears once the operation completes. During active operations, the detail page polls at a higher frequency (every 5 seconds) to keep the status current.
+The progress display appears while an operation runs and disappears when it finishes. During an active operation, the detail page polls every five seconds.
 
 ### Pod Status Details
 
@@ -463,7 +463,7 @@ When a cluster references an AerospikeClusterTemplate, the detail page shows a T
 - **Snapshot Timestamp** — When the template snapshot was captured.
 - **Collapsible Spec Viewer** — Expand to inspect the full template spec that was applied.
 
-If a template is modified after a cluster was created from it, the badge changes to "Out of Sync" and a resync can be triggered via the `POST /api/k8s/clusters/{namespace}/{name}/resync-template` endpoint.
+If you change a template after creating a cluster from it, the badge changes to "Out of Sync." Use `POST /api/k8s/clusters/{namespace}/{name}/resync-template` to resync the cluster.
 
 ### Events Timeline
 
@@ -479,7 +479,7 @@ A circuit breaker health dashboard shows the operator's reconciliation state, in
 
 ### Auto-refresh
 
-The cluster list and detail pages automatically poll for updates when any cluster is in a transitional phase (InProgress, ScalingUp, ScalingDown, WaitingForMigration, RollingRestart, ACLSync, Deleting). The list page polls every 10 seconds; the detail page polls every 5 seconds.
+The cluster list and detail pages poll automatically while a cluster is in a transitional phase (InProgress, ScalingUp, ScalingDown, WaitingForMigration, RollingRestart, ACLSync, Deleting). The list polls every 10 seconds, and the detail page polls every five seconds.
 
 ### Auto-connect
 
@@ -620,7 +620,7 @@ Common use cases include:
 | `GET`    | `/api/k8s/secrets`                                           | List K8s Secrets (for ACL picker)                                                             |
 | `GET`    | `/api/k8s/nodes`                                             | List K8s nodes with zone/region info (for rack config)                                        |
 
-All K8s endpoints are gated by the `K8S_MANAGEMENT_ENABLED` configuration flag. When disabled, a 404 is returned so the UI can hide K8s features gracefully.
+`K8S_MANAGEMENT_ENABLED` controls every K8s endpoint. When it is disabled, the API returns 404 and the UI hides K8s features.
 
 ### Extended Pod Status Fields
 
@@ -761,7 +761,7 @@ pre-commit run --all-files
 
 ## Environment Variables
 
-All environment variables with their defaults and descriptions. See `api/src/aerospike_cluster_manager_api/config.py` for the api source of truth.
+The following tables list environment variables, defaults, and descriptions. See `api/src/aerospike_cluster_manager_api/config.py` for the API source of truth.
 
 ### Aerospike Connection
 
@@ -835,7 +835,7 @@ All environment variables with their defaults and descriptions. See `api/src/aer
 
 ### Split Container Deployment
 
-The project builds standalone API and web images from `Dockerfile.api` and `Dockerfile.web`. Both containers run as a non-root user (`appuser`) and expose one port each:
+The project builds standalone API and web images from `Dockerfile.api` and `Dockerfile.web`. Each container runs as the non-root `appuser` and exposes one port:
 
 - **Port 3100** — UI (Next.js standalone)
 - **Port 8000** — API (Uvicorn)
@@ -863,13 +863,13 @@ A built-in health check (`/api/health`) is configured with a 10-second interval 
 
 ### Production Environment
 
-For production, configure the environment variables listed in the [Environment Variables](#environment-variables) section above. Key settings to review: `CORS_ORIGINS` (must match your domain), `LOG_FORMAT` (set to `json` for structured logging), and `K8S_MANAGEMENT_ENABLED` (set to `true` when deploying inside Kubernetes).
+For production, review the [environment variables](#environment-variables). Set `CORS_ORIGINS` to your domain, use `LOG_FORMAT=json` for structured logs, and set `K8S_MANAGEMENT_ENABLED=true` when you deploy inside Kubernetes.
 
 Inside the container, `SQLITE_PATH` defaults to `/app/data/connections.db`. Mount a volume to `/app/data` to persist data across container restarts.
 
 ### Database Setup
 
-Connection profiles are persisted in **SQLite by default** — no external database required. The SQLite file is written to `SQLITE_PATH` (defaults to `/app/data/connections.db` inside the container).
+By default, **SQLite** stores connection profiles and needs no external database. The API writes the SQLite file to `SQLITE_PATH`, which defaults to `/app/data/connections.db` in the container.
 
 **SQLite (default):**
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@
 
 # Documentation
 
-Guides for the Aerospike Cluster Manager.
+Use these guides to configure, operate, and troubleshoot Aerospike Cluster Manager.
 
 - [Architecture Overview](./architecture.md) -- System architecture, component roles, deployment models, and environment configuration.
 - [Data Management Guide](./data-management.md) -- Connection management, record browser, query builder, indexes, ACL, UDFs, and metrics.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,10 +1,10 @@
 # Architecture Guide
 
-This document describes how the Aerospike Cluster Manager integrates with the Aerospike CE Kubernetes Operator and the broader Kubernetes ecosystem.
+This guide explains how Aerospike Cluster Manager works with the Aerospike CE Kubernetes Operator and Kubernetes.
 
 ## System Overview
 
-The Aerospike Cluster Manager is a web-based GUI that provides two primary capabilities:
+Aerospike Cluster Manager has two main responsibilities:
 
 1. **Aerospike Data Management** -- Direct interaction with Aerospike clusters (record browsing, queries, index management, ACL, UDFs, metrics).
 2. **Kubernetes Cluster Lifecycle Management** -- Full GUI for managing `AerospikeCluster` and `AerospikeClusterTemplate` custom resources deployed by the Aerospike CE Kubernetes Operator.
@@ -82,23 +82,23 @@ The Aerospike Cluster Manager is a web-based GUI that provides two primary capab
 
 ### Aerospike CE Kubernetes Operator
 
-The operator is a separate project ([aerospike-ce-kubernetes-operator](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator)) that runs as a controller-manager in the Kubernetes cluster. It:
+The operator is a separate project: [aerospike-ce-kubernetes-operator](https://github.com/aerospike-ce-ecosystem/aerospike-ce-kubernetes-operator). It runs as a controller-manager in the Kubernetes cluster and:
 
 - Watches `AerospikeCluster` custom resources (CRD group: `acko.io`, version: `v1alpha1`).
 - Reconciles the desired state into Kubernetes primitives (StatefulSets, Services, ConfigMaps, NetworkPolicies, etc.).
 - Reports cluster phase, conditions, pod status, and operation progress back into the CR status.
 - Supports `AerospikeClusterTemplate` as cluster-scoped resources for reusable configuration presets.
 
-The Cluster Manager UI reads these status fields and displays them as dashboards, progress bars, and health indicators.
+Cluster Manager reads these status fields and presents them as dashboards, progress bars, and health indicators.
 
 ## Communication Flow
 
 ### K8s Cluster Creation (example)
 
-1. User fills out the multi-step wizard in the UI.
-2. UI sends `POST /api/k8s/clusters` with the `CreateK8sClusterRequest` payload.
-3. API's `k8s_clusters.py` router validates the request and calls `build_cr()` to construct the AerospikeCluster CR manifest.
-4. API calls `k8s_client.create_cluster(namespace, cr)` which submits the CR to the Kubernetes API via `CustomObjectsApi.create_namespaced_custom_object()`.
+1. The user completes the multi-step wizard in the UI.
+2. The UI sends `POST /api/k8s/clusters` with the `CreateK8sClusterRequest` payload.
+3. The `k8s_clusters.py` router validates the request and calls `build_cr()` to build the AerospikeCluster CR manifest.
+4. The API calls `k8s_client.create_cluster(namespace, cr)`. This method submits the CR through `CustomObjectsApi.create_namespaced_custom_object()`.
 5. The operator detects the new CR and begins reconciliation (creating StatefulSet, Services, etc.).
 6. The UI polls `GET /api/k8s/clusters/{namespace}/{name}` to track the cluster phase as it transitions through `InProgress` -> `Completed`.
 7. If auto-connect was enabled, the API also creates a connection profile pointing to the cluster's headless service DNS name (`<name>.<namespace>.svc.cluster.local`).
@@ -116,7 +116,7 @@ The Cluster Manager interacts with two CRD types:
 
 ### Standalone (Podman Compose)
 
-For local development or non-Kubernetes environments, the Cluster Manager runs as a container alongside Aerospike nodes and PostgreSQL. K8s management is disabled by default (`K8S_MANAGEMENT_ENABLED=false`). Only data management features are available.
+For local development or non-Kubernetes environments, run Cluster Manager in containers beside Aerospike nodes and PostgreSQL. K8s management is off by default (`K8S_MANAGEMENT_ENABLED=false`), so only data management features are available.
 
 ```bash
 podman compose -f compose.yaml up --build
@@ -124,7 +124,7 @@ podman compose -f compose.yaml up --build
 
 ### Inside Kubernetes (with operator)
 
-When deployed inside a Kubernetes cluster alongside the Aerospike CE Operator, set `K8S_MANAGEMENT_ENABLED=true`. The API automatically loads in-cluster Kubernetes config and uses the pod's service account for API access.
+Set `K8S_MANAGEMENT_ENABLED=true` when you deploy Cluster Manager beside the Aerospike CE Operator. The API loads the in-cluster Kubernetes configuration and uses the pod's service account.
 
 **Required RBAC permissions** for the service account:
 
@@ -145,7 +145,7 @@ The operator's Helm chart can deploy the Cluster Manager as a sidecar or standal
 
 ### Deployment via Operator Helm Chart
 
-The recommended production deployment for Kubernetes uses the operator's Helm chart with the UI component enabled:
+For production on Kubernetes, use the operator's Helm chart with the UI enabled:
 
 ```yaml
 # values.yaml
@@ -169,7 +169,7 @@ ui:
     K8S_LOG_TIMEOUT: "30"
 ```
 
-This deploys the Cluster Manager as a Deployment with:
+This configuration deploys Cluster Manager with:
 - A ServiceAccount with the required RBAC permissions
 - An Ingress or Service for external access
 - Environment variables preconfigured for in-cluster operation
@@ -177,11 +177,11 @@ This deploys the Cluster Manager as a Deployment with:
 
 ## Database Backend
 
-The Aerospike Cluster Manager supports two database backends for persisting connection profiles and application state.
+Cluster Manager can store connection profiles and application state in SQLite or PostgreSQL.
 
 ### SQLite (Default)
 
-SQLite is the default database backend. It requires no external service and works out of the box. The API creates the database file automatically on first startup.
+SQLite is the default. It needs no external service, and the API creates the database file on first startup.
 
 - **WAL mode** is enabled for better read concurrency. Multiple readers can access the database simultaneously while a single writer holds a lock, making it suitable for typical single-instance deployments.
 - **File path** is configurable via the `SQLITE_PATH` environment variable (default: `./data/connections.db`).
@@ -189,7 +189,7 @@ SQLite is the default database backend. It requires no external service and work
 
 ### PostgreSQL (Opt-in)
 
-PostgreSQL can be enabled by setting `ENABLE_POSTGRES=true` and providing a `DATABASE_URL` connection string. This is recommended for high-availability or multi-instance deployments.
+For high-availability or multi-instance deployments, set `ENABLE_POSTGRES=true` and provide `DATABASE_URL` to use PostgreSQL.
 
 ```bash
 ENABLE_POSTGRES=true

--- a/docs/data-management.md
+++ b/docs/data-management.md
@@ -1,10 +1,10 @@
 # Aerospike Data Management Guide
 
-This guide covers the data-oriented features of the Aerospike Cluster Manager for interacting with Aerospike clusters directly.
+This guide explains how to work directly with Aerospike data in Cluster Manager.
 
 ## Connection Management
 
-The home page (`/`) displays all saved connection profiles. Each connection is represented by a color-coded card with a live health indicator.
+The home page (`/`) lists saved connection profiles. Each color-coded card includes a live health indicator.
 
 ### Connection Profiles
 
@@ -40,13 +40,13 @@ The cluster overview page (`/cluster/{connId}`) shows:
 
 ## Record Browser
 
-The record browser (`/browser/{connId}`) provides a spreadsheet-like data grid for browsing Aerospike records.
+The record browser (`/browser/{connId}`) displays Aerospike records in a spreadsheet-like grid.
 
 ### Navigation
 
 1. Select a namespace from the namespace list.
 2. Select a set within the namespace.
-3. Records are displayed in a paginated data grid with configurable page size (up to 500).
+3. Browse the records in a paginated grid. You can set the page size up to 500.
 
 ### CRUD Operations
 
@@ -66,11 +66,11 @@ Scan records with expression-based filters:
 
 ### Batch Read
 
-Retrieve multiple records by primary key in a single request. Enter a list of primary keys and the batch read returns all matching records.
+Enter several primary keys to retrieve matching records in one batch request.
 
 ## Query Builder
 
-The Query Builder is not a separate route -- it is accessed via the **query toolbar** on the Record Browser page (`/browser/{connId}`). It supports three query strategies:
+Open the Query Builder from the **query toolbar** on the Record Browser page (`/browser/{connId}`). It is not a separate route. Choose one of three query strategies:
 
 1. **Primary Key Lookup** -- Direct record retrieval by namespace, set, and primary key. Integer keys are auto-detected.
 2. **Predicate Query** -- Filter records using secondary index predicates (equality match, range query) on indexed bins.
@@ -83,7 +83,7 @@ All strategies support:
 
 ## Secondary Index Management
 
-The indexes page (`/indexes/{connId}`) manages secondary indexes on Aerospike bins.
+Use the indexes page (`/indexes/{connId}`) to manage secondary indexes on Aerospike bins.
 
 - **Create Index** -- Define indexes on numeric, string, or geo2dsphere bin types for any namespace/set/bin combination.
 - **Delete Index** -- Remove indexes by name from a given namespace.
@@ -91,7 +91,7 @@ The indexes page (`/indexes/{connId}`) manages secondary indexes on Aerospike bi
 
 ## User & Role Management (ACL)
 
-The admin page (`/admin/{connId}`) manages Aerospike access control lists. Requires security to be enabled in `aerospike.conf`.
+Use the admin page (`/admin/{connId}`) to manage Aerospike access control lists. Enable security in `aerospike.conf` first.
 
 ### Users
 
@@ -106,7 +106,7 @@ The admin page (`/admin/{connId}`) manages Aerospike access control lists. Requi
 - Create roles with granular privileges (per-namespace, per-set permissions) and CIDR-based allowlists.
 - Delete unused roles.
 
-A CE limitation banner is shown when security features are not available.
+When security is unavailable, the page shows a CE limitation banner.
 
 ## UDF Management
 
@@ -129,7 +129,7 @@ The cluster dashboard provides real-time metrics with historical time-series dat
 
 ## Sample Data Generator
 
-Generate deterministic sample data for testing and demonstration:
+Create deterministic sample data for tests and demonstrations:
 
 - **Record Generation** -- Create a configurable number of sample records in any namespace/set.
 - **Secondary Indexes** -- Optionally create indexes on sample data bins.

--- a/docs/k8s-management.md
+++ b/docs/k8s-management.md
@@ -1,6 +1,6 @@
 # Kubernetes Cluster Management Guide
 
-This guide covers the Kubernetes cluster lifecycle management features of the Aerospike Cluster Manager, including the creation wizard, template management, operations, and monitoring.
+This guide explains how to create, monitor, and operate Kubernetes clusters with Aerospike Cluster Manager. It also covers templates and day-two operations.
 
 ## Prerequisites
 
@@ -10,7 +10,7 @@ This guide covers the Kubernetes cluster lifecycle management features of the Ae
 
 ## Cluster Creation Wizard
 
-The wizard guides you through creating an AerospikeCluster resource in up to 10 steps. You can start from scratch or use a template.
+The wizard creates an AerospikeCluster resource in up to 10 steps. Start with an empty configuration or an existing template.
 
 ### Step 0: Creation Mode
 
@@ -47,7 +47,7 @@ For persistent storage, each volume supports:
 | Wipe Method | Volume cleanup method |
 | Cascade Delete | Delete PVC when cluster is deleted |
 
-Multiple volumes can be configured independently with different storage classes and sizes.
+You can give each volume its own storage class and size.
 
 ### Step 3: Monitoring & Options
 
@@ -97,7 +97,7 @@ Configure multi-rack deployments for topology-aware data placement:
 
 ### Step 8: Sidecars & Init Containers
 
-Add custom sidecar containers (e.g., log shippers, backup agents) and init containers (e.g., data loaders, certificate generators) with full configuration: image, command, args, env, volume mounts, and resources.
+Add sidecars such as log shippers and backup agents, or init containers such as data loaders and certificate generators. Configure their image, command, arguments, environment, volume mounts, and resources.
 
 ### Step 9: Advanced Configuration
 
@@ -125,7 +125,7 @@ Add custom sidecar containers (e.g., log shippers, backup agents) and init conta
 
 ### Step 10: Review
 
-Summary of all configured settings. The wizard displays the full configuration including Seeds Finder Services, storage volumes, monitoring, and ACL before submission.
+Review every setting before you submit the resource. The summary includes Seeds Finder Services, storage volumes, monitoring, and ACL.
 
 ### Image Validation
 
@@ -134,11 +134,11 @@ The wizard and edit dialog enforce CE-specific image validation on the Aerospike
 - **Enterprise image rejection** -- Images containing `enterprise` in the name, or tags prefixed with `ee-` or `ent-`, are rejected with a clear error message. The CE operator only supports Community Edition images (e.g., `aerospike:ce-8.1.1.1`).
 - **Minimum version** -- Only Aerospike CE 8.x and above are supported. Images with tags indicating CE 7.x or earlier are rejected.
 
-These validations run client-side before submission and are also enforced server-side by the operator's webhook.
+The UI runs these checks before submission. The operator webhook enforces them again on the server.
 
 ## Cluster Operations
 
-From the cluster detail page (`/k8s/clusters/{namespace}/{name}`), the following operations are available:
+Open `/k8s/clusters/{namespace}/{name}` to run these operations:
 
 ### Scale
 
@@ -173,7 +173,7 @@ The edit dialog now performs early validation before sending updates to the oper
 
 #### Rack Config Edit in Edit Dialog
 
-After a cluster is created, rack topology can be fully edited through the Edit dialog. This enables operators to adjust data placement, add new availability zones, or remove racks without recreating the cluster.
+After cluster creation, use the Edit dialog to change rack topology. You can adjust data placement, add availability zones, or remove racks without recreating the cluster.
 
 **Adding and removing racks:**
 
@@ -217,7 +217,7 @@ The following settings apply to all racks and control batch operations during ra
 
 #### Node Blocklist Picker
 
-The Edit dialog includes an interactive node blocklist picker that replaces manual text input with a visual node selection interface.
+The Edit dialog provides a node blocklist picker, so you can select nodes instead of entering names manually.
 
 **How the picker works:**
 
@@ -231,7 +231,7 @@ The Edit dialog includes an interactive node blocklist picker that replaces manu
 
 **Fallback behavior:**
 
-If the node list cannot be fetched (e.g., due to RBAC restrictions or network issues), the picker falls back to a plain text input field where node names can be entered manually, one per line.
+If RBAC or network problems prevent the node list from loading, enter node names in the fallback text field, one per line.
 
 **Visual indicators:**
 
@@ -240,7 +240,7 @@ If the node list cannot be fetched (e.g., due to RBAC restrictions or network is
 
 #### Rack Revision
 
-Each rack has an optional **Revision** field (a free-form string, e.g., `rev-1`, `restart-20260322`). Changing the revision value for a rack signals the operator to perform a rolling restart of the pods in that rack, even when no other configuration has changed. This is useful when you need to force a restart of a specific rack -- for example, after an external dependency update or to pick up a new node image -- without affecting the rest of the cluster.
+Each rack has an optional **Revision** field for a free-form value such as `rev-1` or `restart-20260322`. Changing it tells the operator to restart that rack's pods, even when no other configuration changed. Use this field to restart one rack after an external dependency or node image update without affecting the rest of the cluster.
 
 To trigger a rack-specific rolling restart:
 
@@ -277,7 +277,7 @@ The Edit dialog includes a **Container Security Context** section that configure
 
 ### HPA (Horizontal Pod Autoscaler)
 
-The HPA dialog provides full lifecycle management for Kubernetes HorizontalPodAutoscaler resources targeting the AerospikeCluster:
+Use the HPA dialog to create, inspect, update, and delete a Kubernetes HorizontalPodAutoscaler for the AerospikeCluster:
 
 **Creating an HPA:**
 
@@ -318,7 +318,7 @@ The dialog shows the current HPA state including current/desired replicas and sc
 
 **Operation in-progress guard:**
 
-The **Warm Restart** and **Pod Restart** buttons in the cluster detail page toolbar are automatically disabled when another operation is already in progress. This prevents accidental double-operations that could disrupt the cluster. The buttons re-enable once the active operation completes or is cleared.
+The toolbar disables **Warm Restart** and **Pod Restart** while another operation is active. This prevents overlapping operations. The buttons return when the active operation finishes or is cleared.
 
 **Pod-level operation selection:**
 
@@ -343,7 +343,7 @@ When an operation is active, the cluster detail page displays real-time progress
 - The operation type indicator (WarmRestart or PodRestart).
 - The target pod list when specific pods were selected.
 
-The progress display appears automatically during active operations and the detail page polls every 5 seconds.
+The progress display appears during an active operation, and the detail page polls every five seconds.
 
 **API endpoint:**
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,15 +1,13 @@
 # Logging
 
-The API server uses Python's standard ``logging`` module. The default
-configuration emits a single stdout handler with either text or JSON
-output (selected by ``LOG_FORMAT``).
+The API uses Python's standard ``logging`` module. By default, one stdout
+handler writes text or JSON, as selected by ``LOG_FORMAT``.
 
-External log routing — PII redaction, sampling, field enrichment,
-vendor-specific exporters (Datadog, Loki, Elasticsearch, Sentry, ...) —
-is delegated to an **OpenTelemetry Collector** that receives this
-process's logs. Any transform pipeline lives in the Collector
-configuration, so operators swap backends from helm values alone
-without touching the application image.
+An **OpenTelemetry Collector** handles external routing, PII redaction,
+sampling, field enrichment, and vendor exporters such as Datadog, Loki,
+Elasticsearch, and Sentry. Keep transformation pipelines in the Collector
+configuration. Operators can then change backends through Helm values without
+rebuilding the application image.
 
 ## Architecture
 
@@ -28,15 +26,14 @@ without touching the application image.
                                          Tempo / Sentry                    your-vendor-bridge
 ```
 
-The OTel Collector itself is **not** deployed by the ACKO helm chart —
-the assumption is that the cluster already has one (a DaemonSet for
-node-level, a Deployment for namespace-level, or one per-namespace
-when isolation matters). The chart only opt-in deploys the **sidecar
-that forwards to it**.
+The ACKO Helm chart does **not** deploy the OTel Collector. It assumes the
+cluster already has a node-level DaemonSet, a namespace-level Deployment, or
+one Collector per namespace when isolation matters. The chart can optionally
+deploy the **sidecar that forwards logs to the Collector**.
 
 ## Modes
 
-Two modes:
+Choose one of two modes:
 
 1. **Default — stdout only**
    A single ``StreamHandler(sys.stdout)`` with the existing
@@ -84,9 +81,9 @@ The chart pre-bakes a fluent-bit config that:
 - forwards records to ``otlp.endpoint`` via the ``opentelemetry`` output
 - propagates ``otlp.headers`` as OTLP HTTP/gRPC metadata
 
-Operators who need a different shipper (vector, promtail, vendor agent)
-can override ``sidecar.image`` and ``sidecar.config.content`` — the
-schema is documented in the ACKO chart's ``values.yaml``.
+To use another shipper, such as vector, promtail, or a vendor agent, override
+``sidecar.image`` and ``sidecar.config.content``. The ACKO chart's
+``values.yaml`` documents the schema.
 
 ## OpenTelemetry trace correlation
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,13 +1,11 @@
 # Observability (OpenTelemetry)
 
-The API server emits OpenTelemetry **traces, metrics, and logs** when
-``OTEL_SDK_DISABLED=false`` is set. Defaults are off — there is zero
-runtime cost when the variable is at its default and OTel API calls fall
-back to NoOp providers.
+Set ``OTEL_SDK_DISABLED=false`` to make the API emit OpenTelemetry **traces,
+metrics, and logs**. OpenTelemetry is off by default, so API calls use NoOp
+providers and add no runtime cost.
 
-All exporter / sampler / resource configuration uses the **OTel SDK
-standard environment variables**. The API does not introduce wrapper
-variables for any of them.
+Configure exporters, samplers, and resources with the **standard OTel SDK
+environment variables**. The API does not add wrapper variables.
 
 ## Quick start: send everything to a local collector
 
@@ -19,7 +17,7 @@ full stack with OTel turned on:
 OTEL_SDK_DISABLED=false podman compose --profile observability up
 ```
 
-Then tail the collector to watch every signal arrive:
+Then follow the Collector logs to confirm that signals arrive:
 
 ```bash
 podman logs -f otel-collector
@@ -41,7 +39,7 @@ OTEL_SERVICE_NAME=aerospike-cluster-manager-api \
 uvicorn aerospike_cluster_manager_api.main:app --host 0.0.0.0 --port 8000
 ```
 
-Open the collector logs and you will see:
+The Collector logs show:
 
 - HTTP server spans for every API request (``/api/v1/clusters/...`` etc.)
 - ``aerospike.<op>`` spans for every Aerospike operation — emitted by
@@ -76,8 +74,8 @@ The exporter selection in the API picks the right module per
 
 ## aerospike-py native instrumentation
 
-ACM's Aerospike client, ``aerospike-py``, runs an async Rust core. That core
-carries its own observability surface, and ACM opts into both halves of it.
+The ``aerospike-py`` client uses an asynchronous Rust core with its own
+observability surface. ACM enables both parts of that surface.
 
 ### Traces — ``aerospike.<op>`` spans
 
@@ -116,9 +114,9 @@ like any other ACM log line. ``shutdown_observability()`` additionally surfaces
 | ``AEROSPIKE_PY_LOG_LEVEL`` | Verbosity of the aerospike-py Rust-core log bridge. Accepts standard level names (``DEBUG``, ``INFO``, ``WARNING``, ``ERROR``) plus ``TRACE`` and ``OFF``. Kept separate from ``LOG_LEVEL`` because the core is very chatty at ``DEBUG``/``TRACE``. | value of ``LOG_LEVEL`` |
 | ``AEROSPIKE_PY_TRACING`` | Start aerospike-py's native OTLP span exporter. Only takes effect when OTel is enabled; set falsy to suppress the high-volume per-operation spans. | ``true`` |
 
-All aerospike-py observability calls are best-effort: a failure in
-``init_tracing``, ``set_log_level``, or ``shutdown_tracing`` is caught and
-logged as a warning — it never blocks ACM startup or shutdown.
+All aerospike-py observability calls are best effort. ACM catches failures in
+``init_tracing``, ``set_log_level``, or ``shutdown_tracing`` and logs a
+warning. These failures never block startup or shutdown.
 
 ## Custom metrics emitted
 
@@ -181,8 +179,7 @@ http.server
     └── (no aerospike-py spans — k8s-only flow)
 ```
 
-This shape is what makes the trace useful for diagnosing both
-**aerospike-py behaviour** (how many retries did one op produce, what was
-the cluster-tend latency at the moment of failure) and **cluster-manager
-internal flow** (where in our handler chain time was spent, whether a 500
-came from k8s API or from our own validation).
+This trace shape helps diagnose both **aerospike-py behavior** and
+**Cluster Manager's internal flow**. You can see retry counts and cluster-tend
+latency, find slow handlers, and tell whether a 500 came from the K8s API or
+from Cluster Manager validation.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,6 +1,6 @@
 # Troubleshooting Guide
 
-Common issues and their solutions when running the Aerospike Cluster Manager.
+Use this guide to diagnose common Aerospike Cluster Manager problems.
 
 ## Connection Issues
 
@@ -318,7 +318,7 @@ See the [Architecture Guide](./architecture.md) for a complete RBAC configuratio
 
 ### Migrating from SQLite to PostgreSQL
 
-When scaling from a single-instance deployment to a multi-replica setup, you may need to migrate data from SQLite to PostgreSQL.
+Move from SQLite to PostgreSQL when you scale a single-instance deployment to several replicas.
 
 **Steps:**
 
@@ -334,7 +334,7 @@ When scaling from a single-instance deployment to a multi-replica setup, you may
 
 3. **Start the backend with PostgreSQL** -- Set `ENABLE_POSTGRES=true` and `DATABASE_URL` to point to the new database. The backend will create the required tables on startup.
 
-4. **Re-create connection profiles** -- Connection profiles can be re-created via the UI or by importing a previously exported JSON backup. The SQLite and PostgreSQL schemas are identical, but SQL dialect differences (e.g., autoincrement syntax) make direct SQL import unreliable. Using the application-level import/export feature is the safest approach.
+4. **Re-create connection profiles** -- Use the UI or import a JSON backup. Although SQLite and PostgreSQL use the same application schema, SQL dialect differences such as autoincrement syntax make direct SQL import unreliable. Prefer the application's import and export feature.
 
 ### Migrating from PostgreSQL to SQLite
 
@@ -353,7 +353,7 @@ To simplify a deployment by removing the PostgreSQL dependency:
 
 **Possible causes and solutions:**
 
-1. **Actual split-brain** -- Network partitions can cause Aerospike nodes to form separate sub-clusters. Each sub-cluster thinks it is the full cluster, leading to data inconsistency. Check Aerospike server logs for heartbeat timeout messages and verify network connectivity between all pods:
+1. **Actual split-brain** -- A network partition can split Aerospike nodes into separate sub-clusters and cause inconsistent data. Check server logs for heartbeat timeouts and verify network connectivity between pods:
    ```bash
    kubectl exec -n <namespace> <pod-name> -- asinfo -v "cluster-stable:"
    ```
@@ -362,7 +362,7 @@ To simplify a deployment by removing the PostgreSQL dependency:
 
 3. **Node rejoining** -- If a node recently restarted or rejoined, the reported cluster size may temporarily lag behind the actual cluster state. The split-brain flag should clear on the next health poll once all nodes converge.
 
-**Note:** Split-brain detection is intentionally suppressed during transitional phases (`InProgress`, `ScalingUp`, `ScalingDown`, `RollingRestart`, etc.) and when not all expected pods are ready, to avoid false positives.
+**Note:** To avoid false positives, Cluster Manager suppresses split-brain detection during transitional phases (`InProgress`, `ScalingUp`, `ScalingDown`, `RollingRestart`, etc.) and while expected pods are not ready.
 
 ## Circuit Breaker Stuck
 
@@ -372,7 +372,7 @@ To simplify a deployment by removing the PostgreSQL dependency:
 
 **Possible causes and solutions:**
 
-1. **Repeated reconciliation failures** -- The operator trips the circuit breaker after reaching the failure threshold to prevent rapid retry loops. Check the "Last reconcile error" field in the health card for the root cause (e.g., invalid CR spec, missing secrets, storage provisioning errors).
+1. **Repeated reconciliation failures** -- The operator trips the circuit breaker at the failure threshold to stop rapid retries. Check "Last reconcile error" in the health card for the cause, such as an invalid CR spec, missing secret, or storage provisioning error.
 
 2. **Transient issue resolved** -- If the underlying issue has been fixed (e.g., a missing secret was created, a node came back online), click the **Reset Circuit Breaker** button on the reconciliation health card or call the API directly:
    ```bash
@@ -389,7 +389,7 @@ To simplify a deployment by removing the PostgreSQL dependency:
 
 **Possible causes and solutions:**
 
-1. **Expected behavior** -- Kubernetes StatefulSet PVCs are intentionally retained after scale-down to preserve data. If you scale back up, the PVCs will be reattached to the new pods automatically.
+1. **Expected behavior** -- Kubernetes keeps StatefulSet PVCs after scale-down to preserve data. If you scale up again, Kubernetes attaches the PVCs to the new pods.
 
 2. **Manual cleanup needed** -- If the scale-down is permanent and you want to reclaim storage, delete the orphaned PVCs manually:
    ```bash
@@ -402,7 +402,7 @@ To simplify a deployment by removing the PostgreSQL dependency:
 
 - **Check api logs** -- The API logs detailed error information. Set `LOG_LEVEL=DEBUG` for verbose output.
 - **Use the health endpoint** -- `GET /api/health?detail=true` returns component-level health status including database connectivity.
-- **Verify environment variables** -- Many issues stem from misconfigured environment variables. Double-check `K8S_MANAGEMENT_ENABLED`, `DATABASE_URL`, and `CORS_ORIGINS`. See the [Architecture Guide](./architecture.md#environment-configuration) for the full variable reference.
+- **Verify environment variables** -- Check `K8S_MANAGEMENT_ENABLED`, `DATABASE_URL`, and `CORS_ORIGINS`. See the [Architecture Guide](./architecture.md#environment-configuration) for the full variable reference.
 - **Inspect Kubernetes events** -- The events timeline in the UI (or `kubectl get events`) provides operator-level diagnostic information.
 - **Check operator logs** -- For K8s management issues, the operator logs often contain the root cause. Look at the operator pod logs in the operator's namespace.
 - **Tune timeouts** -- For slow environments, adjust `K8S_API_TIMEOUT`, `K8S_LOG_TIMEOUT`, and `DB_COMMAND_TIMEOUT` as needed.


### PR DESCRIPTION
## Summary

- rewrite the README and user-facing guides in clear, natural English
- simplify dense sentences while preserving Aerospike, Kubernetes, API, and observability terminology
- keep commands, headings, code blocks, and link destinations unchanged

## Validation

- git diff --check
- heading sequence comparison against main
- fenced-code-block count comparison against main
- Markdown link destination comparison against main

Documentation-only change; no API or runtime behavior changes.