### PR TITLE
fix(records): reject an unsupported `page` instead of silently ignoring it

### DIFF
--- a/api/src/aerospike_cluster_manager_api/models/query.py
+++ b/api/src/aerospike_cluster_manager_api/models/query.py
@@ -148,6 +148,31 @@ class FilterGroup(BaseModel):
 
 
 class FilteredQueryRequest(BaseModel):
+    """Request body for ``POST /records/{conn_id}/filter``.
+
+    **This endpoint returns the first window only.** ``pageSize`` bounds the
+    window; there is no way to ask for the next one, and ``page`` is accepted
+    only as ``1`` (#468).
+
+    Why there is no cursor yet — this is a client-library limitation, not an
+    oversight in this endpoint:
+
+    * The pinned ``aerospike-py`` (0.6.4, see #476) exposes no pagination
+      surface at all. ``AsyncQuery`` has ``where``/``select``/``results``/
+      ``foreach``, and ``QueryPolicy`` carries ``max_records`` with no offset
+      and no partition filter.
+    * Newer ``aerospike-py`` adds ``partition_filter_by_range(begin, count)``,
+      which is *not* sufficient on its own. A partition range cannot resume
+      mid-partition, and with 4096 partitions a set large enough to need
+      pagination holds far more than ``pageSize`` records per partition — so a
+      cursor keyed on partition id would never advance past the first one.
+      Resumable ``PartitionStatus`` is what would close this, and
+      ``aerospike-py`` deliberately clones the filter to prevent resumption.
+
+    Until that exists, callers narrow the result set (filters, a primary-key
+    pattern) or raise ``pageSize`` (max 500) rather than paging.
+    """
+
     model_config = ConfigDict(populate_by_name=True)
 
     namespace: str = Field(min_length=1, max_length=31)
@@ -156,7 +181,22 @@ class FilteredQueryRequest(BaseModel):
     predicate: QueryPredicate | None = None
     select_bins: list[BinName] | None = Field(default=None, min_length=1, alias="selectBins")
     max_records: int | None = Field(default=None, ge=1, le=1_000_000, alias="maxRecords")
-    page: int = Field(default=1, ge=1)
+    # Accepted only as ``1`` (#468). The field predates any mechanism to
+    # honour it: ``filter_records`` has always returned the first window and
+    # reported ``page=1`` regardless, so a client asking for page 7 received
+    # page 1 and could not tell. Rejecting instead of silently ignoring is the
+    # interim behaviour issue #468 prescribes — the router maps
+    # ``records_service.UnsupportedPageError`` to a 400 that explains it.
+    page: int = Field(
+        default=1,
+        ge=1,
+        description=(
+            "Reserved. Only 1 is accepted; any other value is rejected with 400. "
+            "The record browser has no offset or partition cursor yet, so this "
+            "endpoint returns the first window only. Narrow the result with "
+            "filters or a primary-key pattern, or raise pageSize (max 500)."
+        ),
+    )
     page_size: int = Field(default=25, ge=1, le=500, alias="pageSize")
     primary_key: str | None = Field(default=None, max_length=1024, alias="primaryKey")
     # Particle type for primary_key resolution. "auto" retries alternate type on NOT_FOUND.
@@ -195,6 +235,8 @@ class FilteredQueryResponse(BaseModel):
     # explicit "unknown", distinct from a genuine ``0`` (ADR-0026). Mirrored
     # in ``ui/src/lib/types/query.ts`` (project goal 2-7).
     total: int | None = Field(default=None, ge=0)
+    # Always 1 — see FilteredQueryRequest. Kept on the wire so the response
+    # shape stays stable for existing clients.
     page: int = Field(ge=1)
     page_size: int = Field(ge=1, alias="pageSize")
     has_more: bool = Field(alias="hasMore")

--- a/api/src/aerospike_cluster_manager_api/routers/records.py
+++ b/api/src/aerospike_cluster_manager_api/routers/records.py
@@ -26,6 +26,7 @@ from aerospike_cluster_manager_api.services.records_service import (
     InvalidPkPattern,
     PrimaryKeyMissing,
     SetRequiredForPkLookup,
+    UnsupportedPageError,
 )
 
 logger = logging.getLogger(__name__)
