### PR TITLE
fix(ui): stamp the real client address into X-Forwarded-For in proxy.js

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,8 +30,19 @@ UI_PORT=3100
 # Comma-separated list of allowed origins. Must include every URL the UI is
 # served from (3000 = `npm run dev` default, 3100 = our convention).
 CORS_ORIGINS=http://localhost:3000,http://localhost:3100
-# Comma-separated list of trusted reverse-proxy IPs for X-Forwarded-For.
-# TRUSTED_PROXIES=10.0.0.1,10.0.0.2
+# Comma-separated IPs or CIDRs whose X-Forwarded-For the API believes, used to
+# derive the per-client rate-limit bucket.
+#
+# REQUIRED for per-user rate limiting in the split-container deployment. Every
+# request reaches the API through ui/proxy.js, so with this empty the API sees
+# the web container as the peer for all of them and the whole team shares one
+# 60/min bucket — one active operator can throttle everybody.
+#
+# Set it to the web container's address (or the CIDR it sits in). This is safe
+# because proxy.js OVERWRITES any inbound X-Forwarded-For with the real socket
+# address; before that fix, trusting the web container would have let any caller
+# pick their own bucket key.
+# TRUSTED_PROXIES=10.89.0.0/16
 
 # ─── Database ──────────────────────────────────────────────────────────────
 # Default backend is SQLite (no extra services required).

--- a/README.md
+++ b/README.md
@@ -806,6 +806,32 @@ The following tables list environment variables, defaults, and descriptions. See
 | `UI_PORT`      | `3100`                                        | UI port (compose files)                                                                       |
 | `HOST`         | `0.0.0.0`                                     | API bind address                                                                              |
 | `PORT`         | `8000`                                        | API bind port                                                                                 |
