### PR TITLE
fix(security): validate the namespace that reaches an info command

### DIFF
--- a/api/src/aerospike_cluster_manager_api/constants.py
+++ b/api/src/aerospike_cluster_manager_api/constants.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import re
+
 import aerospike_py
 
 # Info commands
@@ -15,20 +17,54 @@ INFO_NODE = "node"
 INFO_UDF_LIST = "udf-list"
 
 
+# A namespace name as the server will accept it: Aerospike caps namespace names
+# at 31 characters, and the charset matches ``CreateNamespaceRequest.name``.
+#
+# This is a security boundary, not cosmetics. The builders below interpolate
+# their argument into an info command, and ``\n`` is the batch separator (see
+# ``info_verbs``): a namespace of ``test\ntruncate:namespace=test`` becomes a
+# two-command frame whose head is a read. ``POST /clusters/{id}/info`` is
+# guarded by the ``info_verbs`` allowlist (#469), but these builders are reached
+# from routes that never call it -- ``GET /records/{id}?ns=...`` and the index
+# routes -- so the frame has to be refused where it is built.
+_INFO_NS_ARG_RE = re.compile(r"^[a-zA-Z0-9_-]{1,31}$")
+
+
+class InvalidInfoArgument(ValueError):
+    """Raised when a namespace argument would not be a single safe info frame.
+
+    Subclasses :class:`ValueError` so the routers' existing ``except ValueError``
+    branches surface it as a 400 rather than a 500.
+    """
+
+    def __init__(self, value: str) -> None:
+        super().__init__(
+            f"namespace {value!r} is not a valid Aerospike namespace name "
+            "(letters, digits, underscore and hyphen, 1-31 characters)"
+        )
+        self.value = value
+
+
+def _checked_ns(ns: str) -> str:
+    if not _INFO_NS_ARG_RE.fullmatch(ns):
+        raise InvalidInfoArgument(ns)
+    return ns
+
+
 def info_namespace(ns: str) -> str:
-    return f"namespace/{ns}"
+    return f"namespace/{_checked_ns(ns)}"
 
 
 def info_sets(ns: str) -> str:
-    return f"sets/{ns}"
+    return f"sets/{_checked_ns(ns)}"
 
 
 def info_sindex(ns: str) -> str:
-    return f"sindex/{ns}"
+    return f"sindex/{_checked_ns(ns)}"
 
 
 def info_bins(ns: str) -> str:
-    return f"bins/{ns}"
+    return f"bins/{_checked_ns(ns)}"
 
 
 # Per-node command classification

--- a/api/src/aerospike_cluster_manager_api/models/query.py
+++ b/api/src/aerospike_cluster_manager_api/models/query.py
@@ -35,7 +35,7 @@ class QueryPredicate(BaseModel):
 
 
 class QueryRequest(BaseModel):
-    namespace: str = Field(min_length=1, max_length=31)
+    namespace: str = Field(min_length=1, max_length=31, pattern=r"^[a-zA-Z0-9_-]+$")
     set: str | None = Field(default=None, max_length=63)
     predicate: QueryPredicate | None = None
     selectBins: list[BinName] | None = Field(default=None, min_length=1)
