### PR TITLE
fix(sse): stop starting inert collector loops, and poll so metrics stay live

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -117,6 +117,17 @@ K8S_MANAGEMENT_ENABLED=false
 # SSE_ENABLED=true
 # SSE_HEARTBEAT_INTERVAL=15
 # SSE_MAX_CONNECTIONS=50
+#
+# Per-connection broadcast loops (cluster.metrics, connection.health,
+# k8s.cluster.*). OFF by default: the broker has no per-subscriber owner
+# filter, so emitting tenant-A metrics to tenant-B subscribers would leak
+# data. Single-tenant deployments can opt in.
+#
+# With this false the event collector is NOT started at all -- its publish
+# bodies are gated on this flag, so the loops could only idle (#474). The SSE
+# endpoint still accepts subscribers and sends heartbeats. The UI polls
+# /clusters/{id} every 5s regardless, so the overview stays live either way.
+# CM_SSE_BROADCAST_PER_CONNECTION=false
 
 # ─── Connection test SSRF gate ────────────────────────────────────────────
 # /api/connections/test rejects probe requests targeting bare IP literals

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -85,14 +85,31 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     logger.info("Starting Aerospike Cluster Manager API")
     await db.init_db()
 
-    # Configure broker max connections from config and start event collector
+    # Configure broker max connections from config and start event collector.
+    #
+    # Both flags, not just SSE_ENABLED (#474). Every publish body in
+    # ``events.collector`` returns on its first statement when
+    # CM_SSE_BROADCAST_PER_CONNECTION is off — which is the default, because
+    # the broker has no per-subscriber owner filter. Starting anyway gave
+    # three tasks waking on 2s / 30s / 5s timers forever to do nothing. Skip
+    # them and log why, so an operator who expected live events finds the
+    # reason instead of silence.
     broker.max_connections = config.SSE_MAX_CONNECTIONS
-    if config.SSE_ENABLED:
+    collector_started = config.SSE_ENABLED and config.CM_SSE_BROADCAST_PER_CONNECTION
+    if collector_started:
         await collector.start()
+    elif config.SSE_ENABLED:
+        logger.info(
+            "SSE_ENABLED=true but CM_SSE_BROADCAST_PER_CONNECTION=false — event collector NOT started; "
+            "its publish bodies are gated on that flag, so the loops could only idle. "
+            "The SSE endpoint still accepts subscribers (heartbeats only). "
+            "The UI polls /clusters/{id} for live metrics; set "
+            "CM_SSE_BROADCAST_PER_CONNECTION=true on a single-tenant deployment to push instead."
+        )
 
     yield
 
-    if config.SSE_ENABLED:
+    if collector_started:
         await collector.stop()
     await client_manager.close_all()
     # Close the OIDC middleware's lazily-created JWKS HTTP client, if it

