### PR TITLE
fix(security): gate the raw asinfo write passthrough with an allowlist, opt-in flag, and rate limit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,6 +142,22 @@ K8S_MANAGEMENT_ENABLED=false
 # Never enable in production.
 # ACM_ALLOW_EPHEMERAL_KEK=false
 
+# ─── asinfo write passthrough ─────────────────────────────────────────────
+# POST /clusters/{conn_id}/info with readOnly=false transmits STATE-CHANGING
+# asinfo commands to the cluster. Off by default: the route answers 403
+# until this is true. readOnly=true (diagnostics) is unaffected and needs
+# no opt-in.
+#
+# Enabling this does not remove the other two gates: the verb must still be
+# on info_verbs.WRITE_INFO_VERBS (set-config, recluster, log-set, jobs) or
+# the read-only list, and each write is charged against a 5/minute per-client
+# budget. Destructive verbs (truncate-namespace, sindex-delete, roster-set,
+# quiesce, ...) are never accepted here — use the typed routes.
+#
+# Enable only alongside OIDC_ENABLED=true. With auth off, anyone who can
+# reach the API port can drive whatever this flag permits.
+# ACM_ALLOW_INFO_WRITE=false
+
 # ─── Embedded AI Copilot (UI, optional) ───────────────────────────────────
 # In-UI chat assistant (CopilotKit) served by the web container. Disabled
 # unless BOTH a model and the matching provider key are set — deployments

--- a/README.md
+++ b/README.md
@@ -788,6 +788,31 @@ The following tables list environment variables, defaults, and descriptions. See
 | `ACM_PASSWORD_KEK`        | _(empty)_ | Fernet key used to encrypt stored Aerospike connection passwords. Required for persistent credentials                                       |
 | `ACM_ALLOW_EPHEMERAL_KEK` | `false`   | Dev-only escape hatch that generates a process-local key when `ACM_PASSWORD_KEK` is unset. Stored passwords become unreadable after restart |
 
