### PR TITLE
fix(security): apply the workspace ACL to the SSE stream

### DIFF
--- a/api/src/aerospike_cluster_manager_api/events/collector.py
+++ b/api/src/aerospike_cluster_manager_api/events/collector.py
@@ -19,6 +19,7 @@ from aerospike_cluster_manager_api import config, db
 from aerospike_cluster_manager_api.client_manager import client_manager
 from aerospike_cluster_manager_api.events.broker import broker
 from aerospike_cluster_manager_api.services.metrics_service import build_cluster_metrics
+from aerospike_cluster_manager_api.workspace_acl import cr_workspace_id
 
 logger = logging.getLogger(__name__)
 _tracer = trace.get_tracer("aerospike_cluster_manager_api.events.collector")
@@ -201,6 +202,18 @@ class EventCollector:
                     if not ns or not name:
                         logger.debug("Skipping cluster with missing metadata.namespace/name: %r", metadata)
                         continue
+                    # Stamp the CR's workspace onto every event this cluster
+                    # produces, so the per-subscriber filter in
+                    # ``routers/events`` can decide delivery without a K8s
+                    # round trip per subscriber per event. ``k8s.cluster.events``
+                    # and ``.health`` carry no labels of their own, so
+                    # attribution has to happen here, where the CR is in hand.
+                    #
+                    # ``workspaceId`` rides on the envelope, not inside
+                    # ``data``: ``_event_generator`` serialises only
+                    # event/data/id, so it never reaches the wire.
+                    workspace_id = cr_workspace_id(cluster)
+
                     try:
                         detail = await k8s_client.get_cluster(ns, name)
                         await broker.publish(
@@ -209,6 +222,7 @@ class EventCollector:
                                 "data": detail if isinstance(detail, dict) else detail.model_dump(),
                                 "id": f"k8s-detail-{ns}-{name}-{int(time.time() * 1000)}",
                                 "timestamp": int(time.time() * 1000),
+                                "workspaceId": workspace_id,
                             }
                         )
                     except Exception:
@@ -223,6 +237,7 @@ class EventCollector:
                                 "data": {"namespace": ns, "name": name, "events": events},
                                 "id": f"k8s-events-{ns}-{name}-{int(time.time() * 1000)}",
                                 "timestamp": int(time.time() * 1000),
+                                "workspaceId": workspace_id,
                             }
                         )
                     except Exception:
@@ -239,6 +254,7 @@ class EventCollector:
                                 "data": {"namespace": ns, "name": name, "health": health},
                                 "id": f"k8s-health-{ns}-{name}-{int(time.time() * 1000)}",
                                 "timestamp": int(time.time() * 1000),
+                                "workspaceId": workspace_id,
                             }
                         )
                     except Exception:

--- a/api/src/aerospike_cluster_manager_api/routers/events.py
+++ b/api/src/aerospike_cluster_manager_api/routers/events.py
@@ -24,9 +24,11 @@ from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
 
 from aerospike_cluster_manager_api import config
+from aerospike_cluster_manager_api.dependencies import _resolve_caller_owner_id
 from aerospike_cluster_manager_api.events.broker import broker
 from aerospike_cluster_manager_api.events.tickets import TicketCapacityError, ticket_store
 from aerospike_cluster_manager_api.rate_limit import limiter
+from aerospike_cluster_manager_api.workspace_acl import is_cr_visible
 
 logger = logging.getLogger(__name__)
 
@@ -40,15 +42,47 @@ class SSETicketResponse(BaseModel):
     expires_in: int
 
 