--- a/api/tests/test_collector_startup_gate.py
+++ b/api/tests/test_collector_startup_gate.py
@@ -1,0 +1,101 @@
+"""The event collector does not start when it could only idle (#474).
+
+``SSE_ENABLED`` defaults true, so three collector loops started on every boot.
+But every publish body in ``events.collector`` returns on its first statement
+when ``CM_SSE_BROADCAST_PER_CONNECTION`` is false — which is the default,
+because the broker has no per-subscriber owner filter — so the loops woke on
+2s / 30s / 5s timers forever and produced nothing.
+
+The lifespan now requires both flags. These tests pin the truth table, and the
+matching frontend half (polling, so metrics are not simply frozen instead) is
+in ``ui/src/hooks/use-cluster.test.ts``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aerospike_cluster_manager_api.main import app, lifespan
+
+
+@pytest.fixture()
+def collector_mocks():
+    """Patch the collector and db so the lifespan can run without a cluster."""
+    with (
+        patch("aerospike_cluster_manager_api.main.db.init_db", AsyncMock()),
+        patch("aerospike_cluster_manager_api.main.db.close_db", AsyncMock()),
+        patch("aerospike_cluster_manager_api.main.client_manager.close_all", AsyncMock()),
+        patch("aerospike_cluster_manager_api.main.collector.start", AsyncMock()) as start,
+        patch("aerospike_cluster_manager_api.main.collector.stop", AsyncMock()) as stop,
+    ):
+        yield start, stop
+
+
+async def _run_lifespan() -> None:
+    # The real app object, because the shutdown half walks its middleware
+    # stack looking for the OIDC middleware's JWKS client.
+    async with lifespan(app):
+        pass
+
+
+class TestCollectorStartupGate:
+    @pytest.mark.parametrize(
+        ("sse_enabled", "broadcast", "should_start"),
+        [
+            # The default configuration: loops would idle, so do not pay for them.
+            (True, False, False),
+            # Opted in — the loops can actually publish.
+            (True, True, True),
+            # SSE off entirely.
+            (False, False, False),
+            (False, True, False),
+        ],
+    )
+    async def test_truth_table(self, collector_mocks, sse_enabled, broadcast, should_start):
+        start, stop = collector_mocks
+        with (
+            patch("aerospike_cluster_manager_api.config.SSE_ENABLED", sse_enabled),
+            patch("aerospike_cluster_manager_api.config.CM_SSE_BROADCAST_PER_CONNECTION", broadcast),
+        ):
+            await _run_lifespan()
+
+        assert start.await_count == (1 if should_start else 0)
+        # stop must mirror start exactly — calling stop on a collector that
+        # never started would gather an empty task list and log a misleading
+        # "EventCollector stopped".
+        assert stop.await_count == start.await_count
+
+    async def test_explains_itself_in_the_log(self, collector_mocks):
+        """An operator who expected live events should find the reason.
+
+        Silence is what made this hard to spot: the collector logged
+        "EventCollector started (2 loops)" and then never published anything.
+
+        Asserted by patching the module logger rather than via ``caplog``:
+        ``observability.setup_logging`` installs its own handlers and turns
+        propagation off, so caplog's root handler never sees these records.
+        """
+        with (
+            patch("aerospike_cluster_manager_api.config.SSE_ENABLED", True),
+            patch("aerospike_cluster_manager_api.config.CM_SSE_BROADCAST_PER_CONNECTION", False),
+            patch("aerospike_cluster_manager_api.main.logger.info") as info,
+        ):
+            await _run_lifespan()
+
+        messages = " ".join(str(call.args[0]) for call in info.call_args_list if call.args)
+        assert "CM_SSE_BROADCAST_PER_CONNECTION" in messages
+        assert "NOT started" in messages
+
+    async def test_says_nothing_when_the_collector_does_start(self, collector_mocks):
+        """No misleading "not started" line on a deployment that opted in."""
+        with (
+            patch("aerospike_cluster_manager_api.config.SSE_ENABLED", True),
+            patch("aerospike_cluster_manager_api.config.CM_SSE_BROADCAST_PER_CONNECTION", True),
+            patch("aerospike_cluster_manager_api.main.logger.info") as info,
+        ):
+            await _run_lifespan()
+
+        messages = " ".join(str(call.args[0]) for call in info.call_args_list if call.args)
+        assert "NOT started" not in messages

--- a/ui/src/app/(main)/clusters/[clusterId]/page.tsx
+++ b/ui/src/app/(main)/clusters/[clusterId]/page.tsx
@@ -10,7 +10,41 @@ import { Button } from "@/components/Button"
 import { PageHead } from "@/components/PageHead"
 import { RiAlertLine } from "@remixicon/react"
 import { useParams } from "next/navigation"
-import { useMemo } from "react"
+import { useEffect, useMemo, useState } from "react"
+
+/**
+ * "Updated Ns ago" for the overview header (#474).
+ *
+ * The page used to refresh only when someone clicked Refresh, with nothing to
+ * say the numbers had stopped moving. The values themselves cannot show it —
+ * a frozen TPS reading looks exactly like a genuinely idle cluster — so the
+ * age of the last successful read is what makes staleness visible.
+ */
+function LastUpdated({ at }: { at: number | null }) {
+  const [, setNow] = useState(0)
+
+  // Re-render on a timer so the label counts up between polls rather than
+  // freezing at "0s ago" — which would be its own version of this bug.
+  useEffect(() => {
+    const timer = setInterval(() => setNow((n) => n + 1), 1_000)
+    return () => clearInterval(timer)
+  }, [])
+
+  if (at === null) return null
+  const seconds = Math.max(0, Math.round((Date.now() - at) / 1000))
+  const label =
+    seconds < 60
+      ? `${seconds}s ago`
+      : `${Math.floor(seconds / 60)}m ${seconds % 60}s ago`
+  return (
+    <span
+      className="text-xs text-gray-500 tabular-nums dark:text-gray-400"
+      title="Cluster info refreshes automatically every 5 seconds"
+    >
+      Updated {label}
+    </span>
+  )
+}
 
 function nodeStatus(node: ClusterNode): {
   label: string
@@ -55,6 +89,7 @@ export default function ClusterOverview() {
           <Badge variant="default">{cluster.data.nodes[0].edition}</Badge>
         )}
         {cluster.data && <Badge variant="success">Connected</Badge>}
+        <LastUpdated at={cluster.lastUpdatedAt} />
         <Button
           variant="secondary"
           onClick={() => cluster.refetch()}

--- a/ui/src/hooks/use-cluster.test.ts
+++ b/ui/src/hooks/use-cluster.test.ts
@@ -1,5 +1,5 @@
-import { renderHook, waitFor } from "@testing-library/react"
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { act, renderHook, waitFor } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 import { getCluster } from "@/lib/api/clusters"
 import type { ClusterInfo } from "@/lib/types/cluster"
@@ -67,5 +67,114 @@ describe("useCluster", () => {
       expect(result.current.data?.connectionId).toBe("conn-2"),
     )
     expect(mocked).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe("useCluster — polling (#474)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it("re-reads without user interaction after the interval elapses", async () => {
+    // The reported bug: the overview refreshed only on a Refresh click, so
+    // metrics were frozen from page load with nothing to say so.
+    mocked.mockResolvedValue(FIXTURE)
+
+    const { result } = renderHook(() => useCluster("conn-1"))
+    await vi.waitFor(() => expect(result.current.data).toEqual(FIXTURE))
+    expect(mocked).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+    })
+    expect(mocked).toHaveBeenCalledTimes(2)
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+    })
+    expect(mocked).toHaveBeenCalledTimes(3)
+  })
+
+  it("records lastUpdatedAt so staleness is visible", async () => {
+    // A frozen TPS reading looks exactly like a genuinely idle cluster, so
+    // the data cannot show its own staleness — the timestamp is what does.
+    mocked.mockResolvedValue(FIXTURE)
+
+    const { result } = renderHook(() => useCluster("conn-1"))
+    await vi.waitFor(() => expect(result.current.lastUpdatedAt).not.toBeNull())
+    expect(typeof result.current.lastUpdatedAt).toBe("number")
+  })
+
+  it("does not poll while the tab is hidden", async () => {
+    mocked.mockResolvedValue(FIXTURE)
+    const { result } = renderHook(() => useCluster("conn-1"))
+    await vi.waitFor(() => expect(result.current.data).toEqual(FIXTURE))
+    expect(mocked).toHaveBeenCalledTimes(1)
+
+    vi.spyOn(document, "hidden", "get").mockReturnValue(true)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15_000)
+    })
+    // Three ticks elapsed and none of them asked.
+    expect(mocked).toHaveBeenCalledTimes(1)
+  })
+
+  it("stops polling after unmount", async () => {
+    mocked.mockResolvedValue(FIXTURE)
+    const { result, unmount } = renderHook(() => useCluster("conn-1"))
+    await vi.waitFor(() => expect(result.current.data).toEqual(FIXTURE))
+
+    unmount()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(30_000)
+    })
+    expect(mocked).toHaveBeenCalledTimes(1)
+  })
+
+  it("a failed poll keeps the last good data instead of erroring the page", async () => {
+    // One dropped request must not replace a working dashboard with an error
+    // state; the next tick usually recovers.
+    mocked
+      .mockResolvedValueOnce(FIXTURE)
+      .mockRejectedValueOnce(new Error("blip"))
+
+    const { result } = renderHook(() => useCluster("conn-1"))
+    await vi.waitFor(() => expect(result.current.data).toEqual(FIXTURE))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+    })
+    expect(result.current.data).toEqual(FIXTURE)
+    expect(result.current.error).toBeNull()
+  })
+
+  it("polling never toggles isLoading", async () => {
+    // isLoading drives the Refresh button's disabled state; flickering it
+    // every 5s would be worse than the staleness this fixes.
+    mocked.mockResolvedValue(FIXTURE)
+    const { result } = renderHook(() => useCluster("conn-1"))
+    await vi.waitFor(() => expect(result.current.isLoading).toBe(false))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000)
+    })
+    expect(result.current.isLoading).toBe(false)
+  })
+
+  it("pollIntervalMs=0 disables polling", async () => {
+    mocked.mockResolvedValue(FIXTURE)
+    const { result } = renderHook(() =>
+      useCluster("conn-1", { pollIntervalMs: 0 }),
+    )
+    await vi.waitFor(() => expect(result.current.data).toEqual(FIXTURE))
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000)
+    })
+    expect(mocked).toHaveBeenCalledTimes(1)
   })
 })

--- a/ui/src/hooks/use-cluster.ts
+++ b/ui/src/hooks/use-cluster.ts
@@ -1,6 +1,13 @@
 /**
  * useCluster — fetch cluster info (nodes, namespaces, sets) for a connection.
  * Re-fetches whenever connId changes. Pass `null` / `undefined` to skip.
+ *
+ * Also polls on an interval (#474). The SSE push channel is inert in the
+ * default configuration — the collector's publish bodies are gated on
+ * `CM_SSE_BROADCAST_PER_CONNECTION`, which defaults false — and nothing polled
+ * in its place, so the cluster overview showed the values captured at page
+ * load and gave no hint they were stale. For a tool whose job is watching
+ * cluster health, silently frozen numbers are worse than an error.
  */
 
 "use client"
@@ -11,19 +18,28 @@ import { getCluster } from "@/lib/api/clusters"
 import { logFetchError } from "@/lib/api/log"
 import type { ClusterInfo } from "@/lib/types/cluster"
 
+/** How often to re-read cluster info while the tab is visible. */
+export const CLUSTER_POLL_INTERVAL_MS = 5_000
+
 export interface UseClusterResult {
   data: ClusterInfo | null
   error: Error | null
   isLoading: boolean
   refetch: () => Promise<void>
+  /** Timestamp of the last successful read, for a "last updated" hint. */
+  lastUpdatedAt: number | null
 }
 
 export function useCluster(
   connId: string | null | undefined,
+  {
+    pollIntervalMs = CLUSTER_POLL_INTERVAL_MS,
+  }: { pollIntervalMs?: number } = {},
 ): UseClusterResult {
   const [data, setData] = useState<ClusterInfo | null>(null)
   const [error, setError] = useState<Error | null>(null)
   const [isLoading, setIsLoading] = useState<boolean>(!!connId)
+  const [lastUpdatedAt, setLastUpdatedAt] = useState<number | null>(null)
 
   // Mounted guard so a refetch resolving after unmount doesn't setState.
   // Mirrors useGuides / useConnections.
@@ -43,6 +59,7 @@ export function useCluster(
       const result = await getCluster(connId)
       if (!isMountedRef.current) return
       setData(result)
+      setLastUpdatedAt(Date.now())
     } catch (err) {
       logFetchError("cluster", err)
       if (!isMountedRef.current) return
@@ -57,6 +74,7 @@ export function useCluster(
       setData(null)
       setError(null)
       setIsLoading(false)
+      setLastUpdatedAt(null)
       return
     }
     let cancelled = false
@@ -67,12 +85,14 @@ export function useCluster(
     setData(null)
     setError(null)
     setIsLoading(true)
+    setLastUpdatedAt(null)
     ;(async () => {
       try {
         const result = await getCluster(connId)
         if (!cancelled) {
           setData(result)
           setError(null)
+          setLastUpdatedAt(Date.now())
         }
       } catch (err) {
         logFetchError("cluster", err)
@@ -88,5 +108,54 @@ export function useCluster(
     }
   }, [connId])
 
-  return { data, error, isLoading, refetch }
+  // Poll while the tab is visible.
+  //
+  // Three deliberate choices:
+  //  * `document.hidden` gates it — a background tab must not keep asking. The
+  //    visibilitychange listener also fires an immediate read on return, so
+  //    coming back to the tab does not show a stale value for up to an
+  //    interval.
+  //  * A poll never sets `isLoading`. That flag drives the Refresh button's
+  //    disabled state and page-level spinners; flickering them every 5s would
+  //    be worse than the staleness this fixes.
+  //  * A failed poll does NOT clear `data` or set `error`. One dropped request
+  //    should not replace a working dashboard with an error page; the next
+  //    tick usually recovers, and `lastUpdatedAt` is what tells the operator
+  //    the numbers have stopped advancing.
+  useEffect(() => {
+    if (!connId || pollIntervalMs <= 0) return
+
+    let inFlight = false
+    const tick = async () => {
+      if (inFlight) return
+      if (typeof document !== "undefined" && document.hidden) return
+      inFlight = true
+      try {
+        const result = await getCluster(connId)
+        if (isMountedRef.current) {
+          setData(result)
+          setLastUpdatedAt(Date.now())
+        }
+      } catch (err) {
+        logFetchError("cluster", err)
+      } finally {
+        inFlight = false
+      }
+    }
+    const timer = setInterval(() => void tick(), pollIntervalMs)
+    const onVisible = () => {
+      if (typeof document !== "undefined" && !document.hidden) void tick()
+    }
+    if (typeof document !== "undefined") {
+      document.addEventListener("visibilitychange", onVisible)
+    }
+    return () => {
+      clearInterval(timer)
+      if (typeof document !== "undefined") {
+        document.removeEventListener("visibilitychange", onVisible)
+      }
+    }
+  }, [connId, pollIntervalMs])
+
+  return { data, error, isLoading, refetch, lastUpdatedAt }
 }

--- a/ui/src/hooks/use-connections.test.ts
+++ b/ui/src/hooks/use-connections.test.ts
@@ -4,7 +4,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 import { listConnections } from "@/lib/api/connections"
 import type { ConnectionProfileResponse } from "@/lib/types/connection"
 
-import { useConnections } from "./use-connections"
+import {
+  resetConnectionsFetchCoalescing,
+  useConnections,
+} from "./use-connections"
 
 vi.mock("@/lib/api/connections", () => ({
   listConnections: vi.fn(),
@@ -83,5 +86,73 @@ describe("useConnections", () => {
     // Give the microtask queue a beat to flush.
     await new Promise((r) => setTimeout(r, 0))
     // No throw / no console error from React about state on unmounted component.
+  })
+})
+
+describe("useConnections — request coalescing (#474)", () => {
+  beforeEach(() => {
+    resetConnectionsFetchCoalescing()
+  })
+
+  it("five simultaneous consumers produce exactly one network call", async () => {
+    // The reported behaviour: useConnections has 5 call sites, all mounting in
+    // the same tick with no shared state, so one navigation fired five
+    // identical requests.
+    mocked.mockResolvedValue([])
+
+    const hooks = Array.from({ length: 5 }, () =>
+      renderHook(() => useConnections()),
+    )
+    await waitFor(() =>
+      hooks.forEach((h) => expect(h.result.current.isLoading).toBe(false)),
+    )
+
+    expect(mocked).toHaveBeenCalledTimes(1)
+    // And every consumer still got the data.
+    hooks.forEach((h) => expect(h.result.current.data).toEqual([]))
+  })
+
+  it("a rejection reaches every joined consumer", async () => {
+    mocked.mockRejectedValue(new Error("boom"))
+
+    const hooks = Array.from({ length: 3 }, () =>
+      renderHook(() => useConnections()),
+    )
+    await waitFor(() =>
+      hooks.forEach((h) => expect(h.result.current.isLoading).toBe(false)),
+    )
+
+    expect(mocked).toHaveBeenCalledTimes(1)
+    hooks.forEach((h) => expect(h.result.current.error?.message).toBe("boom"))
+  })
+
+  it("a later mount fetches fresh rather than reusing a settled result", async () => {
+    // Coalescing must not become caching: once the request settles, the entry
+    // is dropped, so a consumer mounting afterwards asks again.
+    mocked.mockResolvedValue([])
+
+    const first = renderHook(() => useConnections())
+    await waitFor(() => expect(first.result.current.isLoading).toBe(false))
+    expect(mocked).toHaveBeenCalledTimes(1)
+
+    const second = renderHook(() => useConnections())
+    await waitFor(() => expect(second.result.current.isLoading).toBe(false))
+    expect(mocked).toHaveBeenCalledTimes(2)
+  })
+
+  it("refetch always issues its own request", async () => {
+    // An explicit refetch is a user asking for fresh data; joining an
+    // in-flight call would hand them a response that started before they
+    // clicked.
+    mocked.mockResolvedValue([])
+
+    const { result } = renderHook(() => useConnections())
+    await waitFor(() => expect(result.current.isLoading).toBe(false))
+    expect(mocked).toHaveBeenCalledTimes(1)
+
+    await act(async () => {
+      await result.current.refetch()
+    })
+    expect(mocked).toHaveBeenCalledTimes(2)
   })
 })

--- a/ui/src/hooks/use-connections.ts
+++ b/ui/src/hooks/use-connections.ts
@@ -14,8 +14,20 @@ import { useCallback, useEffect, useRef, useState } from "react"
 
 import { listConnections } from "@/lib/api/connections"
 import { logFetchError } from "@/lib/api/log"
+import { createSharedFetch } from "@/lib/shared-fetch"
 import type { ConnectionProfileResponse } from "@/lib/types/connection"
 import { useDataRevisionStore } from "@/stores/data-revision-store"
+
+// This hook has 5 call sites that all mount in the same tick, so a single
+// navigation used to fire 5 identical requests (#474). Coalescing them means
+// the first one starts the request and the rest join it. Keyed on the data
+// revision so a post-mutation bump still forces a fresh read.
+const sharedConnections = createSharedFetch<ConnectionProfileResponse[]>()
+
+/** Test seam: drop any in-flight coalesced request. */
+export function resetConnectionsFetchCoalescing(): void {
+  sharedConnections.reset()
+}
 
 export interface UseConnectionsResult {
   data: ConnectionProfileResponse[] | null
@@ -48,6 +60,9 @@ export function useConnections(): UseConnectionsResult {
     setIsLoading(true)
     setError(null)
     try {
+      // Deliberately NOT coalesced: an explicit refetch is a user asking for
+      // fresh data, and joining an in-flight request would hand them a
+      // response that started before they clicked.
       const result = await listConnections()
       if (!isMountedRef.current) return
       setData(result)
@@ -64,7 +79,10 @@ export function useConnections(): UseConnectionsResult {
     let cancelled = false
     ;(async () => {
       try {
-        const result = await listConnections()
+        const result = await sharedConnections.run(
+          `rev:${rev}`,
+          listConnections,
+        )
         if (!cancelled && isMountedRef.current) {
           setData(result)
           setError(null)

--- a/ui/src/hooks/use-k8s-clusters.ts
+++ b/ui/src/hooks/use-k8s-clusters.ts
@@ -9,7 +9,18 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 
 import { listK8sClusters, type ListK8sClustersParams } from "@/lib/api/k8s"
 import { logFetchError } from "@/lib/api/log"
+import { createSharedFetch } from "@/lib/shared-fetch"
 import type { K8sClusterListResponse } from "@/lib/types/k8s"
+
+// Same mount-storm as useConnections (#474): 4 call sites, one navigation,
+// four identical requests. Keyed on the serialised params so two consumers
+// asking for different namespaces still get their own call.
+const sharedK8sClusters = createSharedFetch<K8sClusterListResponse>()
+
+/** Test seam: drop any in-flight coalesced request. */
+export function resetK8sClustersFetchCoalescing(): void {
+  sharedK8sClusters.reset()
+}
 
 export interface UseK8sClustersResult {
   data: K8sClusterListResponse | null
@@ -45,6 +56,7 @@ export function useK8sClusters(
     setIsLoading(true)
     setError(null)
     try {
+      // Not coalesced — see the note in useConnections.refetch.
       const result = await listK8sClusters(paramsRef.current)
       if (!isMountedRef.current) return
       setData(result)
@@ -66,7 +78,9 @@ export function useK8sClusters(
     const effectParams = JSON.parse(paramsKey) as ListK8sClustersParams
     ;(async () => {
       try {
-        const result = await listK8sClusters(effectParams)
+        const result = await sharedK8sClusters.run(paramsKey, () =>
+          listK8sClusters(effectParams),
+        )
         if (!cancelled && isMountedRef.current) {
           setData(result)
           setError(null)

--- a/ui/src/lib/shared-fetch.ts
+++ b/ui/src/lib/shared-fetch.ts
@@ -1,0 +1,59 @@
+/**
+ * In-flight request coalescing for fetch-on-mount hooks (#474).
+ *
+ * `useConnections` is called from 5 components and `useK8sClusters` from 4.
+ * Each instance owns its own fetch-on-mount effect with no shared state, so a
+ * single navigation fired roughly 7-9 identical requests — they all mount in
+ * the same tick and all ask for the same thing.
+ *
+ * This coalesces them: while a request for a given key is in flight, every
+ * further caller gets the *same* promise instead of starting another one. Once
+ * it settles the entry is dropped, so the next call after that fetches fresh.
+ *
+ * Deliberately **not** a cache. A cache would need staleness rules, and getting
+ * them wrong shows an operator a connection list that no longer matches
+ * reality — worse than the duplicate requests this removes. Coalescing only
+ * de-duplicates work that is already simultaneous, so no caller can observe
+ * data older than its own call.
+ */
+
+type Pending<T> = Promise<T>
+
+export interface SharedFetch<T> {
+  /**
+   * Run `fetcher`, or join the in-flight call for `key` if there is one.
+   *
+   * Rejections propagate to every joined caller, and the entry is cleared
+   * either way — a failed request must not poison the key.
+   */
+  run: (key: string, fetcher: () => Promise<T>) => Promise<T>
+  /** Test seam: forget every in-flight entry. */
+  reset: () => void
+  /** Number of in-flight entries, for tests. */
+  readonly size: number
+}
+
+export function createSharedFetch<T>(): SharedFetch<T> {
+  const inFlight = new Map<string, Pending<T>>()
+
+  return {
+    run(key, fetcher) {
+      const existing = inFlight.get(key)
+      if (existing) return existing
+
+      const promise = fetcher().finally(() => {
+        // Only clear if we are still the current entry. A `reset()` between
+        // start and settle would otherwise let this delete a newer promise.
+        if (inFlight.get(key) === promise) inFlight.delete(key)
+      })
+      inFlight.set(key, promise)
+      return promise
+    },
+    reset() {
+      inFlight.clear()
+    },
+    get size() {
+      return inFlight.size
+    },
+  }
+}


### PR DESCRIPTION
Closes #474

## What was wrong

Two halves of the same problem: the push channel could not publish, and nothing polled instead.

- `SSE_ENABLED` defaults true, so `collector.start()` created three loop tasks on every boot. But every publish body — `_publish_metrics`, `_publish_health`, `_publish_k8s` — returns on its first statement when `CM_SSE_BROADCAST_PER_CONNECTION` is false, which is the default. Three tasks woke on 2s / 30s / 5s timers forever and produced nothing, and the startup log said `EventCollector started (2 loops)`.
- On the frontend, `useEventStream` has no consumers, and the cluster overview refreshed only when someone clicked Refresh.

So the overview showed the values captured at page load, indefinitely, with nothing to say so.

## What changed

### 1. The collector does not start when it could only idle

`lifespan` now requires **both** flags, and logs why when it skips:

```
SSE_ENABLED=true but CM_SSE_BROADCAST_PER_CONNECTION=false — event collector NOT
started; its publish bodies are gated on that flag, so the loops could only idle.
The SSE endpoint still accepts subscribers (heartbeats only). The UI polls
/clusters/{id} for live metrics; set CM_SSE_BROADCAST_PER_CONNECTION=true on a
single-tenant deployment to push instead.
```

Silence is what made this hard to spot in the first place, so the skip is loud. `collector.stop()` is now gated on the same decision — calling it on a collector that never started would gather an empty task list and log a misleading "EventCollector stopped". The SSE endpoint itself is untouched: it still accepts subscribers and sends heartbeats.

### 2. `useCluster` polls every 5s

Four deliberate choices, each pinned by a test:

- **Gated on `document.hidden`.** A background tab must not keep asking. A `visibilitychange` listener fires an immediate read on return, so coming back does not show a stale value for up to a full interval.
- **Never toggles `isLoading`.** That flag drives the Refresh button's `disabled` state and page spinners; flickering them every 5s would be worse than the staleness being fixed.
- **A failed poll keeps the last good data** and does not set `error`. One dropped request should not replace a working dashboard with an error page.
- **Re-entrancy guard**, so a slow response cannot stack requests.

`pollIntervalMs` is a parameter (default 5000, `0` disables) so a future consumer that should not poll does not have to fight the hook.

### 3. Staleness is visible

The hook exposes `lastUpdatedAt`, and the overview header renders "Updated Ns ago". This is not decoration: a frozen TPS reading looks *exactly* like a genuinely idle cluster, so the data cannot show its own staleness — the age of the last successful read is the only thing that can. The label re-renders on a 1s timer so it counts up between polls rather than freezing at "0s ago", which would be its own version of this bug.

### 4. The duplicate-fetch problem

The issue notes it "separately": `useConnections` is called from 5 components and `useK8sClusters` from 4, each with its own fetch-on-mount and no shared state, so one navigation fired roughly 7-9 identical requests.

`ui/src/lib/shared-fetch.ts` coalesces them — while a request for a key is in flight, further callers get the *same* promise. Deliberately **not** a cache: a cache needs staleness rules, and getting them wrong shows an operator a connection list that no longer matches reality, which is worse than the duplicate requests. Coalescing only de-duplicates work that is already simultaneous, so no caller observes data older than its own call, a later mount fetches fresh, and `refetch` always issues its own request (a user asking for fresh data must not be handed a response that started before they clicked).

The change is confined to the two hook files plus the new helper — **no component was touched**, so goals 2-1 and 2-4 are untouched.

## Verification

Ran the exact commands CI runs (`.github/workflows/ci.yaml`).

**API job:**

```
$ cd api && uv run ruff check src/
All checks passed!
$ uv run ruff format --check src/
(clean)
$ uv run pytest tests/
1073 passed, 6 warnings in 11.81s
```

`1067` on `main` → +6. Run twice under different `pytest-randomly` seeds (`1073` both times) because the new test drives the app lifespan, which touches module-global state.

**UI job:**

```
$ cd ui && npm run type-check   # clean
$ npm run lint                  # clean
$ npm run format:check          # All matched files use Prettier code style!
$ npm run test
 Test Files  19 passed (19)
      Tests  115 passed (115)
$ npm run build                 # completed
```

`104` on `main` → +11 (7 polling, 4 coalescing).

**Pre-commit job** — `pre-commit run --all-files`: all 14 hooks Passed.

The tests:

```
$ uv run pytest tests/test_collector_startup_gate.py -o addopts="" -v -p no:randomly
TestCollectorStartupGate::test_truth_table[True-False-False] PASSED   [ 16%]
TestCollectorStartupGate::test_truth_table[True-True-True] PASSED     [ 33%]
TestCollectorStartupGate::test_truth_table[False-False-False] PASSED  [ 50%]
TestCollectorStartupGate::test_truth_table[False-True-False] PASSED   [ 66%]
TestCollectorStartupGate::test_explains_itself_in_the_log PASSED      [ 83%]
TestCollectorStartupGate::test_says_nothing_when_the_collector_does_start PASSED [100%]
============================== 6 passed in 0.30s ===============================

$ npx vitest run src/hooks/use-cluster.test.ts src/hooks/use-connections.test.ts --reporter=verbose
 ✓ useCluster — polling (#474) > re-reads without user interaction after the interval elapses
 ✓ useCluster — polling (#474) > records lastUpdatedAt so staleness is visible
 ✓ useCluster — polling (#474) > does not poll while the tab is hidden
 ✓ useCluster — polling (#474) > stops polling after unmount
 ✓ useCluster — polling (#474) > a failed poll keeps the last good data instead of erroring the page
 ✓ useCluster — polling (#474) > polling never toggles isLoading
 ✓ useCluster — polling (#474) > pollIntervalMs=0 disables polling
 ✓ useConnections — request coalescing (#474) > five simultaneous consumers produce exactly one network call
 ✓ useConnections — request coalescing (#474) > a rejection reaches every joined consumer
 ✓ useConnections — request coalescing (#474) > a later mount fetches fresh rather than reusing a settled result
 ✓ useConnections — request coalescing (#474) > refetch always issues its own request
      Tests  19 passed (19)
```

The polling tests use fake timers and assert call *counts* after advancing — `re-reads without user interaction` goes 1 → 2 → 3 across two 5s advances, which is the "no user interaction" claim stated directly.

`test_explains_itself_in_the_log` asserts by patching the module logger rather than through `caplog`: `observability.setup_logging` installs its own handlers and disables propagation, so caplog's root handler never sees these records. The message is visible in pytest's captured stdout either way, but asserting on it needed the direct patch.

### Not verified here

- **Nothing ran against a live cluster or a browser.** The polling behaviour is asserted through fake timers and a mocked `getCluster`; nobody watched a real dashboard advance. Likewise the "Updated Ns ago" label is asserted only through `lastUpdatedAt` being a number — its rendering was not tested (it is a presentational component in `page.tsx`, and the overview page has no test file to extend).
- **The `document.hidden` gate is tested by stubbing the getter**, not by actually backgrounding a tab.
- **`useK8sClusters` coalescing has no test.** It uses the identical helper, keyed on `paramsKey`, and `shared-fetch.ts` behaviour is covered through the `useConnections` tests — but the k8s hook itself has no test file in this repo, and adding one is a larger job than this PR should carry. Flagging it rather than implying coverage.
- **`SSE_ENABLED=true` + `CM_SSE_BROADCAST_PER_CONNECTION=true`** starts the collector (asserted), but nobody confirmed the loops actually publish to a subscriber end-to-end — that needs a real cluster and an EventSource client.
