### PR TITLE
fix(records): return null, not 0, when a set's object count is unavailable (ADR-0026)

### DIFF
--- a/api/src/aerospike_cluster_manager_api/models/query.py
+++ b/api/src/aerospike_cluster_manager_api/models/query.py
@@ -191,7 +191,10 @@ class FilteredQueryResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True, serialize_by_alias=True)
 
     records: list[AerospikeRecord]
-    total: int = Field(ge=0)
+    # ``null`` means the set's object count could not be determined — an
+    # explicit "unknown", distinct from a genuine ``0`` (ADR-0026). Mirrored
+    # in ``ui/src/lib/types/query.ts`` (project goal 2-7).
+    total: int | None = Field(default=None, ge=0)
     page: int = Field(ge=1)
     page_size: int = Field(ge=1, alias="pageSize")
     has_more: bool = Field(alias="hasMore")

--- a/api/src/aerospike_cluster_manager_api/models/record.py
+++ b/api/src/aerospike_cluster_manager_api/models/record.py
@@ -58,7 +58,14 @@ class AerospikeRecord(BaseModel):
 
 class RecordListResponse(BaseModel):
     records: list[AerospikeRecord]
-    total: int
+    # ``null`` means the set's object count could not be determined — an
+    # explicit "unknown", distinct from a genuine ``0`` (ADR-0026). Clients
+    # must not read ``null`` as "no records": show the loaded count instead
+    # ("~N+ records") and keep pagination controls live.
+    #
+    # Mirrored in ``ui/src/lib/types/record.ts`` — keep both sides in sync
+    # (project goal 2-7).
+    total: int | None
     page: int
     pageSize: int
     hasMore: bool

--- a/api/src/aerospike_cluster_manager_api/services/records_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/records_service.py
@@ -117,7 +117,9 @@ class ListRecordsResult(NamedTuple):
     """
 
     records: list[Record]
-    total: int
+    # ``None`` means "unknown", not "zero" (ADR-0026). See
+    # :func:`_get_set_object_count`.
+    total: int | None
     page: int
     page_size: int
     has_more: bool
@@ -133,7 +135,8 @@ class FilterRecordsResult(NamedTuple):
     """
 
     records: list[Record]
-    total: int
+    # ``None`` means "unknown", not "zero" (ADR-0026).
+    total: int | None
     page: int
     page_size: int
     has_more: bool
@@ -148,23 +151,33 @@ class FilterRecordsResult(NamedTuple):
 # ---------------------------------------------------------------------------
 
 
-async def _get_set_object_count(client: aerospike_py.AsyncClient, ns: str, set_name: str) -> int:
-    """Approximate object count for a set via the namespace/sets info commands.
+async def _get_set_object_count(client: aerospike_py.AsyncClient, ns: str, set_name: str) -> int | None:
+    """Approximate object count for a set, or ``None`` when it is unknowable.
 
     Fetches the namespace replication-factor first to de-duplicate counts
     across nodes, matching the same approach used in ``clusters_service``.
 
+    Returns:
+        * ``int`` — the count, including a genuine ``0`` when the set is
+          absent from ``sets/<ns>``. Aerospike drops a set from that listing
+          once it holds no records, so absent really does mean empty.
+        * ``None`` — the count could not be determined. Per ADR-0026 this is
+          the *explicit* "unknown" state; it used to be ``0``, which a client
+          cannot tell from "this set is empty". The frontend showed "no
+          records" over a populated set and disabled pagination on it.
+
     Connectivity / timeout / backpressure errors (``ClusterError``,
     ``AerospikeTimeoutError``, ``BackpressureError``) are re-raised so the