+# Event families that carry per-tenant Kubernetes objects and therefore need
+# the same workspace ACL the REST routes apply. Matched by prefix so a new
+# ``k8s.cluster.<something>`` event is filtered by default rather than
+# shipping unfiltered until someone notices — which is how #496 happened.
+_OWNER_SCOPED_EVENT_PREFIX = "k8s.cluster."
+
+
+async def _is_event_visible(event: dict, caller_owner_id: str) -> bool:
+    """Return True iff this event may be delivered to ``caller_owner_id``.
+
+    Non-K8s events (``cluster.metrics``, ``connection.health``) are unchanged.
+    They are scoped by connection rather than workspace, and are separately
+    gated off by default via ``CM_SSE_BROADCAST_PER_CONNECTION`` for the same
+    tenant-isolation reason — out of scope here, still open.
+
+    ``k8s.cluster.*`` events carry the CR's workspace on the envelope, stamped
+    by the collector. ``strict=True``: this channel has never had a filter, so
+    there is no legacy behaviour to preserve and it fails closed. An event
+    published without attribution is treated as unlabelled — visible to the
+    system caller only.
+    """
+    if not str(event.get("event", "")).startswith(_OWNER_SCOPED_EVENT_PREFIX):
+        return True
+    return await is_cr_visible(event.get("workspaceId"), caller_owner_id, strict=True)
+
+
 async def _event_generator(
     request: Request,
     subscriber_id: str,
     queue: asyncio.Queue,
+    caller_owner_id: str,
 ) -> AsyncGenerator[dict]:
     """Async generator that yields SSE-formatted dicts from the broker queue.
 
     Sends a ``:ping`` comment every ``SSE_HEARTBEAT_INTERVAL`` seconds to
     keep the connection alive through proxies.
+
+    Applies the workspace ACL per event (#496). The broker fans one event out
+    to every subscriber, so the filter has to live here, where the connection's
+    identity is: filtering in the broker would need a per-subscriber predicate,
+    and filtering in the collector cannot work at all because it has no caller.
     """
     heartbeat_interval = config.SSE_HEARTBEAT_INTERVAL
     try:
@@ -57,6 +91,10 @@ async def _event_generator(
                 break
             try:
                 event = await asyncio.wait_for(queue.get(), timeout=heartbeat_interval)
+                if not await _is_event_visible(event, caller_owner_id):
+                    # Dropped, not errored: the subscriber simply never learns
+                    # this object exists, matching the REST identity-404.
+                    continue
                 yield {
                     "event": event.get("event", "message"),
                     "data": json.dumps(event.get("data", {})),
@@ -123,13 +161,19 @@ async def event_stream(
     if types:
         event_types = {t.strip() for t in types.split(",") if t.strip()}
 
+    # The identity was already in hand and unused: OIDCAuthMiddleware redeems
+    # the ticket and populates ``request.state.user_claims`` before this runs.
+    # Resolved with the same helper every REST route uses, so the stream and
+    # the pull path agree on who the caller is.
+    caller_owner_id = _resolve_caller_owner_id(request)
+
     try:
         subscriber_id, queue = await broker.subscribe(event_types)
     except ConnectionError:
         return JSONResponse(status_code=429, content={"detail": "Too many SSE connections"})
 
     return EventSourceResponse(
-        _event_generator(request, subscriber_id, queue),
+        _event_generator(request, subscriber_id, queue, caller_owner_id),
         headers={
             "Cache-Control": "no-cache",
             "X-Accel-Buffering": "no",

--- a/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
+++ b/api/src/aerospike_cluster_manager_api/routers/k8s_clusters.py
@@ -69,6 +69,11 @@ from aerospike_cluster_manager_api.services.k8s_service import (
     extract_template_summary,
     has_update_fields,
 )
+from aerospike_cluster_manager_api.workspace_acl import (
+    WORKSPACE_LABEL,
+    cr_workspace_id,
+    is_workspace_visible,
+)
 
 logger = logging.getLogger(__name__)
 _tracer = trace.get_tracer("aerospike_cluster_manager_api.routers.k8s_clusters")
@@ -79,42 +84,14 @@ def _require_k8s() -> None:
         raise HTTPException(status_code=404, detail="Kubernetes management is not enabled")
 
 
-_WORKSPACE_LABEL = "acm.aerospike.com/workspace"
-
-
-def _cr_workspace_id(item: dict[str, Any]) -> str | None:
-    """Return the workspace id stamped on a CR's metadata labels, if any.
-
-    CRs without the workspace label are treated as system-shared — the
-    same rule the connection-profile ACL applies for ``SYSTEM_OWNER_ID``.
-    Returning ``None`` lets the caller decide whether to gate (mutations
-    require an owned workspace, reads with no label show to everyone).
-    """
-    labels = item.get("metadata", {}).get("labels") or {}
-    raw = labels.get(_WORKSPACE_LABEL)
-    return raw if isinstance(raw, str) and raw else None
-
-
-async def _is_workspace_visible(workspace_id: str, caller_owner_id: str) -> bool:
-    """Return True iff the caller can see ``workspace_id``.
-
-    Visibility = ``ownerId == caller`` OR ``ownerId == SYSTEM_OWNER_ID``.
-    Missing rows are invisible. Mirrors the rule used by
-    :func:`dependencies._get_verified_connection` for connection
-    profiles, so K8s and connection ACLs stay in lock-step.
-
-    When the workspace metaDB has not been initialised (unit-test paths
-    that exercise the K8s router in isolation), the check degrades to
-    permissive -- the same convention notes / records use to keep
-    legacy single-tenant fixtures green.
-    """
-    try:
-        ws = await db.get_workspace(workspace_id)
-    except db.DBNotInitialized:
-        return True
-    if ws is None:
-        return False
-    return ws.ownerId == caller_owner_id or ws.ownerId == SYSTEM_OWNER_ID
+# Re-exported under the module-private names this router has always used, so
+# the many call sites below stay unchanged. The definitions moved to
+# :mod:`workspace_acl` because this router was not the only consumer of the
+# rule: ``events/collector`` published the same CRs over SSE with no check at
+# all (#496). A second copy of an ACL predicate is how that happens again.
+_WORKSPACE_LABEL = WORKSPACE_LABEL
+_cr_workspace_id = cr_workspace_id
+_is_workspace_visible = is_workspace_visible
 
 
 async def _assert_caller_owns_k8s_cluster(

--- a/api/src/aerospike_cluster_manager_api/workspace_acl.py
+++ b/api/src/aerospike_cluster_manager_api/workspace_acl.py
@@ -1,0 +1,98 @@
+"""Workspace visibility — the one rule, in one place.
+
+This module exists because the rule had two consumers and only one gate.
+``routers/k8s_clusters.py`` enforced it on all 24 ``{name}`` routes and on the
+list filter; ``events/collector.py`` published the same objects over SSE with
+no check at all, so a tenant received unasked the very CRs that 404 for them
+on REST (#496).
+
+Duplicating an ACL predicate in the second consumer would have set up the same
+failure again, one refactor later. Both consumers now import from here.
+
+The rule, unchanged from the REST gate:
+
+* a **labelled** CR is visible to the owner of its workspace, and to everyone
+  when that workspace is system-owned (``ws-default``);
+* an **unlabelled** CR is visible only to :data:`SYSTEM_OWNER_ID` — ACM stamps
+  a label on every cluster it creates, so unlabelled means "ACM did not create
+  this" (see #471).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from aerospike_cluster_manager_api import db
+from aerospike_cluster_manager_api.models.workspace import SYSTEM_OWNER_ID
+
+logger = logging.getLogger(__name__)
+
+WORKSPACE_LABEL = "acm.aerospike.com/workspace"
+
+__all__ = [
+    "WORKSPACE_LABEL",
+    "cr_workspace_id",
+    "is_cr_visible",
+    "is_workspace_visible",
+]
+
+
+def cr_workspace_id(item: dict[str, Any]) -> str | None:
+    """Return the workspace id stamped on a CR's metadata labels, if any."""
+    labels = (item.get("metadata", {}) or {}).get("labels") or {}
+    raw = labels.get(WORKSPACE_LABEL)
+    return raw if isinstance(raw, str) and raw else None
+
+
+async def is_workspace_visible(workspace_id: str, caller_owner_id: str) -> bool:
+    """Return True iff ``caller_owner_id`` can see ``workspace_id``.
+
+    Visibility = ``ownerId == caller`` OR ``ownerId == SYSTEM_OWNER_ID``.
+    Missing rows are invisible.
+
+    When the workspace metaDB has not been initialised, this degrades to
+    **permissive**. That is a permissive branch inside a default-deny gate and
+    it is deliberate, not an oversight: unit-test paths exercise the K8s router
+    without a workspace DB, and the same convention is used by notes and
+    records. No production path reaches it — ``db.init_db()`` runs in the
+    lifespan before any route is served. Callers that must fail closed
+    regardless should use :func:`is_cr_visible` with ``strict=True``.
+    """
+    try:
+        ws = await db.get_workspace(workspace_id)
+    except db.DBNotInitialized:
+        return True
+    if ws is None:
+        return False
+    return ws.ownerId == caller_owner_id or ws.ownerId == SYSTEM_OWNER_ID
+
+
+async def is_cr_visible(
+    workspace_id: str | None,
+    caller_owner_id: str,
+    *,
+    strict: bool = False,
+) -> bool:
+    """Return True iff a CR carrying ``workspace_id`` is visible to the caller.
+
+    ``workspace_id=None`` (an unlabelled CR) is visible only to the system
+    caller — anything applied with ``kubectl`` or by another team carries no
+    ACM label, and those must not reach a tenant (#471).
+
+    ``strict=True`` also denies when the workspace metaDB is unavailable. The
+    SSE path uses it: there is no legacy behaviour to preserve on a push
+    channel that has never had a filter, so it fails closed.
+    """
+    if workspace_id is None:
+        return caller_owner_id == SYSTEM_OWNER_ID
+    if not strict:
+        return await is_workspace_visible(workspace_id, caller_owner_id)
+    try:
+        ws = await db.get_workspace(workspace_id)
+    except db.DBNotInitialized:
+        logger.warning("Workspace DB unavailable; denying SSE delivery for workspace %s", workspace_id)
+        return False
+    if ws is None:
+        return False
+    return ws.ownerId == caller_owner_id or ws.ownerId == SYSTEM_OWNER_ID

--- a/api/tests/test_sse_workspace_filter.py
+++ b/api/tests/test_sse_workspace_filter.py
@@ -1,0 +1,188 @@
+"""The SSE stream applies the same workspace ACL as the REST routes (#496).
+
+#471 / PR #483 closed the pull path: all 24 ``{name}`` routes in
+``routers/k8s_clusters`` gate on the workspace label, and the list filter fails
+closed. The push path had no filter at all — ``events/collector`` published the
+full CR of every cluster and ``routers/events`` fanned it to every subscriber,
+so a tenant received unasked exactly the objects that 404 for them on REST.
+
+The lesson these tests encode: a gate is only as good as its *least* guarded
+consumer. ``workspace_acl`` now holds the single rule and both consumers import
+it, so a third consumer cannot quietly reintroduce this.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from aerospike_cluster_manager_api.models.workspace import SYSTEM_OWNER_ID
+from aerospike_cluster_manager_api.routers.events import _is_event_visible
+
+TENANT = "user-tenant-a"
+
+
+def _k8s_event(kind: str = "detail", workspace_id: str | None = None) -> dict:
+    """An envelope shaped like what ``EventCollector._publish_k8s`` emits."""
+    return {
+        "event": f"k8s.cluster.{kind}",
+        "data": {"metadata": {"name": "demo", "namespace": "aerospike"}},
+        "id": f"k8s-{kind}-aerospike-demo-1",
+        "timestamp": 1,
+        "workspaceId": workspace_id,
+    }
+
+
+class TestUnlabelledClustersDoNotReachTenants:
+    """The exact bypass: what 404s on REST must not arrive over SSE."""
+
+    @pytest.mark.parametrize("kind", ["detail", "events", "health"])
+    async def test_tenant_does_not_receive_an_unlabelled_cluster(self, kind: str) -> None:
+        assert await _is_event_visible(_k8s_event(kind), TENANT) is False
+
+    @pytest.mark.parametrize("kind", ["detail", "events", "health"])
+    async def test_system_caller_still_receives_it(self, kind: str) -> None:
+        # Same rule as the REST gate: unlabelled means "ACM did not create
+        # this", visible to the system caller only.
+        assert await _is_event_visible(_k8s_event(kind), SYSTEM_OWNER_ID) is True
+
+    async def test_all_three_event_families_are_covered(self) -> None:
+        """``events`` and ``health`` carry no labels of their own.
+
+        Their payloads are ``{namespace, name, ...}`` — attribution has to be
+        stamped by the collector, where the CR is in hand. If it were not, they
+        would be the two families that slipped through.
+        """
+        for kind in ("detail", "events", "health"):
+            assert await _is_event_visible(_k8s_event(kind), TENANT) is False
+
+
+class TestLabelledClusterVisibility:
+    async def test_owner_receives_their_own_workspace(self) -> None:
+        with patch(
+            "aerospike_cluster_manager_api.workspace_acl.db.get_workspace",
+            AsyncMock(return_value=type("W", (), {"ownerId": TENANT})()),
+        ):
+            assert await _is_event_visible(_k8s_event(workspace_id="ws-a"), TENANT) is True
+
+    async def test_other_tenant_does_not(self) -> None:
+        with patch(
+            "aerospike_cluster_manager_api.workspace_acl.db.get_workspace",
+            AsyncMock(return_value=type("W", (), {"ownerId": "user-tenant-b"})()),
+        ):
+            assert await _is_event_visible(_k8s_event(workspace_id="ws-b"), TENANT) is False
+
+    async def test_system_owned_workspace_is_shared(self) -> None:
+        with patch(
+            "aerospike_cluster_manager_api.workspace_acl.db.get_workspace",
+            AsyncMock(return_value=type("W", (), {"ownerId": SYSTEM_OWNER_ID})()),
+        ):
+            assert await _is_event_visible(_k8s_event(workspace_id="ws-default"), TENANT) is True
+
+    async def test_deleted_workspace_is_invisible(self) -> None:
+        with patch(
+            "aerospike_cluster_manager_api.workspace_acl.db.get_workspace",
+            AsyncMock(return_value=None),
+        ):
+            assert await _is_event_visible(_k8s_event(workspace_id="ws-gone"), TENANT) is False
+
+
+class TestFailsClosed:
+    async def test_unavailable_workspace_db_denies_delivery(self) -> None:
+        """``strict=True`` on the SSE path.
+
+        The REST gate degrades permissive on ``DBNotInitialized`` to keep
+        legacy unit-test fixtures green. This channel has never had a filter,
+        so there is no legacy behaviour to preserve and it fails closed.
+        """
+        from aerospike_cluster_manager_api import db
+
+        with patch(
+            "aerospike_cluster_manager_api.workspace_acl.db.get_workspace",
+            AsyncMock(side_effect=db.DBNotInitialized("not initialised")),
+        ):
+            assert await _is_event_visible(_k8s_event(workspace_id="ws-a"), TENANT) is False
+
+    async def test_event_published_without_attribution_is_denied(self) -> None:
+        """A future publisher that forgets to stamp workspaceId fails safe."""
+        event = _k8s_event()
+        del event["workspaceId"]
+        assert await _is_event_visible(event, TENANT) is False
+
+    async def test_a_new_k8s_cluster_event_family_is_filtered_by_default(self) -> None:
+        """Prefix matching, not an allowlist of known suffixes.
+
+        A new ``k8s.cluster.<something>`` event is filtered the moment it
+        exists, rather than shipping unfiltered until someone notices — which
+        is how this bug arose.
+        """
+        assert await _is_event_visible(_k8s_event("somethingNew"), TENANT) is False
+
+
+class TestNonK8sEventsAreUnchanged:
+    @pytest.mark.parametrize("name", ["cluster.metrics", "connection.health", "message"])
+    async def test_passed_through(self, name: str) -> None:
+        # These are scoped by connection rather than workspace, and are gated
+        # off by default via CM_SSE_BROADCAST_PER_CONNECTION for their own
+        # tenant-isolation reason. Out of scope here — not silently "fixed".
+        assert await _is_event_visible({"event": name, "data": {}}, TENANT) is True
+
+
+class TestCollectorStampsAttribution:
+    """The filter is only as good as the attribution it reads."""
+
+    async def test_publishes_workspace_id_on_every_k8s_event(self) -> None:
+        from aerospike_cluster_manager_api.events.collector import EventCollector
+
+        cr = {
+            "metadata": {
+                "name": "demo",
+                "namespace": "aerospike",
+                "labels": {"acm.aerospike.com/workspace": "ws-a"},
+            }
+        }
+        published: list[dict] = []
+
+        with (
+            patch("aerospike_cluster_manager_api.config.CM_SSE_BROADCAST_PER_CONNECTION", True),
+            # subscriber_count is a read-only property on EventBroker, so
+            # patch the underlying registry rather than the property.
+            patch.dict(
+                "aerospike_cluster_manager_api.events.collector.broker._subscribers",
+                {"sub-1": (None, None)},
+            ),
+            patch(
+                "aerospike_cluster_manager_api.events.collector.broker.publish",
+                AsyncMock(side_effect=lambda e: published.append(e)),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.k8s_client.k8s_client.list_clusters",
+                AsyncMock(return_value=([cr], None)),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.k8s_client.k8s_client.get_cluster",
+                AsyncMock(return_value=cr),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.k8s_client.k8s_client.list_events",
+                AsyncMock(return_value=[]),
+            ),
+        ):
+            await EventCollector()._publish_k8s()
+
+        assert published, "collector published nothing"
+        kinds = {e["event"] for e in published}
+        assert kinds == {"k8s.cluster.detail", "k8s.cluster.events", "k8s.cluster.health"}
+        # Every one of them, not just the detail event that carries the CR.
+        assert all(e.get("workspaceId") == "ws-a" for e in published), published
+
+    async def test_workspace_id_never_reaches_the_wire(self) -> None:
+        """It rides on the envelope, which the generator does not serialise."""
+        import inspect
+
+        from aerospike_cluster_manager_api.routers import events as events_mod
+
+        source = inspect.getsource(events_mod._event_generator)
+        yielded = source[source.index("yield {") :]
+        assert "workspaceId" not in yielded


### PR DESCRIPTION
Closes #496

## The shape of the bug

#471 / PR #483 closed the pull path. All 24 `{name}` routes in `routers/k8s_clusters.py` call `_assert_caller_owns_k8s_cluster`, and the list filter fails closed. The audit's finding was that **it was not the only consumer**: `events/collector.py` published the same CRs over SSE with no check, so tenant isolation held on REST and was absent on the stream.

Reproduced against merged `main` — one `kubectl`-applied cluster (no ACM label, so it 404s for every tenant on REST):

```
======================= BEFORE (merged main) =======================
collector published 3 events for a kubectl-applied CR
  k8s.cluster.detail     workspaceId='<ABSENT>'
  k8s.cluster.events     workspaceId='<ABSENT>'
  k8s.cluster.health     workspaceId='<ABSENT>'

routers/events._is_event_visible exists: False
_event_generator params: ['request', 'subscriber_id', 'queue']
  no filter — every event above is delivered to every subscriber
```

```
======================= AFTER (this branch) =======================
collector published 3 events for a kubectl-applied CR
  k8s.cluster.detail     workspaceId=None
  k8s.cluster.events     workspaceId=None
  k8s.cluster.health     workspaceId=None

routers/events._is_event_visible exists: True
_event_generator params: ['request', 'subscriber_id', 'queue', 'caller_owner_id']
  tenant receives k8s.cluster.detail     -> False
  tenant receives k8s.cluster.events     -> False
  tenant receives k8s.cluster.health     -> False
```

## What changed

**1. The rule lives in one place.** New `workspace_acl.py`, imported by both consumers. Copying the predicate into `routers/events` would have rebuilt the exact condition that produced this bug — two consumers, one gate — a refactor later. `routers/k8s_clusters` keeps `_cr_workspace_id` / `_is_workspace_visible` as aliases, so its many call sites are untouched and the diff there is a deletion plus three assignments.

**2. The collector stamps attribution.** All three `k8s.cluster.*` events now carry `workspaceId`.

This is the part worth reviewing closely: `k8s.cluster.events` and `k8s.cluster.health` carry **no label of their own** — their payloads are `{namespace, name, events}` and `{namespace, name, health}`. Filtering them would otherwise need a K8s round trip per event per subscriber. Stamping at publish time, where the CR is already in hand, makes the filter a dict lookup. `workspaceId` rides on the envelope, not inside `data`, and `_event_generator` serialises only `event`/`data`/`id`/`retry` — so it never reaches the wire. There is a test asserting that by inspecting the generator's `yield`.

**3. The generator filters per subscriber.** The identity was already there and unused, exactly as the issue said: the middleware redeems the ticket into `request.state.user_claims`, and the stream now resolves it with the same `_resolve_caller_owner_id` every REST route uses — so the two paths cannot disagree about who the caller is.

Per-subscriber is the only workable layer. The broker fans one event to many queues, so it would need a per-subscriber predicate; the collector has no caller at all. The generator is where the connection's identity lives.

**Fails closed, three ways:**
- Matching is by `k8s.cluster.` **prefix**, so a future `k8s.cluster.<something>` is filtered the moment it exists rather than shipping unfiltered until someone notices — which is how this arose.
- An event published *without* `workspaceId` is treated as unlabelled → system caller only. A future publisher that forgets to stamp fails safe.
- `strict=True` on this path: an unavailable workspace DB **denies** delivery.

## On the related `DBNotInitialized` finding

The issue flagged that `_is_workspace_visible` returns `True` on `db.DBNotInitialized` — a permissive branch inside a default-deny gate, "posture rather than a live bug".

I did **not** flip it for the REST gate. Unit-test paths exercise the K8s router without a workspace DB and rely on it, and no production path reaches it (`db.init_db()` runs in the lifespan before any route is served). Flipping it would trade a documented, unreachable branch for a broad test-fixture change inside a security PR.

What I did instead: moved it into `workspace_acl` with the reasoning written down so it reads as a decision, and gave the new SSE path `strict=True`, which denies. The new channel fails closed; the old one keeps its documented behaviour.

## Verification

19 new tests in `api/tests/test_sse_workspace_filter.py`:

```
$ uv run pytest tests/test_sse_workspace_filter.py
19 passed in 0.19s
```

covering: all three event families denied to a tenant for an unlabelled CR; the system caller still receiving them; owner / other-tenant / system-owned-workspace / deleted-workspace for labelled CRs; the three fail-closed paths; non-K8s events passing through unchanged; the collector stamping all three events; and `workspaceId` not reaching the wire.

Full CI commands:

```
$ cd api && uv run ruff check src/            All checks passed!
$ uv run ruff format --check src/             (clean)
$ uv run pytest tests/                        1235 passed, 6 warnings in 16.06s
```

`1216` on `main` (verified at `e0e2497`) → **+19**. Run twice under different `pytest-randomly` seeds. `pre-commit run --all-files`: all 14 hooks Passed. `make generate-types` produces no diff.

### Not verified here

- **No live Kubernetes cluster and no real EventSource client.** The before/after above drives `_publish_k8s` and `_is_event_visible` directly with `k8s_client` mocked; nobody opened an actual SSE connection as two different tenants and compared what arrived. The end-to-end path (`ticket → middleware → claims → generator`) is exercised only in pieces.
- **`_event_generator` itself has no test.** The filter function it calls is well covered, and the wiring is one `if` plus one parameter, but the generator is an async loop over a queue with heartbeats and I did not build a harness for it.
- **The collector is off by default** (`CM_SSE_BROADCAST_PER_CONNECTION=false`, and after #494 it does not even start), so this bug was only reachable on a deployment that had opted in. That lowers the severity but not the correctness of the fix.
- **Payload size was not reduced.** The issue asked whether the stream needs the whole CR rather than name/namespace/phase/size. I left it: nothing consumes `k8s.cluster.*` today (no `ui/src` reference, no test), so trimming would be a change with no consumer to validate against, and the owner filter is what closes the leak. Worth its own issue if the payload is ever wired to a UI.
