### PR TITLE
fix(security): reject multi-command frames in the read-only info gate

### DIFF
--- a/api/src/aerospike_cluster_manager_api/info_verbs.py
+++ b/api/src/aerospike_cluster_manager_api/info_verbs.py
@@ -105,40 +105,59 @@ class InfoVerbNotAllowed(InfoCommandRejected):
 
 
 class InfoCommandNotSingle(InfoCommandRejected):
-    """Raised when one command frame carries more than a single asinfo command.
+    """Raised when one command frame does not hold exactly one asinfo command.
 
     Inspecting only the leading verb is not enough to decide a frame's
     safety: the asinfo wire format is multi-command, so a frame whose head
-    is an allowlisted read verb can carry a further command behind a
-    separator. Rather than trying to decide whether each trailing command
-    is also read-only, the read-only gate accepts only single-command
-    frames — one command per ``commands[]`` entry.
+    is an allowlisted read verb can carry further text behind a separator
+    that the verb check never covers. Rather than trying to decide whether
+    each trailing command is also read-only, the read-only gate accepts only
+    single-command frames — one command per ``commands[]`` entry.
 
-    ``reason`` names the separator that made the frame multi-command; it is
+    ``reason`` names the separator that broke the single-command shape; it is
     derived from the input's *shape*, never from its content, so the HTTP
     400 does not echo an unvalidated string back to the caller.
     """
 
     def __init__(self, reason: str) -> None:
         super().__init__(
-            f"Command carries more than one asinfo command ({reason}); "
+            f"Command is not a single asinfo command ({reason}); "
             "the read-only endpoint accepts exactly one command per entry — "
             "submit each command as its own element of 'commands'."
         )
         self.reason = reason
 
 
-# asinfo wire format treats any of these as "verb stops here" *within a single
-# command*. This tuple is only about locating the verb — it is deliberately
-# not the safety boundary, because splitting on a separator and keeping the
-# head silently accepts whatever followed it. ``assert_single_command`` is the
-# boundary: it runs first and rejects any frame holding a second command, so
-# by the time the verb is extracted only intra-command separators remain.
+# asinfo wire format treats any of these as "verb stops here". This tuple is
+# only about locating the verb — it is deliberately NOT the safety boundary,
+# because splitting on a separator and keeping the head silently accepts
+# whatever followed it. ``assert_single_command`` is the boundary: it runs
+# first and rejects any frame whose shape puts text beyond the verb's reach.
+#
+# The whitespace entries overlap with the whitespace rule below, which makes
+# them unreachable on the validated path. They stay because ``extract_verb``
+# is public: called directly on ``"version <second command>"`` it must still
+# stop at the space rather than return a mangled verb.
 _VERB_TERMINATORS: tuple[str, ...] = (":", "/", ";", "\n", " ", "\t")
 
-# Characters the asinfo wire protocol uses to delimit a *batch* of commands.
-# Never legitimate inside one command, so their presence is decisive.
-_COMMAND_SEPARATORS: tuple[str, ...] = ("\n", "\r")
+# Whitespace INSIDE a command frame is never legitimate. Every read-only verb
+# is a single space-free token and every argument is `key=value` or a
+# `/`-separated path, so once surrounding padding is stripped any whitespace
+# left is a separator putting a second token beyond the verb check's reach:
+# `"\n"` is the batch separator, and space / tab are verb terminators — the
+# `_VERB_TERMINATORS` tuple above says so — which means the verb check reads
+# only the text ahead of them.
+#
+# The test is ``str.isspace()`` rather than a fixed set, so the exotic members
+# (VT, FF, NEL, NBSP) are rejected by the same rule and carry the same error
+# class as the common ones instead of incidentally failing the verb lookup.
+# These four are named for a legible message; anything else says "whitespace".
+_SEPARATOR_NAMES: dict[str, str] = {
+    "\n": "newline",
+    "\r": "carriage return",
+    " ": "space",
+    "\t": "tab",
+}
 
 
 def extract_verb(command: str) -> str:
@@ -195,7 +214,9 @@ def assert_single_command(command: str) -> str:
 
     Rejected as multi-command:
 
-    * any ``\\n`` / ``\\r`` — the batch separator
+    * any internal whitespace once padding is stripped — ``\\n`` (the batch
+      separator), ``\\r``, and space / tab (verb terminators, so the verb
+      check would read only the text ahead of them)
     * a ``;`` ahead of the ``:``, which cannot be an argument separator
       because the argument section has not started
     * a second ``:``, i.e. a further colon-style command riding in the
@@ -212,9 +233,11 @@ def assert_single_command(command: str) -> str:
     if not cmd:
         raise InfoVerbNotAllowed("")
 
-    for sep in _COMMAND_SEPARATORS:
-        if sep in cmd:
-            raise InfoCommandNotSingle("embedded newline — the asinfo batch separator")
+    # Surrounding padding is already gone, so any whitespace left is internal.
+    for ch in cmd:
+        if ch.isspace():
+            name = _SEPARATOR_NAMES.get(ch, "whitespace")
+            raise InfoCommandNotSingle(f"embedded {name} — an asinfo command separator")
 
     # One trailing ';' terminates a single command, so take it off before
     # reasoning about the separators that remain.
@@ -243,10 +266,13 @@ def assert_single_command(command: str) -> str:
 class ValidatedInfoCommand(NamedTuple):
     """An asinfo command that passed the read-only gate.
 
-    ``command`` is the only string a caller may put on the wire. Returning
-    it — rather than just the verb — is what keeps the gate structural: a
-    caller cannot accidentally validate one string and transmit another,
-    which is exactly how a rejected suffix used to reach the cluster.
+    ``command`` is the string callers must put on the wire. Returning it —
+    rather than just the verb — is defence in depth, not a guarantee: this
+    is a plain NamedTuple with no validating constructor, so an instance can
+    still be built by hand around any string. What it buys is that a caller
+    following the signature no longer has to *remember* to transmit the
+    validated value, which is exactly the mistake that let a rejected suffix
+    reach the cluster.
 
     ``verb`` is the parsed leading verb, kept for telemetry (OTel span
     attributes, structured log fields) so callers need not re-parse.

