### PR TITLE
docs: record that CM_SSE_BROADCAST_PER_CONNECTION is still single-tenant-only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,6 +138,13 @@ K8S_MANAGEMENT_ENABLED=false
 # bodies are gated on this flag, so the loops could only idle (#474). The SSE
 # endpoint still accepts subscribers and sends heartbeats. The UI polls
 # /clusters/{id} every 5s regardless, so the overview stays live either way.
+#
+# SINGLE-TENANT ONLY -- still true after #511. That change ACL'd the
+# k8s.cluster.detail/.events/.health families per subscriber, but
+# cluster.metrics and connection.health are published with no owner
+# attribution and are broadcast to EVERY subscriber unfiltered. One switch
+# covers all three loops, so you cannot enable live K8s events without also
+# enabling the two un-ACL'd families. See #496.
 # CM_SSE_BROADCAST_PER_CONNECTION=false
 
 # ─── Connection target SSRF gate ──────────────────────────────────────────

--- a/api/src/aerospike_cluster_manager_api/config.py
+++ b/api/src/aerospike_cluster_manager_api/config.py
@@ -127,11 +127,38 @@ SSE_TICKET_TTL_SECONDS: int = _get_int("SSE_TICKET_TTL_SECONDS", 30)
 SSE_TICKET_MAX_PENDING: int = _get_int("SSE_TICKET_MAX_PENDING", 1024)
 
 # CM_SSE_BROADCAST_PER_CONNECTION gates the per-connection broadcast loops in
-# ``events.collector`` (cluster.metrics, connection.health, k8s.cluster.*).
-# Default ``false`` because the broker has no per-subscriber owner filter --
-# emitting tenant-A connection metrics to tenant-B subscribers leaks data.
-# Operators of single-tenant deployments can opt back in by setting this to
-# true. Tracked as follow-up to ADR-0040 (per-subscriber filtering).
+# ``events.collector`` (cluster.metrics, connection.health, k8s.cluster.*), and
+# ``main.lifespan`` gates the collector's start on it too, so it is one switch
+# for all three loops.
+#
+# SINGLE-TENANT ONLY. Still true after #511, which added a workspace ACL to the
+# SSE stream — that fix covers ONE of the three event families:
+#
+#   ACL'd since #511 | k8s.cluster.detail / .events / .health
+#                    |   The collector stamps each with the CR's ``workspaceId``
+#                    |   and ``routers.events._is_event_visible`` drops the ones
+#                    |   the subscriber cannot see.
+#   NOT ACL'd        | cluster.metrics, connection.health
+#                    |   Published with no ``workspaceId`` at all, so there is
+#                    |   nothing to filter on. Every subscriber receives every
+#                    |   connection's metrics and health.
+#
+# That asymmetry is why ``_is_event_visible`` short-circuits on the
+# ``k8s.cluster.`` prefix rather than filtering everything on ``workspaceId``:
+# filtering the other two on a field they do not carry would drop them
+# entirely, not secure them.
+#
+# The practical consequence, and the reason this note exists: a multi-tenant
+# operator who wants live K8s cluster events has no way to get them without
+# also re-enabling un-ACL'd ``cluster.metrics`` and ``connection.health``. The
+# switch is binary. "The SSE workspace ACL landed" is exactly the kind of news
+# that invites the conclusion that the whole channel is now tenant-safe; only
+# the K8s half is.
+#
+# Default ``false`` for that reason -- emitting tenant-A connection metrics to
+# tenant-B subscribers leaks data. Splitting the flag per event family, or
+# giving the broker a per-subscriber owner filter, is the ADR-0040 follow-up
+# that would make this safe to enable on a multi-tenant deployment. See #496.
 CM_SSE_BROADCAST_PER_CONNECTION: bool = os.getenv("CM_SSE_BROADCAST_PER_CONNECTION", "false").lower() in (
     "true",
     "1",

--- a/api/src/aerospike_cluster_manager_api/main.py
+++ b/api/src/aerospike_cluster_manager_api/main.py
@@ -90,10 +90,12 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
     # Both flags, not just SSE_ENABLED (#474). Every publish body in
     # ``events.collector`` returns on its first statement when
     # CM_SSE_BROADCAST_PER_CONNECTION is off — which is the default, because
-    # the broker has no per-subscriber owner filter. Starting anyway gave
-    # three tasks waking on 2s / 30s / 5s timers forever to do nothing. Skip
-    # them and log why, so an operator who expected live events finds the
-    # reason instead of silence.
+    # ``cluster.metrics`` and ``connection.health`` carry no owner attribution
+    # and so cannot be filtered per subscriber. (#511 added that filter for
+    # ``k8s.cluster.*`` only; see the flag's definition in ``config`` for the
+    # full split.) Starting anyway gave three tasks waking on 2s / 30s / 5s
+    # timers forever to do nothing. Skip them and log why, so an operator who
+    # expected live events finds the reason instead of silence.
     broker.max_connections = config.SSE_MAX_CONNECTIONS
     collector_started = config.SSE_ENABLED and config.CM_SSE_BROADCAST_PER_CONNECTION
     if collector_started:
@@ -104,7 +106,8 @@ async def lifespan(_app: FastAPI) -> AsyncIterator[None]:
             "its publish bodies are gated on that flag, so the loops could only idle. "
             "The SSE endpoint still accepts subscribers (heartbeats only). "
             "The UI polls /clusters/{id} for live metrics; set "
-            "CM_SSE_BROADCAST_PER_CONNECTION=true on a single-tenant deployment to push instead."
+            "CM_SSE_BROADCAST_PER_CONNECTION=true on a SINGLE-TENANT deployment to push instead "
+            "— cluster.metrics and connection.health are broadcast to every subscriber unfiltered."
         )
 
     yield


