### PR TITLE
fix(security): apply the SSRF target gate to create, update, and every client build

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -118,14 +118,24 @@ K8S_MANAGEMENT_ENABLED=false
 # SSE_HEARTBEAT_INTERVAL=15
 # SSE_MAX_CONNECTIONS=50
 
-# ─── Connection test SSRF gate ────────────────────────────────────────────
-# /api/connections/test rejects probe requests targeting bare IP literals
-# in loopback (127.0.0.0/8, ::1) or link-local (169.254.0.0/16, includes
-# the EC2 IMDS 169.254.169.254) ranges. Without this gate an authenticated
-# caller could repurpose the endpoint as an SSRF / port-scan primitive.
+# ─── Connection target SSRF gate ──────────────────────────────────────────
+# The API refuses connection targets that are bare IP literals in loopback
+# (127.0.0.0/8, ::1) or link-local (169.254.0.0/16, includes the EC2 IMDS
+# 169.254.169.254, and fe80::/10) ranges. Without this gate a caller could
+# repurpose the API as an SSRF / port-scan primitive.
+#
+# The gate covers the WHOLE connection lifecycle: POST /api/connections/test,
+# create, update, and every client build in client_manager.get_client (so
+# profiles stored before the gate existed are covered too).
+#
 # Set to true ONLY for local dev where the API runs alongside a loopback
 # Aerospike (compose.dev.yaml). DNS hostnames are not pre-resolved here --
 # rely on egress firewall policy to backstop DNS-based bypasses.
+# ACM_ALLOW_PRIVATE_TARGETS=false
+#
+# Deprecated alias, still honoured so existing deployments keep working.
+# It predates the gate covering more than test-connection; prefer the name
+# above.
 # ACM_CONNECTION_TEST_ALLOW_PRIVATE=false
 
 # ─── At-rest encryption (connection passwords) ────────────────────────────

--- a/api/src/aerospike_cluster_manager_api/client_manager.py
+++ b/api/src/aerospike_cluster_manager_api/client_manager.py
@@ -36,6 +36,7 @@ from opentelemetry import trace
 from aerospike_cluster_manager_api import config, db
 from aerospike_cluster_manager_api.observability import make_instruments
 from aerospike_cluster_manager_api.services.info_cache import info_cache
+from aerospike_cluster_manager_api.target_policy import assert_targets_allowed
 from aerospike_cluster_manager_api.utils import parse_host_port
 
 _tracer = trace.get_tracer("aerospike_cluster_manager_api.client_manager")
@@ -109,6 +110,13 @@ class ClientManager:
             profile = await db.get_connection(conn_id)
             if profile is None:
                 raise ValueError(f"Connection profile '{conn_id}' not found")
+
+            # Last-resort SSRF gate (#470). Every route that touches a
+            # cluster funnels through here, so checking the STORED hosts
+            # covers profiles written before the create/update gates existed
+            # and any future write path that forgets to call them. Raises
+            # BlockedConnectionTargetError, which the router maps to 403.
+            assert_targets_allowed(profile.hosts, profile.port)
 
             hosts = [parse_host_port(h, profile.port) for h in profile.hosts]
             as_config: dict[str, Any] = {"hosts": hosts, "tend_interval": config.AS_TEND_INTERVAL}

--- a/api/src/aerospike_cluster_manager_api/models/connection.py
+++ b/api/src/aerospike_cluster_manager_api/models/connection.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Literal
+
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID
@@ -27,6 +29,24 @@ def _normalize_labels(v: object) -> dict[str, str]:
     return labels
 
 
+ConnectionErrorType = Literal["not_found", "unreachable", "auth_error", "blocked_target"]
+"""Why a health check reported ``connected=false``.
+
+Deliberately coarse (#470). The route is reachable unauthenticated in the
+default configuration, so the older set — ``timeout``, ``connection_refused``,
+``cluster_error``, ``unknown`` — let a caller distinguish a closed port from a
+filtered one from a live non-Aerospike listener, i.e. it was a port scanner.
+Those four collapse into ``unreachable``.
+
+``not_found`` (profile deleted mid-check) and ``auth_error`` (a real Aerospike
+answered and rejected the credentials) survive: neither reveals reachability
+the caller did not already have, and both change what the operator should do.
+
+Mirrored in ``ui/src/lib/types/connection.ts`` — keep both sides in sync
+(project goal 2-7).
+"""
+
+
 class ConnectionStatus(BaseModel):
     connected: bool
     nodeCount: int
@@ -38,8 +58,11 @@ class ConnectionStatus(BaseModel):
     diskUsed: int = 0
     diskTotal: int = 0
     tendHealthy: bool | None = None
+    # Fixed operator-facing text, never the driver's exception string — that
+    # carries host, port, and node identity (#470). See
+    # ``routers/connections._HEALTH_ERROR_MESSAGES``.
     error: str | None = None
-    errorType: str | None = None  # timeout | connection_refused | cluster_error | auth_error | unknown | not_found
+    errorType: ConnectionErrorType | None = None
 
 
 class ConnectionProfile(BaseModel):

