### PR TITLE
fix(api): stop namespace config from resetting omitted params on a live namespace

### DIFF
--- a/api/src/aerospike_cluster_manager_api/constants.py
+++ b/api/src/aerospike_cluster_manager_api/constants.py
@@ -62,6 +62,17 @@ NS_SUM_KEYS = frozenset(
     }
 )
 
+# Namespace tunables reachable through POST /clusters/{conn_id}/namespaces,
+# mapped from CreateNamespaceRequest field name to its asinfo set-config
+# parameter name. Insertion order is the order parameters appear in the
+# emitted command. Adding an entry widens what that endpoint can change on a
+# live namespace — the model field must be Optional so that omitting it
+# leaves the running value untouched.
+NS_CONFIG_PARAMS: dict[str, str] = {
+    "memorySize": "memory-size",
+    "replicationFactor": "replication-factor",
+}
+
 # Cache TTLs (seconds)
 INFO_CACHE_TTL_STATIC = 60.0  # build, edition — rarely change at runtime
 INFO_CACHE_TTL_VOLATILE = 5.0  # statistics, namespace/*, sets/* — balances freshness vs load

--- a/api/src/aerospike_cluster_manager_api/models/cluster.py
+++ b/api/src/aerospike_cluster_manager_api/models/cluster.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class ClusterNode(BaseModel):
@@ -55,9 +55,25 @@ class ClusterInfo(BaseModel):
 
 
 class CreateNamespaceRequest(BaseModel):
+    """Partial ``set-config`` update for an existing namespace.
+
+    Every tunable is ``None``-by-default and only the fields actually
+    supplied are sent to the cluster — see
+    ``clusters_service.configure_namespace``. Defaults here would be
+    *applied*, not ignored: a default ``memorySize`` would dynamically
+    shrink whatever the operator has running, so omission must mean
+    "leave alone" rather than "reset to our guess". Mirrors
+    :class:`models.connection.UpdateConnectionRequest`.
+
+    ``extra="forbid"`` for the same reason: a misspelled ``memory_size``
+    must 422 rather than silently reach the wire as a no-op field.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
     name: str = Field(min_length=1, pattern=r"^[a-zA-Z0-9_-]{1,63}$")
-    memorySize: int = Field(default=1_073_741_824, ge=1_000_000)  # min 1 MB
-    replicationFactor: int = Field(default=2, ge=1, le=8)
+    memorySize: int | None = Field(default=None, ge=1_000_000)  # min 1 MB
+    replicationFactor: int | None = Field(default=None, ge=1, le=8)
 
 
 class ExecuteInfoRequest(BaseModel):

--- a/api/src/aerospike_cluster_manager_api/routers/clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/clusters.py
@@ -17,6 +17,7 @@ from aerospike_cluster_manager_api.models.common import MessageResponse
 from aerospike_cluster_manager_api.rate_limit import limiter
 from aerospike_cluster_manager_api.services import clusters_service
 from aerospike_cluster_manager_api.services.clusters_service import (
+    NamespaceConfigEmptyError,
     NamespaceConfigError,
     NamespaceNotFoundError,
     NodeNotFoundError,
@@ -43,7 +44,13 @@ async def get_cluster(client: AerospikeClient, conn_id: VerifiedConnId) -> Clust
     status_code=200,
     response_model=MessageResponse,
     summary="Configure namespace",
-    description="Update runtime-tunable parameters of an existing Aerospike namespace.",
+    description=(
+        "Update runtime-tunable parameters of an existing Aerospike namespace. "
+        "Partial update: only the parameters present in the body are applied, "
+        "an omitted parameter keeps its running value, and a body naming no "
+        "parameter at all is rejected with 400. Unknown fields are rejected "
+        "with 422 so a misspelled parameter cannot look like a success."
+    ),
 )
 @limiter.limit("10/minute")
 async def configure_namespace(
@@ -52,6 +59,8 @@ async def configure_namespace(
     """Update runtime-tunable parameters of an existing Aerospike namespace."""
     try:
         message = await clusters_service.configure_namespace(client, body)
+    except NamespaceConfigEmptyError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except NamespaceNotFoundError as exc:
         raise HTTPException(
             status_code=400,

--- a/api/src/aerospike_cluster_manager_api/services/clusters_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/clusters_service.py
@@ -33,6 +33,7 @@ from aerospike_cluster_manager_api.constants import (
     INFO_NAMESPACES,
     INFO_SERVICE,
     INFO_STATISTICS,
+    NS_CONFIG_PARAMS,
     NS_SUM_KEYS,
     info_namespace,
     info_sets,
@@ -86,6 +87,21 @@ class NamespaceConfigError(ValueError):
         super().__init__(f"Failed to configure namespace '{namespace}': {response}")
         self.namespace = namespace
         self.response = response
+
+
+class NamespaceConfigEmptyError(ValueError):
+    """Raised when a namespace config request supplies no tunable field.
+
+    ``set-config`` with only ``context``/``id`` and no parameter is not a
+    meaningful call, and silently succeeding would tell the caller their
+    (misspelled, dropped, or forgotten) parameter was applied. The
+    message names the settable fields so the caller can fix the body
+    without consulting the schema.
+    """
+
+    def __init__(self, settable: tuple[str, ...]) -> None:
+        super().__init__("No namespace parameter to apply; supply at least one of: " + ", ".join(settable))
+        self.settable = settable
 
 
 # ---------------------------------------------------------------------------
@@ -424,7 +440,16 @@ async def configure_namespace(client: aerospike_py.AsyncClient, body: CreateName
     be defined in ``aerospike.conf`` and the server restarted.  This call
     only updates parameters on a namespace that already exists.
 
+    The emitted command carries **only the fields the caller actually
+    supplied**. ``set-config`` is applied to a live namespace, so a field
+    we fill in ourselves is a real config change: interpolating a default
+    ``memory-size`` shrinks the namespace's memory ceiling below its
+    current usage, crossing the stop-writes / eviction thresholds. Omission
+    therefore means "leave this parameter alone", and a request that names
+    no parameter at all is rejected rather than sent as a no-op.
+
     Raises:
+        NamespaceConfigEmptyError: no tunable field was supplied.
         NamespaceNotFoundError: ``body.name`` is not a known namespace.
         NamespaceConfigError: the cluster rejected the ``set-config`` call.
 
@@ -432,15 +457,21 @@ async def configure_namespace(client: aerospike_py.AsyncClient, body: CreateName
         A success message suitable for direct inclusion in an HTTP
         response.
     """
