### PR TITLE
fix(security): block alternative IP literal forms in the SSRF target gate

### DIFF
--- a/api/src/aerospike_cluster_manager_api/target_policy.py
+++ b/api/src/aerospike_cluster_manager_api/target_policy.py
@@ -25,23 +25,27 @@ from __future__ import annotations
 
 import ipaddress
 import os
+import socket
 
 from aerospike_cluster_manager_api.utils import parse_host_port
 
 __all__ = [
+    "ALLOW_LOOPBACK_TARGETS_ENV",
     "ALLOW_PRIVATE_TARGETS_ENV",
     "BlockedConnectionTargetError",
     "assert_targets_allowed",
     "is_blocked_target",
 ]
 
-# Preferred name. The gate governs the whole connection lifecycle now —
-# create, update, and every client build — not just ``POST /connections/test``,
-# so the original name understates it.
-ALLOW_PRIVATE_TARGETS_ENV = "ACM_ALLOW_PRIVATE_TARGETS"
+# Preferred name, and the one ``.env.example`` documents. What the gate denies
+# is loopback / link-local / unspecified — not "private" ranges, which it has
+# never blocked (10/8 and 192.168/16 targets are legitimate). The older names
+# invited the wrong threat model.
+ALLOW_LOOPBACK_TARGETS_ENV = "ACM_ALLOW_LOOPBACK_TARGETS"
 
-# The original name, still honoured so existing deployments keep working.
-# Either variable being truthy opens the gate.
+# Superseded names, still honoured so no deployment breaks on upgrade. Any of
+# the three being truthy opens the gate.
+ALLOW_PRIVATE_TARGETS_ENV = "ACM_ALLOW_PRIVATE_TARGETS"
 _LEGACY_ALLOW_PRIVATE_TARGETS_ENV = "ACM_CONNECTION_TEST_ALLOW_PRIVATE"
 
 _TRUTHY = {"1", "true", "yes", "on"}
@@ -76,18 +80,58 @@ def allow_private_targets() -> bool:
     loopback / link-local to keep the connection API from being repurposed
     as an internal port scanner or IMDS exfil channel.
     """
-    for name in (ALLOW_PRIVATE_TARGETS_ENV, _LEGACY_ALLOW_PRIVATE_TARGETS_ENV):
+    for name in (
+        ALLOW_LOOPBACK_TARGETS_ENV,
+        ALLOW_PRIVATE_TARGETS_ENV,
+        _LEGACY_ALLOW_PRIVATE_TARGETS_ENV,
+    ):
         if os.environ.get(name, "").strip().lower() in _TRUTHY:
             return True
     return False
 
 
+def _parse_ip_literal(candidate: str) -> ipaddress.IPv4Address | ipaddress.IPv6Address | None:
+    """Parse ``candidate`` the way the client's resolver will, or return None.
+
+    ``ipaddress.ip_address`` accepts only the canonical forms. ``getaddrinfo``,
+    which is what the Aerospike client actually dials through, additionally
+    accepts the historical ``inet_aton`` encodings — and each one is a working
+    alias for an address this gate is supposed to deny::
+
+        127.1        -> 127.0.0.1        (short form)
+        2130706433   -> 127.0.0.1        (decimal)
+        0x7f000001   -> 127.0.0.1        (hex)
+        2852039166   -> 169.254.169.254  (IMDS, decimal)
+
+    Treating a canonical-parse failure as "not a literal, let it through" made
+    every one of those a bypass. So fall back to ``socket.inet_aton`` and judge
+    the quad it yields. ``inet_aton`` still rejects anything that is not a
+    numeric address (``example.com``, ``1.2.3.4.5``, ``127.0.0.1x`` all raise),
+    so a real hostname is unaffected and the documented scope limit — hostnames
+    are not pre-resolved — is unchanged.
+    """
+    try:
+        return ipaddress.ip_address(candidate)
+    except ValueError:
+        pass
+    try:
+        return ipaddress.IPv4Address(socket.inet_aton(candidate))
+    except (OSError, ipaddress.AddressValueError):
+        return None
+
+
 def is_blocked_target(host: str) -> bool:
     """Return True iff ``host`` is a denied IP literal.
 
-    Blocks loopback (``127.0.0.0/8``, ``::1``) and link-local
-    (``169.254.0.0/16`` — includes the EC2 IMDS ``169.254.169.254``, and the
-    IPv6 ``fe80::/10`` equivalent).
+    Blocks loopback (``127.0.0.0/8``, ``::1``), link-local (``169.254.0.0/16``
+    — includes the EC2 IMDS ``169.254.169.254`` — and the IPv6 ``fe80::/10``
+    equivalent), and the unspecified address (``0.0.0.0``, ``::``), which most
+    stacks route to localhost.
+
+    Every alternative spelling of those addresses is denied too; see
+    :func:`_parse_ip_literal`. IPv4-mapped IPv6 (``::ffff:127.0.0.1``) needs no
+    special handling — :mod:`ipaddress` already reports the mapped address's
+    properties.
 
     Hostnames that are not bare IP literals are *not* blocked here; see the
     module docstring for why.