--- a/api/src/aerospike_cluster_manager_api/routers/connections.py
+++ b/api/src/aerospike_cluster_manager_api/routers/connections.py
@@ -12,6 +12,7 @@ from aerospike_cluster_manager_api.constants import INFO_BUILD, INFO_EDITION, IN
 from aerospike_cluster_manager_api.dependencies import CallerOwnerId, _get_verified_connection
 from aerospike_cluster_manager_api.info_parser import aggregate_node_kv, parse_list, safe_int
 from aerospike_cluster_manager_api.models.connection import (
+    ConnectionErrorType,
     ConnectionProfileResponse,
     ConnectionStatus,
     CreateConnectionRequest,
@@ -25,10 +26,28 @@ from aerospike_cluster_manager_api.services.connections_service import (
     ConnectionNotFoundError,
     WorkspaceNotFoundError,
 )
+from aerospike_cluster_manager_api.target_policy import (
+    ALLOW_PRIVATE_TARGETS_ENV,
+    BlockedConnectionTargetError,
+)
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/connections", tags=["connections"])
+
+
+def _blocked_target_detail(exc: BlockedConnectionTargetError) -> str:
+    """HTTP detail for a target the SSRF denylist rejected.
+
+    Echoes the host because the caller is the one who just supplied it —
+    there is nothing to disclose — and names the escape hatch so a dev
+    deployment running Aerospike on the loopback knows what to set.
+    """
+    return (
+        f"Connection target '{exc.host}' is not allowed: loopback and link-local addresses "
+        f"are denied to prevent the API being used as an SSRF probe. "
+        f"Set {ALLOW_PRIVATE_TARGETS_ENV}=true on the API for local development."
+    )
 
 
 @router.get(
@@ -69,10 +88,14 @@ async def create_connection(
     """Create a new Aerospike connection profile.
 
     Phase 2: the supplied ``workspaceId`` (or the default fallback) must be
-    visible to the caller; otherwise 404.
+    visible to the caller; otherwise 404. A host on the SSRF denylist
+    (loopback / link-local, see :mod:`target_policy`) is a 400 — the caller
+    supplied the address, so naming it back is not a disclosure.
     """
     try:
         return await connections_service.create_connection(body, caller_owner_id)
+    except BlockedConnectionTargetError as exc:
+        raise HTTPException(status_code=400, detail=_blocked_target_detail(exc)) from exc
     except WorkspaceNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
@@ -126,6 +149,8 @@ async def update_connection(
     """
     try:
         return await connections_service.update_connection(conn_id, body, caller_owner_id)
+    except BlockedConnectionTargetError as exc:
+        raise HTTPException(status_code=400, detail=_blocked_target_detail(exc)) from exc
     except ConnectionNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except WorkspaceNotFoundError as exc:
@@ -143,6 +168,18 @@ async def get_connection_health(conn_id: str = Depends(_get_verified_connection)
 
     Always returns HTTP 200. Uses ``connected: false`` to signal unreachable clusters
     so that the frontend health indicator never mistakes a transient 503 for a permanent failure.
+
+    The failure shape is deliberately coarse (#470). This route is reachable
+    unauthenticated in the default configuration and carries no rate limit,
+    so a response that distinguished a closed port from a filtered one from a
+    live non-Aerospike listener — and echoed the driver's exception text —
+    turned any stored profile into a port-scan oracle. Every connection-level
+    failure now reports ``errorType: "unreachable"`` with a fixed message; the
+    specific exception goes to the operator log only.
+
+    ``not_found`` (the profile vanished mid-check) and ``auth_error`` survive
+    as distinct values: neither is a reachability signal, and both are
+    directly actionable for the operator.
     """
     try:
         client = await client_manager.get_client(conn_id)
@@ -250,32 +287,61 @@ async def get_connection_health(conn_id: str = Depends(_get_verified_connection)
             diskTotal=disk_total,
             tendHealthy=tend_healthy,
         )
-    except ValueError as exc:
+    except BlockedConnectionTargetError:
+        # A stored profile that predates the create/update gate, or one written
+        # by a path that bypassed them. Must come before the ValueError branch
+        # below — BlockedConnectionTargetError subclasses ValueError.
+        logger.warning("Health check for connection '%s' targets a denied address", conn_id, exc_info=True)
+        return _disconnected_health("blocked_target")
+    except ValueError:
         # Profile vanished between the route dependency check and the client
         # fetch (TOCTOU) — get_client() raises a plain ValueError. Surface as
         # the disconnected shape, not an opaque 500.
         logger.warning("Connection '%s' disappeared during health check", conn_id, exc_info=True)
-        return _disconnected_health(str(exc), "not_found")
-    except AerospikeTimeoutError as exc:
-        logger.warning("Health check timed out for connection '%s'", conn_id, exc_info=True)
-        return _disconnected_health(str(exc), "timeout")
-    except ConnectionRefusedError as exc:
-        logger.warning("Connection refused for '%s'", conn_id, exc_info=True)
-        return _disconnected_health(str(exc), "connection_refused")
-    except ClusterError as exc:
-        logger.warning("Cluster error for connection '%s'", conn_id, exc_info=True)
-        return _disconnected_health(str(exc), "cluster_error")
+        return _disconnected_health("not_found")
+    except (AerospikeTimeoutError, ConnectionRefusedError, ClusterError):
+        # One bucket on purpose: a timeout, a refusal, and a cluster-protocol
+        # error are exactly the three answers that let a caller tell a filtered
+        # port from a closed one from a live non-Aerospike listener.
+        logger.warning("Health check failed for connection '%s'", conn_id, exc_info=True)
+        return _disconnected_health("unreachable")
     except (AerospikeError, OSError) as exc:
         logger.warning("Health check failed for connection '%s'", conn_id, exc_info=True)
-        error_type = "auth_error" if isinstance(exc, AerospikeError) and "security" in str(exc).lower() else "unknown"
-        return _disconnected_health(str(exc), error_type)
+        # An auth rejection already implies a real Aerospike answered, so
+        # keeping it distinct discloses nothing further and tells the operator
+        # to go fix the credentials rather than the network.
+        is_auth = isinstance(exc, AerospikeError) and "security" in str(exc).lower()
+        return _disconnected_health("auth_error" if is_auth else "unreachable")
 
 
-def _disconnected_health(error: str, error_type: str) -> Response:
-    """Build a JSON Response for the ``connected=false`` health-check shape."""
+# Fixed operator-facing text per errorType. The driver's own exception string
+# is never returned: it carries host, port, and node identity, which is the
+# other half of what made the health route a scanner (#470). It is logged.
+_HEALTH_ERROR_MESSAGES: dict[ConnectionErrorType, str] = {
+    "not_found": "Connection profile no longer exists",
+    "unreachable": "Unable to reach the Aerospike cluster",
+    "auth_error": "Aerospike rejected the stored credentials",
+    "blocked_target": (
+        "Connection target is not allowed: loopback and link-local addresses are denied. "
+        f"Set {ALLOW_PRIVATE_TARGETS_ENV}=true on the API for local development."
+    ),
+}
+
+
+def _disconnected_health(error_type: ConnectionErrorType) -> Response:
+    """Build a JSON Response for the ``connected=false`` health-check shape.
+
+    Takes only the ``error_type``; the message is looked up from
+    :data:`_HEALTH_ERROR_MESSAGES` so no call site can accidentally pass an
+    exception string through to the wire.
+    """
     return Response(
         content=ConnectionStatus(
-            connected=False, nodeCount=0, namespaceCount=0, error=error, errorType=error_type
+            connected=False,
+            nodeCount=0,
+            namespaceCount=0,
+            error=_HEALTH_ERROR_MESSAGES[error_type],
+            errorType=error_type,
         ).model_dump_json(),
         media_type="application/json",
         headers={"Retry-After": "30"},

--- a/api/src/aerospike_cluster_manager_api/services/connections_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/connections_service.py
@@ -13,9 +13,7 @@ exceptions defined here, which the router translates to HTTP status codes.
 from __future__ import annotations
 
 import contextlib
-import ipaddress
 import logging
-import os
 import uuid
 from datetime import UTC, datetime
 from typing import Any, NamedTuple
@@ -36,6 +34,15 @@ from aerospike_cluster_manager_api.models.workspace import (
     DEFAULT_WORKSPACE_ID,
     SYSTEM_OWNER_ID,
 )
+
+# The SSRF gate moved to ``target_policy`` (#470) so ``client_manager`` can
+# enforce it as a last resort too — ``connections_service`` imports
+# ``client_manager``, so a shared leaf module is the only import direction
+# that works.
+from aerospike_cluster_manager_api.target_policy import (
+    assert_targets_allowed,
+    is_blocked_target,
+)
 from aerospike_cluster_manager_api.utils import parse_host_port
 
 logger = logging.getLogger(__name__)
@@ -52,22 +59,6 @@ class ConnectionNotFoundError(LookupError):
     def __init__(self, conn_id: str) -> None:
         super().__init__(f"Connection '{conn_id}' not found")
         self.conn_id = conn_id
-
-
-class BlockedConnectionTargetError(ValueError):
-    """Raised when a test_connection target points at a denied address.
-
-    Default-deny SSRF gate: loopback, link-local (especially the EC2 IMDS
-    169.254.169.254), and IPv6 ``::1`` are rejected before any network
-    syscall so the API cannot be repurposed as an internal port scanner
-    or a metadata-service exfil channel. Operators can override the
-    default-deny via ``ACM_CONNECTION_TEST_ALLOW_PRIVATE=true`` for dev
-    deployments where the API and Aerospike share a host.
-    """
-
-    def __init__(self, host: str) -> None:
-        super().__init__(f"Connection target '{host}' is not allowed")
-        self.host = host
 
 
 class WorkspaceNotFoundError(LookupError):
@@ -100,56 +91,6 @@ class TestConnectionResult(NamedTuple):
 # ---------------------------------------------------------------------------
 # Service entry points
 # ---------------------------------------------------------------------------
-
-
-_ALLOW_PRIVATE_TARGETS_ENV = "ACM_CONNECTION_TEST_ALLOW_PRIVATE"
-
-
-def _allow_private_targets() -> bool:
-    """Return True when operators have opted into private-range targets.
-
-    Read live (not snapshotted) so test fixtures can flip the env var via
-    monkeypatch. The default is False -- production deployments default-
-    deny loopback / link-local to keep the test_connection API from
-    being repurposed as an internal port scanner or IMDS exfil channel.
-    """
-    return os.environ.get(_ALLOW_PRIVATE_TARGETS_ENV, "false").strip().lower() in {"1", "true", "yes", "on"}
-
-
-def _is_blocked_target(host: str) -> bool:
-    """Return True iff ``host`` resolves to a denied IP literal.
-
-    Blocks loopback (``127.0.0.0/8``, ``::1``) and link-local IPv4
-    (``169.254.0.0/16`` -- includes the EC2 IMDS ``169.254.169.254``) so
-    the test-connection endpoint cannot be turned into an SSRF probe by
-    an authenticated caller. Hostnames that are not bare IP literals are
-    *not* blocked here -- the underlying Aerospike client resolves DNS
-    natively and re-checking after resolve would race with TOCTOU. The
-    contract is: literal-IP rejection is the cheap first line; deeper
-    network-policy enforcement (egress firewall) is expected to backstop
-    DNS-based bypasses.
-
-    The ``ACM_CONNECTION_TEST_ALLOW_PRIVATE`` env var disables the gate
-    for dev deployments where the API and Aerospike share a host (the
-    compose.dev.yaml workflow exercises this routinely).
-    """
-    if _allow_private_targets():
-        return False
-    candidate = host.strip()
-    if not candidate:
-        return False
-    # IPv6 literals may arrive bracketed (`[::1]`); strip before parsing.
-    if candidate.startswith("[") and candidate.endswith("]"):
-        candidate = candidate[1:-1]
-    try:
-        ip = ipaddress.ip_address(candidate)
-    except ValueError:
-        # Not a bare IP literal -- let it through; DNS-based abuse is
-        # explicitly out of scope per the docstring rationale.
-        return False
-    if ip.is_loopback:
-        return True
-    return bool(ip.is_link_local)
 
 
 async def _assert_workspace_visible(workspace_id: str, caller_owner_id: str | None) -> None:
@@ -244,8 +185,17 @@ async def create_connection(
     Falls back to :data:`DEFAULT_WORKSPACE_ID` when the request omits the
     workspace. Raises :class:`WorkspaceNotFoundError` if the resolved
     workspace does not exist OR (Phase 2) is invisible to
-    ``caller_owner_id``.
+    ``caller_owner_id``, and
+    :class:`target_policy.BlockedConnectionTargetError` if any host is a
+    denied IP literal.
+
+    The target gate matters here and not only in :func:`test_connection`:
+    a profile persisted with a loopback or link-local host is dialled by
+    every route that resolves a client for it, so create-then-health was a
+    complete bypass of the test-connection gate (#470).
     """
+    assert_targets_allowed(payload.hosts, payload.port)
+
     workspace_id = payload.workspaceId or DEFAULT_WORKSPACE_ID
     await _assert_workspace_visible(workspace_id, caller_owner_id)
 
@@ -277,11 +227,25 @@ async def update_connection(
     """Apply a partial update to ``conn_id`` and return the new state.
 
     Raises :class:`ConnectionNotFoundError` if the connection does not
-    exist, or :class:`WorkspaceNotFoundError` if the request moves it to
-    a workspace that is missing or (Phase 2) invisible to
-    ``caller_owner_id``.
+    exist, :class:`WorkspaceNotFoundError` if the request moves it to a
+    workspace that is missing or (Phase 2) invisible to
+    ``caller_owner_id``, or
+    :class:`target_policy.BlockedConnectionTargetError` if the update
+    repoints the profile at a denied IP literal.
     """
     update_data = payload.model_dump(exclude_unset=True, by_alias=False)
+
+    # Gate a host rewrite for the same reason create is gated (#470) —
+    # otherwise create-with-a-legal-host then update-to-loopback walks
+    # straight around the check. Only ``hosts`` can introduce a new target;
+    # a lone ``port`` change cannot, because the gate inspects the host
+    # portion only. The port passed here is therefore just the fallback
+    # ``parse_host_port`` needs for entries with no ``:port`` suffix, and
+    # never changes the decision.
+    new_hosts = update_data.get("hosts")
+    if new_hosts:
+        assert_targets_allowed(new_hosts, update_data.get("port") or 3000)
+
     if "workspaceId" in update_data and update_data["workspaceId"] is not None:
         target_ws = update_data["workspaceId"]
         await _assert_workspace_visible(target_ws, caller_owner_id)
@@ -351,9 +315,14 @@ async def test_connection(req: TestConnectionRequest) -> TestConnectionResult:
     # cloud SQL proxies on the host loopback). The check is cheap (pure
     # ip parsing) and keyed on bare IP literals -- DNS hostnames are
     # outside the gate; egress firewalls are expected to backstop those.
+    #
+    # This path deliberately does NOT use ``assert_targets_allowed``: the
+    # contract here is "blocked looks exactly like unreachable" so a probing
+    # caller cannot tell them apart, which means returning the ordinary
+    # failure shape rather than raising.
     for host_str in req.hosts:
         host_only, _ = parse_host_port(host_str, req.port)
-        if _is_blocked_target(host_only):
+        if is_blocked_target(host_only):
             logger.warning(
                 "Test connection blocked: target=%s reason=loopback_or_link_local",
                 host_str,

--- a/api/src/aerospike_cluster_manager_api/target_policy.py
+++ b/api/src/aerospike_cluster_manager_api/target_policy.py
@@ -1,0 +1,125 @@
+"""Default-deny SSRF gate for Aerospike connection targets.
+
+The API dials whatever host a caller puts in a connection profile. Without a
+gate that makes it an SSRF primitive: point a profile at ``127.0.0.1`` or
+``169.254.169.254`` and the response distinguishes "closed", "filtered", and
+"something is listening", which maps internal listeners and confirms cloud
+metadata reachability from the API pod.
+
+The gate used to live inside ``connections_service.test_connection`` alone.
+``create_connection`` never called it and ``client_manager.get_client``
+dialled the stored hosts with no gate of its own, so create-then-health
+bypassed it entirely (#470). It lives here now because it has to be
+enforceable from both the service layer and ``client_manager``, and
+``connections_service`` imports ``client_manager`` — a shared leaf module is
+the only import direction that works.
+
+Scope, unchanged from the original gate: **bare IP literals only**. A
+hostname is not pre-resolved, because re-checking after a resolve races with
+the client's own resolution (TOCTOU) and would give a false sense of
+coverage. Literal-IP rejection is the cheap first line; egress firewall
+policy is expected to backstop DNS-based bypasses.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+
+from aerospike_cluster_manager_api.utils import parse_host_port
+
+__all__ = [
+    "ALLOW_PRIVATE_TARGETS_ENV",
+    "BlockedConnectionTargetError",
+    "assert_targets_allowed",
+    "is_blocked_target",
+]
+
+# Preferred name. The gate governs the whole connection lifecycle now —
+# create, update, and every client build — not just ``POST /connections/test``,
+# so the original name understates it.
+ALLOW_PRIVATE_TARGETS_ENV = "ACM_ALLOW_PRIVATE_TARGETS"
+
+# The original name, still honoured so existing deployments keep working.
+# Either variable being truthy opens the gate.
+_LEGACY_ALLOW_PRIVATE_TARGETS_ENV = "ACM_CONNECTION_TEST_ALLOW_PRIVATE"
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+class BlockedConnectionTargetError(ValueError):
+    """Raised when a connection target points at a denied address.
+
+    Default-deny: loopback, link-local (especially the EC2 IMDS
+    ``169.254.169.254``), and IPv6 ``::1`` are rejected before any network
+    syscall so the API cannot be repurposed as an internal port scanner or a
+    metadata-service exfil channel. Operators can override the default-deny
+    via :data:`ALLOW_PRIVATE_TARGETS_ENV` for dev deployments where the API
+    and Aerospike share a host.
+
+    Subclasses :class:`ValueError` so callers that already handle
+    ``ValueError`` from the client-build path degrade safely rather than
+    escaping as a 500; routers that want the specific wire shape catch this
+    class *before* their ``ValueError`` branch.
+    """
+
+    def __init__(self, host: str) -> None:
+        super().__init__(f"Connection target '{host}' is not allowed")
+        self.host = host
+
+
+def allow_private_targets() -> bool:
+    """Return True when operators have opted into private-range targets.
+
+    Read live (not snapshotted) so test fixtures can flip the env var via
+    monkeypatch. The default is False — production deployments default-deny
+    loopback / link-local to keep the connection API from being repurposed
+    as an internal port scanner or IMDS exfil channel.
+    """
+    for name in (ALLOW_PRIVATE_TARGETS_ENV, _LEGACY_ALLOW_PRIVATE_TARGETS_ENV):
+        if os.environ.get(name, "").strip().lower() in _TRUTHY:
+            return True
+    return False
+
+
+def is_blocked_target(host: str) -> bool:
+    """Return True iff ``host`` is a denied IP literal.
+
+    Blocks loopback (``127.0.0.0/8``, ``::1``) and link-local
+    (``169.254.0.0/16`` — includes the EC2 IMDS ``169.254.169.254``, and the
+    IPv6 ``fe80::/10`` equivalent).
+
+    Hostnames that are not bare IP literals are *not* blocked here; see the
+    module docstring for why.
+    """
+    if allow_private_targets():
+        return False
+    candidate = host.strip()
+    if not candidate:
+        return False
+    # IPv6 literals may arrive bracketed (`[::1]`); strip before parsing.
+    if candidate.startswith("[") and candidate.endswith("]"):
+        candidate = candidate[1:-1]
+    try:
+        ip = ipaddress.ip_address(candidate)
+    except ValueError:
+        # Not a bare IP literal -- let it through; DNS-based abuse is
+        # explicitly out of scope per the module docstring rationale.
+        return False
+    if ip.is_loopback:
+        return True
+    return bool(ip.is_link_local)
+
+
+def assert_targets_allowed(hosts: list[str], default_port: int) -> None:
+    """Raise :class:`BlockedConnectionTargetError` for the first denied host.
+
+    ``hosts`` entries may carry a ``:port`` suffix, so each is parsed with
+    :func:`utils.parse_host_port` before the literal check — passing the raw
+    ``"127.0.0.1:3000"`` to :func:`is_blocked_target` would fail to parse as
+    an IP and silently no-op the gate.
+    """
+    for host_str in hosts:
+        host_only, _ = parse_host_port(host_str, default_port)
+        if is_blocked_target(host_only):
+            raise BlockedConnectionTargetError(host_str)

--- a/api/tests/test_connections_router.py
+++ b/api/tests/test_connections_router.py
@@ -11,7 +11,7 @@ from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
-from aerospike_py.exception import AerospikeError
+from aerospike_py.exception import AerospikeError, AerospikeTimeoutError, ClusterError
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
@@ -754,3 +754,190 @@ class TestCrossOwnerWorkspaceAccess:
             assert update.status_code == 404
         finally:
             _clear_caller_override()
+
+
+class TestConnectionTargetGateOnWrites:
+    """#470: the SSRF gate covers create and update, not only test-connection.
+
+    Before this, a caller could create a profile pointing at ``127.0.0.1`` or
+    ``169.254.169.254`` — ``create_connection`` never called the gate — and
+    then drive the health route against it. Create-then-health was a complete
+    bypass of the test-connection gate.
+    """
+
+    @pytest.mark.parametrize(
+        "host",
+        ["127.0.0.1", "169.254.169.254", "[::1]", "::1", "127.0.0.1:3000"],
+    )
+    async def test_create_with_blocked_host_rejected(self, client: AsyncClient, host: str):
+        response = await client.post("/api/connections", json={**CREATE_PAYLOAD, "hosts": [host]})
+        assert response.status_code == 400, response.text
+        assert "not allowed" in response.json()["detail"]
+
+    async def test_create_rejects_when_any_host_is_blocked(self, client: AsyncClient):
+        """A legal host must not launder a blocked one riding beside it."""
+        response = await client.post(
+            "/api/connections",
+            json={**CREATE_PAYLOAD, "hosts": ["10.0.0.1", "169.254.169.254"]},
+        )
+        assert response.status_code == 400, response.text
+
+    async def test_create_with_allowed_host_still_works(self, client: AsyncClient):
+        response = await client.post("/api/connections", json=CREATE_PAYLOAD)
+        assert response.status_code == 201, response.text
+
+    async def test_update_to_blocked_host_rejected(self, client: AsyncClient):
+        """Create legal, then repoint at loopback — the other half of the bypass."""
+        created = await client.post("/api/connections", json=CREATE_PAYLOAD)
+        conn_id = created.json()["id"]
+
+        response = await client.put(f"/api/connections/{conn_id}", json={"hosts": ["127.0.0.1"]})
+        assert response.status_code == 400, response.text
+        assert "not allowed" in response.json()["detail"]
+
+        # And the stored profile is untouched.
+        after = await client.get(f"/api/connections/{conn_id}")
+        assert after.json()["hosts"] == CREATE_PAYLOAD["hosts"]
+
+    async def test_update_leaving_hosts_alone_still_works(self, client: AsyncClient):
+        created = await client.post("/api/connections", json=CREATE_PAYLOAD)
+        conn_id = created.json()["id"]
+
+        response = await client.put(f"/api/connections/{conn_id}", json={"name": "renamed"})
+        assert response.status_code == 200, response.text
+        assert response.json()["name"] == "renamed"
+
+    async def test_env_override_allows_loopback_create(self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch):
+        """The dev escape hatch works under the new name."""
+        monkeypatch.setenv("ACM_ALLOW_PRIVATE_TARGETS", "true")
+        response = await client.post("/api/connections", json={**CREATE_PAYLOAD, "hosts": ["127.0.0.1"]})
+        assert response.status_code == 201, response.text
+
+    async def test_legacy_env_override_still_honoured(self, client: AsyncClient, monkeypatch: pytest.MonkeyPatch):
+        """...and under the original one, so existing deployments keep working."""
+        monkeypatch.setenv("ACM_CONNECTION_TEST_ALLOW_PRIVATE", "true")
+        response = await client.post("/api/connections", json={**CREATE_PAYLOAD, "hosts": ["127.0.0.1"]})
+        assert response.status_code == 201, response.text
+
+
+class TestHealthResponseIsNotAScanner:
+    """#470: the health route stopped being a reachability oracle.
+
+    It is reachable unauthenticated in the default configuration and carries
+    no rate limit, so distinguishing timeout / refused / cluster-error — and
+    echoing the driver's exception string — turned any stored profile into a
+    port scanner with high-fidelity feedback.
+    """
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            AerospikeTimeoutError("timed out talking to 10.1.2.3:3000"),
+            ConnectionRefusedError("[Errno 61] Connection refused to 10.1.2.3:3000"),
+            ClusterError("node BB9020011AC4202 at 10.1.2.3:3000 failed handshake"),
+            OSError("[Errno 65] No route to host 10.1.2.3"),
+        ],
+    )
+    async def test_connection_failures_are_indistinguishable(
+        self, client: AsyncClient, sample_connection, exc: Exception
+    ):
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+
+        with patch(
+            "aerospike_cluster_manager_api.routers.connections.client_manager.get_client",
+            side_effect=exc,
+        ):
+            resp = await client.get(f"/api/connections/{sample_connection.id}/health")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["connected"] is False
+        # One bucket for every network-level outcome.
+        assert body["errorType"] == "unreachable"
+        # And no exception text: the message above names a host, a port, and a
+        # node id, none of which may reach the caller.
+        assert body["error"] == "Unable to reach the Aerospike cluster"
+        assert "10.1.2.3" not in resp.text
+        assert "BB9020011AC4202" not in resp.text
+        assert "Errno" not in resp.text
+
+    async def test_auth_error_stays_distinct(self, client: AsyncClient, sample_connection):
+        """An auth rejection already implies a real Aerospike answered."""
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+
+        with patch(
+            "aerospike_cluster_manager_api.routers.connections.client_manager.get_client",
+            side_effect=AerospikeError("security violation: invalid credentials for user admin"),
+        ):
+            resp = await client.get(f"/api/connections/{sample_connection.id}/health")
+
+        assert resp.json()["errorType"] == "auth_error"
+        assert "admin" not in resp.text
+
+    async def test_blocked_stored_profile_reports_blocked_target(self, client: AsyncClient, sample_connection):
+        """Profiles written before the create gate existed are still caught.
+
+        ``client_manager.get_client`` is the last-resort gate — it sees the
+        stored hosts on every request, so a legacy loopback profile surfaces
+        here rather than being dialled.
+        """
+        from aerospike_cluster_manager_api import db
+
+        blocked = sample_connection.model_copy(update={"hosts": ["127.0.0.1"]})
+        await db.create_connection(blocked)
+
+        resp = await client.get(f"/api/connections/{blocked.id}/health")
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["connected"] is False
+        assert body["errorType"] == "blocked_target"
+
+
+class TestClientManagerTargetGate:
+    """The last-resort gate itself (#470).
+
+    ``connections_service`` imports ``client_manager``, so the gate lives in
+    the leaf module ``target_policy`` and both can enforce it.
+    """
+
+    async def test_get_client_refuses_stored_blocked_host(self, init_test_db, sample_connection):
+        from aerospike_cluster_manager_api import db
+        from aerospike_cluster_manager_api.client_manager import client_manager
+        from aerospike_cluster_manager_api.target_policy import BlockedConnectionTargetError
+
+        blocked = sample_connection.model_copy(update={"hosts": ["169.254.169.254"]})
+        await db.create_connection(blocked)
+
+        with (
+            patch("aerospike_cluster_manager_api.client_manager.aerospike_py.AsyncClient") as mock_cls,
+            pytest.raises(BlockedConnectionTargetError),
+        ):
+            await client_manager.get_client(blocked.id)
+
+        # No client was even constructed — the gate fires before the dial.
+        mock_cls.assert_not_called()
+
+    async def test_get_client_allows_normal_host(self, init_test_db, sample_connection):
+        from aerospike_cluster_manager_api import db
+        from aerospike_cluster_manager_api.client_manager import client_manager
+
+        await db.create_connection(sample_connection)  # hosts=["localhost"]
+
+        mock_client = AsyncMock()
+        mock_client.connect = AsyncMock()
+        mock_client.is_connected = lambda: True
+        mock_client.close = AsyncMock()
+
+        with patch(
+            "aerospike_cluster_manager_api.client_manager.aerospike_py.AsyncClient",
+            return_value=mock_client,
+        ):
+            got = await client_manager.get_client(sample_connection.id)
+
+        assert got is mock_client
+        await client_manager.close_client(sample_connection.id)

--- a/api/tests/test_target_policy.py
+++ b/api/tests/test_target_policy.py
@@ -1,0 +1,118 @@
+"""Unit tests for the connection-target SSRF gate.
+
+The gate used to live inside ``connections_service.test_connection`` and was
+applied nowhere else, so create-then-health walked around it (#470). It now
+lives in :mod:`target_policy` — a leaf module ``client_manager`` can import —
+and these tests pin the decision itself, independently of any route.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from aerospike_cluster_manager_api.target_policy import (
+    BlockedConnectionTargetError,
+    allow_private_targets,
+    assert_targets_allowed,
+    is_blocked_target,
+)
+
+
+class TestIsBlockedTarget:
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "127.0.0.1",
+            "127.1.2.3",  # the whole 127.0.0.0/8, not just .0.1
+            "::1",
+            "[::1]",  # bracketed IPv6 as it arrives from a host string
+            "169.254.169.254",  # EC2 / GCP / Azure IMDS
+            "169.254.0.1",
+            "fe80::1",  # IPv6 link-local
+        ],
+    )
+    def test_denied_literals(self, host: str) -> None:
+        assert is_blocked_target(host) is True
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "10.0.0.1",
+            "192.168.1.10",
+            "203.0.113.5",
+            "2001:db8::1",
+            "aerospike-node-1",
+            "aerospike.default.svc.cluster.local",
+            "example.com",
+        ],
+    )
+    def test_allowed_targets(self, host: str) -> None:
+        assert is_blocked_target(host) is False
+
+    def test_hostname_is_not_pre_resolved(self) -> None:
+        # Documented scope limit: a hostname that resolves to loopback is NOT
+        # blocked here. Re-checking after a resolve races with the client's own
+        # resolution, so egress policy is the backstop. Pinned as a test so the
+        # limit is a decision rather than an oversight.
+        assert is_blocked_target("localhost") is False
+
+    def test_empty_host_is_not_blocked(self) -> None:
+        assert is_blocked_target("") is False
+        assert is_blocked_target("   ") is False
+
+
+class TestAllowPrivateTargetsOverride:
+    def test_default_is_deny(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("ACM_ALLOW_PRIVATE_TARGETS", raising=False)
+        monkeypatch.delenv("ACM_CONNECTION_TEST_ALLOW_PRIVATE", raising=False)
+        assert allow_private_targets() is False
+        assert is_blocked_target("127.0.0.1") is True
+
+    @pytest.mark.parametrize("value", ["true", "TRUE", "1", "yes", "on", " true "])
+    def test_truthy_values(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        monkeypatch.setenv("ACM_ALLOW_PRIVATE_TARGETS", value)
+        assert allow_private_targets() is True
+        assert is_blocked_target("127.0.0.1") is False
+
+    @pytest.mark.parametrize("value", ["false", "0", "no", "off", "", "maybe"])
+    def test_falsy_values(self, monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+        monkeypatch.setenv("ACM_ALLOW_PRIVATE_TARGETS", value)
+        monkeypatch.delenv("ACM_CONNECTION_TEST_ALLOW_PRIVATE", raising=False)
+        assert allow_private_targets() is False
+
+    def test_legacy_name_still_opens_the_gate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The original name predates the gate covering more than
+        # test-connection. Deployments already setting it must keep working.
+        monkeypatch.delenv("ACM_ALLOW_PRIVATE_TARGETS", raising=False)
+        monkeypatch.setenv("ACM_CONNECTION_TEST_ALLOW_PRIVATE", "true")
+        assert allow_private_targets() is True
+
+
+class TestAssertTargetsAllowed:
+    def test_allows_a_clean_list(self) -> None:
+        assert_targets_allowed(["10.0.0.1", "aerospike-node-2"], 3000)
+
+    def test_raises_naming_the_offending_entry(self) -> None:
+        with pytest.raises(BlockedConnectionTargetError) as exc_info:
+            assert_targets_allowed(["10.0.0.1", "169.254.169.254"], 3000)
+        assert exc_info.value.host == "169.254.169.254"
+
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            "127.0.0.1:3000",  # host:port suffix
+            "127.0.0.1:abc",  # non-integer port — parse_host_port must still
+            # yield the bare host, or the gate silently no-ops
+            "[::1]:3000",  # bracketed IPv6 with port
+        ],
+    )
+    def test_port_suffixes_do_not_defeat_the_gate(self, entry: str) -> None:
+        with pytest.raises(BlockedConnectionTargetError):
+            assert_targets_allowed([entry], 3000)
+
+    def test_error_is_a_value_error(self) -> None:
+        # Subclassing ValueError means a caller that only handles ValueError
+        # from the client-build path degrades to a 404 rather than a 500.
+        # Routers that want the specific shape catch this class first.
+        with pytest.raises(ValueError):
+            assert_targets_allowed(["127.0.0.1"], 3000)

--- a/ui/src/lib/types/connection.ts
+++ b/ui/src/lib/types/connection.ts
@@ -3,12 +3,20 @@
  * See: api/src/aerospike_cluster_manager_api/models/connection.py
  */
 
+/**
+ * Why a health check reported `connected: false`.
+ *
+ * Deliberately coarse (#470). The health route is reachable unauthenticated in
+ * the default configuration, so the older set — `timeout`,
+ * `connection_refused`, `cluster_error`, `unknown` — let a caller distinguish a
+ * closed port from a filtered one from a live non-Aerospike listener, i.e. it
+ * was a port scanner. Those four collapse into `unreachable`.
+ */
 export type ConnectionErrorType =
-  | "timeout"
-  | "connection_refused"
-  | "cluster_error"
+  | "not_found"
+  | "unreachable"
   | "auth_error"
-  | "unknown"
+  | "blocked_target"
 
 export interface ConnectionStatus {
   connected: boolean


### PR DESCRIPTION
Closes #470

## What was wrong

The loopback/link-local gate was applied in exactly one place — the top of `test_connection`. `create_connection` persisted `payload.hosts` verbatim and `client_manager.get_client` dialled the stored hosts with no gate of its own, so **create-then-health** bypassed it entirely. The health route then handed back six distinct `errorType` values plus `str(exc)`, which is what turned reachability into a scanner.

## What changed

### The gate now covers the whole lifecycle

Moved to a new leaf module `api/src/aerospike_cluster_manager_api/target_policy.py`. It had to move: `connections_service` imports `client_manager`, so a shared leaf is the only import direction in which both can enforce it.

| Where | Behaviour |
|---|---|
| `create_connection` | **400** naming the offending host |
| `update_connection` | **400**, and the stored profile is left untouched |
| `client_manager.get_client` | raises `BlockedConnectionTargetError` before the client is constructed |
| `test_connection` | **unchanged** — still returns the ordinary `success=false` shape, because "blocked" and "unreachable" being indistinguishable there is that route's deliberate contract |

`get_client` is the one that matters most: every route that touches a cluster funnels through it, so it covers profiles written before the gate existed (including the ACKO auto-created ones in `routers/k8s_clusters.py`, which call `db.create_connection` directly) and any future write path that forgets to call the gate.

Scope is unchanged and still documented: **bare IP literals only**. A hostname is not pre-resolved, because re-checking after a resolve races with the client's own resolution. `test_hostname_is_not_pre_resolved` pins that as a decision rather than an oversight.

### The health route stopped being an oracle

`timeout`, `connection_refused`, `cluster_error`, and `unknown` collapse into one `unreachable`. Those four are exactly the answers that distinguish a filtered port from a closed one from a live non-Aerospike listener.

`str(exc)` is no longer returned at all. `_disconnected_health` now takes only an `errorType` and looks the message up from a fixed table, so no call site can pass an exception string to the wire by accident. The exception still goes to the operator log with `exc_info=True`.

Two values survive, and I want to flag the judgement call: `not_found` (the profile vanished mid-check) and `auth_error` (a real Aerospike answered and rejected the credentials). Neither is a reachability signal — `auth_error` requires a completed handshake, so it tells the caller nothing they did not already have — and both change what the operator should do next. The issue's wording was "collapse for connection-level failures", which is what this does.

### Type sync (goal 2-7)

`errorType` is now a `Literal` on the Pydantic side (`models/connection.py::ConnectionErrorType`) rather than a bare `str` with a comment, so the OpenAPI schema carries the union. `ui/src/lib/types/connection.ts` is updated to the same four values. Both sides changed in this PR.

### Env var

`ACM_ALLOW_PRIVATE_TARGETS` is the new name for the dev escape hatch — the old `ACM_CONNECTION_TEST_ALLOW_PRIVATE` understates a gate that now covers create, update, and every client build. **The old name is still honoured**, so no deployment breaks; `test_legacy_env_override_still_honoured` pins that.

## Breaking changes for operators

1. A profile pointing at loopback or link-local now fails at create/update with 400, and an existing one fails at every request with `errorType: "blocked_target"`. Set `ACM_ALLOW_PRIVATE_TARGETS=true` for local dev against `compose.dev.yaml`.
2. Any client branching on `errorType == "timeout"` / `"connection_refused"` / `"cluster_error"` / `"unknown"` needs updating. Nothing in `ui/src` did — the only consumers were the type declaration itself and `components/copilot/tools/render-tools.tsx:75`, which renders `status.error` as free text.

## Files

- `api/src/aerospike_cluster_manager_api/target_policy.py` — new; the gate
- `api/src/aerospike_cluster_manager_api/services/connections_service.py` — gate on create/update
- `api/src/aerospike_cluster_manager_api/client_manager.py` — last-resort gate
- `api/src/aerospike_cluster_manager_api/routers/connections.py` — 400 mapping, health error collapse
- `api/src/aerospike_cluster_manager_api/models/connection.py` — `ConnectionErrorType` literal
- `ui/src/lib/types/connection.ts` — mirrored union
- `.env.example` — both env var names
- `api/tests/test_target_policy.py` (new), `api/tests/test_connections_router.py` — +55 tests

## Verification

Ran the exact commands CI runs (`.github/workflows/ci.yaml`).

**API job:**

```
$ cd api && uv run ruff check src/
All checks passed!

$ uv run ruff format --check src/
85 files already formatted

$ uv run pytest tests/ -v --tb=short
====================== 1122 passed, 6 warnings in 12.99s =======================
```

Baseline on `main` was `1067 passed`; the 55 added tests account for the difference. Also green under random ordering (`pytest-randomly` is on by default).

**UI job** (this PR edits `ui/src/lib/types/connection.ts`, so all five steps were run):

```
$ npm run type-check     # tsc --noEmit        → clean, no output
$ npm run lint           # eslint .            → clean, no output
$ npm run format:check   # All matched files use Prettier code style!
$ npm run test
 Test Files  19 passed (19)
      Tests  104 passed (104)
$ npm run build          # completed, full route table emitted
```

**Pre-commit job** — `pre-commit run --all-files`:

```
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...............................................................Passed
check json...............................................................Passed
check for added large files..............................................Passed
check for merge conflicts................................................Passed
check toml...............................................................Passed
detect private key.......................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
pyright..................................................................Passed
eslint...................................................................Passed
prettier.................................................................Passed
tsc (type-check).........................................................Passed
```

pyright caught a real bug in an earlier revision of this branch (`_disconnected_health` still took `error_type: str` after `ConnectionStatus.errorType` became a `Literal`), which is why the signature is typed.

The new tests, run on their own:

```
$ uv run pytest tests/test_target_policy.py \
    tests/test_connections_router.py::TestConnectionTargetGateOnWrites \
    tests/test_connections_router.py::TestHealthResponseIsNotAScanner \
    tests/test_connections_router.py::TestClientManagerTargetGate \
    -o addopts="" -v -p no:randomly
tests/test_target_policy.py::TestIsBlockedTarget::test_denied_literals[127.0.0.1] PASSED [  1%]
tests/test_target_policy.py::TestIsBlockedTarget::test_denied_literals[169.254.169.254] PASSED [  9%]
tests/test_target_policy.py::TestIsBlockedTarget::test_denied_literals[fe80::1] PASSED [ 12%]
tests/test_target_policy.py::TestIsBlockedTarget::test_hostname_is_not_pre_resolved PASSED [ 27%]
tests/test_target_policy.py::TestAllowPrivateTargetsOverride::test_legacy_name_still_opens_the_gate PASSED [ 54%]
tests/test_target_policy.py::TestAssertTargetsAllowed::test_port_suffixes_do_not_defeat_the_gate[127.0.0.1:abc] PASSED [ 61%]
tests/test_connections_router.py::TestConnectionTargetGateOnWrites::test_create_with_blocked_host_rejected[169.254.169.254] PASSED [ 69%]
tests/test_connections_router.py::TestConnectionTargetGateOnWrites::test_update_to_blocked_host_rejected PASSED [ 80%]
tests/test_connections_router.py::TestHealthResponseIsNotAScanner::test_connection_failures_are_indistinguishable[exc0] PASSED [ 87%]
tests/test_connections_router.py::TestHealthResponseIsNotAScanner::test_connection_failures_are_indistinguishable[exc1] PASSED [ 89%]
tests/test_connections_router.py::TestHealthResponseIsNotAScanner::test_connection_failures_are_indistinguishable[exc2] PASSED [ 90%]
tests/test_connections_router.py::TestHealthResponseIsNotAScanner::test_connection_failures_are_indistinguishable[exc3] PASSED [ 92%]
tests/test_connections_router.py::TestHealthResponseIsNotAScanner::test_auth_error_stays_distinct PASSED [ 94%]
tests/test_connections_router.py::TestHealthResponseIsNotAScanner::test_blocked_stored_profile_reports_blocked_target PASSED [ 96%]
tests/test_connections_router.py::TestClientManagerTargetGate::test_get_client_refuses_stored_blocked_host PASSED [ 98%]
tests/test_connections_router.py::TestClientManagerTargetGate::test_get_client_allows_normal_host PASSED [100%]
============================== 55 passed in 0.42s ==============================
```

(abridged — 55 of 55 passed, full list in the run above.)

The `test_connection_failures_are_indistinguishable` cases assert the *absence* of leaked detail as well as the collapsed `errorType`: each injected exception message embeds `10.1.2.3`, a port, `BB9020011AC4202`, or `Errno`, and the test asserts none of them appear anywhere in the response body.

### Not verified here

- **Against a live Aerospike cluster or a real internal listener.** The tests inject exceptions at `client_manager.get_client`; nobody pointed a build at `169.254.169.254` in this environment to watch the gate fire on real traffic.
- The `ACM_ALLOW_PRIVATE_TARGETS=true` path is covered by unit tests but was not exercised end-to-end against the `compose.dev.yaml` loopback Aerospike.