+    # exclude_unset keeps omitted fields out; the None filter also drops an
+    # explicit `"memorySize": null`, which is "unset" in intent but "set"
+    # to Pydantic.
+    supplied = body.model_dump(exclude_unset=True, by_alias=False)
+    params = [
+        f"{param}={supplied[field]}" for field, param in NS_CONFIG_PARAMS.items() if supplied.get(field) is not None
+    ]
+    if not params:
+        raise NamespaceConfigEmptyError(tuple(NS_CONFIG_PARAMS))
+
     existing = await list_namespaces(client)
     if body.name not in existing:
         raise NamespaceNotFoundError(body.name)
 
-    cmd = (
-        f"set-config:context=namespace;id={body.name}"
-        f";memory-size={body.memorySize}"
-        f";replication-factor={body.replicationFactor}"
-    )
+    cmd = ";".join([f"set-config:context=namespace;id={body.name}", *params])
     resp = await client.info_random_node(cmd)
 
     if resp.strip().lower() != "ok":

--- a/api/tests/test_clusters_router_namespaces.py
+++ b/api/tests/test_clusters_router_namespaces.py
@@ -1,0 +1,125 @@
+"""Integration tests for ``POST /clusters/{conn_id}/namespaces``.
+
+Drives the FastAPI surface end-to-end (httpx ASGITransport) so the HTTP
+status codes of the partial-update contract are pinned at the boundary
+callers actually see: 400 for a body that names no parameter, 422 for an
+unknown field, 200 for a partial update. The matching service-layer unit
+tests for command construction live in ``test_clusters_service.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from aerospike_cluster_manager_api.main import app
+from aerospike_cluster_manager_api.services.info_cache import info_cache
+
+
+def _make_mock_client() -> AsyncMock:
+    """Mock AsyncClient whose ``info_random_node`` answers both round-trips.
+
+    ``configure_namespace`` calls it twice — first the ``namespaces``
+    existence check (``"test"``), then the ``set-config`` call (``"ok"``).
+    """
+    mock = AsyncMock()
+    mock.get_node_names = Mock(return_value=["BB9020011AC4202"])
+    mock.is_connected.return_value = True
+    mock.info_random_node = AsyncMock(side_effect=["test", "ok"])
+    return mock
+
+
+@asynccontextmanager
+async def _noop_lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    yield
+
+
+@pytest.fixture()
+async def client(init_test_db):
+    original_lifespan = app.router.lifespan_context
+    app.router.lifespan_context = _noop_lifespan
+    app.state.limiter.enabled = False
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.state.limiter.enabled = True
+    app.router.lifespan_context = original_lifespan
+
+
+@pytest.fixture(autouse=True)
+async def _clear_cache():
+    await info_cache.clear()
+    yield
+    await info_cache.clear()
+
+
+class TestConfigureNamespacePartialUpdate:
+    @pytest.mark.asyncio
+    async def test_name_only_body_is_rejected_400(self, client: AsyncClient, sample_connection):
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/namespaces",
+                json={"name": "test"},
+            )
+
+        assert resp.status_code == 400, resp.text
+        detail = resp.json()["detail"]
+        # The message must name what IS settable so the caller can fix the body.
+        assert "memorySize" in detail
+        assert "replicationFactor" in detail
+        # Nothing reached the cluster.
+        assert mock_as_client.info_random_node.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_unknown_field_is_rejected_422(self, client: AsyncClient, sample_connection):
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/namespaces",
+                # snake_case misspelling of memorySize — previously dropped
+                # silently, which then applied the model default instead.
+                json={"name": "test", "memory_size": 8_000_000_000},
+            )
+
+        assert resp.status_code == 422, resp.text
+        assert mock_as_client.info_random_node.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_single_parameter_body_applies_only_that_parameter(self, client: AsyncClient, sample_connection):
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/namespaces",
+                json={"name": "test", "memorySize": 8_000_000_000},
+            )
+
+        assert resp.status_code == 200, resp.text
+        cmd = mock_as_client.info_random_node.await_args_list[1].args[0]
+        assert cmd == "set-config:context=namespace;id=test;memory-size=8000000000"

--- a/api/tests/test_clusters_service.py
+++ b/api/tests/test_clusters_service.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from pydantic import ValidationError
 
 from aerospike_cluster_manager_api.models.cluster import (
     ClusterInfo,
@@ -21,6 +22,7 @@ from aerospike_cluster_manager_api.models.cluster import (
 )
 from aerospike_cluster_manager_api.services import clusters_service
 from aerospike_cluster_manager_api.services.clusters_service import (
+    NamespaceConfigEmptyError,
     NamespaceConfigError,
     NamespaceNotFoundError,
     NodeNotFoundError,
@@ -479,6 +481,90 @@ class TestConfigureNamespace:
         assert "id=test" in cmd
         assert "memory-size=4000000000" in cmd
         assert "replication-factor=3" in cmd
+
+
+class TestConfigureNamespacePartialUpdate:
+    """Omitted parameters must not reach the wire.
+
+    ``set-config`` lands on a *live* namespace, so any value this service
+    fills in for a field the caller didn't send is a real config change.
+    The regression these tests pin: a name-only body used to emit
+    ``memory-size=1073741824;replication-factor=2`` from model defaults,
+    dynamically shrinking the namespace's memory ceiling under its current
+    usage. Every pre-existing test passed both fields explicitly, which is
+    why the defaults went unnoticed.
+    """
+
+    @staticmethod
+    def _set_config_cmd(client: Mock) -> str:
+        # info_random_node is called twice: [0] the namespaces existence
+        # check, [1] the set-config call under test.
+        return str(client.info_random_node.await_args_list[1].args[0])
+
+    async def test_name_only_body_emits_no_tunables(self):
+        client = _make_mock_client()
+        client.info_random_node = AsyncMock(side_effect=["test", "ok"])
+        body = CreateNamespaceRequest(name="test")
+        with pytest.raises(NamespaceConfigEmptyError):
+            await clusters_service.configure_namespace(client, body)
+        # Rejected before any wire round-trip — not even the existence check.
+        assert client.info_random_node.await_count == 0
+
+    async def test_memory_size_only_omits_replication_factor(self):
+        client = _make_mock_client()
+        client.info_random_node = AsyncMock(side_effect=["test", "ok"])
+        body = CreateNamespaceRequest(name="test", memorySize=8_000_000_000)
+        await clusters_service.configure_namespace(client, body)
+        cmd = self._set_config_cmd(client)
+        assert cmd == "set-config:context=namespace;id=test;memory-size=8000000000"
+        assert "replication-factor" not in cmd
+
+    async def test_replication_factor_only_omits_memory_size(self):
+        client = _make_mock_client()
+        client.info_random_node = AsyncMock(side_effect=["test", "ok"])
+        body = CreateNamespaceRequest(name="test", replicationFactor=3)
+        await clusters_service.configure_namespace(client, body)
+        cmd = self._set_config_cmd(client)
+        assert cmd == "set-config:context=namespace;id=test;replication-factor=3"
+        assert "memory-size" not in cmd
+
+    async def test_explicit_null_is_treated_as_omitted(self):
+        # `{"memorySize": null}` is "set" to Pydantic but means "leave alone"
+        # to the caller, so it must not be interpolated as the literal None.
+        client = _make_mock_client()
+        client.info_random_node = AsyncMock(side_effect=["test", "ok"])
+        body = CreateNamespaceRequest.model_validate({"name": "test", "memorySize": None, "replicationFactor": 2})
+        await clusters_service.configure_namespace(client, body)
+        cmd = self._set_config_cmd(client)
+        assert cmd == "set-config:context=namespace;id=test;replication-factor=2"
+
+    async def test_empty_body_error_names_the_settable_fields(self):
+        client = _make_mock_client()
+        client.info_random_node = AsyncMock(side_effect=["test", "ok"])
+        with pytest.raises(NamespaceConfigEmptyError) as exc:
+            await clusters_service.configure_namespace(client, CreateNamespaceRequest(name="test"))
+        msg = str(exc.value)
+        assert "memorySize" in msg
+        assert "replicationFactor" in msg
+
+    def test_tunables_default_to_none(self):
+        # Guards the actual defect: a non-None default here is applied to a
+        # running namespace, so re-introducing one must fail loudly.
+        body = CreateNamespaceRequest(name="test")
+        assert body.memorySize is None
+        assert body.replicationFactor is None
+
+    def test_unknown_field_is_rejected(self):
+        # A misspelled parameter must 422 rather than silently drop out of
+        # the body and leave the caller believing it was applied.
+        with pytest.raises(ValidationError):
+            CreateNamespaceRequest.model_validate({"name": "test", "memory_size": 8_000_000_000})
+
+    def test_supplied_tunables_still_range_checked(self):
+        with pytest.raises(ValidationError):
+            CreateNamespaceRequest.model_validate({"name": "test", "memorySize": 1})
+        with pytest.raises(ValidationError):
+            CreateNamespaceRequest.model_validate({"name": "test", "replicationFactor": 9})
 
 
 # ---------------------------------------------------------------------------

--- a/ui/src/lib/types/cluster.ts
+++ b/ui/src/lib/types/cluster.ts
@@ -53,6 +53,15 @@ export interface ClusterInfo {
   namespaces: NamespaceInfo[]
 }
 
+/**
+ * Partial `set-config` update for an existing namespace.
+ *
+ * The optional fields are a real partial update, not "use a default":
+ * an omitted parameter keeps the namespace's running value. The API
+ * rejects a body carrying only `name` (400) because `set-config` applies
+ * to a live namespace, and unknown fields (422) so a misspelled
+ * parameter cannot read as a success.
+ */
 export interface CreateNamespaceRequest {
   name: string
   memorySize?: number


### PR DESCRIPTION
## Problem

`POST /clusters/{conn_id}/namespaces` applied model defaults for every tunable the caller omitted, so an omitted field was a *change*, not a no-op.

`api/src/aerospike_cluster_manager_api/models/cluster.py:57-60` (before this PR):

```python
class CreateNamespaceRequest(BaseModel):
    name: str = Field(min_length=1, pattern=r"^[a-zA-Z0-9_-]{1,63}$")
    memorySize: int = Field(default=1_073_741_824, ge=1_000_000)  # min 1 MB
    replicationFactor: int = Field(default=2, ge=1, le=8)
```

`api/src/aerospike_cluster_manager_api/services/clusters_service.py:436-443` (before this PR) interpolated both unconditionally:

```python
cmd = (
    f"set-config:context=namespace;id={body.name}"
    f";memory-size={body.memorySize}"
    f";replication-factor={body.replicationFactor}"
)
```

So a body of `{"name": "test"}` meant "set memory-size to 1 GiB and replication-factor to 2" on whatever was running. `set-config` is dynamic: on a namespace configured larger than 1 GiB that is an immediate shrink of the memory ceiling below current usage — stop-writes and eviction thresholds are crossed, live data is evicted and writes are rejected. An unintended replication-factor change triggers a rebalance on top. The route is rate-limited to 10/minute (`routers/clusters.py:48`) and unauthenticated in the default configuration (`OIDC_ENABLED` defaults false, `config.py:188`).

The model carried no `model_config`, so Pydantic's default `extra="ignore"` also dropped a misspelled `memory_size` and applied the 1 GiB default in its place — reporting success.

Why it survived: all four existing `configure_namespace` tests passed both fields explicitly (`api/tests/test_clusters_service.py:451,459,466,473`), so no test ever exercised an omitted field.

The typed frontend client made the destructive call type-check cleanly — `ui/src/lib/types/cluster.ts:56-60` already declared both fields `?`-optional, so `configureNamespace(id, { name: "test" })` compiled. (`configureNamespace` is exported at `ui/src/lib/api/clusters.ts:15-19` but no component calls it today.)

## Fix

Follows the partial-update pattern the codebase already uses for `UpdateConnectionRequest` (`models/connection.py:88-98` + `model_dump(exclude_unset=True)`).

- Both tunables are `int | None = None`. The existing `ge`/`le` range checks still apply to values that ARE supplied.
- `configure_namespace` builds the `set-config` string from `model_dump(exclude_unset=True)`, emitting only the parameters the caller actually sent. An explicit `null` is treated as omitted (it is "set" to Pydantic but "leave alone" in intent).
- A body naming no tunable raises the new `NamespaceConfigEmptyError` → HTTP 400 listing the settable fields, raised **before** any wire round-trip (not even the namespace existence check runs).
- `model_config = ConfigDict(extra="forbid")` so a misspelled parameter is a 422 rather than a silent default. **This is a breaking change for ackoctl — see Risk.**
- The field → asinfo-parameter mapping moved to `constants.NS_CONFIG_PARAMS`, so widening what this endpoint can change on a live namespace is one reviewable place with the Optional requirement documented next to it.
- The OpenAPI route description now states the partial-update semantics.

Frontend: `ui/src/lib/types/cluster.ts` already declared both fields optional, and after this change optional is *correct*, so the type shape is unchanged. Added a doc comment recording that optional means "keep the running value", plus the 400/422 behaviour, so the next reader does not re-introduce a default. No component, layout or navigation change.

## Verification

```
$ cd api && uv run pytest tests/ -p no:cacheprovider
1025 passed, 6 warnings in 12.21s
```
(1014 collected on `main` before this PR; +11 new tests, 0 modified, 0 removed. The 842 figure in the review report is `grep -c 'def test_'` — test *definitions*; 1014 is pytest's collected count after parametrization, which is what a reviewer reproduces.)

```
$ cd api && uv run ruff check src
All checks passed!

$ cd api && uv run ruff format --check src tests
138 files already formatted

$ cd api && uv run pyright src/
0 errors, 0 warnings, 0 informations

$ cd ui && npm run type-check
> tsc --noEmit
(clean, no output)

$ cd ui && npm run test
Test Files  19 passed (19)
     Tests  104 passed (104)

$ cd ui && npx prettier --check src/lib/types/cluster.ts
All matched files use Prettier code style!
```

**Do the new tests fail on unpatched code?** Checked, per test: the two new/changed test files were checked out onto `main` and run against unmodified source. **10 of the 11 fail there.** `test_clusters_service.py` cannot even import on `main` (`ImportError: cannot import name 'NamespaceConfigEmptyError'`), so for a per-test answer that module got a no-op import shim for the new exception class — the shim is never raised, so every assertion still measures unpatched behaviour.

```
tests/test_clusters_router_namespaces.py  (0/3 pass on main)
FAILED test_name_only_body_is_rejected_400                 - AssertionError: {"message":"Namespace 'test' configured successfully"}
FAILED test_unknown_field_is_rejected_422                  - AssertionError: {"message":"Namespace 'test' configured successfully"}
FAILED test_single_parameter_body_applies_only_that_parameter - assert 'set-config:...replication-factor=2' == 'set-config:...memory-size...'

tests/test_clusters_service.py  (1/8 passes on main)
FAILED test_name_only_body_emits_no_tunables               - DID NOT RAISE NamespaceConfigEmptyError
FAILED test_memory_size_only_omits_replication_factor      - assert 'set-config:...replication-factor=2' == '...'
FAILED test_replication_factor_only_omits_memory_size      - assert 'set-config:...replication-factor=3' == '...'
FAILED test_explicit_null_is_treated_as_omitted            - ValidationError for CreateNamespaceRequest
FAILED test_empty_body_error_names_the_settable_fields     - DID NOT RAISE NamespaceConfigEmptyError
FAILED test_tunables_default_to_none                       - assert 1073741824 is None
FAILED test_unknown_field_is_rejected                      - DID NOT RAISE ValidationError
```

The first two failures are the defect stated in its own words: on `main` a name-only body and a body with a misspelled parameter both return **200 "configured successfully"**.

The one test that passes both before and after is `test_supplied_tunables_still_range_checked` — deliberately a guard, not a detector: the `ge`/`le` constraints already existed and it pins that making the fields Optional did not drop them.

New tests — `api/tests/test_clusters_service.py::TestConfigureNamespacePartialUpdate` (8) covers: name-only body → 0 wire calls and `NamespaceConfigEmptyError`; `memorySize` only → command is exactly `set-config:context=namespace;id=test;memory-size=8000000000`; `replicationFactor` only → the mirror case; explicit `null` treated as omitted; error message names both settable fields; defaults are `None`; unknown field rejected; supplied values still range-checked.

`api/tests/test_clusters_router_namespaces.py` (3, new file) pins the HTTP status codes end-to-end through ASGITransport: 400 for a name-only body, 422 for `memory_size`, 200 for a single-parameter body — the last asserting the exact emitted command. No Aerospike server, database or container is needed; the mock client answers both `info_random_node` round-trips.

## Risk

Behaviour change for any caller that relied on omission meaning "reset to 1 GiB / RF 2". Nothing in this repo does, and that behaviour is the defect. Three client-visible changes:

- A body of only `{"name": ...}` now 400s instead of returning 200. Previously it returned 200 *after* damaging the namespace, so the new failure is strictly better, but it is a status-code change on an existing endpoint.
- Unknown fields now 422 instead of being ignored. `extra="forbid"` applies only to `CreateNamespaceRequest`, not to other models.
- Supplied values may be JSON strings and still work: Pydantic's lax mode coerces `{"memorySize": "8000000000"}` to `8000000000`, which matters because ackoctl sends every `--param` value as a string.

### Breaking change for ackoctl `cluster configure-namespace`

`ackoctl` posts to this exact endpoint through an intentionally open map — `ConfigureNamespaceRequest map[string]any` (`internal/client/types.go:151-155`, commented "we pass it through as a map to avoid drifting against the server's evolving knobs") — populated from repeatable `--param key=value` flags (`internal/cli/cluster.go:70-100`). So `--param` accepts *any* key, and only `memorySize` / `replicationFactor` are keys this endpoint understands.

What that means concretely:

- `--param memorySize=…` / `--param replicationFactor=…` keep working, before and after.
- Any other key — e.g. `--param high-water-memory-pct=80`, or the asinfo spelling `--param memory-size=…` — **was already broken before this PR, and destructively so**: `extra="ignore"` dropped it, then the model defaults applied `memory-size=1073741824;replication-factor=2` and the CLI printed the server's "configured successfully". The parameter the operator asked for never reached the cluster; a namespace shrink they never asked for did.
- After this PR those invocations fail loudly: 422 with `extra="forbid"`, or 400 ("supply at least one of: memorySize, replicationFactor") if `extra="forbid"` were dropped. **The hard failure is inherent to fixing the defect, not to `extra="forbid"`** — once omitted fields stop being back-filled, a body whose only recognised field is `name` has nothing to apply either way. `extra="forbid"` only chooses which of the two errors the caller sees, and 422-naming-the-bad-field is the more actionable one.

I kept `extra="forbid"` on that reasoning, but it is the maintainer's call — say so and I will drop it, which moves those requests from 422 to 400 and changes nothing else.

Follow-up, not in this PR: the real gap is that the endpoint supports only two tunables while ackoctl's UX promises arbitrary ones. `constants.NS_CONFIG_PARAMS` is where an additional tunable gets added, one line each, and each needs an Optional model field. Tracked against `ackoctl#85`.

No change to the successful path when both fields are supplied: the emitted command is byte-identical to before. Nothing touches authentication, rate limiting, or the raw `POST /info` passthrough — the missing verb allowlist on that route (#467) is a separate defect and is not addressed here.

Closes #466

🤖 Generated with [Claude Code](https://claude.com/claude-code)
