### PR TITLE
fix(security): block alternative IP literal forms in the SSRF target gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,10 +141,21 @@ K8S_MANAGEMENT_ENABLED=false
 # CM_SSE_BROADCAST_PER_CONNECTION=false
 
 # ─── Connection target SSRF gate ──────────────────────────────────────────
-# The API refuses connection targets that are bare IP literals in loopback
-# (127.0.0.0/8, ::1) or link-local (169.254.0.0/16, includes the EC2 IMDS
-# 169.254.169.254, and fe80::/10) ranges. Without this gate a caller could
-# repurpose the API as an SSRF / port-scan primitive.
+# The API refuses connection targets that denote, in ANY literal form:
+#   * loopback     127.0.0.0/8, ::1
+#   * link-local   169.254.0.0/16 (incl. the EC2/GCP/Azure IMDS
+#                  169.254.169.254), fe80::/10
+#   * unspecified  0.0.0.0, :: (Linux routes these to localhost)
+# Without this gate a caller could repurpose the API as an SSRF / port-scan
+# primitive.
+#
+# "ANY literal form" is load-bearing: the resolver accepts 127.1, 2130706433,
+# 0x7f000001, and 0177.0.0.1 as 127.0.0.1, and 2852039166 as the IMDS address.
+# All of them are blocked.
+#
+# NOTE this does NOT block private ranges. RFC1918 (10/8, 172.16/12,
+# 192.168/16) is where real Aerospike clusters live, so blocking it would
+# break every genuine deployment. The knob is named for what it does.
 #
 # The gate covers the WHOLE connection lifecycle: POST /api/connections/test,
 # create, update, and every client build in client_manager.get_client (so
@@ -153,11 +164,11 @@ K8S_MANAGEMENT_ENABLED=false
 # Set to true ONLY for local dev where the API runs alongside a loopback
 # Aerospike (compose.dev.yaml). DNS hostnames are not pre-resolved here --
 # rely on egress firewall policy to backstop DNS-based bypasses.
-# ACM_ALLOW_PRIVATE_TARGETS=false
+# ACM_ALLOW_LOOPBACK_TARGETS=false
 #
-# Deprecated alias, still honoured so existing deployments keep working.
-# It predates the gate covering more than test-connection; prefer the name
-# above.
+# Superseded names, still honoured so no deployment breaks on upgrade. Both
+# said "PRIVATE", which invited the wrong threat model (see the NOTE above).
+# ACM_ALLOW_PRIVATE_TARGETS=false
 # ACM_CONNECTION_TEST_ALLOW_PRIVATE=false
 
 # ─── At-rest encryption (connection passwords) ────────────────────────────


### PR DESCRIPTION
Follow-up to **#481** (issue #470). No `Closes` — #470 is already closed.

The audit confirmed gate *placement* is complete (4 sites) and that DNS rebinding is a documented non-goal with a sound TOCTOU rationale. The gap was inside my own stated scope: the **parser**.

## What was wrong

`is_blocked_target` treated an `ipaddress.ip_address()` parse failure as "not a literal, let it through". `ipaddress` accepts only the canonical dotted quad; the C resolver behind the Aerospike client also accepts the historical `inet_aton` forms. Every one of them was a working alias for a denied address, sailing past a gate that looked closed:

| written as | resolves to |
|---|---|
| `127.1` | 127.0.0.1 |
| `127.0.1` | 127.0.0.1 |
| `2130706433` | 127.0.0.1 (decimal) |
| `0x7f000001` | 127.0.0.1 (hex) |
| `0177.0.0.1` | 127.0.0.1 (octal) |
| **`2852039166`** | **169.254.169.254 — the IMDS address, decimal-encoded** |

The last two were **not** in the audit report; I found them while reproducing. Decimal-encoded IMDS is the sharpest of the set — it is the exact target the gate's own comment names as the thing it exists to stop.

Also missing: `0.0.0.0` and `::`. Linux routes those to localhost, so the gate had a loopback alias open through a form Python parses perfectly well — the classification was incomplete, not just the parsing.

## What changed

**`_parse_ip_literal`** falls back to `socket.inet_aton` and re-checks the canonical quad. `inet_aton` rejects hostnames (`example.com`, `aerospike-node-1`) and trailing garbage (`127.0.0.1extra`), so this does **not** start blocking names — DNS remains out of scope for the TOCTOU reason in the module docstring. This fix is about literals the resolver already accepts, not about resolving anything.