--- a/api/src/aerospike_cluster_manager_api/info_verbs.py
+++ b/api/src/aerospike_cluster_manager_api/info_verbs.py
@@ -6,9 +6,18 @@ The Aerospike asinfo protocol multiplexes both reads (``namespaces``,
 endpoint therefore cannot decide a command's safety from its shape alone
 — it needs to inspect the *verb* (the leading token of the command).
 
+The verb alone is not sufficient, though: asinfo is a *multi-command* wire
+format, so a frame whose leading verb is read-only can carry a second
+command behind a separator. :func:`assert_read_only` therefore gates on two
+things — the frame holds exactly one command
+(:func:`assert_single_command`), and that command's verb is whitelisted —
+and returns the validated string so callers transmit that rather than the
+caller's original.
+
 This module is the single source of truth for that decision. The service
-layer raises :class:`InfoVerbNotAllowed`, which the router maps to an
-HTTP 400 with a "pick a different verb" hint.
+layer raises :class:`InfoCommandRejected` subclasses, which the router maps
+to an HTTP 400 with a "pick a different verb" / "one command per entry"
+hint.
 
 To add a verb:
 
@@ -24,6 +33,8 @@ To add a verb:
 """
 
 from __future__ import annotations
+
+from typing import NamedTuple
 
 READ_ONLY_INFO_VERBS: frozenset[str] = frozenset(
     {
@@ -67,7 +78,16 @@ READ_ONLY_INFO_VERBS: frozenset[str] = frozenset(
 _HINT_VERBS: tuple[str, ...] = ("namespaces", "version", "nodes", "statistics", "latencies")
 
 
-class InfoVerbNotAllowed(ValueError):
+class InfoCommandRejected(ValueError):
+    """Base for every read-only info validation failure.
+
+    Callers that only need "was this command accepted?" catch this; the
+    REST router discriminates on the subclasses to produce a specific
+    HTTP 400 message per failure mode.
+    """
+
+
+class InfoVerbNotAllowed(InfoCommandRejected):
     """Raised when an asinfo command's leading verb is not on the read-only allowlist.
 
     The REST router maps this to HTTP 400 with a "pick a different verb"
@@ -84,11 +104,41 @@ class InfoVerbNotAllowed(ValueError):
         self.verb = verb
 
 
-# asinfo wire format treats any of these as "verb stops here". Embedding any
-# of them in a single command frame is unusual but legitimate (`namespaces;`
-# is canonical when piping multiple commands), so we normalise the head
-# rather than rejecting the whole command outright.
+class InfoCommandNotSingle(InfoCommandRejected):
+    """Raised when one command frame carries more than a single asinfo command.
+
+    Inspecting only the leading verb is not enough to decide a frame's
+    safety: the asinfo wire format is multi-command, so a frame whose head
+    is an allowlisted read verb can carry a further command behind a
+    separator. Rather than trying to decide whether each trailing command
+    is also read-only, the read-only gate accepts only single-command
+    frames — one command per ``commands[]`` entry.
+
+    ``reason`` names the separator that made the frame multi-command; it is
+    derived from the input's *shape*, never from its content, so the HTTP
+    400 does not echo an unvalidated string back to the caller.
+    """
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(
+            f"Command carries more than one asinfo command ({reason}); "
+            "the read-only endpoint accepts exactly one command per entry — "
+            "submit each command as its own element of 'commands'."
+        )
+        self.reason = reason
+
+
+# asinfo wire format treats any of these as "verb stops here" *within a single
+# command*. This tuple is only about locating the verb — it is deliberately
+# not the safety boundary, because splitting on a separator and keeping the
+# head silently accepts whatever followed it. ``assert_single_command`` is the
+# boundary: it runs first and rejects any frame holding a second command, so
+# by the time the verb is extracted only intra-command separators remain.
 _VERB_TERMINATORS: tuple[str, ...] = (":", "/", ";", "\n", " ", "\t")
+
+# Characters the asinfo wire protocol uses to delimit a *batch* of commands.
+# Never legitimate inside one command, so their presence is decisive.
+_COMMAND_SEPARATORS: tuple[str, ...] = ("\n", "\r")
 
 
 def extract_verb(command: str) -> str:
@@ -108,6 +158,11 @@ def extract_verb(command: str) -> str:
     raises :class:`InfoVerbNotAllowed` with an empty verb so the caller
     surfaces a sensible error.
 
+    This function answers "where does the verb end", not "is this command
+    safe" — keeping the head of a frame that held two commands is the bug
+    :func:`assert_single_command` exists to prevent. Call
+    :func:`assert_read_only` for the safety decision.
+
     Note: case-sensitive — asinfo itself is case-sensitive
     (``Namespaces`` is not the same verb as ``namespaces``).
     """
@@ -120,15 +175,104 @@ def extract_verb(command: str) -> str:
     return head
 
 
-def assert_read_only(command: str) -> str:
-    """Validate ``command`` against the read-only whitelist.
+def assert_single_command(command: str) -> str:
+    """Return ``command`` stripped, having confirmed it holds ONE asinfo command.
 
-    Returns the parsed verb on success — callers can use it for telemetry
-    (OTel span attributes, structured log fields). Raises
-    :class:`InfoVerbNotAllowed` if the verb is not whitelisted; raises
+    The asinfo wire format is a multi-command format: a newline delimits a
+    batch, and a ``;`` delimits commands outside the ``:``-argument section.
+    A frame whose leading verb is read-only can therefore carry a second,
+    unrelated command — so the read-only gate needs this frame-level check
+    in addition to the verb check.
+
+    The legitimate single-command shapes all survive:
+
+    * bare verb — ``"namespaces"``, and ``"namespaces;"`` (one trailing
+      ``;`` is the canonical terminator)
+    * path-style — ``"sets/test/myset"``
+    * colon-style — ``"roster:namespace=test"``, and multiple
+      ``;``-separated ``key=value`` arguments as in
+      ``"latencies:back=10;duration=10"``
+
+    Rejected as multi-command:
+
+    * any ``\\n`` / ``\\r`` — the batch separator
+    * a ``;`` ahead of the ``:``, which cannot be an argument separator
+      because the argument section has not started
+    * a second ``:``, i.e. a further colon-style command riding in the
+      argument section
+    * a ``;``-separated argument segment that is not ``key=value``, i.e. a
+      bare verb riding in the argument section
+
+    Raises:
+        InfoCommandNotSingle: the frame holds more than one command.
+        InfoVerbNotAllowed: the frame is empty or whitespace-only (empty
+            verb), matching :func:`extract_verb`.
+    """
+    cmd = command.strip()
+    if not cmd:
+        raise InfoVerbNotAllowed("")
+
+    for sep in _COMMAND_SEPARATORS:
+        if sep in cmd:
+            raise InfoCommandNotSingle("embedded newline — the asinfo batch separator")
+
+    # One trailing ';' terminates a single command, so take it off before
+    # reasoning about the separators that remain.
+    body = cmd[:-1] if cmd.endswith(";") else cmd
+    head, colon, args = body.partition(":")
+
+    # No argument section has started yet, so a ';' here separates commands.
+    # With no ':' at all (bare or path-style), head is the whole command and
+    # this same check covers it.
+    if ";" in head:
+        raise InfoCommandNotSingle("';' before the ':' argument separator")
+    if not colon:
+        return cmd
+
+    if ":" in args:
+        raise InfoCommandNotSingle("second ':' verb separator inside the argument section")
+    segments = args.split(";")
+    # A lone segment is either `key=value` or the single bare argument form
+    # (`namespace:test`). Two or more means the ';' is acting as an argument
+    # separator, which only holds if every segment really is an argument.
+    if len(segments) > 1 and not all("=" in s for s in segments):
+        raise InfoCommandNotSingle("';'-separated segment that is not a key=value argument")
+    return cmd
+
+
+class ValidatedInfoCommand(NamedTuple):
+    """An asinfo command that passed the read-only gate.
+
+    ``command`` is the only string a caller may put on the wire. Returning
+    it — rather than just the verb — is what keeps the gate structural: a
+    caller cannot accidentally validate one string and transmit another,
+    which is exactly how a rejected suffix used to reach the cluster.
+
+    ``verb`` is the parsed leading verb, kept for telemetry (OTel span
+    attributes, structured log fields) so callers need not re-parse.
+    """
+
+    command: str
+    verb: str
+
+
+def assert_read_only(command: str) -> ValidatedInfoCommand:
+    """Validate ``command`` as a single, whitelisted read-only asinfo command.
+
+    Two independent checks, both of which must pass:
+
+    1. :func:`assert_single_command` — the frame holds exactly one command,
+       so the verb decides the safety of the whole frame rather than just
+       of its head.
+    2. the leading verb is on :data:`READ_ONLY_INFO_VERBS`.
+
+    Returns a :class:`ValidatedInfoCommand`; transmit ``.command``, never
+    the caller's original string. Raises :class:`InfoCommandNotSingle` or
+    :class:`InfoVerbNotAllowed` (both :class:`InfoCommandRejected`)
     immediately, so no wire round-trip happens for a rejected command.
     """
-    verb = extract_verb(command)
+    validated = assert_single_command(command)
+    verb = extract_verb(validated)
     if verb not in READ_ONLY_INFO_VERBS:
         raise InfoVerbNotAllowed(verb)
-    return verb
+    return ValidatedInfoCommand(command=validated, verb=verb)

--- a/api/src/aerospike_cluster_manager_api/routers/clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/clusters.py
@@ -162,8 +162,12 @@ async def execute_info(
             results.append(InfoCommandResult(command=cmd, node=target_node, output=response))
 
         else:
-            # Fan-out across every node (readOnly applies only to the
-            # upfront verb check — per-node results are returned verbatim).
+            # Fan-out across every node. `cmd` comes from the validated list
+            # when readOnly is on, so this branch transmits only what the gate
+            # returned. It previously read body.commands directly, which left
+            # the allowlist advisory here — and this is the DEFAULT branch,
+            # taken whenever the caller names no node. Per-node responses are
+            # still returned verbatim.
             node_results = await clusters_service.execute_info(client, cmd)
             if not node_results:
                 # No node responded at all — emit a single attribution-less

--- a/api/src/aerospike_cluster_manager_api/routers/clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/clusters.py
@@ -5,7 +5,11 @@ import logging
 from fastapi import APIRouter, HTTPException, Request
 
 from aerospike_cluster_manager_api.dependencies import AerospikeClient, VerifiedConnId
-from aerospike_cluster_manager_api.info_verbs import InfoVerbNotAllowed, assert_read_only
+from aerospike_cluster_manager_api.info_verbs import (
+    InfoCommandNotSingle,
+    InfoVerbNotAllowed,
+    assert_read_only,
+)
 from aerospike_cluster_manager_api.models.cluster import (
     ClusterInfo,
     CreateNamespaceRequest,
@@ -87,9 +91,11 @@ async def configure_namespace(
         "Mirrors the MCP execute_info / execute_info_on_node / "
         "execute_info_read_only contracts so ackoctl can drive raw asinfo "
         "diagnostics over the REST surface. "
-        "When readOnly=true (default), each command's leading verb is "
-        "validated against the read-only whitelist BEFORE any wire "
-        "round-trip — a single bad verb fails the entire call with 400."
+        "When readOnly=true (default), each command is validated BEFORE any "
+        "wire round-trip: it must hold exactly one asinfo command (the wire "
+        "format is multi-command) and its leading verb must be on the "
+        "read-only whitelist. A single rejected command fails the entire "
+        "call with 400, and only the validated string is transmitted."
     ),
 )
 async def execute_info(
@@ -98,23 +104,30 @@ async def execute_info(
     conn_id: VerifiedConnId,
 ) -> ExecuteInfoResponse:
     """Run asinfo commands per the ExecuteInfoRequest semantics."""
-    # When readOnly is on, fail-fast on the FIRST non-whitelisted verb so
-    # a bad verb never reaches the wire. Pydantic already enforces
-    # commands non-empty.
+    # When readOnly is on, fail-fast on the FIRST rejected command so it
+    # never reaches the wire. Pydantic already enforces commands non-empty.
+    #
+    # Keep the VALIDATED strings and run those: forwarding body.commands
+    # after validating it is the bug that let a frame carrying an
+    # allowlisted verb plus a trailing second command through, since only
+    # the leading verb was ever inspected.
+    validated: list[str] = []
     if body.readOnly:
         for cmd in body.commands:
             try:
-                assert_read_only(cmd)
+                validated.append(assert_read_only(cmd).command)
             except InfoVerbNotAllowed as exc:
                 raise HTTPException(
                     status_code=400,
                     detail=(f"command '{exc.verb}' not in read-only whitelist; pass readOnly=false to allow"),
                 ) from exc
+            except InfoCommandNotSingle as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     results: list[InfoCommandResult] = []
     target_node = body.node or None
 
-    for cmd in body.commands:
+    for cmd in validated if body.readOnly else body.commands:
         if target_node is not None and body.readOnly:
             # Single-node read-only: whitelist already enforced above;
             # service still re-validates as a defense-in-depth.

--- a/api/src/aerospike_cluster_manager_api/services/clusters_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/clusters_service.py
@@ -231,12 +231,16 @@ async def execute_info_read_only(
 ) -> tuple[str, str]:
     """Run a whitelisted read-only asinfo command.
 
-    Validates the verb against :data:`info_verbs.READ_ONLY_INFO_VERBS`
-    *before* hitting the wire — a bad verb raises
-    :class:`info_verbs.InfoVerbNotAllowed` (mapped to HTTP 400 at the REST
-    boundary). The whitelist is the single source of truth for what the
-    read-only info endpoint can call; the unrestricted variants
+    Validates ``command`` against :func:`info_verbs.assert_read_only`
+    *before* hitting the wire — a rejected command raises an
+    :class:`info_verbs.InfoCommandRejected` subclass (mapped to HTTP 400 at
+    the REST boundary). The whitelist is the single source of truth for what
+    the read-only info endpoint can call; the unrestricted variants
     (``execute_info``, ``execute_info_on_node``) accept any verb.
+
+    What goes on the wire is the *validated* string, not ``command``.
+    Forwarding the original is what let a frame holding a whitelisted verb
+    plus a trailing second command through: only the head was inspected.
 
     Returns a ``(node_name, response)`` tuple. With ``node_name=None`` we
     fan out via ``info_all`` and pick the first node that returned a
@@ -245,8 +249,8 @@ async def execute_info_read_only(
     explicit ``node_name`` we filter the same fan-out to the named node
     and raise :class:`NodeNotFoundError` if it didn't respond.
     """
-    assert_read_only(command)
-    results = await client.info_all(command)
+    validated = assert_read_only(command)
+    results = await client.info_all(validated.command)
 
     if node_name is None:
         for name, err, resp in results:

--- a/api/tests/test_clusters_router_info.py
+++ b/api/tests/test_clusters_router_info.py
@@ -233,7 +233,7 @@ class TestExecuteInfoWhitelistRejection:
 
         assert resp.status_code == 400, resp.text
         detail = resp.json()["detail"]
-        assert "more than one asinfo command" in detail
+        assert "not a single asinfo command" in detail
         # Wire was NOT touched — fail-fast before any info_all call.
         mock_as_client.info_all.assert_not_called()
 
@@ -257,7 +257,7 @@ class TestExecuteInfoWhitelistRejection:
             )
 
         assert resp.status_code == 400, resp.text
-        assert "more than one asinfo command" in resp.json()["detail"]
+        assert "not a single asinfo command" in resp.json()["detail"]
         mock_as_client.info_all.assert_not_called()
 
     @pytest.mark.asyncio

--- a/api/tests/test_clusters_router_info.py
+++ b/api/tests/test_clusters_router_info.py
@@ -209,6 +209,82 @@ class TestExecuteInfoWhitelistRejection:
         mock_as_client.info_all.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_multi_command_frame_rejected_with_400(self, client: AsyncClient, sample_connection):
+        # asinfo is a multi-command wire format, so a frame whose LEADING
+        # verb is whitelisted can carry a further command behind a newline.
+        # Checking only the head accepted the frame and then transmitted it
+        # whole; the gate must reject the frame instead.
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={
+                    "commands": ["namespaces\nrecluster:"],
+                    "readOnly": True,
+                },
+            )
+
+        assert resp.status_code == 400, resp.text
+        detail = resp.json()["detail"]
+        assert "more than one asinfo command" in detail
+        # Wire was NOT touched — fail-fast before any info_all call.
+        mock_as_client.info_all.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_semicolon_chained_frame_rejected_with_400(self, client: AsyncClient, sample_connection):
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={
+                    "commands": ["namespaces;recluster:"],
+                    "readOnly": True,
+                },
+            )
+
+        assert resp.status_code == 400, resp.text
+        assert "more than one asinfo command" in resp.json()["detail"]
+        mock_as_client.info_all.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fan_out_transmits_the_validated_string(self, client: AsyncClient, sample_connection):
+        # The fan-out branch is the default (no `node`) and used to forward
+        # body.commands rather than the validated string, so validation had
+        # no bearing on what reached the wire. Whitespace padding is the
+        # observable proxy: only the validated (stripped) form may be sent.
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={"commands": ["  namespaces  "], "readOnly": True},
+            )
+
+        assert resp.status_code == 200, resp.text
+        sent = [c.args[0] for c in mock_as_client.info_all.call_args_list]
+        assert sent == ["namespaces"]
+
+    @pytest.mark.asyncio
     async def test_readonly_false_allows_unwhitelisted_verb(self, client: AsyncClient, sample_connection):
         from aerospike_cluster_manager_api import db
 

