### PR TITLE
fix(security): run the asinfo write gate before the client dependency, and frame `/`

### DIFF
--- a/api/src/aerospike_cluster_manager_api/info_verbs.py
+++ b/api/src/aerospike_cluster_manager_api/info_verbs.py
@@ -50,6 +50,7 @@ above :data:`WRITE_INFO_VERBS`, and update
 
 from __future__ import annotations
 
+import re
 from typing import NamedTuple
 
 READ_ONLY_INFO_VERBS: frozenset[str] = frozenset(
@@ -221,6 +222,13 @@ class InfoCommandNotSingle(InfoCommandRejected):
 # whatever followed it. ``assert_single_command`` is the boundary: it runs
 # first and rejects any frame whose shape puts text beyond the verb's reach.
 #
+# Every member is handled there, which was not true before: ``/`` was the one
+# terminator the framing check ignored, so ``namespaces/truncate-namespace:namespace=test``
+# passed both gates and went to the wire. ``/`` is now framed by
+# ``_PATH_STYLE_VERBS``. ``:`` remains looser by design — it is the argument
+# separator, and the bare form ``namespace:test`` is legitimate; see
+# ``tests/test_info_verbs.py::TestPathStyleFraming::test_colon_keeps_its_looser_bare_argument_rule``.
+#
 # The whitespace entries overlap with the whitespace rule below, which makes
 # them unreachable on the validated path. They stay because ``extract_verb``
 # is public: called directly on ``"version <second command>"`` it must still
@@ -281,6 +289,39 @@ def extract_verb(command: str) -> str:
     return head
 
 
+# Verbs that legitimately take ``/``-separated arguments, mapped to the maximum
+# number of argument segments each accepts.
+#
+#   namespace/<ns>            sets/<ns>       sets/<ns>/<set>
+#   sindex/<ns>               sindex/<ns>/<idx>
+#   bins/<ns>
+#
+# ``/`` was the one member of :data:`_VERB_TERMINATORS` that
+# :func:`assert_single_command` did not treat as a separator, so text after a
+# slash was checked by neither gate: ``namespaces/truncate-namespace:namespace=test``
+# was accepted with ``verb='namespaces'`` and transmitted whole. Every other
+# terminator was rejected; this closes the asymmetry.
+#
+# The bound matters as much as the membership. ``namespaces`` takes no path
+# arguments at all, so ``namespaces/<anything>`` is never legitimate and is now
+# rejected outright rather than sent on the strength of its head.
+_PATH_STYLE_VERBS: dict[str, int] = {
+    "namespace": 1,
+    "sets": 2,
+    "sindex": 2,
+    # Framed here to match ``constants.info_bins``, but note ``bins`` is NOT on
+    # READ_ONLY_INFO_VERBS — ``bins/test`` still fails the verb check. This map
+    # governs framing only; it grants nothing.
+    "bins": 1,
+}
+
+# Aerospike namespace / set / index names. Deliberately narrow: a path segment
+# is an identifier, never a command, so anything carrying a ``:`` (the
+# colon-style argument separator) or a character outside this set is a second
+# command riding in the path.
+_PATH_SEGMENT_RE = re.compile(r"^[A-Za-z0-9_.$-]+$")
+
+
 def assert_single_command(command: str) -> str:
     """Return ``command`` stripped, having confirmed it holds ONE asinfo command.
 
@@ -329,6 +370,25 @@ def assert_single_command(command: str) -> str:
     # One trailing ';' terminates a single command, so take it off before
     # reasoning about the separators that remain.
     body = cmd[:-1] if cmd.endswith(";") else cmd
+
+    # Path-style framing. Checked before the ':' logic below, because a ':'
+    # appearing after a '/' is a colon-style command in the path rather than
+    # this command's own argument section.
+    if "/" in body:
+        verb, *segments = body.split("/")
+        allowed = _PATH_STYLE_VERBS.get(verb)
+        if allowed is None:
+            raise InfoCommandNotSingle(f"'/' after a verb that takes no path arguments ({verb!r})")
+        if len(segments) > allowed:
+            raise InfoCommandNotSingle(f"{len(segments)} '/'-separated arguments; {verb!r} accepts at most {allowed}")
+        for segment in segments:
+            if not _PATH_SEGMENT_RE.match(segment):
+                # Names the shape, never the content — the HTTP 400 must not
+                # echo an unvalidated string back to the caller.
+                reason = "':' inside a path argument" if ":" in segment else "non-identifier path argument"
+                raise InfoCommandNotSingle(reason)
+        return cmd
+
     head, colon, args = body.partition(":")
 
     # No argument section has started yet, so a ';' here separates commands.

--- a/api/src/aerospike_cluster_manager_api/routers/clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/clusters.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from aerospike_cluster_manager_api import config, rate_limit
 from aerospike_cluster_manager_api.dependencies import AerospikeClient, VerifiedConnId
@@ -94,6 +94,58 @@ async def configure_namespace(
     return MessageResponse(message=message)
 
 
+async def _assert_info_write_allowed(request: Request, body: ExecuteInfoRequest) -> None:
+    """Gate the ``readOnly=false`` path BEFORE anything dials the cluster.
+
+    This has to be a dependency, not a check in the handler body. FastAPI
+    resolves the whole dependency tree before the endpoint function runs, and
+    ``client: AerospikeClient`` is a dependency — so the original in-body check
+    (#480) fired only *after* ``client_manager.get_client`` had already built a
+    real connection. A deployment with the write path disabled therefore still
+    dialled the cluster on every probe, and still answered 404 / 503 / 403
+    depending on whether the connection id existed and whether its cluster was
+    reachable. That is an inventory-and-reachability oracle, and it is
+    unauthenticated under the ``OIDC_ENABLED=false`` default. The budget check
+    was in the body too, so probes were metered by the 60/minute global rather
+    than the 5/minute write budget they were supposed to consume.
+
+    Declared via the route's ``dependencies=[...]`` list rather than as a
+    handler parameter: FastAPI inserts those at position 0 of the dependency
+    tree (``routing.APIRoute.__init__``), so this runs ahead of ``client`` and
+    ``conn_id`` regardless of parameter order. ``tests/…::TestWriteGateRunsBefore
+    TheConnection`` pins that empirically rather than trusting the reading —
+    an unverified ordering claim is what produced the original gap.
+
+    Declaring ``body`` here does not re-read the request: FastAPI parses the
+    body once per request and hands the same parsed value to every dependant.
+
+    ``readOnly=true`` is untouched — the diagnostics path ackoctl polls must
+    keep reaching the cluster.
+    """
+    if body.readOnly:
+        return
+
+    if not config.ACM_ALLOW_INFO_WRITE:
+        # 403 before the ACL, so this also cannot be used to probe which
+        # connection ids exist. It discloses only the server's own config
+        # flag, which is not per-tenant information.
+        raise HTTPException(
+            status_code=403,
+            detail=(
+                "asinfo write passthrough is disabled; set ACM_ALLOW_INFO_WRITE=true "
+                "on the API to enable readOnly=false, or use readOnly=true for diagnostics."
+            ),
+        )
+
+    # Charged before validation, so a caller cannot enumerate the allowlist for
+    # free by sending commands that 400.
+    if not rate_limit.consume_budget(request, rate_limit.INFO_WRITE_LIMIT, "clusters:info:write"):
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit exceeded: 5 per 1 minute (asinfo write passthrough)",
+        )
+
+
 @router.post(
     "/{conn_id}/info",
     response_model=ExecuteInfoResponse,
@@ -114,6 +166,7 @@ async def configure_namespace(
         "destructive verbs such as truncate-namespace — and is charged against "
         "a dedicated 5/minute per-client budget (429 when exhausted)."
     ),
+    dependencies=[Depends(_assert_info_write_allowed)],
 )
 async def execute_info(
     request: Request,
@@ -121,30 +174,12 @@ async def execute_info(
     client: AerospikeClient,
     conn_id: VerifiedConnId,
 ) -> ExecuteInfoResponse:
-    """Run asinfo commands per the ExecuteInfoRequest semantics."""
-    # The write path is opt-in and off by default (#467). Refuse before
-    # touching the connection so a deployment that never enabled it cannot be
-    # probed for which verbs it would have accepted.
-    if not body.readOnly and not config.ACM_ALLOW_INFO_WRITE:
-        raise HTTPException(
-            status_code=403,
-            detail=(
-                "asinfo write passthrough is disabled; set ACM_ALLOW_INFO_WRITE=true "
-                "on the API to enable readOnly=false, or use readOnly=true for diagnostics."
-            ),
-        )
+    """Run asinfo commands per the ExecuteInfoRequest semantics.
 
-    # Charge the write budget before validation, so a caller cannot probe the
-    # allowlist for free by sending commands that 400. Reads keep the 60/minute
-    # global default — this route is the diagnostic path ackoctl polls, and a
-    # route-level decorator could not tell the two apart (see
-    # rate_limit.consume_budget).
-    if not body.readOnly and not rate_limit.consume_budget(request, rate_limit.INFO_WRITE_LIMIT, "clusters:info:write"):
-        raise HTTPException(
-            status_code=429,
-            detail="Rate limit exceeded: 5 per 1 minute (asinfo write passthrough)",
-        )
-
+    The opt-in flag and the write rate limit are enforced by
+    :func:`_assert_info_write_allowed`, which runs before the ``client``
+    dependency builds a connection.
+    """
     # Fail-fast on the FIRST rejected command so it never reaches the wire.
     # Pydantic already enforces commands non-empty.
     #

--- a/api/tests/test_clusters_router_info.py
+++ b/api/tests/test_clusters_router_info.py
@@ -669,3 +669,121 @@ class TestExecuteInfoValidation:
 
         assert resp.status_code == 200, resp.text
         assert len(resp.json()["results"]) == 2  # fan-out across 2 nodes
+
+
+class TestWriteGateRunsBeforeTheConnection:
+    """The 403 must precede the client build, not follow it.
+
+    #480 claimed the write gate "runs before the connection is touched". It did
+    not: the check lived in the handler body, while ``client: AerospikeClient``
+    is a FastAPI dependency, and FastAPI resolves the whole dependency tree
+    before the body runs. So a disabled deployment still dialled the cluster and
+    still discriminated 404 / 503 / 403 — an inventory-and-reachability oracle,
+    unauthenticated under the OIDC_ENABLED=false default. ``consume_budget`` sat
+    in the body too, so probes were governed by the 60/minute global rather than
+    the 5/minute write budget.
+    """
+
+    @pytest.mark.asyncio
+    async def test_403_is_raised_without_building_a_client(self, client: AsyncClient, sample_connection):
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_get_client = AsyncMock(return_value=_make_mock_client())
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            mock_get_client,
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={"commands": ["set-config:context=service;migrate-threads=2"], "readOnly": False},
+            )
+
+        assert resp.status_code == 403, resp.text
+        mock_get_client.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_403_precedes_an_unreachable_cluster_503(self, client: AsyncClient, sample_connection):
+        """A dead cluster and a live one must be indistinguishable when writes are off."""
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            AsyncMock(side_effect=ConnectionRefusedError("cluster is down")),
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={"commands": ["set-config:context=service;migrate-threads=2"], "readOnly": False},
+            )
+
+        assert resp.status_code == 403, resp.text
+
+    @pytest.mark.asyncio
+    async def test_403_precedes_a_missing_connection_404(self, client: AsyncClient):
+        """Nor may it discriminate which connection ids exist.
+
+        The 403 discloses only the server's own config flag, which is not
+        per-tenant information; a 404 here would confirm the id is unknown and
+        turn the route into a connection-inventory oracle.
+        """
+        resp = await client.post(
+            "/api/v1/clusters/conn-does-not-exist/info",
+            json={"commands": ["set-config:context=service;migrate-threads=2"], "readOnly": False},
+        )
+        assert resp.status_code == 403, resp.text
+
+    @pytest.mark.asyncio
+    async def test_read_path_still_reaches_the_cluster(self, client: AsyncClient, sample_connection):
+        """The gate must not short-circuit the diagnostics path it does not govern."""
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            AsyncMock(return_value=mock_as_client),
+        ):
+            resp = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={"commands": ["namespaces"], "readOnly": True},
+            )
+
+        assert resp.status_code == 200, resp.text
+        mock_as_client.info_all.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_429_also_precedes_the_connection(
+        self, client: AsyncClient, sample_connection, allow_info_write, enforce_rate_limits
+    ):
+        """Exhausted budget must not cost a cluster dial either."""
+        from aerospike_cluster_manager_api import db
+
+        await db.create_connection(sample_connection)
+        mock_as_client = _make_mock_client()
+        mock_as_client.info_all.side_effect = lambda cmd: [_info_all_result("BB9020011AC4202", "ok")]
+        mock_get_client = AsyncMock(return_value=mock_as_client)
+
+        with patch(
+            "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+            mock_get_client,
+        ):
+            for _ in range(5):
+                ok = await client.post(
+                    f"/api/v1/clusters/{sample_connection.id}/info",
+                    json={"commands": ["recluster:"], "readOnly": False},
+                )
+                assert ok.status_code == 200, ok.text
+            dialled_before = mock_get_client.await_count
+
+            limited = await client.post(
+                f"/api/v1/clusters/{sample_connection.id}/info",
+                json={"commands": ["recluster:"], "readOnly": False},
+            )
+
+        assert limited.status_code == 429, limited.text
+        # The rejected 6th request must not have dialled the cluster.
+        assert mock_get_client.await_count == dialled_before

--- a/api/tests/test_info_verbs.py
+++ b/api/tests/test_info_verbs.py
@@ -557,3 +557,107 @@ class TestAssertWriteAllowed:
         assert "truncate-namespace" in message
         assert "set-config" in message
         assert exc_info.value.verb == "truncate-namespace"
+
+
+class TestPathStyleFraming:
+    """``/`` is a verb terminator too, and used to be the only one ignored.
+
+    Five of the six members of ``_VERB_TERMINATORS`` were rejected by
+    ``assert_single_command`` as command separators. ``/`` was not, so text
+    after a slash was checked by neither gate: ``extract_verb`` stopped at the
+    slash and the framing check never looked past it. The result was that
+    ``namespaces/truncate-namespace:namespace=test`` was accepted with
+    ``verb='namespaces'`` and transmitted whole, on the default, unauthenticated
+    read path.
+
+    Whether an Aerospike server actually dispatches a second verb from a
+    ``/``-suffixed name is **not established** — that needs a live cluster and
+    nobody has run it. What is established is that the server parses ``/``
+    meaningfully for some verbs (``sets/test/myset`` is a real command), and
+    that no gate examined the text after it. These tests pin the closed shape
+    either way.
+    """
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "namespaces/truncate-namespace:namespace=test",
+            "namespaces/recluster:",
+            "statistics/set-config:context=service;migrate-threads=2",
+            # No colon either — `namespaces` takes no path arguments at all, so
+            # anything after the slash is unexplainable.
+            "namespaces/truncate-namespace",
+            "version/recluster",
+            "roster/set-config",
+        ],
+    )
+    def test_path_smuggling_is_rejected(self, command: str) -> None:
+        with pytest.raises(InfoCommandNotSingle):
+            assert_read_only(command)
+
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "sets/test",
+            "sets/test/myset",
+            "namespace/test",
+            "sindex/test",
+            "sindex/test/idx_name",
+            # Aerospike identifiers allow these characters.
+            "sets/my-set_1.$x/a",
+        ],
+    )
+    def test_legitimate_path_style_still_passes(self, command: str) -> None:
+        # The fix must not break the shapes ``constants.info_namespace`` /
+        # ``info_sets`` / ``info_sindex`` actually build.
+        assert assert_read_only(command).command == command
+
+    def test_segment_count_is_bounded(self) -> None:
+        """``sets`` takes at most ns/set — a third segment is not an argument."""
+        with pytest.raises(InfoCommandNotSingle):
+            assert_read_only("sets/test/myset/extra")
+
+    def test_colon_inside_a_path_segment_is_rejected(self) -> None:
+        """A ':' after a '/' starts a colon-style command, not this one's args."""
+        with pytest.raises(InfoCommandNotSingle):
+            assert_read_only("sets/test/myset:truncate")
+
+    @pytest.mark.parametrize("sep", ["/", ";", "\n", " ", "\t"])
+    def test_every_non_colon_terminator_is_a_separator(self, sep: str) -> None:
+        """Each of these puts a token beyond ``extract_verb``'s reach.
+
+        ``/`` is the one that was missing; the other four already held. ``:``
+        is excluded deliberately — see the next test.
+        """
+        with pytest.raises(InfoCommandRejected):
+            assert_read_only(f"namespaces{sep}recluster")
+
+    def test_colon_keeps_its_looser_bare_argument_rule(self) -> None:
+        """RESIDUAL, documented rather than fixed: ``verb:token`` still passes.
+
+        ``:`` is the argument separator, and the single-bare-argument form
+        (``namespace:test``) is legitimate and pinned by
+        ``test_colon_args_pass_when_verb_whitelisted``. A lone segment is
+        therefore accepted without being ``key=value``, so
+        ``namespaces:recluster`` passes framing on the same rule — even though
+        ``namespaces`` takes no arguments at all.
+
+        Closing it would mean allowlisting which verbs may take a bare colon
+        argument, the same treatment ``_PATH_STYLE_VERBS`` gives ``/``. That is
+        a deliberate behaviour change beyond the ``/`` gap this PR closes, and
+        it needs the same Aerospike CE 8.1 audit the module's "to add a verb"
+        checklist demands. Pinned here so the asymmetry is visible and a future
+        change to it is a decision, not a surprise.
+        """
+        assert assert_read_only("namespaces:recluster").verb == "namespaces"
+
+    def test_path_framing_grants_nothing_on_its_own(self) -> None:
+        """``bins`` is framed but not allowlisted — the verb check still bites."""
+        with pytest.raises(InfoVerbNotAllowed):
+            assert_read_only("bins/test")
+
+    def test_write_path_gets_the_same_framing(self) -> None:
+        # assert_write_allowed shares assert_single_command, so the fix covers
+        # the opt-in path without a second implementation.
+        with pytest.raises(InfoCommandNotSingle):
+            assert_write_allowed("set-config/truncate-namespace:namespace=test")


### PR DESCRIPTION
Follow-up to **#480** (issue #467), fixing two gaps an independent audit found in that merged work. No `Closes` — #467 is already closed.

## 1. The 403 did not precede the connection — and I told you it did

My #480 body said the check "runs before the connection is touched, so a deployment that never enabled it cannot be probed". **That was wrong, and I asserted it without testing it.**

`ACM_ALLOW_INFO_WRITE` was checked in the handler body (`routers/clusters.py:128`), but `client: AerospikeClient` is a FastAPI dependency (`dependencies.py:187`), and FastAPI resolves the entire dependency tree before the endpoint body runs. So on a deployment with the write path **disabled**, every probe still called `client_manager.get_client`, still built a real Aerospike connection, and still discriminated:

- **404** — connection id does not exist
- **503** — id exists, cluster unreachable
- **403** — id exists, cluster reachable, writes disabled

That is an inventory-and-reachability oracle, and it is unauthenticated under the `OIDC_ENABLED=false` default. `consume_budget` was in the body too, so these probes were metered by the 60/minute global rather than the 5/minute write budget they were meant to consume.

**Fix.** `_assert_info_write_allowed` is now a dependency, attached via the route's `dependencies=[...]` list rather than as a handler parameter. FastAPI inserts those at position 0 of the dependency tree (`routing.APIRoute.__init__`), so it runs ahead of both `client` and `conn_id` regardless of parameter order — a stronger guarantee than relying on signature order.

The 403 now also precedes the ACL, so it cannot be used to probe which connection ids exist. It discloses only the server's own config flag, which is not per-tenant information.

Declaring `body: ExecuteInfoRequest` in the dependency does not re-read the request — FastAPI parses the body once and hands the same value to every dependant.

**Five tests pin the ordering empirically**, not by reading the framework. That is the specific lesson here: the original gap exists because an ordering claim went into a PR body unverified.

## 2. `/` was the one verb terminator the framing check ignored

Five of the six members of `_VERB_TERMINATORS` were rejected as separators. `/` was not, so text after a slash was checked by **neither** gate — `extract_verb` stopped at the slash, and `assert_single_command` never looked past it:

```
$ python -c "from ...info_verbs import assert_read_only; ..."
ACCEPTED verb='namespaces'   transmits 'namespaces/truncate-namespace:namespace=test'
ACCEPTED verb='sets'         transmits 'sets/test/myset'              <- legitimate
ACCEPTED verb='statistics'   transmits 'statistics/set-config:context=service;migrate-threads=2'
```

on the **default, unauthenticated read path**.

**Fix.** `_PATH_STYLE_VERBS` bounds which verbs may carry `/` and how many segments each takes (`namespace`→1, `sets`→2, `sindex`→2, `bins`→1 — exactly what `constants.py` builds), and each segment must match the Aerospike identifier charset. `namespaces` takes no path arguments, so `namespaces/<anything>` is now rejected outright rather than sent on the strength of its head. `bins` is framed but is **not** on the read allowlist, so `bins/test` still fails the verb check — the map governs framing and grants nothing.

**What is not established:** whether an Aerospike server actually dispatches a second verb from a `/`-suffixed name. That needs a live cluster and nobody has run it. What *is* established is that the server parses `/` meaningfully for some verbs (`sets/test/myset` is a real command) and that no gate examined the text after it. The tests pin the closed shape either way, and say so in their docstring rather than claiming an exploit.

### Residual, documented rather than fixed

`:` keeps its looser bare-argument rule, so `namespaces:recluster` still passes framing even though `namespaces` takes no arguments. `:` is the argument separator and the bare form `namespace:test` is legitimate and pinned by an existing test. Closing it means allowlisting which verbs may take a bare colon argument — the same treatment `/` just received, but a wider behaviour change that needs the Aerospike CE 8.1 audit the module's own "to add a verb" checklist demands. `test_colon_keeps_its_looser_bare_argument_rule` pins it so the asymmetry stays visible and changing it later is a decision, not a surprise.

## Verification

**These tests fail on merged `main` and pass here.** Reverting just the two source files and re-running:

```
$ git checkout main -- routers/clusters.py info_verbs.py
$ uv run pytest tests/test_clusters_router_info.py::TestWriteGateRunsBeforeTheConnection \
                tests/test_info_verbs.py::TestPathStyleFraming -q -p no:randomly
FAILED ...TestWriteGateRunsBeforeTheConnection::test_403_is_raised_without_building_a_client
FAILED ...TestWriteGateRunsBeforeTheConnection::test_403_precedes_an_unreachable_cluster_503
FAILED ...TestWriteGateRunsBeforeTheConnection::test_403_precedes_a_missing_connection_404
FAILED ...TestWriteGateRunsBeforeTheConnection::test_429_also_precedes_the_connection
FAILED ...TestPathStyleFraming::test_path_smuggling_is_rejected[namespaces/truncate-namespace:namespace=test]
FAILED ...TestPathStyleFraming::test_path_smuggling_is_rejected[namespaces/recluster:]
FAILED ...TestPathStyleFraming::test_path_smuggling_is_rejected[statistics/set-config:context=service;migrate-threads=2]
FAILED ...TestPathStyleFraming::test_path_smuggling_is_rejected[namespaces/truncate-namespace]
FAILED ...TestPathStyleFraming::test_path_smuggling_is_rejected[version/recluster]
FAILED ...TestPathStyleFraming::test_path_smuggling_is_rejected[roster/set-config]
FAILED ...TestPathStyleFraming::test_segment_count_is_bounded
FAILED ...TestPathStyleFraming::test_colon_inside_a_path_segment_is_rejected
FAILED ...TestPathStyleFraming::test_every_non_colon_terminator_is_a_separator[/]
FAILED ...TestPathStyleFraming::test_write_path_gets_the_same_framing
14 failed, 13 passed in 0.47s
```

The 13 that pass on `main` are the ones asserting behaviour that already held — `sets/test/myset` still working, the other four terminators, and the read path reaching the cluster. They are there so the fix cannot buy its win by breaking something.

With the fix (27/27):

```
$ uv run pytest ...TestWriteGateRunsBeforeTheConnection ...TestPathStyleFraming -v -p no:randomly
test_403_is_raised_without_building_a_client PASSED
test_403_precedes_an_unreachable_cluster_503 PASSED
test_403_precedes_a_missing_connection_404 PASSED
test_read_path_still_reaches_the_cluster PASSED
test_429_also_precedes_the_connection PASSED
test_path_smuggling_is_rejected[namespaces/truncate-namespace:namespace=test] PASSED
test_path_smuggling_is_rejected[namespaces/recluster:] PASSED
test_path_smuggling_is_rejected[statistics/set-config:context=service;migrate-threads=2] PASSED
test_path_smuggling_is_rejected[namespaces/truncate-namespace] PASSED
test_path_smuggling_is_rejected[version/recluster] PASSED
test_path_smuggling_is_rejected[roster/set-config] PASSED
test_legitimate_path_style_still_passes[sets/test] PASSED
test_legitimate_path_style_still_passes[sets/test/myset] PASSED
test_legitimate_path_style_still_passes[namespace/test] PASSED
test_legitimate_path_style_still_passes[sindex/test] PASSED
test_legitimate_path_style_still_passes[sindex/test/idx_name] PASSED
test_legitimate_path_style_still_passes[sets/my-set_1.$x/a] PASSED
test_segment_count_is_bounded PASSED
test_colon_inside_a_path_segment_is_rejected PASSED
test_every_non_colon_terminator_is_a_separator[/] PASSED
test_every_non_colon_terminator_is_a_separator[;] PASSED
test_every_non_colon_terminator_is_a_separator[\n] PASSED
test_every_non_colon_terminator_is_a_separator[ ] PASSED
test_every_non_colon_terminator_is_a_separator[\t] PASSED
test_colon_keeps_its_looser_bare_argument_rule PASSED
test_path_framing_grants_nothing_on_its_own PASSED
test_write_path_gets_the_same_framing PASSED
============================== 27 passed in 0.34s ==============================
```

Note `test_429_also_precedes_the_connection` asserts `get_client.await_count` is unchanged across the rejected 6th request — the point is that a throttled request costs no cluster dial, not merely that the status code is 429.

Full CI commands:

```
$ cd api && uv run ruff check src/            All checks passed!
$ uv run ruff format --check src/             (clean)
$ uv run pytest tests/                        1243 passed, 6 warnings in 15.87s
```

`1216` on `main` (verified at `e0e2497`) → **+27**.

> **Correction:** an earlier revision of this body cited `1227` as the `main` baseline. That was the count on my `feat/165` branch, which carries 11 extra tests from `tests/test_export_openapi.py` — `main` itself is 1216. The absolute pass count and every other claim were right; only the delta arithmetic was wrong. Run twice under different `pytest-randomly` seeds. `pre-commit run --all-files`: all 14 hooks Passed. `make generate-types` produces no diff — the OpenAPI document is unchanged, since the dependency reuses the same body model.

### Not verified here

- **No live Aerospike cluster.** The `/` question above is the concrete consequence: I closed the asymmetry without being able to test what the server does with `namespaces/truncate-namespace`.
- **The oracle is demonstrated through mocks**, not by probing a running API from outside.
- FastAPI's position-0 insertion for route-level `dependencies` is asserted by the five ordering tests rather than by version-pinning that framework internal. If FastAPI ever changed it, those tests fail — which is the point of writing them that way.