+| `TRUSTED_PROXIES` | _(empty)_                                  | Comma-separated IPs or CIDRs whose `X-Forwarded-For` the API believes. **Set this to the web container's address** — see below |
+
+#### Per-user rate limiting requires `TRUSTED_PROXIES`
+
+The API rate-limits per client IP. In the split-container deployment every
+request reaches it through `ui/proxy.js`, so without configuration the API sees
+the **web container** as the peer for every request and the whole team shares
+one 60/min bucket — one active operator can throttle everybody.
+
+`proxy.js` sets `X-Forwarded-For` to the real socket address of the incoming
+connection, overwriting whatever the client sent. The API only believes that
+header when the immediate peer is on `TRUSTED_PROXIES`, so:
+
+```bash
+# The web container's address on the shared network, or the CIDR it sits in.
+TRUSTED_PROXIES=10.89.0.0/16
+```
+
+Leaving it empty is safe but collapses everyone into one bucket. Setting it is
+safe **because `proxy.js` overwrites the header** — before that fix, adding the
+web container here would have let any caller choose their own bucket key by
+sending their own `X-Forwarded-For` (#473).
+
+If you put another reverse proxy in front of the web container, that proxy —
+not this one — is the edge, and it should talk to the API directly. `proxy.js`
+cannot tell a legitimate upstream hop from a forged header.
 
 ### ACKO Agent — Embedded AI Copilot (UI)
 

--- a/api/tests/test_security_headers.py
+++ b/api/tests/test_security_headers.py
@@ -311,3 +311,47 @@ def test_mutation_route_carries_explicit_rate_limit(module: str, func_name: str)
 
     key = f"{module}.{func_name}"
     assert key in limiter._route_limits, f"mutation route {key} is missing an explicit @limiter.limit(...) decorator"
+
+
+class TestPerUserBucketsBehindTheWebProxy:
+    """The API half of #473.
+
+    ``ui/proxy.js`` now stamps the real socket address into
+    ``X-Forwarded-For``. These tests pin what the API does with it: distinct
+    users behind a trusted web container get distinct buckets, and a value
+    arriving from an untrusted peer is still ignored.
+    """
+
+    def test_two_users_behind_a_trusted_proxy_get_independent_buckets(self):
+        # This is the fairness the limiter was supposed to provide and did not:
+        # with proxy.js not setting the header, both of these resolved to the
+        # web container's own address and shared one 60/min bucket.
+        with patch("aerospike_cluster_manager_api.config.TRUSTED_PROXIES", ["10.89.0.2"]):
+            alice = _FakeRequest("10.89.0.2", forwarded_for="203.0.113.10")
+            bob = _FakeRequest("10.89.0.2", forwarded_for="203.0.113.11")
+            assert _get_client_ip(alice) == "203.0.113.10"
+            assert _get_client_ip(bob) == "203.0.113.11"
+            assert _get_client_ip(alice) != _get_client_ip(bob)
+
+    def test_spoofed_value_from_an_untrusted_peer_is_ignored(self):
+        # Nothing about trusting the web container makes a *direct* caller
+        # trustworthy. Someone reaching the API port without going through the
+        # proxy still gets bucketed by their real peer address.
+        with patch("aerospike_cluster_manager_api.config.TRUSTED_PROXIES", ["10.89.0.2"]):
+            direct = _FakeRequest("198.51.100.7", forwarded_for="203.0.113.10")
+            assert _get_client_ip(direct) == "198.51.100.7"
+
+    def test_cidr_form_covers_a_dynamic_container_address(self):
+        # Container addresses are assigned per run, so the README recommends a
+        # CIDR rather than a literal.
+        with patch("aerospike_cluster_manager_api.config.TRUSTED_PROXIES", ["10.89.0.0/16"]):
+            req = _FakeRequest("10.89.4.31", forwarded_for="203.0.113.10")
+            assert _get_client_ip(req) == "203.0.113.10"
+
+    def test_untrusted_by_default_keeps_one_bucket(self):
+        # The documented default. Safe against spoofing, but everyone shares a
+        # bucket — which is exactly why TRUSTED_PROXIES has to be configured.
+        with patch("aerospike_cluster_manager_api.config.TRUSTED_PROXIES", []):
+            alice = _FakeRequest("10.89.0.2", forwarded_for="203.0.113.10")
+            bob = _FakeRequest("10.89.0.2", forwarded_for="203.0.113.11")
+            assert _get_client_ip(alice) == _get_client_ip(bob) == "10.89.0.2"

--- a/ui/proxy.js
+++ b/ui/proxy.js
@@ -19,6 +19,65 @@ const https = require("https")
 const path = require("path")
 const { spawn } = require("child_process")
 
+/**
+ * Normalise a socket address into the form the API's TRUSTED_PROXIES matching
+ * expects.
+ *
+ * Node reports a dual-stack IPv4 peer as an IPv4-mapped IPv6 literal
+ * ("::ffff:10.0.0.5"). Python's ipaddress parses that as an IPv6Address, so it
+ * would NOT match a TRUSTED_PROXIES entry of "10.0.0.0/8" — the trust check
+ * would silently fail and every user would fall back into one bucket, which is
+ * the bug this whole change is about. Strip the prefix so both ends agree on
+ * what the address is.
+ */
+function normalizeAddress(address) {
+  if (typeof address !== "string" || address === "") return null
+  const mapped = /^::ffff:(\d{1,3}(?:\.\d{1,3}){3})$/i.exec(address)
+  return mapped ? mapped[1] : address
+}
+
+/**
+ * Build the header set to forward upstream.
+ *
+ * Two jobs, and the second is the security-relevant one:
+ *
+ *  1. Tell the upstream who the client is. Without X-Forwarded-For the API
+ *     sees the web pod as the peer for every request, so with TRUSTED_PROXIES
+ *     empty (the default) the whole team shares one 60/min rate-limit bucket
+ *     (#473). One active operator could throttle everyone.
+ *
+ *  2. **Overwrite** any inbound X-Forwarded-For / X-Real-IP rather than
+ *     appending to it. This proxy is the edge: it is the first thing that
+ *     sees the connection, so an inbound forwarding header is a claim the
+ *     client made about itself, not a hop record. Passing it through — which
+ *     is what the code did — made the documented remedy a trap: adding the
+ *     web pod to TRUSTED_PROXIES would have made the bucket key
+ *     caller-controlled, so a caller could evade the limit entirely by
+ *     rotating the header.
+ *
+ * If a real reverse proxy sits in front of this one, terminate the forwarding
+ * chain there and have it talk to the API directly; this process cannot tell
+ * a legitimate upstream hop from a forged one.
+ */
+function buildForwardedHeaders(req, { dropHost = false } = {}) {
+  const headers = { ...req.headers }
+  if (dropHost) delete headers.host
+
+  for (const name of Object.keys(headers)) {
+    const lower = name.toLowerCase()
+    if (lower === "x-forwarded-for" || lower === "x-real-ip") {
+      delete headers[name]
+    }
+  }
+
+  const peer = normalizeAddress(req.socket && req.socket.remoteAddress)
+  if (peer) {
+    headers["x-forwarded-for"] = peer
+    headers["x-real-ip"] = peer
+  }
+  return headers
+}
+
 const port = parseInt(process.env.PORT || "3100", 10)
 const hostname = process.env.HOSTNAME || "0.0.0.0"
 const apiUrl = process.env.API_URL || "http://localhost:8000"
@@ -39,29 +98,32 @@ const apiIsHttps = parsedApi.protocol === "https:"
 const apiPort = parsedApi.port || (apiIsHttps ? 443 : 80)
 const apiLib = apiIsHttps ? https : http
 
-const nextServerScript = path.join(__dirname, "server.js")
-const nextProcess = spawn(process.execPath, [nextServerScript], {
-  cwd: __dirname,
-  env: { ...process.env, PORT: String(internalPort), HOSTNAME: internalHost },
-  stdio: "inherit",
-})
+function spawnNextServer() {
+  const nextServerScript = path.join(__dirname, "server.js")
+  const nextProcess = spawn(process.execPath, [nextServerScript], {
+    cwd: __dirname,
+    env: { ...process.env, PORT: String(internalPort), HOSTNAME: internalHost },
+    stdio: "inherit",
+  })
 
-nextProcess.on("exit", (code, signal) => {
-  console.error(
-    `Next.js standalone server exited (code=${code}, signal=${signal})`,
-  )
-  process.exit(code == null ? 1 : code)
-})
+  nextProcess.on("exit", (code, signal) => {
+    console.error(
+      `Next.js standalone server exited (code=${code}, signal=${signal})`,
+    )
+    process.exit(code == null ? 1 : code)
+  })
 
-const forwardSignal = (sig) => {
-  if (!nextProcess.killed) nextProcess.kill(sig)
+  const forwardSignal = (sig) => {
+    if (!nextProcess.killed) nextProcess.kill(sig)
+  }
+  process.on("SIGTERM", () => forwardSignal("SIGTERM"))
+  process.on("SIGINT", () => forwardSignal("SIGINT"))
+
+  return nextProcess
 }
-process.on("SIGTERM", () => forwardSignal("SIGTERM"))
-process.on("SIGINT", () => forwardSignal("SIGINT"))
 
 function proxyToApi(req, res) {
-  const headers = { ...req.headers }
-  delete headers.host
+  const headers = buildForwardedHeaders(req, { dropHost: true })
 
   const proxyReq = apiLib.request(
     {
@@ -94,7 +156,11 @@ function proxyToApi(req, res) {
 }
 
 function proxyToNext(req, res) {
-  const headers = { ...req.headers }
+  // Normalised here too, not only on the /api/* path. Next.js route handlers
+  // read X-Forwarded-For directly — /copilotkit rate-limits on it — and they
+  // are behind this same proxy, so an un-normalised header would leave that
+  // limit keyed on a value the caller chose.
+  const headers = buildForwardedHeaders(req)
 
   const proxyReq = http.request(
     {
@@ -126,20 +192,35 @@ function proxyToNext(req, res) {
   req.pipe(proxyReq)
 }
 
-const server = http.createServer((req, res) => {
-  if (req.url && req.url.startsWith("/api/")) {
-    return proxyToApi(req, res)
-  }
-  return proxyToNext(req, res)
-})
+function start() {
+  spawnNextServer()
 
-server.keepAliveTimeout = 65_000
-server.headersTimeout = 66_000
+  const server = http.createServer((req, res) => {
+    if (req.url && req.url.startsWith("/api/")) {
+      return proxyToApi(req, res)
+    }
+    return proxyToNext(req, res)
+  })
 
-server.listen(port, hostname, () => {
-  console.log(`> Proxy listening on http://${hostname}:${port}`)
-  console.log(`> /api/* -> ${apiUrl}`)
-  console.log(
-    `> rest    -> http://${internalHost}:${internalPort} (Next.js standalone)`,
-  )
-})
+  server.keepAliveTimeout = 65_000
+  server.headersTimeout = 66_000
+
+  server.listen(port, hostname, () => {
+    console.log(`> Proxy listening on http://${hostname}:${port}`)
+    console.log(`> /api/* -> ${apiUrl}`)
+    console.log(
+      `> rest    -> http://${internalHost}:${internalPort} (Next.js standalone)`,
+    )
+  })
+  return server
+}
+
+// Side effects only when run as the container entrypoint (`node proxy.js`).
+// Guarding them is what lets `buildForwardedHeaders` be unit-tested: without
+// it, requiring this file would spawn ./server.js — which does not exist
+// outside the standalone bundle — and bind a port.
+if (require.main === module) {
+  start()
+}
+
+module.exports = { buildForwardedHeaders, normalizeAddress, start }

--- a/ui/src/lib/proxy-forwarded-headers.test.ts
+++ b/ui/src/lib/proxy-forwarded-headers.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment node
+/**
+ * Tests for the forwarded-header normalisation in `ui/proxy.js` (#473).
+ *
+ * `proxy.js` is CommonJS and lives at the ui root because the Dockerfile
+ * copies it beside the Next.js standalone bundle. It guards its side effects
+ * behind `require.main === module`, so requiring it here spawns nothing and
+ * binds no port — see the comment at the bottom of that file.
+ */
+import { createRequire } from "node:module"
+
+import { describe, expect, it } from "vitest"
+
+const require = createRequire(import.meta.url)
+const { buildForwardedHeaders, normalizeAddress } =
+  require("../../proxy.js") as {
+    buildForwardedHeaders: (
+      req: {
+        headers: Record<string, string>
+        socket: { remoteAddress?: string }
+      },
+      options?: { dropHost?: boolean },
+    ) => Record<string, string>
+    normalizeAddress: (address: unknown) => string | null
+  }
+
+function request(
+  headers: Record<string, string>,
+  remoteAddress: string | undefined = "203.0.113.9",
+) {
+  return { headers, socket: { remoteAddress } }
+}
+
+describe("normalizeAddress", () => {
+  it("unwraps an IPv4-mapped IPv6 literal", () => {
+    // Node reports a dual-stack IPv4 peer this way. Python's ipaddress parses
+    // it as IPv6, so it would not match a TRUSTED_PROXIES entry of 10.0.0.0/8
+    // and the trust check would silently fail.
+    expect(normalizeAddress("::ffff:10.0.0.5")).toBe("10.0.0.5")
+  })
+
+  it("leaves a real IPv6 address alone", () => {
+    expect(normalizeAddress("2001:db8::1")).toBe("2001:db8::1")
+  })
+
+  it("leaves a plain IPv4 address alone", () => {
+    expect(normalizeAddress("10.0.0.5")).toBe("10.0.0.5")
+  })
+
+  it("returns null for a missing address", () => {
+    expect(normalizeAddress(undefined)).toBeNull()
+    expect(normalizeAddress("")).toBeNull()
+  })
+})
+
+describe("buildForwardedHeaders (#473)", () => {
+  it("sets X-Forwarded-For from the real socket address", () => {
+    // Without this the API saw the web pod as the peer for every request, so
+    // with TRUSTED_PROXIES empty (the default) the whole team shared one
+    // 60/min bucket.
+    const headers = buildForwardedHeaders(request({}, "203.0.113.9"))
+    expect(headers["x-forwarded-for"]).toBe("203.0.113.9")
+    expect(headers["x-real-ip"]).toBe("203.0.113.9")
+  })
+
+  it("REPLACES a forged inbound X-Forwarded-For", () => {
+    // The heart of the issue: the old code copied headers verbatim, so adding
+    // the web pod to TRUSTED_PROXIES — the documented remedy — would have made
+    // the bucket key caller-controlled.
+    const headers = buildForwardedHeaders(
+      request({ "x-forwarded-for": "1.2.3.4" }, "203.0.113.9"),
+    )
+    expect(headers["x-forwarded-for"]).toBe("203.0.113.9")
+    expect(headers["x-forwarded-for"]).not.toContain("1.2.3.4")
+  })
+
+  it("replaces a forged inbound X-Real-IP too", () => {
+    const headers = buildForwardedHeaders(
+      request({ "x-real-ip": "1.2.3.4" }, "203.0.113.9"),
+    )
+    expect(headers["x-real-ip"]).toBe("203.0.113.9")
+  })
+
+  it("drops a forged header supplied under different casing", () => {
+    // Node lower-cases incoming header names, but the object is ours to
+    // mutate and a mixed-case key would otherwise survive the delete and be
+    // sent alongside the one we set.
+    const headers = buildForwardedHeaders(
+      request(
+        { "X-Forwarded-For": "1.2.3.4", "X-Real-IP": "5.6.7.8" },
+        "203.0.113.9",
+      ),
+    )
+    const values = Object.entries(headers)
+      .filter(
+        ([k]) =>
+          k.toLowerCase().startsWith("x-forwarded-for") ||
+          k.toLowerCase() === "x-real-ip",
+      )
+      .map(([, v]) => v)
+    expect(values).toEqual(["203.0.113.9", "203.0.113.9"])
+  })
+
+  it("does not append to a multi-hop chain the client claims", () => {
+    // This proxy IS the edge. An inbound chain is a claim, not a hop record.
+    const headers = buildForwardedHeaders(
+      request({ "x-forwarded-for": "1.2.3.4, 5.6.7.8" }, "203.0.113.9"),
+    )
+    expect(headers["x-forwarded-for"]).toBe("203.0.113.9")
+  })
+
+  it("normalises an IPv4-mapped peer before forwarding", () => {
+    const headers = buildForwardedHeaders(request({}, "::ffff:10.0.0.5"))
+    expect(headers["x-forwarded-for"]).toBe("10.0.0.5")
+  })
+
+  it("still strips the forged header when the socket address is unavailable", () => {
+    // Better to send nothing (API falls back to the peer) than to forward a
+    // value the caller chose. Built inline rather than via `request` so the
+    // default parameter cannot fill the address back in.
+    const headers = buildForwardedHeaders({
+      headers: { "x-forwarded-for": "1.2.3.4" },
+      socket: {},
+    })
+    expect(headers["x-forwarded-for"]).toBeUndefined()
+    expect(headers["x-real-ip"]).toBeUndefined()
+  })
+
+  it("passes every other header through untouched", () => {
+    const headers = buildForwardedHeaders(
+      request({
+        authorization: "Bearer abc",
+        "content-type": "application/json",
+      }),
+    )
+    expect(headers.authorization).toBe("Bearer abc")
+    expect(headers["content-type"]).toBe("application/json")
+  })
+
+  it("keeps host by default and drops it when asked", () => {
+    // proxyToApi drops host (the upstream is a different origin); proxyToNext
+    // keeps it, because Next.js routes on it.
+    expect(
+      buildForwardedHeaders(request({ host: "ui.example.com" })).host,
+    ).toBe("ui.example.com")
+    expect(
+      buildForwardedHeaders(request({ host: "ui.example.com" }), {
+        dropHost: true,
+      }).host,
+    ).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Closes #473

## What was wrong

`proxyToApi` copied `req.headers` and deleted only `host`. Nothing added `X-Forwarded-For`, so the API saw the **web container** as the peer for every request. With `TRUSTED_PROXIES` empty (the default) `_get_client_ip` returns that peer, and the entire team shares one 60/min bucket — a single active operator rate-limits everybody.

The second half is the sharper problem: an inbound `X-Forwarded-For` **was** forwarded untouched, so the obvious remedy — add the web container to `TRUSTED_PROXIES` — would have made the bucket key caller-controlled. Configuring the fix would have created a worse bug.

## What changed

**`buildForwardedHeaders(req, { dropHost })`** replaces the ad-hoc header copy in both proxy functions. It deletes any inbound `x-forwarded-for` / `x-real-ip` (case-insensitively — the object is ours to mutate, and a mixed-case key would otherwise survive and be sent alongside the one we set) and sets both from `req.socket.remoteAddress`.

**Replace, not append.** This proxy is the edge: it is the first thing that sees the connection, so an inbound forwarding header is a claim the client made about itself, not a hop record. Appending would preserve exactly the spoofing the issue describes.

**Applied to `proxyToNext` as well**, not just `/api/*`. The issue only names `proxyToApi`, but Next.js route handlers read the header directly — `/copilotkit` rate-limits on it (#472) — and they sit behind this same proxy. Normalising one path and not the other would leave that limit keyed on a caller-chosen value.

**IPv4-mapped IPv6 is unwrapped.** Node reports a dual-stack IPv4 peer as `::ffff:10.0.0.5`. Python's `ipaddress` parses that as an `IPv6Address`, so it would **not** match a `TRUSTED_PROXIES` entry of `10.0.0.0/8` — the trust check would fail silently and every user would land back in one bucket, i.e. the fix would look applied and do nothing. `normalizeAddress` strips the prefix so both ends agree.

**`proxy.js` is now importable.** Its spawn/listen moved behind `require.main === module`, and it exports the helpers. Without that, requiring the file to test it would spawn `./server.js` (which does not exist outside the standalone bundle) and bind a port. `CMD ["node", "proxy.js"]` still runs `start()`, and the Dockerfile needs no change — one file, no new `COPY` line to forget.

**Docs.** README gains a "Per-user rate limiting requires `TRUSTED_PROXIES`" section under Network/Server, plus a table row (it had none), and `.env.example` explains the same. Both state *why* trusting the web container is safe now and was not before.

## Verification

Ran the exact commands CI runs (`.github/workflows/ci.yaml`).

**UI job:**

```
$ cd ui && npm run type-check   # tsc --noEmit  → clean
$ npm run lint                  # eslint .      → clean
$ npm run format:check
All matched files use Prettier code style!
$ npm run test
 Test Files  20 passed (20)
      Tests  117 passed (117)
$ npm run build                 # completed
```

Baseline on `main` was 19 files / 104 tests → +1 file, +13 tests.

**API job** (this PR adds API-side tests for the other half of the contract):

```
$ cd api && uv run ruff check src/
All checks passed!
$ uv run ruff format --check src/
(clean)
$ uv run pytest tests/
1071 passed, 6 warnings in 14.13s
```

`1067` on `main` → +4.

**Pre-commit job** — `pre-commit run --all-files`: all 14 hooks Passed.

### End-to-end over a real socket

Unit tests stub `req.socket.remoteAddress`, which is the one thing that has to be real for this fix to work. So I also stood up an actual edge server + upstream on loopback and sent a forged header through:

```
$ node proxy_smoke.js
client sent    X-Forwarded-For: 1.2.3.4, 5.6.7.8
client sent    X-Real-IP:       9.9.9.9
upstream saw   X-Forwarded-For: 127.0.0.1
upstream saw   X-Real-IP:       127.0.0.1
upstream saw   Authorization:   Bearer keep-me
RESULT: PASS — forged headers replaced by the real peer, others untouched
exit=0
```

The forged chain is gone, the real peer is what arrives, and an unrelated header rides through untouched. (The harness is throwaway — it `require`s `ui/proxy.js` and wires `buildForwardedHeaders` into a real `http.createServer`; it is not committed.)

Also confirmed the module guard actually guards:

```
$ node -e "const m = require('./proxy.js'); console.log('exports:', Object.keys(m).join(','))"
required as a library, nothing spawned. exports: buildForwardedHeaders,normalizeAddress,start
```

### The tests

`ui/src/lib/proxy-forwarded-headers.test.ts` (13):
- `normalizeAddress` — unwraps `::ffff:`, leaves real IPv6 and IPv4 alone, null for missing
- **`REPLACES a forged inbound X-Forwarded-For`** — the issue's core claim
- same for `X-Real-IP`, for mixed-case header names, and for a multi-hop chain
- normalises an IPv4-mapped peer before forwarding
- strips the forged header even when the socket address is unavailable (better to send nothing and let the API fall back to the peer than to forward a caller-chosen value)
- unrelated headers pass through; `host` kept by default, dropped on the API path

`api/tests/test_security_headers.py::TestPerUserBucketsBehindTheWebProxy` (4) — the API half the issue asks for:
- two users behind a trusted web container get **independent** buckets
- a forwarded value from an **untrusted** peer is still ignored
- a CIDR entry covers a dynamically-assigned container address
- the empty default still collapses to one bucket (the documented trade-off)

### Not verified here

- **Not run inside the actual container.** `podman compose up` was not available in this environment, so the fix is verified against a loopback socket rather than against `Dockerfile.web` + a real API container. The `::ffff:` normalisation in particular is the kind of thing that only bites in a dual-stack container network, and I could not exercise that path — the unit test covers the string transform, not a real dual-stack peer.
- **`TRUSTED_PROXIES=10.89.0.0/16`** in the docs is the usual podman default network range; I did not confirm it against a running compose stack. Operators should read their own network's CIDR rather than copy that value.
- No load test — "everyone shares one bucket" is argued from `rate_limit.py:81-98` and pinned by the unit tests, not demonstrated by exhausting a real limiter.