@@ -100,15 +144,12 @@ def is_blocked_target(host: str) -> bool:
     # IPv6 literals may arrive bracketed (`[::1]`); strip before parsing.
     if candidate.startswith("[") and candidate.endswith("]"):
         candidate = candidate[1:-1]
-    try:
-        ip = ipaddress.ip_address(candidate)
-    except ValueError:
-        # Not a bare IP literal -- let it through; DNS-based abuse is
+    ip = _parse_ip_literal(candidate)
+    if ip is None:
+        # Not a numeric address at all -- let it through; DNS-based abuse is
         # explicitly out of scope per the module docstring rationale.
         return False
-    if ip.is_loopback:
-        return True
-    return bool(ip.is_link_local)
+    return bool(ip.is_loopback or ip.is_link_local or ip.is_unspecified)
 
 
 def assert_targets_allowed(hosts: list[str], default_port: int) -> None:

--- a/api/tests/test_target_policy.py
+++ b/api/tests/test_target_policy.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import pytest
 
 from aerospike_cluster_manager_api.target_policy import (
+    ALLOW_LOOPBACK_TARGETS_ENV,
     BlockedConnectionTargetError,
     allow_private_targets,
     assert_targets_allowed,
@@ -49,6 +50,45 @@ class TestIsBlockedTarget:
     def test_allowed_targets(self, host: str) -> None:
         assert is_blocked_target(host) is False
 
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "127.1",  # inet_aton short form
+            "127.0.1",
+            "2130706433",  # decimal
+            "0x7f000001",  # hex
+            "0177.0.0.1",  # octal
+            "2852039166",  # decimal IMDS -- the sharpest of the set
+            "0.0.0.0",  # unspecified; most stacks route it to localhost
+            "::",
+            "::ffff:127.0.0.1",  # IPv4-mapped IPv6
+            "::ffff:169.254.169.254",
+        ],
+    )
+    def test_alternative_spellings_of_denied_addresses(self, host: str) -> None:
+        # `ipaddress.ip_address` accepts only the canonical forms, and treating a
+        # parse failure as "not a literal, let it through" made every one of
+        # these a working bypass of the gate -- `2852039166` reaches the cloud
+        # metadata service. `getaddrinfo`, which the client actually dials
+        # through, accepts them all.
+        assert is_blocked_target(host) is True
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "example.com",
+            "aerospike-node-1",
+            "1.2.3.4.5",  # too many octets: not an address at all
+            "127.0.0.1x",  # trailing garbage
+            "10.0.0.1",  # private, but never in scope -- see the module docstring
+        ],
+    )
+    def test_the_inet_aton_fallback_does_not_over_block(self, host: str) -> None:
+        # The fallback must widen the gate for numeric addresses only. A
+        # hostname that `inet_aton` refuses has to stay allowed, or the gate
+        # starts rejecting legitimate clusters.
+        assert is_blocked_target(host) is False
+
     def test_hostname_is_not_pre_resolved(self) -> None:
         # Documented scope limit: a hostname that resolves to loopback is NOT
         # blocked here. Re-checking after a resolve races with the client's own
@@ -80,6 +120,15 @@ class TestAllowPrivateTargetsOverride:
         monkeypatch.delenv("ACM_CONNECTION_TEST_ALLOW_PRIVATE", raising=False)
         assert allow_private_targets() is False
 
+    def test_documented_name_opens_the_gate(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # `.env.example` documents ACM_ALLOW_LOOPBACK_TARGETS as the name to
+        # set, and for a while nothing read it -- an operator who set it got
+        # silence. Pinned so the documented knob and the honoured knob cannot
+        # drift apart again.
+        monkeypatch.setenv(ALLOW_LOOPBACK_TARGETS_ENV, "true")
+        assert allow_private_targets() is True
+        assert is_blocked_target("2130706433") is False
+
     def test_legacy_name_still_opens_the_gate(self, monkeypatch: pytest.MonkeyPatch) -> None:
         # The original name predates the gate covering more than
         # test-connection. Deployments already setting it must keep working.
@@ -107,6 +156,13 @@ class TestAssertTargetsAllowed:
         ],
     )
     def test_port_suffixes_do_not_defeat_the_gate(self, entry: str) -> None:
