### PR TITLE
fix(security): make the K8s cluster ACL fail closed on unlabelled CRs

### DIFF
--- a/README.md
+++ b/README.md
@@ -622,6 +622,36 @@ Common use cases include:
 
 `K8S_MANAGEMENT_ENABLED` controls every K8s endpoint. When it is disabled, the API returns 404 and the UI hides K8s features.
 
+### Workspace Labelling and K8s Cluster Visibility
+
+Cluster Manager decides who may see, scale, and delete an `AerospikeCluster`
+CR from the `acm.aerospike.com/workspace` label on the CR:
+
+| CR label | Who can read / scale / delete it |
+| --- | --- |
+| `acm.aerospike.com/workspace: <workspace-id>` | Callers who can see that workspace (its owner, or anyone if it is system-owned like `ws-default`) |
+| _absent_ | The system caller only |
+
+Every cluster Cluster Manager creates or imports carries the label —
+`ws-default` when the request names no workspace, which is system-owned and
+therefore shared. So an **unlabelled** CR means "Cluster Manager did not
+create this": a cluster applied with `kubectl`, by an operator's own
+manifests, or by another team. Those are denied to tenants rather than shared
+with them, matching how `AerospikeClusterTemplate` CRs have always behaved.
+
+With `OIDC_ENABLED=false` (the default) every caller is the system caller, so
+this changes nothing. With OIDC on, a tenant who previously saw an unlabelled
+cluster will now get a 404. If that cluster genuinely belongs to their
+workspace, label it:
+
+```bash
+kubectl label aerospikecluster <name> -n <namespace> \
+  acm.aerospike.com/workspace=<workspace-id>
+```
+
+Use `ws-default` for "shared with everyone". `kubectl get aerospikecluster -A
+-L acm.aerospike.com/workspace` lists what is currently labelled.
+
 ### Extended Pod Status Fields
 
 The pod status response now includes additional fields for richer cluster monitoring:

--- a/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
@@ -122,14 +122,25 @@ async def _assert_caller_owns_k8s_cluster(
     name: str,
     caller_owner_id: str,
 ) -> dict[str, Any]:
-    """Default-deny ACL gate for K8s cluster mutations.
+    """Default-deny ACL gate for K8s cluster reads and mutations.
 
     Resolves the cluster CR, reads its ``acm.aerospike.com/workspace``
-    label, and verifies the caller can see that workspace. Clusters with
-    no workspace label are treated as system-shared (visible to every
-    authenticated caller) so legacy CRs created before workspace
-    labelling stay reachable. Returns the CR dict for callers that need
-    it, so we don't pay the ``get_cluster`` round trip twice.
+    label, and verifies the caller can see that workspace. Returns the CR
+    dict for callers that need it, so we don't pay the ``get_cluster``
+    round trip twice.
+
+    Clusters with **no** workspace label are visible ONLY to the system
+    caller. This used to return the CR unconditionally, which fails
+    *open* — and unlabelled CRs are the normal case, not an edge case:
+    anything applied with ``kubectl``, by an operator's own manifests, or
+    by another team carries no ACM label. This gate guards the get,
+    scale, and delete paths, so failing open here let an authenticated
+    tenant delete another tenant's production cluster (#471).
+
+    :func:`_assert_template_visible` in this module has always had the
+    system-only rule; its own docstring calls the permissive version "the
+    pre-fix gap". This is the same rule, applied to the more destructive
+    object.
 
     Raises ``HTTPException(404)`` for a missing cluster (matching
     ``K8sApiError`` mapping) or for a cluster the caller cannot see