--- a/api/tests/test_info_verbs.py
+++ b/api/tests/test_info_verbs.py
@@ -134,8 +134,10 @@ class TestAssertReadOnly:
 
     def test_assert_returns_the_string_callers_must_transmit(self) -> None:
         # The returned command — not the caller's original — is what goes on
-        # the wire. Returning it is what makes the gate structural: a caller
-        # cannot validate one string and transmit another.
+        # the wire, so a caller following the signature cannot forget to
+        # transmit the validated value. Defence in depth, not a guarantee:
+        # ValidatedInfoCommand has no validating constructor, so an instance
+        # can still be hand-built around any string.
         assert assert_read_only("  namespaces  ").command == "namespaces"
         assert assert_read_only("roster:namespace=test").command == "roster:namespace=test"
 
@@ -226,6 +228,45 @@ class TestSingleCommandFrame:
             assert_read_only(command)
         with pytest.raises(InfoCommandNotSingle):
             assert_single_command(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "version truncate-namespace:namespace=test",  # space IS a verb terminator
+            "namespaces\trecluster:",  # tab likewise
+            "version recluster:",
+            "version\t\trecluster:",
+            "namespaces version",  # both halves allowlisted — still two tokens
+        ],
+    )
+    def test_space_and_tab_chained_frames_rejected(self, command: str) -> None:
+        # Space and tab are in _VERB_TERMINATORS, so the verb check reads only
+        # the text AHEAD of them — exactly the newline situation, and it has to
+        # be rejected the same way rather than left to the verb lookup. No
+        # read-only verb or argument shape contains internal whitespace: every
+        # command constant is a space-free token, and the path-style builders
+        # interpolate a namespace name that cannot contain a space.
+        with pytest.raises(InfoCommandNotSingle):
+            assert_read_only(command)
+        with pytest.raises(InfoCommandNotSingle):
+            assert_single_command(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "version\x0brecluster:",  # vertical tab
+            "version\x0crecluster:",  # form feed
+            "version\x85recluster:",  # NEL
+            "version\xa0recluster:",  # non-breaking space
+        ],
+    )
+    def test_exotic_whitespace_rejected_with_the_framing_error(self, command: str) -> None:
+        # These were already rejected before the framing check existed, but
+        # only incidentally: the mangled verb missed the allowlist, so the
+        # caller got "verb not on the whitelist" for what is a framing
+        # problem. The rule is str.isspace(), so they now fail as framing.
+        with pytest.raises(InfoCommandNotSingle):
+            assert_read_only(command)
 
     @pytest.mark.parametrize(
         "command",

--- a/api/tests/test_info_verbs.py
+++ b/api/tests/test_info_verbs.py
@@ -8,6 +8,10 @@ Covers:
   whitelist plus a representative set of write / unknown verbs. The
   parametrized "all whitelisted verbs pass" test is the regression net
   that catches accidental whitelist trims.
+* :func:`assert_single_command` framing decisions — asinfo is a
+  multi-command wire format, so ``TestSingleCommandFrame`` pins both the
+  chained shapes that must be rejected and the legitimate single-command
+  shapes that must keep passing.
 """
 
 from __future__ import annotations
@@ -16,8 +20,11 @@ import pytest
 
 from aerospike_cluster_manager_api.info_verbs import (
     READ_ONLY_INFO_VERBS,
+    InfoCommandNotSingle,
+    InfoCommandRejected,
     InfoVerbNotAllowed,
     assert_read_only,
+    assert_single_command,
     extract_verb,
 )
 
@@ -113,17 +120,24 @@ class TestAssertReadOnly:
         assert_read_only("namespace:test")
 
     def test_trailing_semicolon_accepted(self) -> None:
-        # ``namespaces;`` is the canonical asinfo CLI form when piping
-        # multiple commands. The verb extractor strips the trailing ``;``
-        # so the LLM-friendly form passes the whitelist.
-        assert assert_read_only("namespaces;") == "namespaces"
-        assert assert_read_only("version;") == "version"
+        # ``namespaces;`` is the canonical asinfo CLI terminator for a single
+        # command, so one trailing ``;`` must stay acceptable even though a
+        # ``;`` elsewhere now means "second command".
+        assert assert_read_only("namespaces;").verb == "namespaces"
+        assert assert_read_only("version;").verb == "version"
 
     def test_assert_returns_parsed_verb(self) -> None:
         # Forward-compat for telemetry — callers can attach the parsed
         # verb to OTel span attributes / structured logs.
-        assert assert_read_only("roster:namespace=test") == "roster"
-        assert assert_read_only("sets/test/myset") == "sets"
+        assert assert_read_only("roster:namespace=test").verb == "roster"
+        assert assert_read_only("sets/test/myset").verb == "sets"
+
+    def test_assert_returns_the_string_callers_must_transmit(self) -> None:
+        # The returned command — not the caller's original — is what goes on
+        # the wire. Returning it is what makes the gate structural: a caller
+        # cannot validate one string and transmit another.
+        assert assert_read_only("  namespaces  ").command == "namespaces"
+        assert assert_read_only("roster:namespace=test").command == "roster:namespace=test"
 
     def test_slash_path_pass_when_verb_whitelisted(self) -> None:
         assert_read_only("sets/test/myset")
@@ -185,6 +199,101 @@ class TestAssertReadOnly:
         msg = str(exc.value)
         assert "frobnicate" in msg
         assert "READ_ONLY_INFO_VERBS" in msg
+
+
+class TestSingleCommandFrame:
+    """The read-only gate must reject frames holding more than one command.
+
+    asinfo is a multi-command wire format, so checking only the leading verb
+    decides the safety of the frame's *head*, not of the frame. A frame whose
+    head is an allowlisted read verb could carry a further command behind a
+    separator and be transmitted whole.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "namespaces\nrecluster:",  # LF batch separator
+            "namespaces\r\nrecluster:",  # CRLF
+            "namespaces\rrecluster:",  # bare CR
+            "version\nversion",  # both halves allowlisted — still two commands
+            "namespaces\n\nversion",  # blank line between
+            "  namespaces\nrecluster:  ",  # surrounding whitespace does not hide it
+        ],
+    )
+    def test_newline_chained_frames_rejected(self, command: str) -> None:
+        with pytest.raises(InfoCommandNotSingle):
+            assert_read_only(command)
+        with pytest.raises(InfoCommandNotSingle):
+            assert_single_command(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "namespaces;recluster:",  # ';' ahead of any ':' — a second command
+            "namespaces;version",  # both halves allowlisted — still two commands
+            "roster:namespace=test;recluster:",  # second colon-style command in the args
+            "roster:namespace=test;version",  # bare verb riding in the args
+            "roster:;version",  # empty first arg, then a bare verb
+            "namespaces;;",  # more than the one canonical terminator
+            "sets/test/myset;version",  # path-style head, chained tail
+        ],
+    )
+    def test_semicolon_chained_frames_rejected(self, command: str) -> None:
+        with pytest.raises(InfoCommandNotSingle):
+            assert_read_only(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "namespaces",  # bare verb
+            "namespaces;",  # bare verb + canonical terminator
+            "version;",
+            "sets/test/myset",  # path-style
+            "sindex/test/idx_name",
+            "namespace:test",  # colon-style, single bare argument
+            "roster:namespace=test",  # colon-style, one key=value
+            "roster:namespace=test;",  # ... plus the canonical terminator
+            "latencies:back=10;duration=10",  # ';'-separated key=value args
+            "  version  ",  # surrounding whitespace trimmed, not rejected
+            "namespaces\n",  # trailing newline is a terminator, not a batch
+        ],
+    )
+    def test_legitimate_single_command_shapes_still_accepted(self, command: str) -> None:
+        # Regression net for the syntax the module docstring documents — the
+        # multi-command rejection must not narrow what asinfo really accepts.
+        assert_read_only(command)
+
+    def test_write_verb_still_reports_the_verb_not_the_shape(self) -> None:
+        # A single well-formed command carrying a write verb is a verb
+        # failure, not a framing failure — the two 400s say different things.
+        with pytest.raises(InfoVerbNotAllowed):
+            assert_read_only("truncate-namespace:namespace=test")
+
+    def test_empty_frame_is_a_verb_failure(self) -> None:
+        # Preserves the pre-existing contract: empty input surfaces as an
+        # empty verb rather than as a framing complaint.
+        with pytest.raises(InfoVerbNotAllowed) as exc:
+            assert_single_command("   ")
+        assert exc.value.verb == ""
+
+    def test_rejection_message_does_not_echo_the_command(self) -> None:
+        # The 400 is built from the input's shape, never its content, so an
+        # unvalidated string is not reflected back to the caller.
+        with pytest.raises(InfoCommandNotSingle) as exc:
+            assert_read_only("namespaces\nrecluster:")
+        assert "recluster" not in str(exc.value)
+
+    def test_both_failures_share_one_base(self) -> None:
+        # Callers that only need "was this accepted?" catch the base; the
+        # router discriminates on the subclasses for its 400 message.
+        for command in ("namespaces\nversion", "truncate-namespace:namespace=test"):
+            with pytest.raises(InfoCommandRejected):
+                assert_read_only(command)
+
+    def test_single_command_returns_the_stripped_frame(self) -> None:
+        assert assert_single_command("  namespaces;  ") == "namespaces;"
+        assert assert_single_command("latencies:back=10;duration=10") == "latencies:back=10;duration=10"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The read-only asinfo gate decided a command's safety from its leading verb alone, but the asinfo wire format is *multi-command*.