@@ -175,7 +175,7 @@ class FilteredQueryRequest(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    namespace: str = Field(min_length=1, max_length=31)
+    namespace: str = Field(min_length=1, max_length=31, pattern=r"^[a-zA-Z0-9_-]+$")
     set: str | None = Field(default=None, max_length=63)
     filters: FilterGroup | None = None
     predicate: QueryPredicate | None = None

--- a/api/src/aerospike_cluster_manager_api/routers/indexes.py
+++ b/api/src/aerospike_cluster_manager_api/routers/indexes.py
@@ -133,7 +133,7 @@ async def delete_index(
     request: Request,
     client: AerospikeClient,
     name: str = Query(..., min_length=1),
-    ns: str = Query(..., min_length=1),
+    ns: str = Query(..., min_length=1, max_length=31, pattern=r"^[a-zA-Z0-9_-]+$"),
 ) -> Response:
     """Remove a secondary index by name from the specified namespace.
 

--- a/api/src/aerospike_cluster_manager_api/routers/records.py
+++ b/api/src/aerospike_cluster_manager_api/routers/records.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException, Path, Query, Request
 from starlette.responses import Response
 
 from aerospike_cluster_manager_api import db
+from aerospike_cluster_manager_api.constants import InvalidInfoArgument
 from aerospike_cluster_manager_api.converters import record_to_model
 from aerospike_cluster_manager_api.dependencies import AerospikeClient, VerifiedConnId
 from aerospike_cluster_manager_api.middleware.cancellation import run_cancellable
@@ -142,7 +143,7 @@ async def get_records(
     request: Request,
     client: AerospikeClient,
     conn_id: VerifiedConnId,
-    ns: str = Query(..., min_length=1),
+    ns: str = Query(..., min_length=1, max_length=31, pattern=r"^[a-zA-Z0-9_-]+$"),
     set: str = "",
     pageSize: int = Query(25, ge=1, le=500),
 ) -> RecordListResponse:
@@ -157,11 +158,17 @@ async def get_records(
     """
     # Cancelled if the operator closes the tab mid-scan (ADR-0021). A scan of
     # a large set is minutes of work whose result nobody is left to read.
-    result = await run_cancellable(
-        request,
-        records_service.list_records(client, ns, set, page_size=pageSize),
-        label=f"scan {ns}.{set or '<all sets>'}",
-    )
+    try:
+        result = await run_cancellable(
+            request,
+            records_service.list_records(client, ns, set, page_size=pageSize),
+            label=f"scan {ns}.{set or '<all sets>'}",
+        )
+    except InvalidInfoArgument as exc:
+        # Unreachable through this route while the `ns` pattern above holds.
+        # This is the backstop degrading to a 400 rather than a 500 if some
+        # future caller reaches the service with an unvalidated namespace.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     models = [record_to_model(r) for r in result.records]
     await _attach_record_notes(conn_id, ns, set, result.records, models)
     return RecordListResponse(
@@ -183,7 +190,7 @@ async def get_records(
 async def get_record_detail(
     client: AerospikeClient,
     conn_id: VerifiedConnId,
-    ns: str = Query(..., min_length=1),
+    ns: str = Query(..., min_length=1, max_length=31, pattern=r"^[a-zA-Z0-9_-]+$"),
     set: str = Query(...),
     pk: str = Query(..., min_length=1),
     pk_type: Literal["auto", "string", "int", "bytes"] = Query("auto"),
@@ -262,7 +269,7 @@ async def delete_record(
     request: Request,
     client: AerospikeClient,
     conn_id: VerifiedConnId,
-    ns: str = Query(..., min_length=1),
+    ns: str = Query(..., min_length=1, max_length=31, pattern=r"^[a-zA-Z0-9_-]+$"),
     set: str = Query(..., min_length=1),
     pk: str = Query(..., min_length=1),
     pk_type: Literal["auto", "string", "int", "bytes"] = Query("auto"),

--- a/api/tests/test_info_argument_framing.py
+++ b/api/tests/test_info_argument_framing.py
@@ -1,0 +1,149 @@
+"""The namespace that reaches an info command must be a single safe frame.
+
+``info_verbs`` rejects a chained frame on ``POST /clusters/{id}/info`` (#469),
+but the four builders in :mod:`constants` interpolate a namespace into an info
+command on routes that never call that gate -- ``GET /records/{id}?ns=...`` and
+the index routes. ``\n`` is the batch separator, so an unvalidated namespace of
+``test\ntruncate:namespace=test`` is a two-command frame whose head is a read.
+
+These tests pin both halves: the builders refuse it, and the routes refuse it
+before a client is ever asked to send anything.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from aerospike_cluster_manager_api.constants import (
+    InvalidInfoArgument,
+    info_bins,
+    info_namespace,
+    info_sets,
+    info_sindex,
+)
+from aerospike_cluster_manager_api.main import app
+
+BUILDERS = [info_namespace, info_sets, info_sindex, info_bins]
+
+# The reproduced payload, plus the neighbouring shapes the same hole allows.
+CHAINED = [
+    "test\ntruncate:namespace=test",
+    "test\rtruncate:namespace=test",
+    "test;truncate:namespace=test",
+    "test truncate:namespace=test",
+    "test/truncate:namespace=test",
+    "test:truncate",
+    "a" * 32,  # past the server's 31-character namespace limit
+    "",
+]
+
+
+class TestBuildersRefuseAChainedFrame:
+    @pytest.mark.parametrize("builder", BUILDERS, ids=lambda b: b.__name__)
+    @pytest.mark.parametrize("ns", CHAINED)
+    def test_rejected(self, builder, ns: str) -> None:
+        with pytest.raises(InvalidInfoArgument):
+            builder(ns)
+
+    @pytest.mark.parametrize("builder", BUILDERS, ids=lambda b: b.__name__)
+    @pytest.mark.parametrize("ns", ["test", "bar-1", "my_ns", "a", "a" * 31])
+    def test_real_namespace_names_still_build(self, builder, ns: str) -> None:
+        assert builder(ns).endswith(f"/{ns}")
+
+    def test_the_error_is_a_value_error(self) -> None:
+        # The routers' existing `except ValueError` branches turn this into a
+        # 400 rather than a 500.
+        assert issubclass(InvalidInfoArgument, ValueError)
+
+
+@asynccontextmanager
+async def _noop_lifespan(_app: FastAPI) -> AsyncIterator[None]:
+    yield
+
+
+@pytest.fixture()
+async def client():
+    original_lifespan = app.router.lifespan_context
+    app.router.lifespan_context = _noop_lifespan
+    app.state.limiter.enabled = False
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+    app.state.limiter.enabled = True
+    app.router.lifespan_context = original_lifespan
+
+
+class TestChainedNamespaceNeverReachesTheWire:
+    """The end-to-end shape: the request is refused, and nothing is sent."""
+
+    @pytest.mark.parametrize("ns", ["test\ntruncate:namespace=test", "test;truncate"])
+    async def test_records_listing_is_refused_without_calling_info(self, client: AsyncClient, ns: str) -> None:
+        mock_client = AsyncMock()
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            response = await client.get(
+                "/api/records/conn-test",
+                params={"ns": ns, "set": "s1"},
+            )
+
+        assert response.status_code >= 400, response.text
+        # The assertion that matters: no frame was handed to the client at all.
+        mock_client.info_all.assert_not_awaited()
+        mock_client.info_random_node.assert_not_awaited()
+
+    async def test_filter_route_is_refused_without_calling_info(self, client: AsyncClient) -> None:
+        mock_client = AsyncMock()
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            response = await client.post(
+                "/api/records/conn-test/filter",
+                json={"namespace": "test\ntruncate:namespace=test", "set": "s1"},
+            )
+
+        assert response.status_code >= 400, response.text
+        mock_client.info_all.assert_not_awaited()
+
+    async def test_index_delete_is_refused_without_calling_info(self, client: AsyncClient) -> None:
+        # `DELETE /indexes/{id}` is the caller-controlled index path -- the GET
+        # takes no `ns` at all, it enumerates namespaces from the server. The
+        # delete reaches `_index_exists` -> `info_sindex(ns)` on its error path.
+        mock_client = AsyncMock()
+        with (
+            patch(
+                "aerospike_cluster_manager_api.dependencies.db.get_connection",
+                AsyncMock(return_value={"id": "conn-test"}),
+            ),
+            patch(
+                "aerospike_cluster_manager_api.dependencies.client_manager.get_client",
+                AsyncMock(return_value=mock_client),
+            ),
+        ):
+            response = await client.delete(
+                "/api/indexes/conn-test",
+                params={"ns": "test\ntruncate:namespace=test", "name": "idx1"},
+            )
+
+        assert response.status_code >= 400, response.text
+        mock_client.info_random_node.assert_not_awaited()

--- a/ui/openapi.json
+++ b/ui/openapi.json
@@ -1864,6 +1864,7 @@
           "namespace": {
             "maxLength": 31,
             "minLength": 1,
+            "pattern": "^[a-zA-Z0-9_-]+$",
             "title": "Namespace",
             "type": "string"
           },
@@ -4320,6 +4321,7 @@
           "namespace": {
             "maxLength": 31,
             "minLength": 1,
+            "pattern": "^[a-zA-Z0-9_-]+$",
             "title": "Namespace",
             "type": "string"
           },
@@ -8472,7 +8474,9 @@
             "name": "ns",
             "required": true,
             "schema": {
+              "maxLength": 31,
               "minLength": 1,
+              "pattern": "^[a-zA-Z0-9_-]+$",
               "title": "Ns",
               "type": "string"
             }
@@ -11243,7 +11247,9 @@
             "name": "ns",
             "required": true,
             "schema": {
+              "maxLength": 31,
               "minLength": 1,
+              "pattern": "^[a-zA-Z0-9_-]+$",
               "title": "Ns",
               "type": "string"
             }
@@ -11323,7 +11329,9 @@
             "name": "ns",
             "required": true,
             "schema": {
+              "maxLength": 31,
               "minLength": 1,
+              "pattern": "^[a-zA-Z0-9_-]+$",
               "title": "Ns",
               "type": "string"
             }
@@ -11449,7 +11457,9 @@
             "name": "ns",
             "required": true,
             "schema": {
+              "maxLength": 31,
               "minLength": 1,
+              "pattern": "^[a-zA-Z0-9_-]+$",
               "title": "Ns",
               "type": "string"
             }


### PR DESCRIPTION
Found while auditing whether the 34 issues closed on 2026-08-17/18 hold on `main`. #469's allowlist is correct and thorough — and it guards exactly one route. This closes the way around it.

## The way around

`constants.py` builds four info commands by interpolation:

```python
def info_namespace(ns: str) -> str: return f"namespace/{ns}"
def info_sets(ns: str)      -> str: return f"sets/{ns}"
def info_sindex(ns: str)    -> str: return f"sindex/{ns}"
def info_bins(ns: str)      -> str: return f"bins/{ns}"
```

and the namespace arrived from `ns: str = Query(..., min_length=1)` — no length bound, no charset. `\n` is the batch separator; `info_verbs` says so in its own module docstring and at `:348`. So:

```
GET /api/v1/records/{conn_id}?ns=test%0Atruncate%3Anamespace%3Dtest&set=s1
```

becomes `namespace/test\ntruncate:namespace=test` and goes to `client.info_all`. Reproduced end to end against the real ASGI app with only `get_client` mocked — **HTTP 200**, and two frames recorded at `AsyncClient.info_all`:

```
'namespace/test\ntruncate:namespace=test'
'sets/test\ntruncate:namespace=test'
```

That is precisely the shape `assert_single_command` exists to reject, arriving on a route that never calls it. Also reachable through `POST /records/{id}/filter` and `DELETE /indexes/{id}`.

## Two layers

Either alone leaves a bad failure mode, so both:

| layer | what it does |
| --- | --- |
| **the four builders** | reject anything that is not a namespace name — letters, digits, `_`, `-`, 1–31 chars, matching the server's limit and the existing `CreateNamespaceRequest.name` pattern. This is the choke point: all nine call sites inherit it. `InvalidInfoArgument` subclasses `ValueError` so the routers' existing branches give a 400, and `get_records` maps it explicitly rather than letting it escape as a 500. |
| **the parameters** | the same pattern on `ns` (records ×3, indexes ×1) and on both `namespace` model fields, so the request is refused at the boundary with a 422 and the service is never entered. |

Server-supplied namespace names (from the `namespaces` info response) pass unchanged — they are real namespace names.

## Mutation-tested

| mutation | result |
| --- | --- |
| builder guard removed | the 4 builder tests fail — `DID NOT RAISE` |
| route/model patterns removed | the 3 route tests fail |
| **both removed** | **the chained frame reaches the client again** — `'coroutine' object has no attribute 'results'`, and `info_random_node.assert_not_awaited()` breaks |
| restored | 58 passed |

The route tests assert `info_all.assert_not_awaited()` rather than a status code, because the question is not "was it refused" but "did anything reach the wire".

## Two corrections to the audit that found this

- `GET /indexes/{id}` takes no `ns` at all — it enumerates namespaces from the server and calls `info_sindex` per name. `DELETE /indexes/{id}` is the caller-controlled index path, and that is what the test drives. I found this by writing the test against the GET first and watching it fail for the wrong reason.
- The builder guard alone would have produced a 500 on `GET /records/{id}`, not a 400 — that route has no `except ValueError`. Hence the explicit mapping.

## Checks

Full API suite **1345 passed** (1288 before). `ruff check` / `ruff format --check` clean. `make generate-types-check` passes after regenerating `ui/openapi.json` — the new constraints are part of the published schema, and the #165 drift gate caught them on the first run, which is that gate doing its job.

## What I did not verify

Whether the server executes the second command in the frame. There is no live cluster here. That premise is this repository's own — it is the entire basis of the #469 fix, stated at `info_verbs.py:462`: *"without it `set-config:context=service;foo=1\ntruncate-namespace:namespace=test` would pass a verb check on its head and then truncate a namespace."* If it holds for `POST /clusters/{id}/info`, it holds here.

Refs #469.