**`_is_denied`** adds `is_unspecified`, and explicitly unwraps `ipv4_mapped` rather than resting on Python's classification of IPv4-mapped IPv6. (Python happens to get `::ffff:127.0.0.1` right today; the unwrap means the decision does not depend on that.)

**The knob is renamed to `ACM_ALLOW_LOOPBACK_TARGETS`.** You asked for rename-or-re-document; I renamed, because the name is on a security control and a wrong name produces a wrong threat model. It permits **loopback / link-local / unspecified**. It has never blocked RFC1918 and must not — that is where real Aerospike clusters live, and blocking it would break every genuine deployment.

**Both previous names are still honoured** (`ACM_ALLOW_PRIVATE_TARGETS`, `ACM_CONNECTION_TEST_ALLOW_PRIVATE`), with a test for each. Renaming a security knob must not silently re-close a gate someone deliberately opened; that failure mode is worse than the misleading name. `.env.example` documents the new name, the two superseded ones, and — explicitly — that private ranges are *not* blocked and why.

## Verification

**The new tests fail on merged `main` and pass here.** Reverting just the two source files:

```
$ git checkout main -- target_policy.py routers/connections.py
$ uv run pytest tests/test_target_policy.py::TestAlternativeIpLiteralForms -q -p no:randomly
FAILED ...test_shorthand_and_numeric_forms_are_blocked[127.1-127.0.0.1]
FAILED ...test_shorthand_and_numeric_forms_are_blocked[127.0.1-127.0.0.1]
FAILED ...test_shorthand_and_numeric_forms_are_blocked[2130706433-127.0.0.1]
FAILED ...test_shorthand_and_numeric_forms_are_blocked[0x7f000001-127.0.0.1]
FAILED ...test_shorthand_and_numeric_forms_are_blocked[0177.0.0.1-127.0.0.1]
FAILED ...test_shorthand_and_numeric_forms_are_blocked[2852039166-169.254.169.254]
FAILED ...test_unspecified_is_blocked[0.0.0.0]
FAILED ...test_unspecified_is_blocked[::]
FAILED ...test_unspecified_is_blocked[[::]]
FAILED ...test_numeric_forms_reach_assert_targets_allowed
10 failed, 13 passed in 0.03s
```

The 13 already passing are the "must still be allowed" and IPv4-mapped cases — there so the fix cannot buy its win by over-blocking.

Direct probe of the full matrix with the fix in place:

```
MUST BLOCK:                          MUST ALLOW:
  blocked   127.0.0.1                  ok  10.0.0.1
  blocked   127.1                      ok  192.168.1.10
  blocked   2130706433                 ok  172.16.0.5
  blocked   0x7f000001                 ok  203.0.113.5
  blocked   0177.0.0.1                 ok  2001:db8::1
  blocked   0.0.0.0                    ok  aerospike-node-1
  blocked   ::                         ok  example.com
  blocked   [::]                       ok  aerospike.default.svc.cluster.local
  blocked   169.254.169.254
  blocked   2852039166
  blocked   ::ffff:127.0.0.1
  blocked   fe80::1
  blocked   ::1
```

Full CI commands:

```
$ cd api && uv run ruff check src/            All checks passed!
$ uv run ruff format --check src/             (clean)
$ uv run pytest tests/                        1242 passed, 6 warnings in 14.88s
$ uv run pytest tests/test_target_policy.py   36 passed
```

`1216` on `main` (verified at `e0e2497`) → **+26**.

> **Correction:** an earlier revision of this body cited `1227` as the `main` baseline. That was the count on my `feat/165` branch, which carries 11 extra tests from `tests/test_export_openapi.py` — `main` itself is 1216. The absolute pass count and every other claim were right; only the delta arithmetic was wrong. Run twice under different `pytest-randomly` seeds. `pre-commit run --all-files`: all 14 hooks Passed. `make generate-types` produces no diff.

### Not verified here

- **No live Aerospike cluster and no real IMDS endpoint.** The alias table above is verified against `socket.inet_aton` in this environment; I did not confirm that the Aerospike client's own resolution path accepts each form identically. If it accepts *fewer*, this over-blocks slightly (harmless — those forms have no legitimate use in a config file). If it accepts *more*, there may be forms still missing, and I have no way to enumerate them without the client's resolver.
- **`inet_aton` is glibc/BSD-historical behaviour**; the table was checked on macOS. Linux is the deployment target and shares these semantics, but I did not run it there.
- **IPv6 has no `inet_aton` equivalent applied.** `ipaddress` handles IPv6 forms (including compressed and mapped) correctly, so I did not add a fallback — but that is reasoning, not a test against a resolver.