-    global exception handlers in :mod:`main` can map them to 503/504. The
-    callers (:func:`list_records`, :func:`run_filtered_query`) deliberately
-    propagate those same classes — swallowing them here would make a
-    transient timeout report ``total=0`` on a non-empty set. Only narrow,
-    best-effort failures (other ``AerospikeError`` / ``OSError``) fall back
-    to 0.
+    global exception handlers in :mod:`main` can map them to 503/504 — a dead
+    cluster must not degrade to "unknown count, here is an empty page". Only
+    narrow, best-effort failures (other ``AerospikeError`` / ``OSError``,
+    e.g. an ACL-restricted user who cannot run the info command) resolve to
+    ``None``.
     """
     if not set_name:
-        return 0
+        # A namespace-wide listing has no single set to count. Not zero:
+        # "how many records are in the unnamed set" has no answer.
+        return None
     try:
         ns_all = await client.info_all(info_namespace(ns))
         ns_stats = aggregate_node_kv(ns_all)
@@ -176,10 +189,13 @@ async def _get_set_object_count(client: aerospike_py.AsyncClient, ns: str, set_n
             if s["name"] == set_name:
                 return s["objects"]
     except (ClusterError, AerospikeTimeoutError, BackpressureError):
-        # Infrastructure failure — must surface as 503/504, not a fake 0.
+        # Infrastructure failure — must surface as 503/504, not a fake count.
         raise
     except (AerospikeError, OSError):
         logger.debug("Failed to get set object count for %s.%s", ns, set_name, exc_info=True)
+        return None
+    # Reached only when the set is not in `sets/<ns>` at all, which Aerospike
+    # reports for a set holding no records. That is a real zero, not unknown.
     return 0
 
 
@@ -449,7 +465,18 @@ async def list_records(
     # set_total. set_total is an independent info-command estimate that can
     # lag the actual scan on an eventually-consistent set, which would
     # otherwise make has_more falsely False on a full page.
-    has_more = True if len(raw_results) >= limit else set_total > len(raw_results)
+    #
+    # With set_total unknown (ADR-0026) a short page is the only evidence
+    # available, and it says the scan is done — so has_more is False. The
+    # important part is that unknown does NOT take the `0 > len(...)` branch
+    # the old sentinel took, which reported "no more records" identically for
+    # "the set is empty" and "we could not ask".
+    if len(raw_results) >= limit:
+        has_more = True
+    elif set_total is None:
+        has_more = False
+    else:
+        has_more = set_total > len(raw_results)
 
     return ListRecordsResult(
         records=raw_results,
@@ -595,13 +622,19 @@ async def filter_records(client: aerospike_py.AsyncClient, body: FilteredQueryRe
     # returned count is capped — it does not reflect the true number of
     # records scanned by the Aerospike server. For unfiltered scans we use
     # the info command to get the real set size.
+    set_total: int | None
     if has_filters:
         set_total = returned + (1 if has_more else 0)  # lower bound
         scanned = returned  # lower bound; actual server-side scan may be higher
         total_estimated = True
     else:
         set_total = await _get_set_object_count(client, body.namespace, body.set or "")
-        scanned = set_total  # info-based: represents all objects in the set
+        # ``scanned`` stays an int: it counts what this call actually looked
+        # at, and with the info-command total unavailable the only defensible
+        # number is what came back. Reporting 0 scanned alongside N returned
+        # would be a contradiction; ``total_estimated`` already flags that
+        # neither figure is authoritative.
+        scanned = set_total if set_total is not None else returned
         total_estimated = True
 
     return FilterRecordsResult(

--- a/api/tests/test_records_service.py
+++ b/api/tests/test_records_service.py
@@ -481,16 +481,43 @@ class TestGetSetObjectCount:
         with pytest.raises(BackpressureError):
             await records_service._get_set_object_count(client, "test", "demo")
 
-    async def test_generic_aerospike_error_is_best_effort_zero(self):
-        """Non-infrastructure AerospikeError stays best-effort → 0."""
+    async def test_generic_aerospike_error_reports_unknown_not_zero(self):
+        """Non-infrastructure AerospikeError → None ("unknown"), per ADR-0026.
+
+        This used to return 0, which a client cannot distinguish from "this
+        set is empty" — so the record browser rendered "no records" over a
+        populated set and disabled pagination on it. The realistic trigger is
+        an ACL-restricted user whose role cannot run the info command.
+        """
         client = AsyncMock()
         client.info_all = AsyncMock(side_effect=AerospikeError("sparse namespace"))
 
-        assert await records_service._get_set_object_count(client, "test", "demo") == 0
+        assert await records_service._get_set_object_count(client, "test", "demo") is None
 
-    async def test_os_error_is_best_effort_zero(self):
+    async def test_os_error_reports_unknown_not_zero(self):
         client = AsyncMock()
         client.info_all = AsyncMock(side_effect=OSError("socket hiccup"))
+
+        assert await records_service._get_set_object_count(client, "test", "demo") is None
+
+    async def test_empty_set_name_reports_unknown(self):
+        """A namespace-wide listing has no single set to count.
+
+        Not zero: "how many records are in the unnamed set" has no answer.
+        """
+        client = AsyncMock()
+        assert await records_service._get_set_object_count(client, "test", "") is None
+        client.info_all.assert_not_awaited()
+
+    async def test_set_absent_from_sets_listing_is_a_real_zero(self):
+        """Absent from ``sets/<ns>`` means the set holds no records.
+
+        Aerospike drops a set from that listing once it is empty, so this is
+        the one case where 0 is the honest answer rather than a sentinel —
+        pinned so a future "everything unknown" simplification is a decision.
+        """
+        client = AsyncMock()
+        client.info_all = AsyncMock(return_value=[])
 
         assert await records_service._get_set_object_count(client, "test", "demo") == 0
 
@@ -502,6 +529,66 @@ class TestGetSetObjectCount:
 
         with pytest.raises(AerospikeTimeoutError):
             await records_service.list_records(client, "test", "demo", page_size=25)
+
+
+class TestUnknownTotalReachesTheCaller:
+    """The ``None`` from ``_get_set_object_count`` must survive to the result.
+
+    Collapsing it back to 0 anywhere in between would restore the exact bug
+    ADR-0026 is about, just one layer further out.
+    """
+
+    async def test_list_records_reports_total_none(self):
+        client, _query = _build_query_mock([_make_record()])
+        # Narrow error → count unknown, but the scan itself succeeded.
+        client.info_all = AsyncMock(side_effect=AerospikeError("no info privilege"))
+
+        result = await records_service.list_records(client, "test", "demo", page_size=25)
+
+        assert result.total is None
+        assert len(result.records) == 1
+        # The records are still there — "unknown count" is not "empty page".
+
+    async def test_unknown_total_does_not_claim_more_records_exist(self):
+        """A short page with an unknown total means the scan finished.
+
+        The old code took the ``0 > len(records)`` branch, which reported
+        "no more records" for a *populated* set whose count merely failed to
+        resolve. Now the short page — real evidence — is what decides.
+        """
+        client, _query = _build_query_mock([_make_record()])
+        client.info_all = AsyncMock(side_effect=AerospikeError("no info privilege"))
+
+        result = await records_service.list_records(client, "test", "demo", page_size=25)
+
+        assert result.has_more is False
+
+    async def test_unknown_total_still_reports_more_on_a_full_page(self):
+        """A full page is evidence of more data regardless of the total."""
+        recs = [_make_record(key=("test", "demo", f"k{i}", b"\x00")) for i in range(5)]
+        client, _query = _build_query_mock(recs)
+        client.info_all = AsyncMock(side_effect=AerospikeError("no info privilege"))
+
+        result = await records_service.list_records(client, "test", "demo", page_size=5)
+
+        assert result.total is None
+        assert result.has_more is True
+
+    async def test_filter_records_reports_total_none_on_unfiltered_scan(self):
+        from aerospike_cluster_manager_api.models.query import FilteredQueryRequest
+
+        client, _query = _build_query_mock([_make_record()])
+        client.info_all = AsyncMock(side_effect=AerospikeError("no info privilege"))
+
+        result = await records_service.filter_records(
+            client, FilteredQueryRequest(namespace="test", set="demo", pageSize=25)
+        )
+
+        assert result.total is None
+        # ``scanned`` stays an int — it counts what this call looked at.
+        # Reporting 0 scanned next to 1 returned would be a contradiction.
+        assert result.scanned_records == 1
+        assert result.returned_records == 1
 
 
 # ---------------------------------------------------------------------------

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.test.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.test.tsx
@@ -263,3 +263,57 @@ describe("RecordBrowserPage — route param decoding", () => {
     ).toBeInTheDocument()
   })
 })
+
+describe("RecordBrowserPage — unknown record count (ADR-0026 / #168)", () => {
+  it("does not report 0 rows when the server could not determine the total", async () => {
+    // The bug: the API returned total=0 for "the count is unavailable", so
+    // the footer read "12 of 0 rows" under a page of visible records — and a
+    // user reasonably concluded the set was empty. total is now null, and the
+    // footer falls back to a lower bound derived from what actually loaded.
+    mockedFilter.mockResolvedValueOnce({ ...fixtureResponse(12), total: null })
+
+    render(<RecordBrowserPage />)
+
+    const total = await screen.findByText("12+")
+    expect(total).toBeInTheDocument()
+
+    // Scoped to the footer summary, because "0" legitimately appears in the
+    // record rows (ttl/generation). The claim under test is specifically that
+    // the "{returned} of {total} rows" line does not read "12 of 0 rows".
+    // (The separators are their own elements, so textContent has no spaces.)
+    const summary = total.parentElement
+    expect(summary?.textContent).toBe("12of12+rows")
+  })
+
+  it("still shows an exact total when the server knows it", async () => {
+    mockedFilter.mockResolvedValueOnce({ ...fixtureResponse(12), total: 4321 })
+
+    render(<RecordBrowserPage />)
+
+    expect(await screen.findByText("4.3K")).toBeInTheDocument()
+  })
+
+  it("marks a known-but-estimated total with a tilde", async () => {
+    mockedFilter.mockResolvedValueOnce({
+      ...fixtureResponse(12),
+      total: 500,
+      totalEstimated: true,
+    })
+
+    render(<RecordBrowserPage />)
+
+    expect(await screen.findByText("~500")).toBeInTheDocument()
+  })
+
+  it("still renders the empty state for a genuine zero", async () => {
+    // A real 0 must keep behaving as "this set is empty" — the fix is about
+    // telling unknown apart from zero, not about erasing zero.
+    mockedFilter.mockResolvedValueOnce({ ...fixtureResponse(0), total: 0 })
+
+    render(<RecordBrowserPage />)
+
+    expect(
+      await screen.findByText(/no records in this set/i),
+    ).toBeInTheDocument()
+  })
+})

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
@@ -57,14 +57,35 @@ function formatRowCount(n: number): string {
   return String(n)
 }
 
+/**
+ * Render the total in the footer's "{returned} of {total} rows" summary.
+ *
+ * `total: null` means the server could not determine the set's object count
+ * (ADR-0026) — it is NOT zero. Rendering it as 0 put "0 rows" under a page of
+ * visible records. Per the ADR, fall back to a lower bound derived from what
+ * we actually loaded: "12 of 12+ rows" reads as "at least 12", which is the
+ * only honest claim available.
+ */
+function formatTotal(
+  total: number | null,
+  estimated: boolean,
+  loaded: number,
+): string {
+  if (total === null) return `${formatRowCount(loaded)}+`
+  return `${estimated ? "~" : ""}${formatRowCount(total)}`
+}
+
 interface QueryMeta {
-  total: number
+  /** `null` = the count is unknown (ADR-0026), not zero. */
+  total: number | null
   totalEstimated: boolean
   executionTimeMs: number
 }
 
 const EMPTY_META: QueryMeta = {
-  total: 0,
+  // Nothing has been fetched yet, so the count is genuinely unknown rather
+  // than zero — same distinction the API now makes.
+  total: null,
   totalEstimated: false,
   executionTimeMs: 0,
 }
@@ -607,8 +628,7 @@ function StatusBar({
         </span>
         <span className="mx-1 opacity-60">of</span>
         <span className="font-semibold text-gray-900 dark:text-gray-50">
-          {meta.totalEstimated ? "~" : ""}
-          {formatRowCount(meta.total)}
+          {formatTotal(meta.total, meta.totalEstimated, returned)}
         </span>
         <span className="ml-1 opacity-60">rows</span>
       </span>

--- a/ui/src/lib/types/query.ts
+++ b/ui/src/lib/types/query.ts
@@ -106,7 +106,11 @@ export interface FilteredQueryRequest {
 
 export interface FilteredQueryResponse {
   records: AerospikeRecord[]
-  total: number
+  /**
+   * Object count for the set, or `null` when it could not be determined
+   * (ADR-0026). `null` means "unknown", never "zero".
+   */
+  total: number | null
   page: number
   pageSize: number
   hasMore: boolean

--- a/ui/src/lib/types/record.ts
+++ b/ui/src/lib/types/record.ts
@@ -35,7 +35,13 @@ export interface AerospikeRecord {
 
 export interface RecordListResponse {
   records: AerospikeRecord[]
-  total: number
+  /**
+   * Object count for the set, or `null` when it could not be determined
+   * (ADR-0026). `null` is an explicit "unknown" — it must NOT be rendered as
+   * "no records", and it must not disable pagination. Show the loaded count
+   * instead ("~N+ records").
+   */
+  total: number | null
   page: number
   pageSize: number
   hasMore: boolean


### PR DESCRIPTION
Closes #168

Implements the backend + frontend halves of [ADR-0026](https://github.com/aerospike-ce-ecosystem/project-hub/blob/main/docs/docs/architecture/adr/2026-03-30-record-count-accuracy.md).

## Corrections to the issue's plan, before the diff

The issue body is hub-generated and its file map does not match this repo. Verified by reading:

| Issue says | Actually |
|---|---|
| `routers/records.py`의 `get_set_object_count()` | `_get_set_object_count` lives in `api/src/aerospike_cluster_manager_api/services/records_service.py:151` |
| `backend/src/routers/records.py`, `backend/src/schemas/records.py`, `frontend/src/lib/api/types.ts`, `frontend/src/components/records/`, `frontend/src/stores/` | None of those paths exist. The real ones are `api/src/aerospike_cluster_manager_api/...` and `ui/src/lib/types/{record,query}.ts` + `ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx` |
| "API 응답 스키마에 `totalEstimated: bool` 필드 추가" | **Already implemented.** `models/record.py:65`, `models/query.py:201`, set by both routers (`routers/records.py:164` and `:398`), and mirrored at `ui/src/lib/types/record.ts:42` / `query.ts:116`. No work needed. |

The underlying defect the ADR describes is real and is fixed here.

One more citation correction, for the record: the task I was given pointed at `services/clusters_service.py:327` as a `safe_int` call site. That line is `sets_all = ns_results[i * 2 + 1]`. The `safe_int` calls in that file are at `:143`, `:198`, `:201-203`, `:344`, `:347`, and `:353-399`, and none of them are the record-count path — `clusters_service` computes namespace-level totals, which are a separate surface from the set object count this issue is about. I left them alone.

## What was wrong

`_get_set_object_count` returned `0` when the count could not be determined. A client cannot tell that apart from "this set is empty", so:

- the footer read **"12 of 0 rows"** under a page of visible records;
- `has_more = ... else set_total > len(raw_results)` took the `0 > 12` branch and reported **hasMore=False on a populated set**.

Note the timeout case the ADR lists was already handled: `ClusterError` / `AerospikeTimeoutError` / `BackpressureError` already propagate to 503/504 rather than degrading to 0. The live triggers for the remaining bug are a narrow `AerospikeError`/`OSError` — realistically an ACL-restricted user whose role cannot run the info command — and a namespace-wide listing with no set scope.

## What changed

**`_get_set_object_count` → `int | None`.** Three outcomes, each deliberate:

| Situation | Returns | Why |
|---|---|---|
| Set found in `sets/<ns>` | the count | unchanged |
| Set **absent** from `sets/<ns>` | `0` | Aerospike drops a set from that listing once it holds no records, so absent really does mean empty. This is the one place 0 is honest, and there is a test pinning it so a future "make everything unknown" simplification is a decision rather than a slip. |
| Narrow `AerospikeError` / `OSError`, or no set name | `None` | genuinely unknown |

**Propagation.** `total: int | None` on `ListRecordsResult`, `FilterRecordsResult`, `RecordListResponse`, and `FilteredQueryResponse`. Collapsing the `None` back to 0 anywhere in between would restore the bug one layer out, so there are tests at the service boundary for that specifically.

**`has_more`.** No longer takes the `0 > len(records)` branch on an unknown total. A full page still means "more data" and a short page still means "done" — the difference is that "we could not ask" no longer masquerades as "the set is empty".

**`scanned_records` stays an `int`.** With the total unknown, the only defensible number is what this call actually looked at. Reporting `scanned: 0` beside `returned: 12` would be a contradiction, and `totalEstimated` already tells the client neither figure is authoritative.

**Frontend** (goal 2-7 — both sides updated in this PR):
- `total: number | null` in `ui/src/lib/types/record.ts` and `query.ts`.
- The footer renders a lower bound: **"12 of 12+ rows"**, per the ADR's "~N+ records" with N = the loaded count. A known-but-estimated total still renders `~500`; a known exact total still renders `4.3K`; a genuine `0` still shows the empty state.
- `EMPTY_META.total` is now `null` — before the first fetch the count is genuinely unknown, the same distinction the API now makes.

No layout or navigation change (goal 2-4): one existing `<span>`'s contents changed, nothing moved.

## Relationship to #468

ADR-0026 names these `None` semantics as the precondition for correct pagination, and #468 (`page` validated then ignored) is the pagination half. This PR is the precondition only — it does **not** add prev/next controls or a cursor. The "pagination stays enabled when the total is unknown" behaviour the ADR asks for needs pagination to exist first; it belongs in #468's PR, which builds on the nullable `total` this one lands.

## Verification

Ran the exact commands CI runs (`.github/workflows/ci.yaml`).

**API job:**

```
$ cd api && uv run ruff check src/
All checks passed!

$ uv run ruff format --check src/
(clean)

$ uv run pytest tests/
1073 passed, 6 warnings in 12.72s
```

Baseline on `main` was `1067 passed`. Net +6: 4 added, and 2 pre-existing tests **rewritten** rather than added —
`test_generic_aerospike_error_is_best_effort_zero` and `test_os_error_is_best_effort_zero` asserted `== 0`, i.e. they pinned the bug. They are now `test_generic_aerospike_error_reports_unknown_not_zero` / `test_os_error_reports_unknown_not_zero` asserting `is None`, with the reason in the docstring. Flagging that explicitly since "tests changed" is the part a reviewer should look at hardest.

**UI job:**

```
$ cd ui && npm run type-check     # tsc --noEmit  → clean
$ npm run lint                    # eslint .      → clean
$ npm run format:check
All matched files use Prettier code style!
$ npm run test
 Test Files  19 passed (19)
      Tests  108 passed (108)
$ npm run build                   # completed
```

Baseline was 19 files / 104 tests → +4 tests, no file added (they extend the existing record-browser suite).

**Pre-commit job** — `pre-commit run --all-files`: all 14 hooks Passed (trailing-whitespace, end-of-file, check-yaml/json/toml, large-files, merge-conflicts, private-key, ruff, ruff-format, pyright, eslint, prettier, tsc).

The tests that carry this change:

```
$ uv run pytest tests/test_records_service.py::TestGetSetObjectCount \
    tests/test_records_service.py::TestUnknownTotalReachesTheCaller -o addopts="" -v -p no:randomly
TestGetSetObjectCount::test_cluster_error_propagates_not_zero PASSED
TestGetSetObjectCount::test_timeout_error_propagates_not_zero PASSED
TestGetSetObjectCount::test_backpressure_error_propagates_not_zero PASSED
TestGetSetObjectCount::test_generic_aerospike_error_reports_unknown_not_zero PASSED
TestGetSetObjectCount::test_os_error_reports_unknown_not_zero PASSED
TestGetSetObjectCount::test_empty_set_name_reports_unknown PASSED
TestGetSetObjectCount::test_set_absent_from_sets_listing_is_a_real_zero PASSED
TestGetSetObjectCount::test_list_records_propagates_set_count_timeout PASSED
TestUnknownTotalReachesTheCaller::test_list_records_reports_total_none PASSED
TestUnknownTotalReachesTheCaller::test_unknown_total_does_not_claim_more_records_exist PASSED
TestUnknownTotalReachesTheCaller::test_unknown_total_still_reports_more_on_a_full_page PASSED
TestUnknownTotalReachesTheCaller::test_filter_records_reports_total_none_on_unfiltered_scan PASSED
============================== 12 passed in 0.04s ==============================

$ npx vitest run "src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.test.tsx"
 Tests  13 passed (13)
```

The UI test `does not report 0 rows when the server could not determine the total` asserts the footer's exact text (`"12of12+rows"` — the separators are their own elements, so `textContent` has no spaces) rather than just the presence of "12+". A looser assertion would not have caught "12 of 0 rows", which is the actual defect.

### Not verified here

- **Against a live Aerospike cluster.** `client.info_all` is mocked, so the `None` path is exercised by injecting `AerospikeError`, not by an ACL-restricted user hitting a real cluster. Whether an Aerospike CE server with ACL enabled raises a *narrow* `AerospikeError` (→ `None`) rather than a `ClusterError` (→ 503) for a denied info command was not confirmed empirically — if it raises the latter, that path stays a 503, which is also correct behaviour, just a different one.
- **The "pagination stays enabled on an unknown total" behaviour from the ADR is not implemented here**, because there is no pagination control to enable yet. See the #468 note above.