+### asinfo Write Passthrough
+
+| Variable               | Default | Description                                                                                                                                     |
+| ---------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ACM_ALLOW_INFO_WRITE` | `false` | Allow `POST /clusters/{conn_id}/info` with `readOnly=false`. Off by default; the route answers 403 until it is set. See the note below |
+
+`POST /clusters/{conn_id}/info` backs `ackoctl info`. With `readOnly=true`
+(the default) it runs read-only asinfo diagnostics and needs no opt-in.
+
+`readOnly=false` selects the write passthrough, which is off by default and
+has three independent gates even once enabled:
+
+1. `ACM_ALLOW_INFO_WRITE=true` must be set, or the route answers **403**.
+2. The command's verb must be on `info_verbs.WRITE_INFO_VERBS`
+   (`set-config`, `recluster`, `log-set`, `jobs`) or on the read-only list,
+   and the frame must hold exactly one command — otherwise **400**.
+   Destructive verbs such as `truncate-namespace` are never accepted here;
+   use the dedicated typed routes, which are authenticated and rate-limited.
+3. Each write request is charged against a **5/minute per-client** budget,
+   separate from the 60/minute global default that reads use — **429** when
+   exhausted.
+
+Enabling the flag is not a substitute for authentication. Turn on
+`OIDC_ENABLED` before exposing a write-capable API beyond localhost.
+
 ### Kubernetes Management
 
 | Variable                 | Default | Description                                                                                    |

--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -181,6 +181,18 @@ ACM_PASSWORD_KEK_ENV: str = "ACM_PASSWORD_KEK"
 ACM_ALLOW_EPHEMERAL_KEK_ENV: str = "ACM_ALLOW_EPHEMERAL_KEK"
 
 # ---------------------------------------------------------------------------
+# Raw asinfo write passthrough (POST /clusters/{conn_id}/info, readOnly=false)
+# ---------------------------------------------------------------------------
+# Off by default (#467). The read-only path needs no opt-in; the write path
+# transmits state-changing asinfo commands, so an operator has to say yes
+# once — the same shape as ACM_ALLOW_EPHEMERAL_KEK above. Even when this is
+# on, the verb must still be on ``info_verbs.WRITE_INFO_VERBS`` and the
+# request is charged against a dedicated 5/minute budget
+# (``rate_limit.INFO_WRITE_LIMIT``); this flag opens the door, it does not
+# hand over the cluster.
+ACM_ALLOW_INFO_WRITE: bool = _get_bool("ACM_ALLOW_INFO_WRITE", False)
+
+# ---------------------------------------------------------------------------
 # OIDC / Keycloak native JWT verification (Phase 0 contracts C-4, C-6, C-7)
 # ---------------------------------------------------------------------------
 # When OIDC_ENABLED=false the middleware is a no-op (still installed but

--- a/api/src/aerospike_cluster_manager_api/info_verbs.py
+++ b/api/src/aerospike_cluster_manager_api/info_verbs.py
@@ -1,10 +1,10 @@
-"""Read-only asinfo verb whitelist for the REST API info endpoint.
+"""asinfo verb whitelists for the REST API info endpoint.
 
 The Aerospike asinfo protocol multiplexes both reads (``namespaces``,
 ``version``, ``roster:``, ...) and writes (``set-config:``, ``recluster:``,
-``truncate-namespace:``) over the same wire format. The read-only info
-endpoint therefore cannot decide a command's safety from its shape alone
-— it needs to inspect the *verb* (the leading token of the command).
+``truncate-namespace:``) over the same wire format. The info endpoint
+therefore cannot decide a command's safety from its shape alone — it needs
+to inspect the *verb* (the leading token of the command).
 
 The verb alone is not sufficient, though: asinfo is a *multi-command* wire
 format, so a frame whose leading verb is read-only can carry a second
@@ -14,12 +14,23 @@ things — the frame holds exactly one command
 and returns the validated string so callers transmit that rather than the
 caller's original.
 
-This module is the single source of truth for that decision. The service
+There are **two** whitelists, and every command passes exactly one of them:
+
+* :data:`READ_ONLY_INFO_VERBS` via :func:`assert_read_only` — the default
+  path (``readOnly=true``), verbs that change no state at all.
+* :data:`WRITE_INFO_VERBS` via :func:`assert_write_allowed` — the opt-in
+  path (``readOnly=false``), a deliberately small set of *operational*
+  mutations that cannot destroy data. This path used to have no allowlist
+  of any kind, so ``truncate-namespace:`` reached the wire unchallenged
+  (#467); it is now allowlisted like the read path, and the route also
+  requires ``ACM_ALLOW_INFO_WRITE=true`` before it will serve at all.
+
+This module is the single source of truth for both decisions. The service
 layer raises :class:`InfoCommandRejected` subclasses, which the router maps
 to an HTTP 400 with a "pick a different verb" / "one command per entry"
 hint.
 
-To add a verb:
+To add a read verb:
 
 1. Verify in the Aerospike CE 8.1 docs that the verb is purely read-only
    and triggers no persistent state change (no log dump, no metric
@@ -30,6 +41,11 @@ To add a verb:
    ``tests/test_info_verbs.py::test_whitelist_membership_is_pinned`` —
    that pin exists so silent ADDITIONS are caught at review time, not
    just silent removals.
+
+To add a write verb the bar is higher: it must be reversible and must not
+delete, truncate, or render unavailable any record. See the rationale block
+above :data:`WRITE_INFO_VERBS`, and update
+``tests/test_info_verbs.py::test_write_whitelist_membership_is_pinned``.
 """
 
 from __future__ import annotations
@@ -71,6 +87,56 @@ READ_ONLY_INFO_VERBS: frozenset[str] = frozenset(
 )
 
 
+# Write verbs the opt-in (``readOnly=false``) path may transmit.
+#
+# Membership rule — a verb belongs here only if BOTH hold:
+#
+#   * it is an *operational* mutation: runtime configuration, cluster
+#     re-formation, log verbosity, or job control; and
+#   * it cannot delete, truncate, or render unavailable a single record.
+#
+# Deliberately EXCLUDED, with the reason, so the omissions read as decisions
+# rather than oversights:
+#
+#   truncate-namespace, truncate  — immediate, irreversible data loss. This
+#     is the verb #467 was filed about; ACM's own set truncation goes through
+#     the typed ``records_service.truncate_set`` route, which is authenticated,
+#     rate-limited, and takes an explicit LUT cutoff.
+#   sindex-delete, set-drop       — destroy an index / set definition; ACM has
+#     typed routes for both.
+#   roster-set                    — a wrong roster in a strong-consistency
+#     namespace makes partitions unavailable. Not reversible from the same
+#     endpoint under time pressure.
+#   quiesce, quiesce-undo, dun, undun — change cluster membership and therefore
+#     availability. Operationally legitimate, but they belong behind a typed
+#     route with confirmation, not a raw passthrough.
+#
+# This set is intentionally small. Widening it is a security decision: it must
+# come with a docs update and a change to the pin test, exactly as the read
+# list requires.
+WRITE_INFO_VERBS: frozenset[str] = frozenset(
+    {
+        # Runtime configuration — the only write verb ACM itself issues
+        # (``clusters_service.configure_namespace``).
+        "set-config",
+        # Force cluster re-formation after a roster or topology change.
+        "recluster",
+        # Server-side log verbosity: `log-set:id=<id>;<context>=<level>`.
+        "log-set",
+        # Scan/query job control: `jobs:module=scan;cmd=kill-job;trx-id=<id>`.
+        # The operator escape hatch for a runaway scan — it stops work, it
+        # never destroys data.
+        "jobs",
+    }
+)
+
+
+# What the ``readOnly=false`` path accepts. A caller who opted into the write
+# path may still send read verbs — rejecting ``namespaces`` there would be a
+# surprise with no security value — so the write gate checks the union.
+ALLOWED_INFO_VERBS: frozenset[str] = READ_ONLY_INFO_VERBS | WRITE_INFO_VERBS
+
+
 # Curated hint verbs surfaced in error messages — the high-signal diagnostic
 # reads operators actually want. Hand-picked rather than ``sorted()[:5]``,
 # which would surface ``build-*`` triplicates that don't help the LLM pick a
@@ -100,6 +166,27 @@ class InfoVerbNotAllowed(InfoCommandRejected):
         super().__init__(
             f"Verb {verb!r} is not on the read-only asinfo whitelist; "
             f"pick from: {sample} (full list at info_verbs.READ_ONLY_INFO_VERBS)."
+        )
+        self.verb = verb
+
+
+class InfoWriteVerbNotAllowed(InfoCommandRejected):
+    """Raised when a ``readOnly=false`` command's verb is on neither allowlist.
+
+    Distinct from :class:`InfoVerbNotAllowed` because the remedy is
+    different: there is no "pass readOnly=false" escape hatch left to
+    suggest — the caller is already on the write path and the verb is
+    simply not one this endpoint will transmit.
+    """
+
+    def __init__(self, verb: str) -> None:
+        sample = ", ".join(sorted(WRITE_INFO_VERBS))
+        super().__init__(
+            f"Verb {verb!r} is not on the asinfo write allowlist; "
+            f"the write path accepts {sample} plus every read-only verb "
+            "(full lists at info_verbs.WRITE_INFO_VERBS / READ_ONLY_INFO_VERBS). "
+            "Destructive verbs such as 'truncate-namespace' are never accepted here — "
+            "use the dedicated typed route instead."
         )
         self.verb = verb
 
@@ -301,4 +388,33 @@ def assert_read_only(command: str) -> ValidatedInfoCommand:
     verb = extract_verb(validated)
     if verb not in READ_ONLY_INFO_VERBS:
         raise InfoVerbNotAllowed(verb)
+    return ValidatedInfoCommand(command=validated, verb=verb)
+
+
+def assert_write_allowed(command: str) -> ValidatedInfoCommand:
+    """Validate ``command`` for the opt-in ``readOnly=false`` path.
+
+    Same two-check shape as :func:`assert_read_only`, against the wider
+    :data:`ALLOWED_INFO_VERBS` union:
+
+    1. :func:`assert_single_command` — the frame holds exactly one command.
+       This matters *more* on the write path than on the read path: without
+       it ``set-config:context=service;foo=1\\ntruncate-namespace:namespace=test``
+       would pass a verb check on its head and then truncate a namespace.
+    2. the leading verb is on :data:`READ_ONLY_INFO_VERBS` or
+       :data:`WRITE_INFO_VERBS`.
+
+    Returns a :class:`ValidatedInfoCommand`; transmit ``.command``, never the
+    caller's original string. Raises :class:`InfoCommandNotSingle` or
+    :class:`InfoWriteVerbNotAllowed` (both :class:`InfoCommandRejected`)
+    before any wire round-trip.
+
+    This is only the *verb* gate. Whether the write path is reachable at all
+    is a separate decision made at the route, which requires the opt-in
+    ``ACM_ALLOW_INFO_WRITE`` flag and charges a dedicated rate-limit budget.
+    """
+    validated = assert_single_command(command)
+    verb = extract_verb(validated)
+    if verb not in ALLOWED_INFO_VERBS:
+        raise InfoWriteVerbNotAllowed(verb)
     return ValidatedInfoCommand(command=validated, verb=verb)

--- a/api/src/aerospike_cluster_manager_api/models/cluster.py
+++ b/api/src/aerospike_cluster_manager_api/models/cluster.py
@@ -89,6 +89,13 @@ class ExecuteInfoRequest(BaseModel):
         verb must be on :data:`info_verbs.READ_ONLY_INFO_VERBS`.
         Whitelist violations short-circuit with HTTP 400 *before* any
         wire round-trip.
+
+        When ``False`` the caller selects the write passthrough. That path
+        is **not** "no whitelist" — it was, and that was #467. It now
+        requires ``config.ACM_ALLOW_INFO_WRITE`` (403 otherwise), accepts
+        only :data:`info_verbs.ALLOWED_INFO_VERBS` (400 otherwise), and is
+        charged against a dedicated 5/minute budget (429 otherwise). This
+        field selects *which* allowlist applies; it never disables one.
     """
 
     commands: list[str] = Field(min_length=1)

--- a/api/src/aerospike_cluster_manager_api/rate_limit.py
+++ b/api/src/aerospike_cluster_manager_api/rate_limit.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import ipaddress
 
+from limits import RateLimitItem, parse
 from slowapi import Limiter
 from starlette.requests import Request
 
@@ -116,3 +117,40 @@ def _get_client_ip(request: Request) -> str:
 DEFAULT_LIMITS = ["60/minute"]
 
 limiter = Limiter(key_func=_get_client_ip, default_limits=DEFAULT_LIMITS)  # type: ignore[arg-type]  # slowapi default_limits accepts list[str]; pyright strict-checks against alias
+
+
+# ---------------------------------------------------------------------------
+# Body-conditional budgets
+# ---------------------------------------------------------------------------
+# ``@limiter.limit`` decides before the handler runs and cannot see the parsed
+# body — slowapi's own ``exempt_when`` hook is called with no arguments (see
+# ``slowapi.wrappers.Limit.is_exempt``). That is fine for routes where every
+# request costs the same, but ``POST /clusters/{conn_id}/info`` is two routes
+# wearing one path: a read-only diagnostic that ``ackoctl info`` polls, and an
+# opt-in write passthrough. Decorating the route would put the strict write
+# budget on the reads as well.
+#
+# ``consume_budget`` therefore lets a handler charge a named budget once it
+# knows which path the request took. Same key function as the decorator, so
+# the bucket follows the same trusted-proxy rules.
+
+# Raw asinfo write passthrough (#467). Deliberately far below the 60/minute
+# global default: state-changing asinfo is an operator action, not traffic.
+INFO_WRITE_LIMIT: RateLimitItem = parse("5/minute")
+
+
+def consume_budget(request: Request, item: RateLimitItem, scope: str) -> bool:
+    """Charge one hit against ``item`` for this request's client, in ``scope``.
+
+    Returns ``True`` when the request is within budget and ``False`` when it
+    has been exhausted — the caller raises HTTP 429. ``scope`` namespaces the
+    bucket so two budgets sharing a client IP do not share a counter.
+
+    ``limiter.enabled`` is honoured for the same reason slowapi's own
+    ``_check_request_limit`` honours it: "rate limiting is off" has to mean
+    every budget, or a test suite that disables the limiter still trips over
+    the ones the decorator does not own.
+    """
+    if not limiter.enabled:
+        return True
+    return limiter.limiter.hit(item, scope, _get_client_ip(request))

--- a/api/src/aerospike_cluster_manager_api/routers/clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/clusters.py
@@ -4,11 +4,14 @@ import logging
 
 from fastapi import APIRouter, HTTPException, Request
 
+from aerospike_cluster_manager_api import config, rate_limit
 from aerospike_cluster_manager_api.dependencies import AerospikeClient, VerifiedConnId
 from aerospike_cluster_manager_api.info_verbs import (
     InfoCommandNotSingle,
     InfoVerbNotAllowed,
+    InfoWriteVerbNotAllowed,
     assert_read_only,
+    assert_write_allowed,
 )
 from aerospike_cluster_manager_api.models.cluster import (
     ClusterInfo,
@@ -100,43 +103,74 @@ async def configure_namespace(
         "Mirrors the MCP execute_info / execute_info_on_node / "
         "execute_info_read_only contracts so ackoctl can drive raw asinfo "
         "diagnostics over the REST surface. "
-        "When readOnly=true (default), each command is validated BEFORE any "
-        "wire round-trip: it must hold exactly one asinfo command (the wire "
-        "format is multi-command) and its leading verb must be on the "
-        "read-only whitelist. A single rejected command fails the entire "
-        "call with 400, and only the validated string is transmitted."
+        "Every command is validated BEFORE any wire round-trip: it must hold "
+        "exactly one asinfo command (the wire format is multi-command) and its "
+        "leading verb must be on a whitelist. A single rejected command fails "
+        "the entire call with 400, and only the validated string is transmitted. "
+        "When readOnly=true (default) the whitelist is the read-only verb set. "
+        "readOnly=false selects the write passthrough, which additionally "
+        "requires ACM_ALLOW_INFO_WRITE=true on the API (403 otherwise), accepts "
+        "only info_verbs.WRITE_INFO_VERBS plus the read-only verbs — never "
+        "destructive verbs such as truncate-namespace — and is charged against "
+        "a dedicated 5/minute per-client budget (429 when exhausted)."
     ),
 )
 async def execute_info(
+    request: Request,
     body: ExecuteInfoRequest,
     client: AerospikeClient,
     conn_id: VerifiedConnId,
 ) -> ExecuteInfoResponse:
     """Run asinfo commands per the ExecuteInfoRequest semantics."""
-    # When readOnly is on, fail-fast on the FIRST rejected command so it
-    # never reaches the wire. Pydantic already enforces commands non-empty.
+    # The write path is opt-in and off by default (#467). Refuse before
+    # touching the connection so a deployment that never enabled it cannot be
+    # probed for which verbs it would have accepted.
+    if not body.readOnly and not config.ACM_ALLOW_INFO_WRITE:
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "asinfo write passthrough is disabled; set ACM_ALLOW_INFO_WRITE=true "
+                "on the API to enable readOnly=false, or use readOnly=true for diagnostics."
+            ),
+        )
+
+    # Charge the write budget before validation, so a caller cannot probe the
+    # allowlist for free by sending commands that 400. Reads keep the 60/minute
+    # global default — this route is the diagnostic path ackoctl polls, and a
+    # route-level decorator could not tell the two apart (see
+    # rate_limit.consume_budget).
+    if not body.readOnly and not rate_limit.consume_budget(request, rate_limit.INFO_WRITE_LIMIT, "clusters:info:write"):
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit exceeded: 5 per 1 minute (asinfo write passthrough)",
+        )
+
+    # Fail-fast on the FIRST rejected command so it never reaches the wire.
+    # Pydantic already enforces commands non-empty.
     #
     # Keep the VALIDATED strings and run those: forwarding body.commands
     # after validating it is the bug that let a frame carrying an
     # allowlisted verb plus a trailing second command through, since only
     # the leading verb was ever inspected.
     validated: list[str] = []
-    if body.readOnly:
-        for cmd in body.commands:
-            try:
-                validated.append(assert_read_only(cmd).command)
-            except InfoVerbNotAllowed as exc:
-                raise HTTPException(
-                    status_code=400,
-                    detail=(f"command '{exc.verb}' not in read-only whitelist; pass readOnly=false to allow"),
-                ) from exc
-            except InfoCommandNotSingle as exc:
-                raise HTTPException(status_code=400, detail=str(exc)) from exc
+    for cmd in body.commands:
+        try:
+            gate = assert_read_only if body.readOnly else assert_write_allowed
+            validated.append(gate(cmd).command)
+        except InfoVerbNotAllowed as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=(f"command '{exc.verb}' not in read-only whitelist; pass readOnly=false to allow"),
+            ) from exc
+        except InfoWriteVerbNotAllowed as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except InfoCommandNotSingle as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     results: list[InfoCommandResult] = []
     target_node = body.node or None
 
-    for cmd in validated if body.readOnly else body.commands:
+    for cmd in validated:
         if target_node is not None and body.readOnly:
             # Single-node read-only: whitelist already enforced above;
             # service still re-validates as a defense-in-depth.
@@ -155,7 +189,10 @@ async def execute_info(
             results.append(InfoCommandResult(command=cmd, node=node, output=response))
 
         elif target_node is not None and not body.readOnly:
-            # Single-node, no whitelist gate.
+            # Single-node write passthrough. `cmd` came out of
+            # assert_write_allowed above, so the verb is on the write
+            # allowlist and the frame holds exactly one command; the service
+            # primitive itself stays unrestricted by design.
             try:
                 response = await clusters_service.execute_info_on_node(client, cmd, target_node)
             except NodeNotFoundError as exc:
@@ -172,7 +209,7 @@ async def execute_info(
 
         else:
             # Fan-out across every node. `cmd` comes from the validated list
-            # when readOnly is on, so this branch transmits only what the gate
+            # on BOTH paths now, so this branch transmits only what a gate
             # returned. It previously read body.commands directly, which left
             # the allowlist advisory here — and this is the DEFAULT branch,
             # taken whenever the caller names no node. Per-node responses are

--- a/api/tests/test_clusters_router_info.py
+++ b/api/tests/test_clusters_router_info.py
@@ -17,7 +17,9 @@ import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
+from aerospike_cluster_manager_api import config
 from aerospike_cluster_manager_api.main import app
+from aerospike_cluster_manager_api.rate_limit import limiter
 from aerospike_cluster_manager_api.services.info_cache import info_cache
 
 
@@ -86,6 +88,34 @@ async def _clear_cache():
     await info_cache.clear()
     yield
     await info_cache.clear()
+
+
+@pytest.fixture()
+def allow_info_write(monkeypatch):
+    """Opt the asinfo write passthrough on for one test (#467).
+
+    Off is the default and is itself asserted by
+    ``TestExecuteInfoWriteGate.test_write_path_is_403_when_flag_is_off`` —
+    every test that wants to reach the verb allowlist has to say so.
+    """
+    monkeypatch.setattr(config, "ACM_ALLOW_INFO_WRITE", True)
+
+
+@pytest.fixture()
+def enforce_rate_limits():
+    """Re-enable the limiter that the ``client`` fixture switches off.
+
+    The suite runs with ``app.state.limiter.enabled = False`` so unrelated
+    tests never bump the 60/minute global default. A test that is *about* a
+    limit has to turn it back on, and clear the storage first so it does not
+    inherit hits from whatever ran before it in the same wall-clock minute.
+    """
+    limiter.limiter.storage.reset()
+    previous = limiter.enabled
+    limiter.enabled = True
+    yield
+    limiter.enabled = previous
+    limiter.limiter.storage.reset()
 
 
 class TestExecuteInfoSingleNodeReadOnly:
@@ -285,7 +315,9 @@ class TestExecuteInfoWhitelistRejection:
         assert sent == ["namespaces"]
 
     @pytest.mark.asyncio
-    async def test_readonly_false_allows_unwhitelisted_verb(self, client: AsyncClient, sample_connection):
+    async def test_readonly_false_allows_allowlisted_write_verb(
+        self, client: AsyncClient, sample_connection, allow_info_write
+    ):
         from aerospike_cluster_manager_api import db
 
         await db.create_connection(sample_connection)
@@ -314,6 +346,183 @@ class TestExecuteInfoWhitelistRejection:
         assert len(rows) == 2
         assert all(r["output"] == "ok" for r in rows)
         assert all(r["error"] is None for r in rows)
+
+
+class TestExecuteInfoWriteGate:
+    """``readOnly=false`` is an opt-in, allowlisted, rate-limited path (#467).
+
+    It used to be the *absence* of a gate: any string the caller supplied was
+    forwarded to ``info_all``, unauthenticated in the default configuration,
+    with no rate limit. Each test below pins one of the three checks that now
+    stand between a caller and the wire.
+    """
+
+    @pytest.mark.asyncio
+    async def test_write_path_is_403_when_flag_is_off(self, client: AsyncClient, sample_connection):
+        """Default configuration refuses the write path outright."""
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={"commands": ["set-config:context=service;migrate-threads=2"], "readOnly": False},
+            )
+
+        assert resp.status_code == 403, resp.text
+        assert "ACM_ALLOW_INFO_WRITE" in resp.json()["detail"]
+        mock_as_client.info_all.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_read_path_unaffected_by_the_flag(self, client: AsyncClient, sample_connection):
+        """The 403 is scoped to writes — diagnostics keep working by default."""
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={"commands": ["namespaces"], "readOnly": True},
+            )
+
+        assert resp.status_code == 200, resp.text
+
+    @pytest.mark.asyncio
+    async def test_destructive_verb_rejected_with_400(self, client: AsyncClient, sample_connection, allow_info_write):
+        """The verb that motivated #467: namespace truncation is data loss."""
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={"commands": ["truncate-namespace:namespace=test"], "readOnly": False},
+            )
+
+        assert resp.status_code == 400, resp.text
+        assert "truncate-namespace" in resp.json()["detail"]
+        mock_as_client.info_all.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_unknown_write_verb_rejected_with_400(self, client: AsyncClient, sample_connection, allow_info_write):
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={"commands": ["some-verb-nobody-audited:x=1"], "readOnly": False},
+            )
+
+        assert resp.status_code == 400, resp.text
+        assert "write allowlist" in resp.json()["detail"]
+        mock_as_client.info_all.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_write_path_rejects_multi_command_frame(
+        self, client: AsyncClient, sample_connection, allow_info_write
+    ):
+        """A whitelisted head must not smuggle a destructive tail.
+
+        Without the single-command check, the verb gate would inspect
+        ``set-config`` and forward the whole frame — truncating the namespace.
+        """
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={
+                    "commands": ["set-config:context=service;migrate-threads=2\ntruncate-namespace:namespace=test"],
+                    "readOnly": False,
+                },
+            )
+
+        assert resp.status_code == 400, resp.text
+        assert "not a single asinfo command" in resp.json()["detail"]
+        mock_as_client.info_all.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_batch_is_atomic_one_bad_verb_blocks_all(
+        self, client: AsyncClient, sample_connection, allow_info_write
+    ):
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={
+                    "commands": ["recluster:", "truncate-namespace:namespace=test"],
+                    "readOnly": False,
+                },
+            )
+
+        assert resp.status_code == 400, resp.text
+        # The legal first command must not have run either.
+        mock_as_client.info_all.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_write_path_is_rate_limited(
+        self, client: AsyncClient, sample_connection, allow_info_write, enforce_rate_limits
+    ):
+        """5/minute, and it is charged even for rejected commands.
+
+        Charging before validation is deliberate: otherwise the allowlist
+        itself becomes a free oracle — a caller could enumerate which verbs a
+        deployment would accept at the 60/minute global rate.
+        """
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+        mock_as_client.info_all.side_effect = lambda cmd: [_info_all_result("BB9020011AC4202", "ok")]
+
+        codes: list[int] = []
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            return_value=mock_as_client,
+        ):
+            for _ in range(6):
+                resp = await client.post(
+                    f"/api/v1/clusters/{sample_connection.id}/info",
+                    json={"commands": ["recluster:"], "readOnly": False},
+                )
+                codes.append(resp.status_code)
+
+        assert codes[:5] == [200] * 5, codes
+        assert codes[5] == 429, codes
 
 
 class TestExecuteInfoFanOut:

--- a/api/tests/test_info_verbs.py
+++ b/api/tests/test_info_verbs.py
@@ -1,4 +1,4 @@
-"""Unit tests for the read-only asinfo verb whitelist domain module.
+"""Unit tests for the asinfo verb whitelist domain module.
 
 Covers:
 
@@ -8,6 +8,10 @@ Covers:
   whitelist plus a representative set of write / unknown verbs. The
   parametrized "all whitelisted verbs pass" test is the regression net
   that catches accidental whitelist trims.
+* :func:`assert_write_allowed` — the ``readOnly=false`` gate added by #467,
+  which replaced "no allowlist at all" on the write path.
+  ``TestAssertWriteAllowed`` pins both whitelists as literal sets so a verb
+  moving between them is a visible decision.
 * :func:`assert_single_command` framing decisions — asinfo is a
   multi-command wire format, so ``TestSingleCommandFrame`` pins both the
   chained shapes that must be rejected and the legitimate single-command
@@ -19,12 +23,16 @@ from __future__ import annotations
 import pytest
 
 from aerospike_cluster_manager_api.info_verbs import (
+    ALLOWED_INFO_VERBS,
     READ_ONLY_INFO_VERBS,
+    WRITE_INFO_VERBS,
     InfoCommandNotSingle,
     InfoCommandRejected,
     InfoVerbNotAllowed,
+    InfoWriteVerbNotAllowed,
     assert_read_only,
     assert_single_command,
+    assert_write_allowed,
     extract_verb,
 )
 
@@ -434,3 +442,118 @@ class TestDumpVerbCatalog:
         # the categories the audit currently produces so the set of
         # legal categories stays explicit in code.
         assert category in {"log_only", "not_in_ce_8_1"}
+
+
+class TestAssertWriteAllowed:
+    """The ``readOnly=false`` gate (#467).
+
+    That path used to have no allowlist at all: whatever the caller sent
+    reached ``client.info_all`` verbatim. These tests pin the two checks it
+    now runs — same framing check as the read path, wider verb set.
+    """
+
+    def test_write_whitelist_membership_is_pinned(self) -> None:
+        """Same deliberate-decision pin as the read list, for the write list.
+
+        The write list guards state-changing commands, so a silent addition
+        matters more here than on the read side: the difference between this
+        set and the next one is the difference between reconfiguring a
+        cluster and truncating it.
+        """
+        expected = frozenset(
+            {
+                "set-config",
+                "recluster",
+                "log-set",
+                "jobs",
+            }
+        )
+        assert expected == WRITE_INFO_VERBS
+        assert len(WRITE_INFO_VERBS) == 4
+        # The two lists must stay disjoint — a verb on both would mean one of
+        # the two classifications is wrong.
+        assert not (WRITE_INFO_VERBS & READ_ONLY_INFO_VERBS)
+        assert ALLOWED_INFO_VERBS == READ_ONLY_INFO_VERBS | WRITE_INFO_VERBS
+
+    @pytest.mark.parametrize(
+        "verb",
+        [
+            "truncate-namespace",
+            "truncate",
+            "sindex-delete",
+            "set-drop",
+            "roster-set",
+            "quiesce",
+            "quiesce-undo",
+            "dun",
+            "undun",
+        ],
+    )
+    def test_destructive_verbs_stay_off_the_write_whitelist(self, verb: str) -> None:
+        """Each of these is excluded for a reason recorded in info_verbs.py.
+
+        Pinned as a test so re-adding one is a visible decision rather than a
+        one-line diff in a frozenset.
+        """
+        assert verb not in WRITE_INFO_VERBS
+        assert verb not in ALLOWED_INFO_VERBS
+
+    @pytest.mark.parametrize("verb", sorted(WRITE_INFO_VERBS))
+    def test_every_write_verb_passes(self, verb: str) -> None:
+        validated = assert_write_allowed(f"{verb}:")
+        assert validated.verb == verb
+        assert validated.command == f"{verb}:"
+
+    @pytest.mark.parametrize("verb", sorted(READ_ONLY_INFO_VERBS))
+    def test_read_verbs_also_pass(self, verb: str) -> None:
+        # Opting into the write path must not *lose* the read verbs — a
+        # caller sending `namespaces` with readOnly=false is doing nothing
+        # dangerous and rejecting it would be a surprise with no upside.
+        assert assert_write_allowed(verb).verb == verb
+
+    def test_set_config_with_multiple_args_passes(self) -> None:
+        # The exact shape clusters_service.configure_namespace builds.
+        cmd = "set-config:context=namespace;id=test;memory-size=2000000"
+        assert assert_write_allowed(cmd).command == cmd
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "truncate-namespace:namespace=test",
+            "truncate:namespace=test;set=foo",
+            "sindex-delete:namespace=test;indexname=idx",
+            "roster-set:namespace=test;nodes=BB9",
+            "quiesce:",
+            "some-verb-nobody-audited",
+        ],
+    )
+    def test_unlisted_verb_rejected(self, command: str) -> None:
+        with pytest.raises(InfoWriteVerbNotAllowed):
+            assert_write_allowed(command)
+
+    def test_rejection_is_an_info_command_rejected(self) -> None:
+        # Callers that only care "was it accepted?" catch the base class.
+        with pytest.raises(InfoCommandRejected):
+            assert_write_allowed("truncate-namespace:namespace=test")
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "set-config:context=service;migrate-threads=2\ntruncate-namespace:namespace=test",
+            "recluster;truncate-namespace:namespace=test",
+            "set-config:context=service;a=1:truncate-namespace:namespace=test",
+        ],
+    )
+    def test_multi_command_frame_rejected(self, command: str) -> None:
+        # The head of each of these is an allowlisted write verb, so without
+        # the framing check the destructive tail would ride along to the wire.
+        with pytest.raises(InfoCommandNotSingle):
+            assert_write_allowed(command)
+
+    def test_error_message_names_the_verb_and_the_alternatives(self) -> None:
+        with pytest.raises(InfoWriteVerbNotAllowed) as exc_info:
+            assert_write_allowed("truncate-namespace:namespace=test")
+        message = str(exc_info.value)
+        assert "truncate-namespace" in message
+        assert "set-config" in message
+        assert exc_info.value.verb == "truncate-namespace"


### PR DESCRIPTION
Closes #467

## What was wrong

`POST /clusters/{conn_id}/info` accepts a client-supplied `readOnly` flag. With `readOnly=false` the allowlist check was skipped entirely and the caller's string went straight to `client.info_all()` — no write-verb allowlist, no rate limit, and in the default configuration (`OIDC_ENABLED=false`) no authentication. `truncate-namespace:` was reachable that way.

## What changed

The `readOnly` field now selects *which* allowlist applies; it never disables one.

**1. Opt-in flag — `ACM_ALLOW_INFO_WRITE`, default `false`** (`config.py`)
The route answers **403** for `readOnly=false` until an operator sets it, mirroring the existing `ACM_ALLOW_EPHEMERAL_KEK` pattern. The check runs before the connection is touched, so a deployment that never enabled it cannot be probed for which verbs it would have accepted. `readOnly=true` diagnostics are unaffected.

**2. Write verb allowlist — `info_verbs.WRITE_INFO_VERBS`**
Four verbs: `set-config`, `recluster`, `log-set`, `jobs`. Membership rule, recorded in the module: an operational mutation that cannot delete, truncate, or render unavailable a single record. `truncate-namespace`, `truncate`, `sindex-delete`, `set-drop`, `roster-set`, `quiesce`/`quiesce-undo`, `dun`/`undun` are excluded, each with its reason in a comment and each pinned by a test so re-adding one is a visible decision.

`assert_write_allowed` checks the union `WRITE_INFO_VERBS | READ_ONLY_INFO_VERBS` — rejecting `namespaces` on the write path would be a surprise with no security value — and runs `assert_single_command` first. That framing check matters more here than on the read path: without it `set-config:context=service;migrate-threads=2\ntruncate-namespace:namespace=test` passes a verb check on its head and then truncates a namespace.

**3. Rate limit — 5/minute per client, charged before validation**
Charging before validation is deliberate: otherwise the allowlist itself becomes a free oracle at the 60/minute global rate.

### Deviation from the issue's suggested fix, and why

The issue suggests `@limiter.limit("5/minute")` on the route. I did not do that. This one URL is two things — the read-only diagnostic `ackoctl info` polls, and the write passthrough — and a route decorator cannot tell them apart: slowapi decides before the handler runs, and its own `exempt_when` hook is called with no arguments (`slowapi/wrappers.py`, `Limit.is_exempt`). Decorating the route would drop every read to 5/minute.

Instead `rate_limit.consume_budget(request, item, scope)` charges a named budget once the handler knows which path the request took, using slowapi's own storage and the same `_get_client_ip` key function, so the bucket follows the same trusted-proxy rules. Reads keep the 60/minute global default. `consume_budget` honours `limiter.enabled` for the same reason slowapi's `_check_request_limit` does.

### Test change worth flagging

`test_readonly_false_allows_unwhitelisted_verb` asserted the vulnerable behaviour (a `set-config:` returning 200 with `readOnly=false`). It is renamed to `test_readonly_false_allows_allowlisted_write_verb` and now takes the `allow_info_write` fixture — the command it sends is still allowlisted, so the assertion it makes is unchanged; what changed is that it has to opt in first.

## Files

- `api/src/aerospike_cluster_manager_api/info_verbs.py` — `WRITE_INFO_VERBS`, `ALLOWED_INFO_VERBS`, `InfoWriteVerbNotAllowed`, `assert_write_allowed`
- `api/src/aerospike_cluster_manager_api/config.py` — `ACM_ALLOW_INFO_WRITE`
- `api/src/aerospike_cluster_manager_api/rate_limit.py` — `INFO_WRITE_LIMIT`, `consume_budget`
- `api/src/aerospike_cluster_manager_api/routers/clusters.py` — the three gates
- `api/src/aerospike_cluster_manager_api/models/cluster.py` — `readOnly` semantics docstring
- `README.md`, `.env.example` — operator documentation
- `api/tests/test_info_verbs.py`, `api/tests/test_clusters_router_info.py` — +57 tests

## Verification

Ran the exact commands CI runs (`.github/workflows/ci.yaml`, `api` job).

```
$ cd api && uv run ruff check src/
All checks passed!