### Finding 1: the validator inspected only the frame's head

`api/src/aerospike_cluster_manager_api/info_verbs.py:91` (before this PR):

```python
_VERB_TERMINATORS: tuple[str, ...] = (":", "/", ";", "\n", " ", "\t")
```

`info_verbs.py:114-120` split the input on each terminator and returned only the head:

```python
    head = cmd
    for sep in _VERB_TERMINATORS:
        head = head.split(sep, 1)[0]
    return head
```

So a frame whose head is an allowlisted read verb passed validation regardless of what followed the separator. The docstring at `info_verbs.py:88-92` acknowledged the multi-command shape and chose to normalise the head rather than reject the frame.

Demonstrated against `main`'s copy of the module, loaded standalone:

```
$ git show main:api/src/aerospike_cluster_manager_api/info_verbs.py > /tmp/info_verbs_main.py
$ python3 -c "import info_verbs_main as old; f='namespaces'+chr(10)+'recluster:'; \
    print(repr(old.extract_verb(f)), repr(old.assert_read_only(f)))"
'namespaces' 'namespaces'      # no exception raised
```

That is finding (1) — a parser bug. There is a second, separate finding underneath it, and it is the more serious of the two.

### Finding 2: the default code path performed no re-validation at all

**The allowlist was advisory on the most common code path.** This is not a parser weakness; it is an unenforced gate, and whoever triages #469 should read it as such.