+        with pytest.raises(BlockedConnectionTargetError):
+            assert_targets_allowed([entry], 3000)
+
+    @pytest.mark.parametrize("entry", ["2852039166", "2130706433:3000", "0x7f000001"])
+    def test_alternative_forms_are_rejected_at_the_list_gate(self, entry: str) -> None:
+        # The three call sites (create, update, every client build) all go
+        # through here, so this is the assertion that actually protects them.
         with pytest.raises(BlockedConnectionTargetError):
             assert_targets_allowed([entry], 3000)
 


### PR DESCRIPTION
## PR #510 merged with none of its code

Found while auditing whether the 34 issues closed on 2026-08-17/18 actually hold on `main`. This one does not — **#470 is closed, and the follow-up that was supposed to finish it landed empty.**

```
$ gh pr view 510 --json files,mergedAt --jq '.mergedAt, (.files[] | .path + "  +" + (.additions|tostring) + "/-" + (.deletions|tostring))'
2026-08-18T04:23:30Z
.env.example  +19/-8
```

Its commit message describes `_parse_ip_literal`, a `socket.inet_aton` fallback, `is_unspecified`, and an `ACM_ALLOW_LOOPBACK_TARGETS` rename. None of it is on main:

```
$ grep -rn "_parse_ip_literal\|inet_aton\|is_unspecified\|ACM_ALLOW_LOOPBACK_TARGETS" . | grep -v .venv/ | grep -v .git/
.env.example:174:# ACM_ALLOW_LOOPBACK_TARGETS=false
```

One hit, and it is documentation for a knob no code reads. Same shape as the orphaned commits on aerospike-py#441/#442 — the docs commit made the squash, the code commits did not.

## The hole, measured

`is_blocked_target` parsed with `ipaddress.ip_address` and treated a parse failure as *not a literal, let it through* (`target_policy.py:105-108`). `getaddrinfo` — what the Aerospike client actually dials through — also accepts the historical `inet_aton` encodings. Run on this machine against the old logic:

| host | blocked (before) | resolves to |
| --- | --- | --- |
| `127.0.0.1` | True | 127.0.0.1 |
| `169.254.169.254` | True | 169.254.169.254 |
| `127.1` | **False** | 127.0.0.1 |
| `127.0.1` | **False** | 127.0.0.1 |
| `2130706433` | **False** | 127.0.0.1 |
| `0x7f000001` | **False** | 127.0.0.1 |
| `2852039166` | **False** | **169.254.169.254** |
| `0.0.0.0` | **False** | 0.0.0.0 |
| `::` | **False** | :: |

`2852039166` is the sharp one — decimal IMDS. It walks `POST /connections` → `GET /connections/{id}/health` straight to the cloud metadata service, which is the scenario `target_policy.py`'s own module docstring opens with.

## The fix

All three changes are in the leaf module, so every call site inherits them — create (`connections_service.py:197`), update (`:247`), and every client build (`client_manager.py:152`), which is the placement work #481 already got right.

- **`_parse_ip_literal`** falls back to `socket.inet_aton` and judges the quad. `inet_aton` still refuses anything non-numeric, so `example.com`, `aerospike-node-1`, `1.2.3.4.5` and `127.0.0.1x` stay allowed — the documented scope limit (hostnames are not pre-resolved) is unchanged. There is a test class for exactly that, so the fallback cannot start over-blocking.
- **`is_unspecified`** joins loopback and link-local.
- **`ACM_ALLOW_LOOPBACK_TARGETS`** is honoured as the preferred name, alongside the two older ones. Nothing breaks on upgrade, and `.env.example` stops lying.

One correction to #510's message: IPv4-mapped IPv6 needs no unwrapping. `ipaddress` already reports `::ffff:127.0.0.1` as loopback and `::ffff:169.254.169.254` as link-local. Pinned as tests anyway so a refactor cannot quietly lose it.

## Mutation-tested, part by part

| mutation | result |
| --- | --- |
| remove the `inet_aton` fallback | 6+ failures, incl. `assert_targets_allowed` **DID NOT RAISE** for `2852039166` |
| drop `is_unspecified` | `[0.0.0.0]` and `[::]` fail |
| stop reading `ACM_ALLOW_LOOPBACK_TARGETS` | `test_documented_name_opens_the_gate` fails |
| all restored | 56 passed |

Full API suite: **1307 passed** (1288 before, 19 new cases). `ruff check` and `ruff format --check` clean.

## Not addressed here

The audit also reproduced a separate live bypass of the #469 read-only allowlist through `GET /records/{conn_id}?ns=...` — a caller-controlled namespace is interpolated into `info_namespace(ns)` with no validation, so a newline-chained frame reaches `client.info_all` on a route that never calls the gate. Different module, different fix; filing separately rather than widening this PR.

Refs #470, #510.