$ uv run ruff format --check src/
84 files already formatted

$ uv run pytest tests/ -v --tb=short
====================== 1124 passed, 6 warnings in 12.24s =======================
```

Baseline on `main` before this branch was `1067 passed`; the 57 added tests account for the difference. Also passes under random ordering (`pytest-randomly` is active by default) and with `-p no:randomly`.

`pre-commit run --files <every file this PR touches>`:

```
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check for merge conflicts................................................Passed
detect private key.......................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
pyright..................................................................Passed
```

The new tests, run on their own:

```
$ uv run pytest tests/test_clusters_router_info.py::TestExecuteInfoWriteGate \
    tests/test_info_verbs.py::TestAssertWriteAllowed -o addopts="" -v --tb=short -p no:randomly
tests/test_clusters_router_info.py::TestExecuteInfoWriteGate::test_write_path_is_403_when_flag_is_off PASSED [  1%]
tests/test_clusters_router_info.py::TestExecuteInfoWriteGate::test_read_path_unaffected_by_the_flag PASSED [  3%]
tests/test_clusters_router_info.py::TestExecuteInfoWriteGate::test_destructive_verb_rejected_with_400 PASSED [  5%]
tests/test_clusters_router_info.py::TestExecuteInfoWriteGate::test_unknown_write_verb_rejected_with_400 PASSED [  7%]
tests/test_clusters_router_info.py::TestExecuteInfoWriteGate::test_write_path_rejects_multi_command_frame PASSED [  8%]
tests/test_clusters_router_info.py::TestExecuteInfoWriteGate::test_batch_is_atomic_one_bad_verb_blocks_all PASSED [ 10%]
tests/test_clusters_router_info.py::TestExecuteInfoWriteGate::test_write_path_is_rate_limited PASSED [ 12%]
tests/test_info_verbs.py::TestAssertWriteAllowed::test_write_whitelist_membership_is_pinned PASSED [ 14%]
tests/test_info_verbs.py::TestAssertWriteAllowed::test_destructive_verbs_stay_off_the_write_whitelist[truncate-namespace] PASSED [ 15%]
tests/test_info_verbs.py::TestAssertWriteAllowed::test_destructive_verbs_stay_off_the_write_whitelist[truncate] PASSED [ 17%]
tests/test_info_verbs.py::TestAssertWriteAllowed::test_destructive_verbs_stay_off_the_write_whitelist[sindex-delete] PASSED [ 19%]
tests/test_info_verbs.py::TestAssertWriteAllowed::test_destructive_verbs_stay_off_the_write_whitelist[set-drop] PASSED [ 21%]
tests/test_info_verbs.py::TestAssertWriteAllowed::test_destructive_verbs_stay_off_the_write_whitelist[roster-set] PASSED [ 22%]
tests/test_info_verbs.py::TestAssertWriteAllowed::test_destructive_verbs_stay_off_the_write_whitelist[quiesce] PASSED [ 24%]
... (43 more) ...
tests/test_info_verbs.py::TestAssertWriteAllowed::test_multi_command_frame_rejected[set-config:context=service;migrate-threads=2\ntruncate-namespace:namespace=test] PASSED [ 94%]
tests/test_info_verbs.py::TestAssertWriteAllowed::test_multi_command_frame_rejected[recluster;truncate-namespace:namespace=test] PASSED [ 96%]
tests/test_info_verbs.py::TestAssertWriteAllowed::test_multi_command_frame_rejected[set-config:context=service;a=1:truncate-namespace:namespace=test] PASSED [ 98%]
tests/test_info_verbs.py::TestAssertWriteAllowed::test_error_message_names_the_verb_and_the_alternatives PASSED [100%]
============================== 57 passed in 0.33s ==============================
```

### Not verified here

- **UI job** — this PR touches no `ui/` file, so `npm run type-check / lint / test / build` were not run for it.
- **Against a live Aerospike cluster.** The tests mock `client.info_all`, so they pin what the API transmits, not how a real server replies. The four allowlisted verbs were selected from the Aerospike CE 8.1 asinfo surface and their argument shapes are covered by `assert_single_command` tests; nobody exercised them end-to-end on a running node in this environment.

## Note for operators upgrading

Any caller relying on `readOnly=false` will get a 403 until `ACM_ALLOW_INFO_WRITE=true` is set, and a 400 if it used a verb outside the four. That is the intended breaking change — the previous behaviour was unauthenticated arbitrary asinfo write in the default configuration.