`routers/clusters.py:104-112` validated each entry up front, and then three branches ran the request. Only the single-node read-only branch re-validated (via `execute_info_read_only`). The **fan-out branch at `:151-154` — which is the default, since `node` is unset unless the caller names a node — called `clusters_service.execute_info(client, cmd)` with `cmd` taken straight from `body.commands`.** No allowlist check, no re-validation, nothing. The branch's own comment stated the design:

```python
        else:
            # Fan-out across every node (readOnly applies only to the
            # upfront verb check — per-node results are returned verbatim).
            node_results = await clusters_service.execute_info(client, cmd)
```

So on the default path the up-front validation had no bearing whatsoever on what reached the cluster: whatever survived the head-only verb check was discarded, and the caller's original string was transmitted. Even a validator with no parser bug at all would not have gated this path.

The same validate-one-string-transmit-another shape also existed one layer down, which is where the original review located it: `services/clusters_service.py:248-249` called `assert_read_only(command)` for its exception only, then passed the caller's *original* `command` to `client.info_all`.

Reachability: `POST /api/v1/clusters/{conn_id}/info` with `readOnly` left at its default of `true`, which is the path whose whole purpose is to be safe to expose. `conn_id` values are listable, and the endpoint is unauthenticated in the default configuration (`OIDC_ENABLED` defaults false, `config.py:188`). Deliberately not including a formed request body or curl line — this is a public repo.