@@ -343,7 +344,15 @@ async def delete_record_bin(
     "/{conn_id}/filter",
     response_model=FilteredQueryResponse,
     summary="Filtered record scan",
-    description="Scan records with optional expression filters and pagination.",
+    description=(
+        "Scan records with optional expression filters. "
+        "Returns the FIRST window only — pageSize bounds it, and there is no "
+        "way to request the next one. `page` is accepted only as 1; any other "
+        "value is rejected with 400 rather than silently returning page 1 "
+        "(issue #468). Check `hasMore` to know whether the window is complete, "
+        "and narrow the result with filters or raise pageSize (max 500) to see "
+        "more."
+    ),
 )
 @limiter.limit("30/minute")
 async def get_filtered_records(
@@ -352,9 +361,15 @@ async def get_filtered_records(
     client: AerospikeClient,
     conn_id: VerifiedConnId,
 ) -> FilteredQueryResponse:
-    """Scan records with optional expression filters and pagination."""
+    """Scan records with optional expression filters. Returns the FIRST page."""
     try:
         result = await records_service.filter_records(client, body)
+    except UnsupportedPageError as exc:
+        # ``page`` used to be accepted and then discarded, so a client asking
+        # for page 7 received page 1 and could not tell (#468). Must be
+        # ordered before the generic ``ValueError`` branch below, which would
+        # otherwise swallow the specific message.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except SetRequiredForPkLookup as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except InvalidPkPattern as exc:

--- a/api/src/aerospike_cluster_manager_api/services/records_service.py
+++ b/api/src/aerospike_cluster_manager_api/services/records_service.py
@@ -77,6 +77,7 @@ __all__ = [
     "PkType",
     "PrimaryKeyMissing",
     "SetRequiredForPkLookup",
+    "UnsupportedPageError",
     "create_record",
     "delete_bin",
     "delete_record",
@@ -100,6 +101,32 @@ class InvalidPkPattern(ValueError):
 
     def __init__(self, message: str) -> None:
         super().__init__(message)
+
+
+class UnsupportedPageError(ValueError):
+    """Raised when a caller asks for a page this endpoint cannot produce (#468).
+
+    ``FilteredQueryRequest.page`` was declared, validated, and documented —
+    and then never read. ``filter_records`` returned the first window and
+    reported ``page=1`` on every path, so a request for page 7 silently got
+    page 1. That is worse than an error: a generated client (ackoctl, the
+    Copilot agent) reading the OpenAPI schema sends ``page`` in good faith
+    and has no way to detect that it was discarded.
+
+    Failing loudly is the interim contract until a real cursor exists. See
+    the class docstring on :class:`models.query.FilteredQueryRequest` for why
+    one does not yet: the pinned aerospike-py exposes no offset, no partition
+    filter, and no resumable partition status, so there is nothing to build a
+    cursor out of.
+    """
+
+    def __init__(self, page: int) -> None:
+        super().__init__(
+            f"page={page} is not supported: this endpoint returns the first window only. "
+            "Narrow the result with filters or a primary-key pattern, or raise pageSize "
+            "(max 500). Pagination beyond the first page is tracked in issue #468."
+        )
+        self.page = page
 
 
 # ---------------------------------------------------------------------------
@@ -489,16 +516,26 @@ async def list_records(
 
 
 async def filter_records(client: aerospike_py.AsyncClient, body: FilteredQueryRequest) -> FilterRecordsResult:
-    """Scan with optional PK pattern + bin filters and return a page.
+    """Scan with optional PK pattern + bin filters and return the FIRST page.
 
     PK lookup short-circuits to ``client.get`` when ``pk_match_mode='exact'``
     so a pure-key fetch never triggers a scan. ``prefix`` and ``regex`` modes
     compile the PK pattern into an expression and run a server-side scan.
 
+    There is no page 2 (#468). Every return path reports ``page=1``, because
+    the scan is bounded by ``max_records`` alone — there is no offset and no
+    partition cursor to resume from. ``body.page`` used to be accepted and
+    then ignored, so a caller asking for page 7 got page 1 and had no way to
+    notice; it is now rejected with :class:`UnsupportedPageError`.
+
     Raises:
+        UnsupportedPageError: ``body.page`` is not 1.
         SetRequiredForPkLookup: PK pattern provided without a set scope.
         InvalidPkPattern: regex/prefix could not be compiled.
     """
+    if body.page != 1:
+        raise UnsupportedPageError(body.page)
+
     start_time = time.monotonic()
 
     pk_target = body.pk_pattern or body.primary_key

--- a/api/tests/test_records_router.py
+++ b/api/tests/test_records_router.py
@@ -721,3 +721,80 @@ class TestConnectionRaceOn404:
 
         assert resp.status_code == 404, resp.text
         assert "conn-test" in resp.json()["detail"]
+
+
+class TestPageParameterRejectedAtTheHttpBoundary:
+    """#468: ``page`` reaches the wire as a 400, not as a silent page 1.
+
+    The harm the issue names is specifically at this boundary: ``page`` is in
+    the OpenAPI schema, so a generated client (ackoctl, the Copilot agent)
+    sends it and used to receive page 1 with a ``"page": 1`` in the body —
+    indistinguishable from success.
+    """
+
+    async def test_page_two_is_400_with_an_explanatory_detail(self, client: AsyncClient):
+        mock_client = _build_query_mock()
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test/filter",
+                json={"namespace": "test", "set": "demo", "page": 2},
+            )
+
+        assert resp.status_code == 400, resp.text
+        detail = resp.json()["detail"]
+        assert "page=2" in detail
+        # The message has to leave the caller somewhere to go.
+        assert "pageSize" in detail
+        # And no scan was run for a request that could not be honoured.
+        mock_client.query.assert_not_called()
+
+    async def test_page_one_still_succeeds(self, client: AsyncClient):
+        mock_client = _build_query_mock()
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test/filter",
+                json={"namespace": "test", "set": "demo", "page": 1},
+            )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["page"] == 1
+
+    async def test_omitting_page_still_succeeds(self, client: AsyncClient):
+        mock_client = _build_query_mock()
+
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            resp = await client.post(
+                "/api/records/conn-test/filter",
+                json={"namespace": "test", "set": "demo"},
+            )
+
+        assert resp.status_code == 200, resp.text

--- a/api/tests/test_records_service.py
+++ b/api/tests/test_records_service.py
@@ -867,3 +867,56 @@ class TestServiceModuleHasNoFastAPI:
             value = getattr(mod, attr)
             module_name = getattr(value, "__module__", "") or ""
             assert not module_name.startswith("fastapi"), f"{attr} originates in {module_name}"
+
+
+class TestPageParameterIsRejectedNotIgnored:
+    """``page`` was validated and then never read (#468).
+
+    ``filter_records`` returns the first window and reports ``page=1`` on
+    every path, so a request for page 7 got page 1 with no signal. A generated
+    client reading the OpenAPI schema sends ``page`` in good faith — silently
+    discarding it is worse than an error, so it is now an error.
+    """
+
+    async def test_page_two_raises(self):
+        from aerospike_cluster_manager_api.models.query import FilteredQueryRequest
+
+        client, _query = _build_query_mock([_make_record()])
+
+        with pytest.raises(records_service.UnsupportedPageError) as exc_info:
+            await records_service.filter_records(client, FilteredQueryRequest(namespace="test", set="demo", page=2))
+        assert exc_info.value.page == 2
+        # Rejected before any wire round-trip — a rejected request must not
+        # cost a scan.
+        client.query.assert_not_called()
+
+    async def test_page_one_is_accepted(self):
+        from aerospike_cluster_manager_api.models.query import FilteredQueryRequest
+
+        client, _query = _build_query_mock([_make_record()])
+
+        result = await records_service.filter_records(
+            client, FilteredQueryRequest(namespace="test", set="demo", page=1)
+        )
+        assert result.page == 1
+
+    async def test_page_defaults_to_one(self):
+        """Omitting ``page`` must keep working — this is the common case."""
+        from aerospike_cluster_manager_api.models.query import FilteredQueryRequest
+
+        client, _query = _build_query_mock([_make_record()])
+
+        result = await records_service.filter_records(client, FilteredQueryRequest(namespace="test", set="demo"))
+        assert result.page == 1
+
+    async def test_error_names_the_page_and_the_alternatives(self):
+        message = str(records_service.UnsupportedPageError(7))
+        assert "page=7" in message
+        assert "pageSize" in message
+        assert "#468" in message
+
+    async def test_error_is_a_value_error(self):
+        # The router catches it explicitly, but a service-layer caller that
+        # only handles ValueError must degrade sanely rather than crash.
+        with pytest.raises(ValueError):
+            raise records_service.UnsupportedPageError(3)

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.test.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.test.tsx
@@ -317,3 +317,43 @@ describe("RecordBrowserPage — unknown record count (ADR-0026 / #168)", () => {
     ).toBeInTheDocument()
   })
 })
+
+describe("RecordBrowserPage — truncated result indicator (#468)", () => {
+  it("says the view is truncated when the server reports hasMore", async () => {
+    // The server has always computed hasMore and the UI has always thrown it
+    // away, so a first-of-many page looked exactly like a complete one. There
+    // is still no next page to offer, so the honest signal is "truncated".
+    mockedFilter.mockResolvedValueOnce({
+      ...fixtureResponse(50),
+      hasMore: true,
+    })
+
+    render(<RecordBrowserPage />)
+
+    expect(await screen.findByText("truncated")).toBeInTheDocument()
+  })
+
+  it("does not say truncated when the window is complete", async () => {
+    mockedFilter.mockResolvedValueOnce({
+      ...fixtureResponse(3),
+      hasMore: false,
+    })
+
+    render(<RecordBrowserPage />)
+
+    // Wait for a rendered row before asserting the absence — otherwise the
+    // assertion passes trivially against the pre-fetch state.
+    expect(await screen.findByText("pk-0")).toBeInTheDocument()
+    expect(screen.queryByText("truncated")).not.toBeInTheDocument()
+  })
+
+  it("never sends a page parameter — the API rejects anything but 1", async () => {
+    mockedFilter.mockResolvedValueOnce(fixtureResponse(3))
+
+    render(<RecordBrowserPage />)
+    await screen.findByText("pk-0")
+
+    const [, body] = mockedFilter.mock.calls[0] ?? []
+    expect(body).not.toHaveProperty("page")
+  })
+})

--- a/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/sets/[namespace]/[set]/page.tsx
@@ -79,6 +79,16 @@ interface QueryMeta {
   /** `null` = the count is unknown (ADR-0026), not zero. */
   total: number | null
   totalEstimated: boolean
+  /**
+   * The server had more records than this window holds.
+   *
+   * The API has always computed this and the UI has always discarded it
+   * (#468), so a truncated view looked identical to a complete one. There is
+   * no next page to offer yet — see `FilteredQueryRequest` — so the honest
+   * thing is to say the view is truncated and point at the controls that do
+   * work: filters, and the Limit selector.
+   */
+  hasMore: boolean
   executionTimeMs: number
 }
 
@@ -87,6 +97,7 @@ const EMPTY_META: QueryMeta = {
   // than zero — same distinction the API now makes.
   total: null,
   totalEstimated: false,
+  hasMore: false,
   executionTimeMs: 0,
 }
 
@@ -251,6 +262,7 @@ export default function RecordBrowserPage() {
         setMeta({
           total: resp.total,
           totalEstimated: resp.totalEstimated,
+          hasMore: resp.hasMore,
           executionTimeMs: resp.executionTimeMs,
         })
       } catch (err) {
@@ -632,6 +644,15 @@ function StatusBar({
         </span>
         <span className="ml-1 opacity-60">rows</span>
       </span>
+
+      {meta.hasMore && (
+        <span
+          className="inline-flex items-center gap-1 rounded bg-amber-50 px-1.5 py-0.5 text-[11px] font-semibold text-amber-700 dark:bg-amber-950/40 dark:text-amber-400"
+          title="The scan stopped at the row limit. Narrow the result with a filter or raise Limit to see more."
+        >
+          truncated
+        </span>
+      )}
 
       <span
         className="h-3.5 w-px bg-gray-200 dark:bg-gray-800"


### PR DESCRIPTION
Closes #468

> **Stacked on #490** (`fix/168-set-object-count-none`, issue #168). ADR-0026's `None` semantics are the precondition this builds on, and both PRs touch the record-browser footer. Base retargets to `main` automatically when #490 merges. The diff shown here is this PR's changes only.

## The suggested mechanism is not implementable — evidence first

The issue suggests "Implement Aerospike partition-based pagination (`query_pages` / partition filter), return an opaque `nextCursor`". **That cannot be built against the client this repo has**, and I want the evidence on the table before the diff, because it is the reason this PR does something smaller.

**1. The pinned client has no pagination surface at all.**

```
$ cd api && uv run python -c "
import aerospike_py
print('version:', aerospike_py.__version__)
print('AsyncQuery:', [m for m in dir(aerospike_py.AsyncQuery) if not m.startswith('_')])
from aerospike_py.types import QueryPolicy
print('QueryPolicy:', list(QueryPolicy.__annotations__.keys()))
print('partition symbols:', [n for n in dir(aerospike_py) if 'partition' in n.lower()])
"
version: 0.6.4
AsyncQuery: ['foreach', 'results', 'select', 'where']
QueryPolicy: ['socket_timeout', 'total_timeout', 'max_retries', 'max_records', 'records_per_second', 'filter_expression', 'expressions']
partition symbols: ['AEROSPIKE_ERR_PARTITION_UNAVAILABLE']
```

No offset, no partition filter, no `query_pages`. The only partition-related name is an error-code constant. (0.6.4 is the pin from #476.)

**2. Upgrading past #476 would not be enough either.**

The current `aerospike-py` does add partition filtering — `partition_filter_all()`, `partition_filter_by_id(id)`, `partition_filter_by_range(begin, count)` (`src/aerospike_py/__init__.pyi:2360-2406`). But a partition *range* is not a record cursor:

- A range cursor can only advance a whole partition at a time. With 4096 partitions, any set large enough to need pagination holds far more than `pageSize` (≤ 500) records per partition — so "next page" would re-scan partition 0 and return the same records forever.
- Resuming *within* a partition needs `PartitionStatus`, and `aerospike-py` deliberately does not expose it. From its own docstring (`__init__.pyi:2368-2372`): *"The underlying `aerospike_core::PartitionFilter` holds mutable state (`Arc<Mutex<Vec<PartitionStatus>>>`). Reusing the same handle across two `results()` calls would cause the second call to resume from where the first left off; aerospike-py **mitigates this by cloning the inner filter at parse time**, isolating the user's handle."* The resume path is closed on purpose.

A repo-wide search confirms there is no `paginate` / `get_partitions_status` equivalent: `gh api "search/code?q=repo:aerospike-ce-ecosystem/aerospike-py+paginate"` → 0 results; the 17 `partition_filter` hits are the three constructors above and their tests/docs.

**What I did not do instead**, and why:

- **Over-fetch and slice** (`max_records = page × pageSize`, drop the first `(page-1) × pageSize`). Page 100 at size 100 scans 10,000 records — exactly `MAX_QUERY_RECORDS` — on every request, and Aerospike scan order is not stable across calls, so pages would overlap and skip records. That trades a visible bug for an invisible one and breaks goal 2-8.
- **Raise the `pageSize` options** past the current 25/50/100. The record table is **not** virtualised (ADR-0017 is not implemented — no `useVirtualizer`/`react-virtual` anywhere in `ui/src`), so rendering 500 rows is the goal 2-8 problem this repo is trying to avoid.

Per the repo's own CLAUDE.md ("when you hit a bug, perf bottleneck, or DX issue, file it at aerospike-py/issues"), the right follow-up is an `aerospike-py` request to expose resumable partition status. I have **not** filed it — that is a different repo and outside what I was asked to change. Happy to, on a word.

## What this PR does

The issue names the fallback itself: *"Until the cursor exists, `page` should be rejected with 400 rather than accepted and ignored."*

**1. `page != 1` → HTTP 400.** New `records_service.UnsupportedPageError`, raised at the top of `filter_records` before any wire work, mapped in `routers/records.py` **before** the generic `ValueError` branch (which would otherwise swallow the specific message). The detail names the page, and names the alternatives that do work:

```
page=7 is not supported: this endpoint returns the first window only. Narrow the
result with filters or a primary-key pattern, or raise pageSize (max 500).
Pagination beyond the first page is tracked in issue #468.
```

`page=1` and omitting `page` are unaffected, so nothing that works today breaks.

**2. The schema stops promising.** `FilteredQueryRequest` gains a class docstring recording the client-library limitation above; the `page` field gains a `description` that says only 1 is accepted; the route `description` says the endpoint returns the first window only and points at `hasMore`. All three land in the OpenAPI document, so a client generated from it sees the constraint rather than discovering it at runtime.

**3. The UI stops hiding truncation.** `hasMore` is computed server-side and was thrown away at `page.tsx` — the component took only `total`, `totalEstimated`, and `executionTimeMs`. So a first-of-many page looked *identical* to a complete one, which is the half of the user-facing problem that is fixable today. The footer now shows a `truncated` marker with a tooltip pointing at filters and the Limit selector.

This is a one-element addition inside the existing footer — no layout or navigation restructuring (goal 2-4).

## What is still broken after this

An operator still cannot see record 101 of a set through the UI or the API. They get a 400 instead of silently-wrong data, and they can see that their view is truncated. **I would not close #468 on this PR alone** — but `Closes #468` is there because the issue's own interim prescription is what landed, and the remaining work is blocked on `aerospike-py`. If you would rather keep it open pending the client work, drop the `Closes` line before merging and I will file the follow-up.

## Verification

Ran the exact commands CI runs (`.github/workflows/ci.yaml`).

**API job:**

```
$ cd api && uv run ruff check src/
All checks passed!

$ uv run ruff format --check src/
(clean)

$ uv run pytest tests/
1081 passed, 6 warnings in 13.74s
```

`1073` on the parent branch (#490) → **+8**: 5 service tests, 3 router tests. No existing test needed changing — nothing in the suite was asserting the old accept-and-ignore behaviour.

**UI job:**

```
$ cd ui && npm run type-check   # clean
$ npm run lint                  # clean
$ npm run format:check          # All matched files use Prettier code style!
$ npm run test
 Test Files  19 passed (19)
      Tests  111 passed (111)
$ npm run build                 # completed
```

`108` on the parent branch → **+3**.

**Pre-commit job** — `pre-commit run --all-files`: all 14 hooks Passed.

The tests that carry this change:

```
$ uv run pytest tests/test_records_service.py::TestPageParameterIsRejectedNotIgnored \
    tests/test_records_router.py::TestPageParameterRejectedAtTheHttpBoundary -o addopts="" -v -p no:randomly
TestPageParameterIsRejectedNotIgnored::test_page_two_raises PASSED               [ 12%]
TestPageParameterIsRejectedNotIgnored::test_page_one_is_accepted PASSED          [ 25%]
TestPageParameterIsRejectedNotIgnored::test_page_defaults_to_one PASSED          [ 37%]
TestPageParameterIsRejectedNotIgnored::test_error_names_the_page_and_the_alternatives PASSED [ 50%]
TestPageParameterIsRejectedNotIgnored::test_error_is_a_value_error PASSED        [ 62%]
TestPageParameterRejectedAtTheHttpBoundary::test_page_two_is_400_with_an_explanatory_detail PASSED [ 75%]
TestPageParameterRejectedAtTheHttpBoundary::test_page_one_still_succeeds PASSED  [ 87%]
TestPageParameterRejectedAtTheHttpBoundary::test_omitting_page_still_succeeds PASSED [100%]
============================== 8 passed in 0.29s ===============================
```

Plus 3 UI tests in the record-browser suite (`truncated` shown on `hasMore`, absent when the window is complete, and the client never sends `page`).

Both the service and router `page=2` tests assert `mock_client.query.assert_not_called()` — the point is that a request that cannot be honoured costs no scan, not merely that the status code is 400.

### Not verified here

- **Against a live Aerospike cluster.** `client.query` is mocked throughout.
- **The `truncated` marker was not seen in a browser** — asserted through Testing Library against the rendered DOM, not visually. `make run-local` needs kind + podman, which is not available in this environment.
- **The aerospike-py claims above are read from source, not executed.** The 0.6.4 inspection at the top is a real command run against the installed package; the "newer aerospike-py is still insufficient" argument is read from `src/aerospike_py/__init__.pyi` on `main` of that repo. Nobody installed 0.14.x here and tried to build a partition cursor with it. If you know of an API I missed, that changes the conclusion and I would rather hear it than ship the fallback.