@@ -143,7 +154,14 @@ async def _assert_caller_owns_k8s_cluster(
         raise _map_k8s_error(e) from e
     workspace_id = _cr_workspace_id(cr)
     if workspace_id is None:
-        return cr
+        # Unlabelled: only the system caller may read or mutate. ACM no
+        # longer creates unlabelled cluster CRs (``create_k8s_cluster``
+        # stamps DEFAULT_WORKSPACE_ID when the request names no
+        # workspace), so the remaining unlabelled rows are ones ACM did
+        # not create — exactly the ones a tenant must not reach.
+        if caller_owner_id == SYSTEM_OWNER_ID:
+            return cr
+        raise HTTPException(status_code=404, detail=f"Cluster '{namespace}/{name}' not found")
     if not await _is_workspace_visible(workspace_id, caller_owner_id):
         raise HTTPException(status_code=404, detail=f"Cluster '{namespace}/{name}' not found")
     return cr
@@ -231,10 +249,18 @@ async def list_k8s_clusters(
     )
 
     # Filter CRs by workspace visibility. CRs with no workspace label are
-    # treated as system-shared (legacy compatibility). Visibility checks run
-    # in parallel via ``asyncio.gather`` so a 100-cluster page does not
-    # serialize 100 ``db.get_workspace`` round trips — the prior loop turned
-    # a fan-out lookup into an O(N) blocking chain.
+    # surfaced ONLY to the system caller, matching
+    # ``_assert_caller_owns_k8s_cluster`` and ``list_k8s_templates``. The
+    # previous rule treated unlabelled CRs as system-shared, which leaked the
+    # name, namespace, size, and status of every cluster another team applied
+    # with kubectl (#471) — and disagreed with the per-CR gate, so a listed
+    # cluster would 404 on click.
+    #
+    # Visibility checks run in parallel via ``asyncio.gather`` so a
+    # 100-cluster page does not serialize 100 ``db.get_workspace`` round
+    # trips — the prior loop turned a fan-out lookup into an O(N) blocking
+    # chain.
+    unlabelled_visible = caller_owner_id == SYSTEM_OWNER_ID
     workspace_ids: set[str] = set()
     for item in items:
         ws_id = _cr_workspace_id(item)
@@ -245,7 +271,14 @@ async def list_k8s_clusters(
         *(_is_workspace_visible(ws_id, caller_owner_id) for ws_id in ws_id_list),
     )
     visible_workspaces: dict[str, bool] = dict(zip(ws_id_list, visibility_results, strict=True))
-    items = [item for item in items if (ws := _cr_workspace_id(item)) is None or visible_workspaces.get(ws, False)]
+
+    def _visible(item: dict[str, Any]) -> bool:
+        ws = _cr_workspace_id(item)
+        if ws is None:
+            return unlabelled_visible
+        return visible_workspaces.get(ws, False)
+
+    items = [item for item in items if _visible(item)]
 
     # Build the connection-id correlation table from connections visible to the
     # caller only. Without this filter, a tenant would receive another tenant's
@@ -658,13 +691,16 @@ async def create_k8s_cluster(
         )
 
     cr = build_cr(body)
-    # Stamp the workspace label so subsequent ACL checks (list/get/mutate)
-    # can recognise the CR's tenant. Skipped when no workspace is named —
-    # the cluster lands in the system-shared bucket and stays visible to
-    # everyone, matching the legacy pre-#307 contract.
-    if body.workspace_id is not None:
-        labels = cr.setdefault("metadata", {}).setdefault("labels", {})
-        labels[_WORKSPACE_LABEL] = body.workspace_id
+    # ALWAYS stamp the workspace label so subsequent ACL checks
+    # (list/get/mutate) can recognise the CR's tenant. Falling back to
+    # DEFAULT_WORKSPACE_ID — which is system-owned and therefore shared —
+    # keeps "created without naming a workspace" as visible as it was, while
+    # removing the ambiguity that made the fix in #471 impossible: an
+    # unlabelled CR now unambiguously means "ACM did not create this", so the
+    # gate can safely deny it. Mirrors ``import_k8s_cluster`` above, which has
+    # stamped the default this way since #307.
+    labels = cr.setdefault("metadata", {}).setdefault("labels", {})
+    labels[_WORKSPACE_LABEL] = body.workspace_id or DEFAULT_WORKSPACE_ID
     result = await k8s_client.create_cluster(body.namespace, cr)
 
     connection_id: str | None = None

--- a/api/tests/test_k8s_cluster_acl_unlabelled.py
+++ b/api/tests/test_k8s_cluster_acl_unlabelled.py
@@ -1,0 +1,277 @@
+"""The K8s cluster ACL fails CLOSED on unlabelled CRs (#471).
+
+``_assert_caller_owns_k8s_cluster`` used to return an unlabelled
+``AerospikeCluster`` CR to any caller. Unlabelled is the *normal* case —
+anything applied with ``kubectl``, by an operator's own manifests, or by
+another team carries no ACM workspace label — and that gate guards the get,
+scale, and delete paths. An authenticated tenant could therefore read, scale,
+and delete another tenant's production cluster.
+
+``_assert_template_visible``, in the same file, has always had the
+system-only rule; its docstring calls the permissive version "the pre-fix
+gap". These tests pin the same rule for clusters, on every path the gate
+guards, plus the list filter (which leaked cluster metadata by the same
+mechanism) and the create path (which is what stops NEW unlabelled ACM CRs
+appearing).
+"""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from aerospike_cluster_manager_api.models.workspace import SYSTEM_OWNER_ID
+
+_TENANT = "user-tenant-a"
+
+
+@asynccontextmanager
+async def _noop_lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    yield
+
+
+def _cr(name: str = "demo", namespace: str = "aerospike", workspace: str | None = None) -> dict[str, Any]:
+    """Build an AerospikeCluster CR, with or without the ACM workspace label."""
+    metadata: dict[str, Any] = {"name": name, "namespace": namespace}
+    if workspace is not None:
+        metadata["labels"] = {"acm.aerospike.com/workspace": workspace}
+    return {
+        "apiVersion": "acko.io/v1alpha1",
+        "kind": "AerospikeCluster",
+        "metadata": metadata,
+        "spec": {"size": 2, "image": "aerospike/aerospike-server:7.0.0.0"},
+        "status": {"phase": "Running", "size": 2},
+    }
+
+
+UNLABELLED_CR = _cr()
+"""What `kubectl apply -f cluster.yaml` produces — no ACM label."""
+
+
+@pytest.fixture()
+def k8s_app():
+    """Reload the router with K8S_MANAGEMENT_ENABLED=True and yield the app."""
+    with patch("aerospike_cluster_manager_api.config.K8S_MANAGEMENT_ENABLED", True):
+        import aerospike_cluster_manager_api.main as main_mod
+        import aerospike_cluster_manager_api.routers.k8s_clusters as k8s_mod
+
+        importlib.reload(k8s_mod)
+        importlib.reload(main_mod)
+        yield main_mod.app, k8s_mod
+
+
+@pytest.fixture()
+async def make_client(k8s_app):
+    """Return a factory building a client that authenticates as ``owner_id``."""
+    test_app, _ = k8s_app
+
+    @asynccontextmanager
+    async def _build(owner_id: str) -> AsyncIterator[AsyncClient]:
+        from aerospike_cluster_manager_api.dependencies import _resolve_caller_owner_id
+
+        original_lifespan = test_app.router.lifespan_context
+        test_app.router.lifespan_context = _noop_lifespan
+        test_app.state.limiter.enabled = False
+        test_app.dependency_overrides[_resolve_caller_owner_id] = lambda: owner_id
+        transport = ASGITransport(app=test_app)
+        async with AsyncClient(transport=transport, base_url="http://test") as ac:
+            try:
+                yield ac
+            finally:
+                test_app.dependency_overrides.pop(_resolve_caller_owner_id, None)
+                test_app.state.limiter.enabled = True
+                test_app.router.lifespan_context = original_lifespan
+
+    return _build
+
+
+class TestUnlabelledClusterIsInvisibleToTenants:
+    """The three routes ``_assert_caller_owns_k8s_cluster`` guards."""
+
+    @pytest.mark.parametrize(
+        ("method", "path", "json_body"),
+        [
+            ("get", "/api/k8s/clusters/aerospike/demo", None),
+            ("post", "/api/k8s/clusters/aerospike/demo/scale", {"size": 5}),
+            ("delete", "/api/k8s/clusters/aerospike/demo", None),
+        ],
+    )
+    async def test_tenant_gets_404(self, k8s_app, make_client, method: str, path: str, json_body):
+        _, k8s_mod = k8s_app
+
+        mock_get = AsyncMock(return_value=UNLABELLED_CR)
+        mock_patch = AsyncMock(return_value=UNLABELLED_CR)
+        mock_delete = AsyncMock(return_value={})
+
+        with (
+            patch.object(k8s_mod.k8s_client, "get_cluster", mock_get),
+            patch.object(k8s_mod.k8s_client, "patch_cluster", mock_patch),
+            patch.object(k8s_mod.k8s_client, "delete_cluster", mock_delete),
+        ):
+            async with make_client(_TENANT) as client:
+                resp = await client.request(method.upper(), path, json=json_body)
+
+        assert resp.status_code == 404, resp.text
+        # Identity-404: the same wire shape as a genuinely missing cluster, so
+        # a probing tenant cannot tell "not yours" from "does not exist".
+        assert resp.json()["detail"] == "Cluster 'aerospike/demo' not found"
+        # And the destructive calls never happened.
+        mock_patch.assert_not_awaited()
+        mock_delete.assert_not_awaited()
+
+    async def test_system_caller_still_succeeds(self, k8s_app, make_client):
+        """Cluster admins keep their access — the gate is per-tenant, not a wall."""
+        _, k8s_mod = k8s_app
+
+        with (
+            patch.object(k8s_mod.k8s_client, "get_cluster", AsyncMock(return_value=UNLABELLED_CR)),
+            patch.object(k8s_mod.k8s_client, "list_pods", AsyncMock(return_value=[])),
+        ):
+            async with make_client(SYSTEM_OWNER_ID) as client:
+                resp = await client.get("/api/k8s/clusters/aerospike/demo")
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["name"] == "demo"
+
+    async def test_system_caller_can_still_delete(self, k8s_app, make_client):
+        _, k8s_mod = k8s_app
+
+        mock_delete = AsyncMock(return_value={})
+        with (
+            patch.object(k8s_mod.k8s_client, "get_cluster", AsyncMock(return_value=UNLABELLED_CR)),
+            patch.object(k8s_mod.k8s_client, "delete_cluster", mock_delete),
+        ):
+            async with make_client(SYSTEM_OWNER_ID) as client:
+                resp = await client.delete("/api/k8s/clusters/aerospike/demo")
+
+        assert resp.status_code == 202, resp.text
+        mock_delete.assert_awaited_once()
+
+    async def test_labelled_cr_owned_by_the_caller_still_succeeds(self, k8s_app, make_client):
+        """The fix must not break the path it is protecting."""
+        _, k8s_mod = k8s_app
+
+        labelled = _cr(workspace="ws-tenant-a")
+        with (
+            patch.object(k8s_mod.k8s_client, "get_cluster", AsyncMock(return_value=labelled)),
+            patch.object(k8s_mod.k8s_client, "list_pods", AsyncMock(return_value=[])),
+            patch.object(k8s_mod, "_is_workspace_visible", AsyncMock(return_value=True)),
+        ):
+            async with make_client(_TENANT) as client:
+                resp = await client.get("/api/k8s/clusters/aerospike/demo")
+
+        assert resp.status_code == 200, resp.text
+
+    async def test_labelled_cr_owned_by_someone_else_still_404s(self, k8s_app, make_client):
+        """Pre-existing behaviour for labelled CRs is unchanged."""
+        _, k8s_mod = k8s_app
+
+        labelled = _cr(workspace="ws-tenant-b")
+        with (
+            patch.object(k8s_mod.k8s_client, "get_cluster", AsyncMock(return_value=labelled)),
+            patch.object(k8s_mod, "_is_workspace_visible", AsyncMock(return_value=False)),
+        ):
+            async with make_client(_TENANT) as client:
+                resp = await client.get("/api/k8s/clusters/aerospike/demo")
+
+        assert resp.status_code == 404, resp.text
+
+
+class TestListFilterMatchesThePerCrGate:
+    """The list path leaked the same CRs, by the same mechanism.
+
+    Leaving it permissive while the per-CR gate fails closed would both leak
+    name/namespace/size/status of other teams' clusters AND produce a list
+    whose entries 404 on click.
+    """
+
+    async def test_unlabelled_cr_hidden_from_a_tenant(self, k8s_app, make_client):
+        _, k8s_mod = k8s_app
+
+        items = [_cr(name="kubectl-applied"), _cr(name="acm-made", workspace="ws-tenant-a")]
+        with (
+            patch.object(k8s_mod.k8s_client, "list_clusters", AsyncMock(return_value=(items, None))),
+            patch.object(k8s_mod, "_is_workspace_visible", AsyncMock(return_value=True)),
+            patch.object(k8s_mod.db, "get_all_connections", AsyncMock(return_value=[])),
+            patch.object(k8s_mod.db, "get_all_workspaces", AsyncMock(return_value=[])),
+        ):
+            async with make_client(_TENANT) as client:
+                resp = await client.get("/api/k8s/clusters?namespace=aerospike")
+
+        assert resp.status_code == 200, resp.text
+        names = [c["name"] for c in resp.json()["items"]]
+        assert names == ["acm-made"]
+
+    async def test_unlabelled_cr_visible_to_the_system_caller(self, k8s_app, make_client):
+        _, k8s_mod = k8s_app
+
+        items = [_cr(name="kubectl-applied")]
+        with (
+            patch.object(k8s_mod.k8s_client, "list_clusters", AsyncMock(return_value=(items, None))),
+            patch.object(k8s_mod.db, "get_all_connections", AsyncMock(return_value=[])),
+            patch.object(k8s_mod.db, "get_all_workspaces", AsyncMock(return_value=[])),
+        ):
+            async with make_client(SYSTEM_OWNER_ID) as client:
+                resp = await client.get("/api/k8s/clusters?namespace=aerospike")
+
+        assert resp.status_code == 200, resp.text
+        assert [c["name"] for c in resp.json()["items"]] == ["kubectl-applied"]
+
+
+class TestCreateAlwaysStampsTheWorkspaceLabel:
+    """ACM must stop producing unlabelled cluster CRs.
+
+    This is what makes the gate above safe to tighten: after this change an
+    unlabelled CR unambiguously means "ACM did not create this".
+    """
+
+    async def test_stamps_the_named_workspace(self, k8s_app, make_client):
+        _, k8s_mod = k8s_app
+
+        mock_create = AsyncMock(side_effect=lambda _ns, cr: cr)
+        with (
+            patch.object(k8s_mod.k8s_client, "list_namespaces", AsyncMock(return_value=["aerospike"])),
+            patch.object(k8s_mod.k8s_client, "create_cluster", mock_create),
+            patch.object(k8s_mod, "_is_workspace_visible", AsyncMock(return_value=True)),
+        ):
+            async with make_client(_TENANT) as client:
+                resp = await client.post(
+                    "/api/k8s/clusters",
+                    json={"name": "demo", "namespace": "aerospike", "size": 2, "workspaceId": "ws-tenant-a"},
+                )
+
+        assert resp.status_code == 201, resp.text
+        _, sent_cr = mock_create.call_args.args
+        assert sent_cr["metadata"]["labels"]["acm.aerospike.com/workspace"] == "ws-tenant-a"
+
+    async def test_stamps_the_default_when_no_workspace_named(self, k8s_app, make_client):
+        """Previously this left the CR unlabelled — the source of the ambiguity.
+
+        ``ws-default`` is system-owned and therefore shared, so a cluster
+        created without naming a workspace stays exactly as visible as before.
+        """
+        from aerospike_cluster_manager_api.models.workspace import DEFAULT_WORKSPACE_ID
+
+        _, k8s_mod = k8s_app
+
+        mock_create = AsyncMock(side_effect=lambda _ns, cr: cr)
+        with (
+            patch.object(k8s_mod.k8s_client, "list_namespaces", AsyncMock(return_value=["aerospike"])),
+            patch.object(k8s_mod.k8s_client, "create_cluster", mock_create),
+        ):
+            async with make_client(_TENANT) as client:
+                resp = await client.post(
+                    "/api/k8s/clusters",
+                    json={"name": "demo", "namespace": "aerospike", "size": 2},
+                )
+
+        assert resp.status_code == 201, resp.text
+        _, sent_cr = mock_create.call_args.args
+        assert sent_cr["metadata"]["labels"]["acm.aerospike.com/workspace"] == DEFAULT_WORKSPACE_ID


### PR DESCRIPTION
Closes #471

## What was wrong

`_assert_caller_owns_k8s_cluster` returned an unlabelled `AerospikeCluster` CR to **any** caller. That gate guards the get, scale, and delete paths, so an authenticated tenant could read, scale, and delete a cluster they had nothing to do with. `_assert_template_visible`, in the same file, has always required the system identity for the identical case — its own docstring calls the permissive version "the pre-fix gap". Tenant isolation held for templates and failed for clusters, which is the inverse of the risk ordering.

Unlabelled is not an edge case. It is what `kubectl apply -f cluster.yaml` produces.

## What changed

**1. `_assert_caller_owns_k8s_cluster` (`routers/k8s_clusters.py:144`)** — unlabelled CRs go to `SYSTEM_OWNER_ID` only, with the same identity-404 the template gate uses so a tenant cannot tell "not yours" from "does not exist".

**2. `list_k8s_clusters` — the same rule for the list filter.** Not in the issue, but leaving it permissive would be incoherent: it would keep leaking name, namespace, size, and status of every cluster another team applied with `kubectl`, and would produce a list whose entries 404 on click. `list_k8s_templates` already had the system-only rule — this brings clusters in line.

**3. `create_k8s_cluster` — always stamp the workspace label.** It previously stamped only when `body.workspace_id` was set, so ACM itself produced unlabelled CRs. That is what made the gate impossible to tighten safely. It now falls back to `DEFAULT_WORKSPACE_ID`, exactly as `import_k8s_cluster` has since #307. `ws-default` is system-owned and therefore shared, so a cluster created without naming a workspace stays exactly as visible as it was — but an unlabelled CR now unambiguously means "ACM did not create this".

## On the startup migration the issue asked for

The issue suggests "a startup pass that stamps the workspace label onto ACM-created CRs". **I did not implement it**, and I want to be explicit about why rather than quietly omit it.

There is no way to identify an ACM-created CR retroactively. `services/k8s_service.py:507-513` — `build_cr` stamps no ACM marker of any kind on `metadata`; the workspace label was the only signal, and its absence is precisely the case in question. Any startup pass would have to guess.

The two candidate guesses are both worse than not migrating:

- **Stamp `ws-default` on every unlabelled CR.** `ws-default` is system-owned, so this would make every tenant's `kubectl`-applied production cluster visible to every ACM caller — the exact opposite of the fix.
- **Stamp only CRs whose `namespace/name` matches a stored connection profile's `clusterName`.** This covers only `auto_connect=true` creates, and it is a boot-time write to Kubernetes objects ACM may not own, requiring `patch` RBAC the deployment may not have.

Not migrating is also the lower-impact choice. In the default configuration (`OIDC_ENABLED=false`) every caller resolves to `SYSTEM_OWNER_ID` (`dependencies.py:60-63`), so **nothing changes at all**. Only OIDC-on deployments are affected, and those are exactly the ones where the fail-open is a live vulnerability. The remedy is one command, documented in the README:

```bash
kubectl label aerospikecluster <name> -n <namespace> \
  acm.aerospike.com/workspace=<workspace-id>
```

If the maintainer wants the automatic pass anyway, the right shape is probably a marker label on `build_cr` now plus an explicit adoption endpoint later — happy to file that as a follow-up, but it is a bigger design decision than this security fix should carry.

## Breaking change for operators

With OIDC enabled, a tenant who previously saw an unlabelled cluster now gets a 404 on get/scale/delete and no longer sees it in the list. `kubectl get aerospikecluster -A -L acm.aerospike.com/workspace` shows what is currently labelled; the README section "Workspace Labelling and K8s Cluster Visibility" documents the table and the fix.

## Files

- `api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py` — the gate, the list filter, the create stamp
- `README.md` — new "Workspace Labelling and K8s Cluster Visibility" section
- `api/tests/test_k8s_cluster_acl_unlabelled.py` — new, 11 tests

## Verification

Ran the exact commands CI runs (`.github/workflows/ci.yaml`, `api` job).

```
$ cd api && uv run ruff check src/
All checks passed!

$ uv run ruff format --check src/
84 files already formatted

$ uv run pytest tests/ -v --tb=short
====================== 1078 passed, 6 warnings in 14.36s =======================
```

Baseline on `main` was `1067 passed`; the 11 added tests account for the difference. Every pre-existing test passed unchanged — no existing assertion had to be relaxed to accommodate the tighter gate.

Ran three times in a row to check for cross-test leakage, because the fixture uses `importlib.reload` to enable `K8S_MANAGEMENT_ENABLED` (the pattern `test_k8s_workspace_toctou_guard.py` already uses): `1078 passed` / `1078 passed` / `1078 passed`, each under a different `pytest-randomly` seed.

**Pre-commit job** — `pre-commit run --all-files`:

```
trim trailing whitespace.................................................Passed
fix end of files.........................................................Passed
check yaml...............................................................Passed
check json...............................................................Passed
check for added large files..............................................Passed
check for merge conflicts................................................Passed
check toml...............................................................Passed
detect private key.......................................................Passed
ruff (legacy alias)......................................................Passed
ruff format..............................................................Passed
pyright..................................................................Passed
eslint...................................................................Passed
prettier.................................................................Passed
tsc (type-check).........................................................Passed
```

The new tests:

```
$ uv run pytest tests/test_k8s_cluster_acl_unlabelled.py -o addopts="" -v -p no:randomly
TestUnlabelledClusterIsInvisibleToTenants::test_tenant_gets_404[get-/api/k8s/clusters/aerospike/demo-None] PASSED [  9%]
TestUnlabelledClusterIsInvisibleToTenants::test_tenant_gets_404[post-/api/k8s/clusters/aerospike/demo/scale-json_body1] PASSED [ 18%]
TestUnlabelledClusterIsInvisibleToTenants::test_tenant_gets_404[delete-/api/k8s/clusters/aerospike/demo-None] PASSED [ 27%]
TestUnlabelledClusterIsInvisibleToTenants::test_system_caller_still_succeeds PASSED [ 36%]
TestUnlabelledClusterIsInvisibleToTenants::test_system_caller_can_still_delete PASSED [ 45%]
TestUnlabelledClusterIsInvisibleToTenants::test_labelled_cr_owned_by_the_caller_still_succeeds PASSED [ 54%]
TestUnlabelledClusterIsInvisibleToTenants::test_labelled_cr_owned_by_someone_else_still_404s PASSED [ 63%]
TestListFilterMatchesThePerCrGate::test_unlabelled_cr_hidden_from_a_tenant PASSED [ 72%]
TestListFilterMatchesThePerCrGate::test_unlabelled_cr_visible_to_the_system_caller PASSED [ 81%]
TestCreateAlwaysStampsTheWorkspaceLabel::test_stamps_the_named_workspace PASSED [ 90%]
TestCreateAlwaysStampsTheWorkspaceLabel::test_stamps_the_default_when_no_workspace_named PASSED [100%]
============================== 11 passed in 2.40s ==============================
```

The three `test_tenant_gets_404` cases assert both the 404 *and* that `k8s_client.patch_cluster` / `delete_cluster` were never awaited — the point is that the destructive call does not happen, not just that the response says 404.

### Not verified here

- **Against a real Kubernetes cluster.** `k8s_client` is mocked throughout, so these tests pin the router's ACL decision, not the operator's behaviour. Nobody applied an unlabelled CR to the `make run-local` kind cluster and drove the UI against it in this environment.
- **The `kubectl label` remedy** documented in the README was not executed against a live cluster.
- **UI job** — this PR touches no `ui/` file, so `npm run type-check / lint / test / build` were not run for it. (`pre-commit`'s eslint/prettier/tsc hooks ran and passed, but they are scoped to changed files, of which there were none under `ui/`.)