## Fix

**Reject multi-command frames instead of inspecting only the head.** New `assert_single_command` rejects:

- **any internal whitespace** once surrounding padding is stripped — tested with `str.isspace()` rather than a fixed separator set. This covers `\n` (the batch separator), `\r`, space and tab, and also VT / FF / NEL / NBSP. None of it is redundant, and the history is worth keeping in the file:
  - `\n` was the live bypass — the only whitespace character in `_VERB_TERMINATORS` that is also a batch separator.
  - **space and tab were a second live bypass, found in review of this branch and fixed in `e0007c0`.** They are in `_VERB_TERMINATORS`, so the verb check stopped at them, but the first version of the framing check ignored them: `"version truncate-namespace:namespace=test"` was accepted and transmitted verbatim. The module cannot hold both positions at once, and this is the same bypass shape as the newline case via a different separator.
  - bare `\r`, VT, FF, NEL and NBSP were already rejected before any framing check existed, but only *incidentally*: `extract_verb` returned a mangled verb such as `'namespaces\rrecluster'` that happened to miss the allowlist, so the caller got "verb not on the whitelist" for what is a framing problem. They now fail as framing, with the same error class as the rest. **Please don't drop these cases as dead weight** — they are the difference between rejected-on-purpose and rejected-by-luck.

  Checked before tightening: no legitimate read-only syntax contains internal whitespace. Every command constant in `constants.py` is a space-free token, the path-style builders interpolate a namespace name that cannot contain a space, and no existing test passes internal whitespace — only surrounding padding, which `.strip()` removes first. `_VERB_TERMINATORS` keeps its whitespace entries, now unreachable on the validated path, so a direct `extract_verb` call still stops at a space instead of returning a mangled verb.