### PR DESCRIPTION
References #496 — no closing keyword, nothing to close.

## Why

#511 gave the SSE stream a workspace ACL. "The SSE workspace ACL landed" is exactly the kind of news that invites the conclusion that the whole channel is now tenant-safe. **Only the K8s half is.**

| | families | mechanism |
|---|---|---|
| **ACL'd since #511** | `k8s.cluster.detail` / `.events` / `.health` | the collector stamps each with the CR's `workspaceId`; `routers.events._is_event_visible` drops what the subscriber cannot see |
| **NOT ACL'd** | `cluster.metrics`, `connection.health` | published with **no** `workspaceId` at all — there is nothing to filter on |

Verified rather than recalled:

```
$ grep -n '"event":\|workspaceId' api/src/aerospike_cluster_manager_api/events/collector.py
 88:  "event": "cluster.metrics",          <- no workspaceId
138:  "event": "connection.health",        <- no workspaceId
154:  "event": "connection.health",        <- no workspaceId
221:  "event": "k8s.cluster.detail",
225:  "workspaceId": workspace_id,
236:  "event": "k8s.cluster.events",
240:  "workspaceId": workspace_id,
253:  "event": "k8s.cluster.health",
257:  "workspaceId": workspace_id,
```

That asymmetry is *why* `_is_event_visible` short-circuits on the `k8s.cluster.` prefix rather than filtering everything on `workspaceId`. Filtering the other two on a field they do not carry would drop them entirely, not secure them — a detail worth recording next to the flag, because it looks like an omission otherwise.

The consequence: all three collect loops share this one flag, and `main.lifespan` gates the collector's start on it, so **the switch is binary**. A multi-tenant operator who wants live K8s cluster events has no way to get them without also re-enabling un-ACL'd `cluster.metrics` and `connection.health`.

## Three places, not one

You asked for a line at the flag's definition. I changed three, because the same sentence appeared in each and **#511 made it inaccurate**:

- **`config.py`** — the flag definition. Its "the broker has no per-subscriber owner filter" is no longer true: there is one now, for `k8s.cluster.*`. Left as-is it reads as either "nothing is filtered" (wrong, and the thing you want corrected) or "this comment is stale, ignore it" (which invites deleting a warning that still applies).
- **`main.py`** — carried the identical stale claim at `lifespan`, *and* owns the startup log line an operator actually reads. That line said "set `CM_SSE_BROADCAST_PER_CONNECTION=true` on a single-tenant deployment"; it now names what stays unfiltered when they do.
- **`.env.example`** — where an operator actually sets the flag. A warning that lives only in `config.py` is one an operator editing `.env` never sees.

Also recorded that splitting the flag per event family, or giving the broker a per-subscriber owner filter, is the ADR-0040 follow-up that would make this safe on a multi-tenant deployment — so the note points at the fix, not just the hazard.

## Verification

Comments plus one log string; no behaviour change.

```
$ cd api && uv run ruff check src/            All checks passed!
$ uv run ruff format --check src/             86 files already formatted
$ uv run pytest tests/                        1273 passed, 6 warnings
```

`main` at `5abb161` is **1273** — measured on this branch with the change stashed, so the "unchanged" claim is a comparison, not an assumption.

`test_collector_startup_gate::test_explains_itself_in_the_log` asserts against the log line I edited (`"CM_SSE_BROADCAST_PER_CONNECTION"` and `"NOT started"` both still present) — that it still passes is the check that the edit did not break the startup message's contract.

`make generate-types` produces no diff. `pre-commit run --all-files`: all 14 hooks Passed.

### Not verified here

- Nothing was run against a live cluster or a real SSE subscriber; this documents behaviour established by #511 and #494 rather than changing it.
- The claim that `cluster.metrics` / `connection.health` reach every subscriber unfiltered is read from the collector's publish sites and `_is_event_visible`'s prefix check (both quoted above), not demonstrated by connecting two tenants to a running stream.
