### PR TITLE
security(ci): add CodeQL and dependency review

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,64 @@
+name: codeql
+# GitHub-native static analysis. Results land in the repository's Security tab
+# under Code scanning, and on pull requests as inline annotations.
+#
+# Added because no repository in the organisation ran any code scanning, while
+# this one publishes API and UI container images to GHCR.
+# See aerospike-ce-ecosystem/project-hub#160.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly, so new CodeQL queries are applied to code that is not changing.
+    - cron: '17 4 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    permissions:
+      # Required to upload results to the code-scanning API.
+      security-events: write
+      # Required by the CodeQL action to read workflow run status.
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # api/ FastAPI backend
+          - language: python
+            build-mode: none
+          # ui/ Next.js frontend
+          - language: javascript-typescript
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,35 @@
+name: dependency-review
+# Fails a pull request that introduces a dependency with a known vulnerability,
+# before it can reach a published artefact. GitHub-native; reads the dependency
+# graph rather than running a third-party scanner.
+#
+# See aerospike-ce-ecosystem/project-hub#160.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    permissions:
+      contents: read
+      # Lets the action post its summary as a PR comment.
+      pull-requests: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Review dependency changes
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          # Block on high and critical; report the rest without failing, so
+          # this lands without stalling unrelated work on day one.
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
This is the `aerospike-cluster-manager` part of `aerospike-ce-ecosystem/project-hub#160` — no code, dependency, or secret scanning anywhere in the organisation. One PR per repo; this one adds only new files, so it cannot conflict with anything in flight here.

## Evidence this repo has never been scanned

```
$ gh api repos/aerospike-ce-ecosystem/aerospike-cluster-manager/code-scanning/analyses
{"message":"no analysis found","documentation_url":"https://docs.github.com/rest/code-scanning/code-scanning#list-code-scanning-analyses-for-a-repository","status":"404"}
```

## What this adds

- `.github/workflows/codeql.yml`
- `.github/workflows/dependency-review.yml`

Nothing existing is modified:

```
$ git diff --cached --name-status
A	.github/workflows/codeql.yml
A	.github/workflows/dependency-review.yml
```

| CodeQL language | Build mode | Covers |
|---|---|---|
| `python` | `none` | `api/` FastAPI backend — 137 Python files |
| `javascript-typescript` | `none` | `ui/` Next.js frontend — 116 tsx + 80 ts |

### Why this repo matters most

Cluster Manager publishes **API and UI container images to GHCR** and is the web-facing component — it terminates user sessions, handles OIDC tokens, and proxies to Kubernetes. Both a Python and a JavaScript attack surface, neither previously scanned.

**No dependabot file is added**: `.github/dependabot.yml` already exists here and covers `pip /api`, `npm /ui`, `docker /`, and `github-actions /`. Leaving it alone also keeps this PR to new files only.

## Verification

Every added file parses, and the CodeQL matrix resolves to the languages above:

```
$ python3 -c "import yaml; ..."
aerospike-cluster-manager          .github/workflows/codeql.yml               OK
aerospike-cluster-manager          .github/workflows/dependency-review.yml    OK
aerospike-cluster-manager          .github/dependabot.yml                     OK
```
(Full run across all repos in this batch: **21 files parsed, 0 failures**.)

## Why GitHub-native rather than a third-party scanner

The issue asked for GitHub-native tooling, and it is the right call here: CodeQL results land in the repository's Security tab and on the PR itself with no extra account, no extra token, and no new supply-chain dependency in the scanning path. Trivy/gitleaks/semgrep would each add one.

## Actions are SHA-pinned

The issue notes only 3 of ~190 `uses:` references across the org are SHA-pinned. Every action added here is:

```
actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1        # v7.0.1
github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd    # v4
github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
```

Each SHA was resolved from the tag, dereferencing annotated tags to their commit:

```
$ gh api repos/github/codeql-action/git/ref/tags/v4 --jq '.object.type + " " + .object.sha'
tag 988661ebb5e81487b3fb31b2185d2856c0a10679
$ gh api repos/github/codeql-action/git/tags/988661ebb5e81487b3fb31b2185d2856c0a10679 --jq .object.sha
ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd
```

## Secret scanning still needs a settings change — no workflow can do it

GitHub's secret scanning and push protection are repository/org settings, not workflows. Both are off across the whole org:

```
$ gh api repos/aerospike-ce-ecosystem/<repo> \
    --jq '.security_and_analysis.secret_scanning.status + "/" + .security_and_analysis.secret_scanning_push_protection.status'
disabled/disabled
```

I did not change it — that is a settings change and outside what this PR was authorised to do. Enabling it org-wide is **Organisation settings → Code security → Secret scanning / Push protection → Enable for all repositories**, or per repo:

```bash
gh api -X PATCH repos/aerospike-ce-ecosystem/<repo> \
  -f 'security_and_analysis[secret_scanning][status]=enabled' \
  -f 'security_and_analysis[secret_scanning_push_protection][status]=enabled'
```

## Update: these workflows have now actually run on this PR

The earlier caveat that nothing had been exercised no longer applies. Results on `3a46b44`:

```
Analyze (javascript-typescript)    success
Analyze (python)                   success
CodeQL                             success
dependency-review                  success
```

Every added job is green, and no existing check on this PR regressed.

**One thing this flushed out.** `dependency-review` failed on the first attempt in every repo in this batch, with:

```
##[error]Dependency review is not supported on this repository. Please ensure that
Dependency graph is enabled, see .../settings/security_analysis
```

That was not a vulnerability finding and not a workflow defect — the **dependency graph was switched off org-wide**. It has since been enabled, and a re-run of the same job passes unchanged. Secret scanning and push protection were enabled at the same time, which closes the part of #160 that no workflow could address:

```
$ gh api repos/aerospike-ce-ecosystem/aerospike-cluster-manager \
    --jq '"secret_scanning=" + .security_and_analysis.secret_scanning.status \
        + " push_protection=" + .security_and_analysis.secret_scanning_push_protection.status'
secret_scanning=enabled push_protection=enabled
```

Worth knowing for the other repos: if `dependency-review` ever fails with that message again, the fix is the setting, not the workflow.

## Still not verified

- CodeQL's **first analysis of the default branch** only happens after merge, so `code-scanning/analyses` will keep returning 404 until then. The PR-triggered analyses above prove the workflow runs and the language packs resolve; they do not populate the default-branch alert list.
- `fail-on-severity: high` is deliberately not `low`, so this lands without stalling unrelated PRs on day one. Tighten it once a baseline exists.