- a `;` ahead of the `:` argument separator, where no argument section has started yet
- a second `:`, i.e. a further colon-style command riding in the argument section
- a `;`-separated argument segment that is not `key=value`, i.e. a bare verb riding in the argument section

Every legitimate shape the module docstring documents still passes: bare verb, bare verb plus the canonical single trailing `;`, path-style `sets/test/myset`, colon-style `roster:namespace=test`, and `;`-separated `key=value` arguments as in `latencies:back=10;duration=10`. A trailing newline is treated as a terminator, not a batch.

**Close the structural hole.** `assert_read_only` returns a `ValidatedInfoCommand(command, verb)` NamedTuple — matching the `TestConnectionResult` / `ListRecordsResult` convention already used in the service layer. `.command` is the string callers transmit; `.verb` preserves the existing telemetry contract (`test_assert_returns_parsed_verb`).

To be precise about what that buys: this is **defence in depth, not a guarantee**. `ValidatedInfoCommand` is a plain NamedTuple with no validating constructor, so `ValidatedInfoCommand(command="…anything…", verb="namespaces")` constructs fine and nothing stops a determined caller from hand-building one. What the signature does achieve is that a caller following it can no longer *accidentally* forward an unvalidated string — which is precisely the mistake made in both call sites above. A validating constructor was considered and skipped: it would re-run the parse on every hop for a mistake the type signature already makes hard to reach by accident.

- `execute_info_read_only` transmits `validated.command`.
- The router collects the validated strings and iterates over those, closing the fan-out hole. As a side effect the echoed `command` in each result row is now the validated form.

**Error taxonomy.** `InfoVerbNotAllowed` and the new `InfoCommandNotSingle` share an `InfoCommandRejected` base, so callers that only need "was this accepted?" catch one type, while the router discriminates on the subclasses to keep the "pick a different verb" 400 distinct from the "one command per entry" 400. The framing message is built from the input's *shape*, never its content, so an unvalidated string is not reflected back to the caller (pinned by a test).

`readOnly=false` is unchanged: that path has no allowlist at all, which is a separate defect tracked in #467.

## Verification

```
$ cd api && uv run pytest tests/ -p no:cacheprovider
1056 passed, 6 warnings in 12.42s
```
(1014 collected on `main` before this PR; +42 new tests. The 842 figure in the review report is `grep -c 'def test_'` — test *definitions*; 1014 is pytest's collected count after parametrization, which is what a reviewer reproduces. Two existing assertions in `test_assert_returns_parsed_verb` / `test_trailing_semicolon_accepted` were updated from `== "verb"` to `.verb == "verb"` for the new return type; no test was removed or weakened. `test_whitelist_membership_is_pinned` still passes untouched — the allowlist itself is unchanged.)

```
$ cd api && uv run ruff check src
All checks passed!

$ cd api && uv run ruff format --check src tests
137 files already formatted

$ cd api && uv run pyright src/
0 errors, 0 warnings, 0 informations
```

The space/tab bypass, closed in `e0007c0` (each of these was accepted and transmitted verbatim by the first version of this branch):

```
$ cd api && uv run python -c "..."
rejected 'version truncate-namespace:namespace=test' -> InfoCommandNotSingle: Command is not a single
         asinfo command (embedded space — an asinfo command separator)
rejected 'namespaces\trecluster:'                    -> InfoCommandNotSingle: ... (embedded tab ...)
rejected 'version\x0brecluster:'                     -> InfoCommandNotSingle: ... (embedded whitespace ...)
rejected 'version\xa0recluster:'                     -> InfoCommandNotSingle: ... (embedded whitespace ...)
```

All 11 documented single-command shapes still pass unchanged after that tightening (`legit still accepted: True (11/11)`).

Post-fix behaviour, same frame as the reproduction above:

```
$ cd api && uv run python -c "..."
rejected -> InfoCommandNotSingle
message  -> Command carries more than one asinfo command (embedded newline — the asinfo
            batch separator); the read-only endpoint accepts exactly one command per
            entry — submit each command as its own element of 'commands'.
single ok -> ValidatedInfoCommand(command='latencies:back=10;duration=10', verb='latencies')
```

**Do the new tests fail on unpatched code?** Checked, per test: both test files were checked out onto `main` and run against unmodified source. **19 of the original 33 fail there**, plus the 2 pre-existing assertions updated for the new return type. `test_info_verbs.py` cannot import on `main`, so that module got no-op import shims — the new exception classes, and an `assert_single_command` that performs no framing check (i.e. unpatched permissiveness) — so every assertion still measures `main`'s behaviour.

```
tests/test_clusters_router_info.py  (0/3 pass on main)
FAILED test_multi_command_frame_rejected_with_400    - AssertionError: {"results":[{"command":"namespaces\nrecluster:", ...
FAILED test_semicolon_chained_frame_rejected_with_400 - AssertionError: {"results":[{"command":"namespaces;recluster:", ...
FAILED test_fan_out_transmits_the_validated_string   - assert ['  namespaces  '] == ['namespaces']

tests/test_info_verbs.py::TestSingleCommandFrame  (16 of 30 fail on main)
FAILED test_newline_chained_frames_rejected[...]     - 6 params: DID NOT RAISE InfoCommandNotSingle (4), wrong error (2 — see below)
FAILED test_semicolon_chained_frames_rejected[...]   - 7 params: DID NOT RAISE InfoCommandNotSingle
FAILED test_rejection_message_does_not_echo_the_command - DID NOT RAISE
FAILED test_both_failures_share_one_base            - DID NOT RAISE
FAILED test_assert_returns_the_string_callers_must_transmit - AttributeError: 'str' has no attribute 'command'
```

The first router failure is the defect stated in its own words: on `main` the endpoint returned **200**, and the echoed `command` in the result row is the whole two-command frame — accepted *and* transmitted. `test_fan_out_transmits_the_validated_string` shows `['  namespaces  ']` reaching `info_all`, i.e. the router forwarded the caller's original string, not the validated one.

One precise nuance the baseline run surfaced, which refines the brief: `_VERB_TERMINATORS` contained `"\n"` but **not** `"\r"`. So on `main` the two CR-carrying variants were already rejected — by accident, because `extract_verb` returned a mangled verb like `'namespaces\rrecluster'` that missed the allowlist. **LF was the live bypass; bare CR was already blocked, for the wrong reason and with a misleading error.** Both are now rejected deliberately, with the framing error.

**To reproduce the info_verbs half of that table**, `test_info_verbs.py` cannot import on `main` (`ImportError: InfoCommandNotSingle`), so it needs two no-op shims appended to `main`'s `info_verbs.py`: the `InfoCommandRejected` / `InfoCommandNotSingle` classes, and an `assert_single_command` that returns `command.strip()` with no framing check (unpatched permissiveness). `assert_read_only` must be left returning a plain `str`, which is what makes the three return-type assertions fail with `AttributeError` rather than silently passing. The three router tests need no shims and can be verified by reverting the source files alone.

The 14 tests that pass both before and after are deliberately guards, not detectors: the 11 legitimate single-command shapes (bare verb, trailing `;`, path-style, colon-style, `;`-separated `key=value` args, padded whitespace, trailing newline), plus write-verb-still-reports-a-verb-failure, empty-frame-is-a-verb-failure, and single-command-returns-the-stripped-frame. Their job is to fail if the multi-command rejection over-reaches, which is the main risk in this change.

Also from review: the stale `# Fan-out … (readOnly applies only to the upfront verb check — per-node results are returned verbatim)` comment at `routers/clusters.py:164-165` — the text this PR body quotes as evidence of the defect — has been rewritten, since leaving it next to the fixed code is how the next reader concludes the hole is still open.

New tests:

- `api/tests/test_info_verbs.py::TestSingleCommandFrame` — 6 newline-chained shapes (LF, CRLF, bare CR, both-halves-allowlisted, blank line, surrounded by whitespace), 7 `;`-chained shapes, **5 space/tab-chained shapes, and 4 exotic-whitespace shapes (VT, FF, NEL, NBSP)** rejected; 11 legitimate single-command shapes still accepted; a write verb in a well-formed frame still reports a *verb* failure rather than a framing one; empty input still surfaces as an empty verb; the message does not echo the input; both failures catchable via the shared base.
- `api/tests/test_clusters_router_info.py::TestExecuteInfoWhitelistRejection` — 3 added: newline-chained and `;`-chained frames each 400 with `info_all` never called, plus `test_fan_out_transmits_the_validated_string`, which asserts the fan-out branch sends the validated string (whitespace padding as the observable proxy) and so would fail if the router went back to forwarding `body.commands`.

No Aerospike server, database or container was started; the suite runs entirely on mocks.

## Risk

Behaviour change: a `readOnly=true` request whose command entry holds more than one command — or any internal whitespace — now 400s where it previously ran. The whitespace half is the broader of the two: a client that padded *inside* a command (`"sets/ test"`) would start failing. No such syntax is valid asinfo and nothing in this repo or ackoctl produces one, but it is a wider net than the newline rule alone. Nothing in this repo constructs such an entry, and the four multi-command shapes rejected are not valid single asinfo commands. The remaining risk is a client that batched commands into one string on purpose; the fix message tells it to split them across `commands[]`, which the endpoint has always supported.

The `assert_read_only` return type changed from `str` to a NamedTuple. Both in-repo callers are updated. The tuple is not `str`-compatible, so any out-of-repo caller comparing the result to a verb string would fail loudly at its own tests rather than silently — an intentional trade for making the transmitted value explicit. Nothing else in this repo imports the function (verified by grep across `api/src` and `api/tests`).

Unchanged: the allowlist contents, the `readOnly=false` passthrough, authentication, and rate limiting.

Closes #469

🤖 Generated with [Claude Code](https://claude.com/claude-code)
